### PR TITLE
Add html_to_text unit tests

### DIFF
--- a/tests/test_html_to_text.py
+++ b/tests/test_html_to_text.py
@@ -1,0 +1,22 @@
+import pytest
+from src.utils.text import html_to_text
+
+
+@pytest.mark.parametrize("html,expected", [
+    ("Line1<br>Line2", "Line1 • Line2"),
+    ("<div>foo</div><p>bar</p>baz", "foo • bar • baz"),
+    ("<ul><li>foo</li><li>bar</li></ul>baz", "• foo • • bar • baz"),
+    ("<ul><li>Parent<br><ul><li>Child</li></ul></li></ul>End", "• Parent • • Child • End"),
+])
+def test_html_to_text_examples(html, expected):
+    assert html_to_text(html) == expected
+
+
+@pytest.mark.parametrize("html,expected", [
+    ("", ""),
+    ("   ", ""),
+    ("Tom &amp; Jerry", "Tom & Jerry"),
+    ("<div>&nbsp; A &nbsp; &amp; B  </div>End", "A & B • End"),
+])
+def test_html_to_text_edge_cases(html, expected):
+    assert html_to_text(html) == expected


### PR DESCRIPTION
## Summary
- Add tests for html_to_text covering line breaks, block tags, lists, nested structures, and edge cases

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6e77913e8832b9b267a5973d75c91