### PR TITLE
Expose custom feed namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Störungen und Einschränkungen für den Großraum Wien aus offiziellen Quellen.
 
+## Erweiterungen
+
+Der RSS-Feed deklariert den Namespace `ext` (`xmlns:ext="https://wien-oepnv.example/schema"`) für zusätzliche Metadaten:
+
+- `ext:first_seen`: Zeitpunkt, wann eine Meldung erstmals im Feed aufgetaucht ist.
+- `ext:starts_at`: Beginn der Störung bzw. Maßnahme.
+- `ext:ends_at`: Ende der Störung bzw. Maßnahme.
+
 ## Entwicklung/Tests lokal
 
 ```bash

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -225,7 +225,7 @@ def _sort_key(item: Dict[str, Any]) -> Tuple[int, float, str]:
 def _emit_channel_header(now: datetime) -> List[str]:
     h = []
     h.append('<?xml version="1.0" encoding="UTF-8"?>')
-    h.append('<rss version="2.0">')
+    h.append('<rss version="2.0" xmlns:ext="https://wien-oepnv.example/schema">')
     h.append("<channel>")
     h.append(f"<title>{html.escape(FEED_TITLE)}</title>")
     h.append(f"<link>{html.escape(FEED_LINK)}</link>")
@@ -276,11 +276,11 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
     if isinstance(pubDate, datetime):
         parts.append(f"<pubDate>{_fmt_rfc2822(pubDate)}</pubDate>")
 
-    parts.append(f"<first_seen>{_fmt_rfc2822(fs_dt)}</first_seen>")
+    parts.append(f"<ext:first_seen>{_fmt_rfc2822(fs_dt)}</ext:first_seen>")
     if isinstance(starts_at, datetime):
-        parts.append(f"<starts_at>{_fmt_rfc2822(starts_at)}</starts_at>")
+        parts.append(f"<ext:starts_at>{_fmt_rfc2822(starts_at)}</ext:starts_at>")
     if isinstance(ends_at, datetime):
-        parts.append(f"<ends_at>{_fmt_rfc2822(ends_at)}</ends_at>")
+        parts.append(f"<ext:ends_at>{_fmt_rfc2822(ends_at)}</ext:ends_at>")
 
     parts.append(f"<description>{_cdata(desc_out)}</description>")
     parts.append("</item>")


### PR DESCRIPTION
## Summary
- add RSS namespace `ext` for extra metadata
- expose `ext:first_seen`, `ext:starts_at` and `ext:ends_at` fields
- document extension fields in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ea80810c832bba8b677849adebd0