### PR TITLE
Treat th tags as block elements

### DIFF
--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -7,8 +7,8 @@ import re
 
 # Precompiled regular expressions for HTML-to-text conversion
 _BR_RE = re.compile(r"(?i)<\s*br\s*/?\s*>")
-_BLOCK_CLOSE_RE = re.compile(r"(?is)</\s*(p|div|li|ul|ol|h\d|table|tr|td)\s*>")
-_BLOCK_OPEN_RE = re.compile(r"(?is)<\s*(p|div|ul|ol|h\d|table|tr|td)\b[^>]*>")
+_BLOCK_CLOSE_RE = re.compile(r"(?is)</\s*(p|div|li|ul|ol|h\d|table|tr|td|th)\s*>")
+_BLOCK_OPEN_RE = re.compile(r"(?is)<\s*(p|div|ul|ol|h\d|table|tr|td|th)\b[^>]*>")
 _LI_OPEN_RE = re.compile(r"(?is)<\s*li\b[^>]*>")
 _TAG_RE = re.compile(r"(?is)<[^>]+>")
 _WS_RE = re.compile(r"[ \t\r\f\v]+")

--- a/tests/test_html_to_text.py
+++ b/tests/test_html_to_text.py
@@ -7,6 +7,7 @@ from src.utils.text import html_to_text
     ("<div>foo</div><p>bar</p>baz", "foo • bar • baz"),
     ("<ul><li>foo</li><li>bar</li></ul>baz", "• foo • • bar • baz"),
     ("<ul><li>Parent<br><ul><li>Child</li></ul></li></ul>End", "• Parent • • Child • End"),
+    ("<th>Head1</th><th>Head2</th>End", "Head1 • Head2 • End"),
 ])
 def test_html_to_text_examples(html, expected):
     assert html_to_text(html) == expected


### PR DESCRIPTION
## Summary
- handle `<th>` elements as block-level in `html_to_text`
- test that `<th>` tags separate text with bullets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6edd4f4a0832b925711a348e6ca73