### PR TITLE
Handle dedupe for items without identifiers

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import json, os, sys, html, logging, re
+import json, os, sys, html, logging, re, hashlib
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from datetime import datetime, timezone
@@ -143,7 +143,15 @@ def _dedupe_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     seen = set()
     out = []
     for it in items:
-        key = it.get("_identity") or it.get("guid")
+        key: Optional[str]
+        if it.get("_identity"):
+            key = it.get("_identity")
+        elif it.get("guid"):
+            key = it.get("guid")
+        else:
+            raw = f"{it.get('title') or ''}|{it.get('description') or ''}"
+            key = hashlib.sha1(raw.encode("utf-8")).hexdigest()
+            log.warning("Item ohne guid/_identity – Fallback-Schlüssel %s", key)
         if key in seen:
             continue
         seen.add(key)

--- a/tests/test_dedupe_items.py
+++ b/tests/test_dedupe_items.py
@@ -53,3 +53,14 @@ def test_main_dedupes_items(monkeypatch, tmp_path):
         {"guid": "gb", "title": "B"},
         {"guid": "gc", "title": "C"},
     ]
+
+
+def test_items_without_identifier_are_unique(monkeypatch):
+    build_feed = _import_build_feed(monkeypatch)
+
+    items = [
+        {"title": "A", "description": "desc1"},
+        {"title": "B", "description": "desc2"},
+    ]
+
+    assert build_feed._dedupe_items(items) == items


### PR DESCRIPTION
## Summary
- Handle feed items missing `guid` and `_identity` by generating a fallback hash and logging a warning
- Add regression test ensuring items without identifiers aren't deduplicated

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6daaea508832ba9ba1b767ee06a23