### PR TITLE
Add provider toggles and VOR provider integration

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -10,6 +10,7 @@ from email.utils import format_datetime
 # Provider-Imports
 from providers.wiener_linien import fetch_events as wl_fetch
 from providers.oebb import fetch_events as oebb_fetch
+from providers.vor import fetch_events as vor_fetch
 
 # ---------------- Logging ----------------
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -127,14 +128,25 @@ def _identity_for_item(item: Dict[str, Any]) -> str:
 
 def _collect_items() -> List[Dict[str, Any]]:
     items: List[Dict[str, Any]] = []
-    try:
-        items += wl_fetch()
-    except Exception as e:
-        log.exception("WL fetch fehlgeschlagen: %s", e)
-    try:
-        items += oebb_fetch()
-    except Exception as e:
-        log.exception("ÖBB fetch fehlgeschlagen: %s", e)
+
+    if os.getenv("WL_ENABLE", "1").strip().lower() not in {"0", "false"}:
+        try:
+            items += wl_fetch()
+        except Exception as e:
+            log.exception("WL fetch fehlgeschlagen: %s", e)
+
+    if os.getenv("OEBB_ENABLE", "1").strip().lower() not in {"0", "false"}:
+        try:
+            items += oebb_fetch()
+        except Exception as e:
+            log.exception("ÖBB fetch fehlgeschlagen: %s", e)
+
+    if os.getenv("VOR_ENABLE", "1").strip().lower() not in {"0", "false"}:
+        try:
+            items += vor_fetch()
+        except Exception as e:
+            log.exception("VOR fetch fehlgeschlagen: %s", e)
+
     return items
 
 

--- a/tests/test_collect_items_env.py
+++ b/tests/test_collect_items_env.py
@@ -1,0 +1,64 @@
+import importlib
+import sys
+from pathlib import Path
+import types
+import pytest
+
+
+def _import_build_feed(monkeypatch):
+    module_name = "src.build_feed"
+    root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(root))
+    monkeypatch.syspath_prepend(str(root / "src"))
+    providers = types.ModuleType("providers")
+    wl = types.ModuleType("providers.wiener_linien")
+    wl.fetch_events = lambda: []
+    oebb = types.ModuleType("providers.oebb")
+    oebb.fetch_events = lambda: []
+    vor = types.ModuleType("providers.vor")
+    vor.fetch_events = lambda: []
+    monkeypatch.setitem(sys.modules, "providers", providers)
+    monkeypatch.setitem(sys.modules, "providers.wiener_linien", wl)
+    monkeypatch.setitem(sys.modules, "providers.oebb", oebb)
+    monkeypatch.setitem(sys.modules, "providers.vor", vor)
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+@pytest.mark.parametrize(
+    "disabled_env,expected",
+    [
+        ("WL_ENABLE", [{"p": "oebb"}, {"p": "vor"}]),
+        ("OEBB_ENABLE", [{"p": "wl"}, {"p": "vor"}]),
+        ("VOR_ENABLE", [{"p": "wl"}, {"p": "oebb"}]),
+    ],
+)
+def test_disabling_provider_suppresses_items(monkeypatch, disabled_env, expected):
+    build_feed = _import_build_feed(monkeypatch)
+
+    monkeypatch.setattr(build_feed, "wl_fetch", lambda: [{"p": "wl"}])
+    monkeypatch.setattr(build_feed, "oebb_fetch", lambda: [{"p": "oebb"}])
+    monkeypatch.setattr(build_feed, "vor_fetch", lambda: [{"p": "vor"}])
+
+    monkeypatch.setenv("WL_ENABLE", "1")
+    monkeypatch.setenv("OEBB_ENABLE", "1")
+    monkeypatch.setenv("VOR_ENABLE", "1")
+    monkeypatch.setenv(disabled_env, "0")
+
+    items = build_feed._collect_items()
+    assert items == expected
+
+
+def test_enabling_vor_yields_items(monkeypatch):
+    build_feed = _import_build_feed(monkeypatch)
+
+    monkeypatch.setattr(build_feed, "wl_fetch", lambda: [])
+    monkeypatch.setattr(build_feed, "oebb_fetch", lambda: [])
+    monkeypatch.setattr(build_feed, "vor_fetch", lambda: [{"p": "vor"}])
+
+    monkeypatch.setenv("WL_ENABLE", "0")
+    monkeypatch.setenv("OEBB_ENABLE", "0")
+    monkeypatch.setenv("VOR_ENABLE", "1")
+
+    items = build_feed._collect_items()
+    assert items == [{"p": "vor"}]

--- a/tests/test_dedupe_items.py
+++ b/tests/test_dedupe_items.py
@@ -15,9 +15,12 @@ def _import_build_feed(monkeypatch):
     wl.fetch_events = lambda: []
     oebb = types.ModuleType("providers.oebb")
     oebb.fetch_events = lambda: []
+    vor = types.ModuleType("providers.vor")
+    vor.fetch_events = lambda: []
     monkeypatch.setitem(sys.modules, "providers", providers)
     monkeypatch.setitem(sys.modules, "providers.wiener_linien", wl)
     monkeypatch.setitem(sys.modules, "providers.oebb", oebb)
+    monkeypatch.setitem(sys.modules, "providers.vor", vor)
     sys.modules.pop(module_name, None)
     return importlib.import_module(module_name)
 


### PR DESCRIPTION
## Summary
- Integrate VOR provider and gate feed providers behind environment flags
- Allow selectively enabling Wiener Linien, ÖBB, or VOR feeds via WL_ENABLE, OEBB_ENABLE, VOR_ENABLE
- Add tests for disabling providers and for enabling VOR when data is available

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6e019a778832ba6fd3c1cdd325202