### PR TITLE
Remove unused ACTIVE_GRACE_MIN configuration

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -29,7 +29,6 @@ FEED_DESC = os.getenv("FEED_DESC", "Aktive Störungen/Baustellen/Einschränkunge
 DESCRIPTION_CHAR_LIMIT = max(int(os.getenv("DESCRIPTION_CHAR_LIMIT", "170")), 0)
 FRESH_PUBDATE_WINDOW_MIN = int(os.getenv("FRESH_PUBDATE_WINDOW_MIN", "5"))
 MAX_ITEMS = max(int(os.getenv("MAX_ITEMS", "60")), 0)
-ACTIVE_GRACE_MIN = int(os.getenv("ACTIVE_GRACE_MIN", "10"))
 MAX_ITEM_AGE_DAYS = max(int(os.getenv("MAX_ITEM_AGE_DAYS", "45")), 0)
 ABSOLUTE_MAX_AGE_DAYS = max(int(os.getenv("ABSOLUTE_MAX_AGE_DAYS", "365")), 0)
 


### PR DESCRIPTION
## Summary
- remove unused ACTIVE_GRACE_MIN environment variable

## Testing
- `PYTHONPATH=$PWD/src pytest` *(fails: ModuleNotFoundError: No module named 'providers.vor'; 'providers' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e4ce45c4832b8e6719916123b7a0