### PR TITLE
Use Vienna timezone for VOR stationboard

### DIFF
--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os, re, html, hashlib, logging
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 from typing import Any, Dict, Iterable, List, Optional
 from xml.etree import ElementTree as ET
 
@@ -180,7 +181,7 @@ def fetch_events() -> List[Dict[str, Any]]:
         log.info("VOR: keine VOR_STATION_IDS gesetzt – Provider inaktiv.")
         return []
 
-    now_local = datetime.now(timezone.utc)
+    now_local = datetime.now().astimezone(ZoneInfo("Europe/Vienna"))
     station_chunk = _select_stations_round_robin(VOR_STATION_IDS, MAX_STATIONS_PER_RUN, ROTATION_INTERVAL_SEC)
 
     seen: set[str] = set()

--- a/tests/test_vor_timezone.py
+++ b/tests/test_vor_timezone.py
@@ -1,0 +1,21 @@
+import xml.etree.ElementTree as ET
+from zoneinfo import ZoneInfo
+
+import src.providers.vor as vor
+
+
+def test_fetch_events_passes_local_timezone(monkeypatch):
+    vor.VOR_ACCESS_ID = "test"
+    vor.VOR_STATION_IDS = ["123"]
+
+    recorded = {}
+
+    def fake_fetch_stationboard(station_id, now_local):
+        recorded["tz"] = now_local.tzinfo
+        return ET.Element("root")
+
+    monkeypatch.setattr(vor, "_fetch_stationboard", fake_fetch_stationboard)
+
+    result = vor.fetch_events()
+    assert result == []
+    assert recorded["tz"].key == "Europe/Vienna"


### PR DESCRIPTION
## Summary
- Use Europe/Vienna as local timezone when fetching VOR stationboard data
- Add regression test confirming local timezone handling in fetch_events

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d4931b3c832b994d80b5eb21784d