### PR TITLE
Prefer guid over identity for deduplication

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -139,11 +139,12 @@ def _collect_items() -> List[Dict[str, Any]]:
 
 
 def _dedupe_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Behalte nur das erste Item je Identität (oder guid)."""
+    """Behalte nur das erste Item je guid (oder _identity)."""
     seen = set()
     out = []
     for it in items:
-        key = it.get("_identity") or it.get("guid")
+        guid = it.get("guid")
+        key = guid or it.get("_identity")
         if key in seen:
             continue
         seen.add(key)

--- a/tests/test_dedupe_items.py
+++ b/tests/test_dedupe_items.py
@@ -27,9 +27,9 @@ def test_main_dedupes_items(monkeypatch, tmp_path):
 
     sample_items = [
         {"_identity": "a", "guid": "ga", "title": "A"},
-        {"_identity": "a", "guid": "ga_dup", "title": "A2"},
-        {"guid": "gb", "title": "B"},
-        {"guid": "gb", "title": "B2"},
+        {"_identity": "a2", "guid": "ga", "title": "A2"},
+        {"_identity": "b", "title": "B"},
+        {"_identity": "b", "title": "B2"},
         {"guid": "gc", "title": "C"},
     ]
 
@@ -49,7 +49,20 @@ def test_main_dedupes_items(monkeypatch, tmp_path):
     build_feed.main()
 
     assert captured["items"] == [
+        {"_identity": "b", "title": "B"},
         {"_identity": "a", "guid": "ga", "title": "A"},
-        {"guid": "gb", "title": "B"},
         {"guid": "gc", "title": "C"},
+    ]
+
+
+def test_guid_takes_precedence_over_identity(monkeypatch):
+    build_feed = _import_build_feed(monkeypatch)
+
+    sample_items = [
+        {"guid": "same", "_identity": "id1"},
+        {"guid": "same", "_identity": "id2"},
+    ]
+
+    assert build_feed._dedupe_items(sample_items) == [
+        {"guid": "same", "_identity": "id1"}
     ]


### PR DESCRIPTION
## Summary
- Dedupe items primarily by `guid`, falling back to `_identity`
- Add tests ensuring `guid` takes precedence over `_identity`
- Adjust existing dedupe tests for new behavior

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6da9dc320832ba2659076b51b5678