### PR TITLE
Deduplicate feed items before sorting

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -137,6 +137,19 @@ def _collect_items() -> List[Dict[str, Any]]:
         log.exception("ÖBB fetch fehlgeschlagen: %s", e)
     return items
 
+
+def _dedupe_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Behalte nur das erste Item je Identität (oder guid)."""
+    seen = set()
+    out = []
+    for it in items:
+        key = it.get("_identity") or it.get("guid")
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(it)
+    return out
+
 def _sort_key(item: Dict[str, Any]) -> Tuple[int, float, str]:
     pd = item.get("pubDate")
     if isinstance(pd, datetime):
@@ -229,6 +242,7 @@ def main() -> int:
     now = datetime.now(timezone.utc)
     state = _load_state()
     items = _collect_items()
+    items = _dedupe_items(items)
     if not items:
         log.warning("Keine Items gesammelt.")
         items = []

--- a/tests/test_dedupe_items.py
+++ b/tests/test_dedupe_items.py
@@ -1,0 +1,55 @@
+import importlib
+import sys
+from pathlib import Path
+import types
+
+
+def _import_build_feed(monkeypatch):
+    module_name = "src.build_feed"
+    root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(root))
+    monkeypatch.syspath_prepend(str(root / "src"))
+    # Provide lightweight provider stubs to avoid heavy deps during import
+    providers = types.ModuleType("providers")
+    wl = types.ModuleType("providers.wiener_linien")
+    wl.fetch_events = lambda: []
+    oebb = types.ModuleType("providers.oebb")
+    oebb.fetch_events = lambda: []
+    monkeypatch.setitem(sys.modules, "providers", providers)
+    monkeypatch.setitem(sys.modules, "providers.wiener_linien", wl)
+    monkeypatch.setitem(sys.modules, "providers.oebb", oebb)
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_main_dedupes_items(monkeypatch, tmp_path):
+    build_feed = _import_build_feed(monkeypatch)
+
+    sample_items = [
+        {"_identity": "a", "guid": "ga", "title": "A"},
+        {"_identity": "a", "guid": "ga_dup", "title": "A2"},
+        {"guid": "gb", "title": "B"},
+        {"guid": "gb", "title": "B2"},
+        {"guid": "gc", "title": "C"},
+    ]
+
+    def fake_collect():
+        return list(sample_items)
+
+    captured = {}
+
+    def fake_make_rss(items, now, state):
+        captured["items"] = items
+        return ""
+
+    monkeypatch.setattr(build_feed, "_collect_items", fake_collect)
+    monkeypatch.setattr(build_feed, "_make_rss", fake_make_rss)
+    build_feed.OUT_PATH = str(tmp_path / "feed.xml")
+
+    build_feed.main()
+
+    assert captured["items"] == [
+        {"_identity": "a", "guid": "ga", "title": "A"},
+        {"guid": "gb", "title": "B"},
+        {"guid": "gc", "title": "C"},
+    ]


### PR DESCRIPTION
## Summary
- Deduplicate collected events so only the first occurrence of each `_identity` or `guid` is kept
- Call dedupe step before sorting to ensure RSS generation uses unique items
- Add regression test for deduplication in build pipeline

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d7a84cfc832b803b8401e64073e1