### PR TITLE
feat: harden WL dedupe and tidy OEBB titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Wien ÖPNV Feed
+
+Störungen und Einschränkungen für den Großraum Wien aus offiziellen Quellen.
+
+## Entwicklung/Tests lokal
+
+```bash
+python -m pip install -r requirements.txt
+python -m pytest -q
+python -u src/build_feed.py  # erzeugt docs/feed.xml
+```
+
+Der erzeugte Feed liegt unter `docs/feed.xml`.

--- a/tests/test_oebb_title.py
+++ b/tests/test_oebb_title.py
@@ -1,0 +1,7 @@
+from src.providers.oebb import _clean_title_keep_places
+
+
+def test_wien_und_arrow_and_clean():
+    t = "Verkehrsmeldung: Wien Floridsdorf Bahnhof und Wien Meidling Hbf"
+    assert _clean_title_keep_places(t) == "Wien Floridsdorf ↔ Wien Meidling"
+

--- a/tests/test_wl_title.py
+++ b/tests/test_wl_title.py
@@ -1,0 +1,54 @@
+from src.providers import wiener_linien as wl
+
+
+def test_dedupe_topic_shorter_title():
+    ev1 = {
+        "category": "Störung",
+        "title": "5: Falschparker",
+        "topic_key": wl._topic_key_from_title("Falschparker"),
+        "lines_pairs": [("5", "5")],
+        "desc": "",
+        "extras": [],
+        "stop_names": set(),
+        "pubDate": None,
+        "starts_at": None,
+        "ends_at": None,
+        "_identity": "1",
+    }
+    ev2 = {
+        "category": "Störung",
+        "title": "5: Fahrtbehinderung Falschparker",
+        "topic_key": wl._topic_key_from_title("Fahrtbehinderung Falschparker"),
+        "lines_pairs": [("5", "5")],
+        "desc": "",
+        "extras": [],
+        "stop_names": set(),
+        "pubDate": None,
+        "starts_at": None,
+        "ends_at": None,
+        "_identity": "2",
+    }
+
+    buckets = {}
+    for ev in (ev1, ev2):
+        key = wl._guid(
+            "wl",
+            ev["category"],
+            ev["topic_key"],
+            ",".join(sorted(wl._line_tokens_from_pairs(ev["lines_pairs"]))),
+        )
+        b = buckets.get(key)
+        if not b:
+            buckets[key] = dict(ev)
+        else:
+            if len(ev["title"]) < len(b["title"]):
+                b["title"] = ev["title"]
+
+    assert len(buckets) == 1
+    assert list(buckets.values())[0]["title"] == "5: Falschparker"
+
+
+def test_line_prefix_and_house_number_false_positive():
+    assert wl._ensure_line_prefix("Falschparker", ["5"]) == "5: Falschparker"
+    assert wl._detect_line_pairs_from_text("Neubaugasse 69") == []
+


### PR DESCRIPTION
## Summary
- tighten Wiener Linien topic-key dedupe with fallback to core title and shorter-title preference
- scrub bullets after prepositions in WL descriptions for cleaner TV text
- normalise ÖBB titles, handling "Wien X und Wien Y" arrows and trimming station suffixes
- add unit tests for WL dedupe/title and ÖBB title cleanup
- document local test and feed build workflow

## Testing
- `python -m pytest -q`
- `python -u src/build_feed.py`

------
https://chatgpt.com/codex/tasks/task_e_68c6d0819a18832b927d266a0860eb2b