### PR TITLE
Use module logger in Wiener Linien provider

### DIFF
--- a/src/providers/wiener_linien.py
+++ b/src/providers/wiener_linien.py
@@ -473,7 +473,7 @@ def fetch_events(timeout: int = 20) -> List[Dict[str, Any]]:
                 "_identity": identity,
             })
     except Exception as e:
-        logging.exception("WL trafficInfoList fehlgeschlagen: %s", e)
+        log.exception("WL trafficInfoList fehlgeschlagen: %s", e)
 
     # B) News/Hinweise
     try:
@@ -545,7 +545,7 @@ def fetch_events(timeout: int = 20) -> List[Dict[str, Any]]:
                 "_identity": identity,
             })
     except Exception as e:
-        logging.exception("WL newsList fehlgeschlagen: %s", e)
+        log.exception("WL newsList fehlgeschlagen: %s", e)
 
     # C) Bündelung: LINIEN-SET + TOPIC
     buckets: Dict[str, Dict[str, Any]] = {}


### PR DESCRIPTION
## Summary
- use module-level logger for exceptions in `wiener_linien.fetch_events`

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6d47567e8832baff8ab66f1848d72