### PR TITLE
Use defusedxml for XML parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.32.0,<3
 python-dateutil>=2.9,<3
+defusedxml>=0.7.1,<1

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -29,7 +29,7 @@ from email.utils import parsedate_to_datetime
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-from xml.etree import ElementTree as ET
+from defusedxml import ElementTree as ET
 
 log = logging.getLogger(__name__)
 

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import os, re, html, hashlib, logging
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional
-from xml.etree import ElementTree as ET
+from defusedxml import ElementTree as ET
 
 import requests
 from requests.adapters import HTTPAdapter


### PR DESCRIPTION
## Summary
- Replace `xml.etree.ElementTree` with `defusedxml.ElementTree` in ÖBB and VOR providers
- Add `defusedxml` to requirements

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6d48c40c8832bb9484ce124dba8fc