### PR TITLE
Normalize datetimes to UTC in feed builder

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -58,7 +58,17 @@ RFC = "%a, %d %b %Y %H:%M:%S %z"
 # ---------------- Helpers ----------------
 
 def _to_utc(dt: datetime) -> datetime:
-    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    """Return a timezone-aware datetime in UTC.
+
+    If ``dt`` already contains timezone information, it is converted to UTC
+    using ``astimezone``.  Previously, aware datetimes were returned as-is,
+    which meant that values in non-UTC zones stayed in their original
+    timezone.  With this change all consumers receive a true UTC value.
+    Naive datetimes are assumed to already represent UTC and will simply be
+    tagged accordingly.
+    """
+
+    return dt.astimezone(timezone.utc) if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
 def _fmt_rfc2822(dt: datetime) -> str:
     try:

--- a/tests/test_to_utc.py
+++ b/tests/test_to_utc.py
@@ -1,0 +1,40 @@
+import importlib
+import sys
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+import types
+
+
+def _import_build_feed(monkeypatch):
+    module_name = "src.build_feed"
+    root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(root))
+    monkeypatch.syspath_prepend(str(root / "src"))
+    providers = types.ModuleType("providers")
+    wl = types.ModuleType("providers.wiener_linien")
+    wl.fetch_events = lambda: []
+    oebb = types.ModuleType("providers.oebb")
+    oebb.fetch_events = lambda: []
+    monkeypatch.setitem(sys.modules, "providers", providers)
+    monkeypatch.setitem(sys.modules, "providers.wiener_linien", wl)
+    monkeypatch.setitem(sys.modules, "providers.oebb", oebb)
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_to_utc_converts_timezone(monkeypatch):
+    build_feed = _import_build_feed(monkeypatch)
+    cet = timezone(timedelta(hours=2))
+    dt = datetime(2025, 1, 1, 12, 0, tzinfo=cet)
+    result = build_feed._to_utc(dt)
+    assert result.tzinfo == timezone.utc
+    assert result.hour == 10
+
+
+def test_fmt_rfc2822_outputs_utc(monkeypatch):
+    build_feed = _import_build_feed(monkeypatch)
+    cet = timezone(timedelta(hours=2))
+    dt = datetime(2025, 1, 1, 12, 0, tzinfo=cet)
+    formatted = build_feed._fmt_rfc2822(dt)
+    assert formatted.endswith("+0000")
+    assert "10:00:00" in formatted


### PR DESCRIPTION
## Summary
- ensure `_to_utc` converts aware datetimes to UTC using `astimezone`
- test UTC conversion and RFC2822 formatting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6eb73f1f8832b882ae45353ae591d