### PR TITLE
Support configurable state path and pruning

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -4,7 +4,7 @@
 import json, os, sys, html, logging, re, hashlib
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from email.utils import format_datetime
 
 # Provider-Imports
@@ -30,7 +30,8 @@ FRESH_PUBDATE_WINDOW_MIN = int(os.getenv("FRESH_PUBDATE_WINDOW_MIN", "5"))
 MAX_ITEMS = max(int(os.getenv("MAX_ITEMS", "60")), 0)
 ACTIVE_GRACE_MIN = int(os.getenv("ACTIVE_GRACE_MIN", "10"))
 
-STATE_FILE = Path("data/first_seen.json")  # nur Einträge aus *aktuellem* Feed
+STATE_FILE = Path(os.getenv("STATE_PATH", "data/first_seen.json"))  # nur Einträge aus *aktuellem* Feed
+STATE_RETENTION_DAYS = max(int(os.getenv("STATE_RETENTION_DAYS", "60")), 0)
 
 RFC = "%a, %d %b %Y %H:%M:%S %z"
 
@@ -90,16 +91,38 @@ def _load_state() -> Dict[str, Dict[str, Any]]:
     try:
         with STATE_FILE.open("r", encoding="utf-8") as f:
             data = json.load(f)
-        return data if isinstance(data, dict) else {}
+        data = data if isinstance(data, dict) else {}
     except Exception as e:
         log.warning("State laden fehlgeschlagen (%s) – starte leer.", e)
         return {}
 
+    threshold = datetime.now(timezone.utc) - timedelta(days=STATE_RETENTION_DAYS)
+    out: Dict[str, Dict[str, Any]] = {}
+    for k, v in data.items():
+        try:
+            fs_dt = datetime.fromisoformat(v.get("first_seen", ""))
+            fs_dt = _to_utc(fs_dt)
+            if fs_dt >= threshold:
+                out[k] = v
+        except Exception:
+            continue
+    return out
+
 def _save_state(state: Dict[str, Dict[str, Any]]) -> None:
     STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    threshold = datetime.now(timezone.utc) - timedelta(days=STATE_RETENTION_DAYS)
+    pruned: Dict[str, Dict[str, Any]] = {}
+    for k, v in state.items():
+        try:
+            fs_dt = datetime.fromisoformat(v.get("first_seen", ""))
+            fs_dt = _to_utc(fs_dt)
+            if fs_dt >= threshold:
+                pruned[k] = v
+        except Exception:
+            continue
     tmp = STATE_FILE.with_suffix(".tmp")
     with tmp.open("w", encoding="utf-8") as f:
-        json.dump(state, f, ensure_ascii=False, indent=2, sort_keys=True)
+        json.dump(pruned, f, ensure_ascii=False, indent=2, sort_keys=True)
     tmp.replace(STATE_FILE)
 
 def _identity_for_item(item: Dict[str, Any]) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,61 @@
+import importlib
+import sys
+import json
+from pathlib import Path
+from datetime import datetime, timezone, timedelta
+import types
+
+
+def _import_build_feed(monkeypatch):
+    module_name = "src.build_feed"
+    root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(root))
+    monkeypatch.syspath_prepend(str(root / "src"))
+    providers = types.ModuleType("providers")
+    wl = types.ModuleType("providers.wiener_linien")
+    wl.fetch_events = lambda: []
+    oebb = types.ModuleType("providers.oebb")
+    oebb.fetch_events = lambda: []
+    monkeypatch.setitem(sys.modules, "providers", providers)
+    monkeypatch.setitem(sys.modules, "providers.wiener_linien", wl)
+    monkeypatch.setitem(sys.modules, "providers.oebb", oebb)
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_state_path_override(monkeypatch, tmp_path):
+    state_file = tmp_path / "custom_state.json"
+    monkeypatch.setenv("STATE_PATH", str(state_file))
+    build_feed = _import_build_feed(monkeypatch)
+    now = datetime.now(timezone.utc).isoformat()
+    build_feed._save_state({"id": {"first_seen": now}})
+    assert state_file.exists()
+    assert build_feed._load_state() == {"id": {"first_seen": now}}
+
+
+def test_state_retention_drops_old_entries(monkeypatch, tmp_path):
+    state_file = tmp_path / "state.json"
+    monkeypatch.setenv("STATE_PATH", str(state_file))
+    monkeypatch.setenv("STATE_RETENTION_DAYS", "1")
+    build_feed = _import_build_feed(monkeypatch)
+
+    old_dt = datetime.now(timezone.utc) - timedelta(days=2)
+    new_dt = datetime.now(timezone.utc)
+    build_feed._save_state(
+        {
+            "old": {"first_seen": old_dt.isoformat()},
+            "new": {"first_seen": new_dt.isoformat()},
+        }
+    )
+    data = json.loads(state_file.read_text())
+    assert "old" not in data and "new" in data
+
+    with state_file.open("w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "old": {"first_seen": old_dt.isoformat()},
+                "new": {"first_seen": new_dt.isoformat()},
+            },
+            f,
+        )
+    assert build_feed._load_state() == {"new": {"first_seen": new_dt.isoformat()}}


### PR DESCRIPTION
## Summary
- Allow overriding state file path via `STATE_PATH` env var
- Drop state entries older than `STATE_RETENTION_DAYS` during load/save
- Test state path override and state retention pruning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6dfe9aa20832b8ea89360711c86ad