### PR TITLE
Ensure non-negative MAX_ITEMS from env

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -27,7 +27,7 @@ FEED_DESC = os.getenv("FEED_DESC", "Aktive Störungen/Baustellen/Einschränkunge
 
 DESCRIPTION_CHAR_LIMIT = max(int(os.getenv("DESCRIPTION_CHAR_LIMIT", "170")), 0)
 FRESH_PUBDATE_WINDOW_MIN = int(os.getenv("FRESH_PUBDATE_WINDOW_MIN", "5"))
-MAX_ITEMS = int(os.getenv("MAX_ITEMS", "60"))
+MAX_ITEMS = max(int(os.getenv("MAX_ITEMS", "60")), 0)
 ACTIVE_GRACE_MIN = int(os.getenv("ACTIVE_GRACE_MIN", "10"))
 
 STATE_FILE = Path("data/first_seen.json")  # nur Einträge aus *aktuellem* Feed

--- a/tests/test_max_items.py
+++ b/tests/test_max_items.py
@@ -1,0 +1,13 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_max_items_non_negative(monkeypatch):
+    monkeypatch.setenv("MAX_ITEMS", "-5")
+    module_name = "src.build_feed"
+    # Ensure 'providers' package can be found
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1] / "src"))
+    sys.modules.pop(module_name, None)
+    build_feed = importlib.import_module(module_name)
+    assert build_feed.MAX_ITEMS == 0


### PR DESCRIPTION
## Summary
- Guard against negative `MAX_ITEMS` by clamping the env value to zero
- Add regression test validating negative `MAX_ITEMS` input is sanitized

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d484cf18832bae076ce152a0a723