### PR TITLE
Refine bullet handling in HTML to text conversion

### DIFF
--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -25,7 +25,18 @@ def html_to_text(s: str) -> str:
     txt = _LI_OPEN_RE.sub("• ", txt)
     txt = _BLOCK_OPEN_RE.sub("", txt)
     txt = _TAG_RE.sub("", txt)
-    txt = re.sub(r"\s*\n\s*", " • ", txt)
+    txt = re.sub(r"(?<=\S)•", " •", txt)
+    lines = [line.strip() for line in txt.split("\n") if line.strip()]
+    if lines:
+        txt = lines[0]
+        for line in lines[1:]:
+            if line.startswith("•"):
+                txt += " " + line
+            else:
+                txt += " • " + line
+    else:
+        txt = ""
+    txt = txt.lstrip("• ")
     txt = re.sub(r"(\d)([A-Za-zÄÖÜäöüß])", r"\1 \2", txt)
     txt = _WS_RE.sub(" ", txt)
     txt = re.sub(r"\s{2,}", " ", txt).strip()

--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -7,8 +7,8 @@ import re
 
 # Precompiled regular expressions for HTML-to-text conversion
 _BR_RE = re.compile(r"(?i)<\s*br\s*/?\s*>")
-_BLOCK_CLOSE_RE = re.compile(r"(?is)</\s*(p|div|li|ul|ol|h\d|table|tr|td)\s*>")
-_BLOCK_OPEN_RE = re.compile(r"(?is)<\s*(p|div|ul|ol|h\d|table|tr|td)\b[^>]*>")
+_BLOCK_CLOSE_RE = re.compile(r"(?is)</\s*(p|div|li|ul|ol|h\d|table|tr|td|th)\s*>")
+_BLOCK_OPEN_RE = re.compile(r"(?is)<\s*(p|div|ul|ol|h\d|table|tr|td|th)\b[^>]*>")
 _LI_OPEN_RE = re.compile(r"(?is)<\s*li\b[^>]*>")
 _TAG_RE = re.compile(r"(?is)<[^>]+>")
 _WS_RE = re.compile(r"[ \t\r\f\v]+")

--- a/tests/test_html_to_text.py
+++ b/tests/test_html_to_text.py
@@ -5,8 +5,10 @@ from src.utils.text import html_to_text
 @pytest.mark.parametrize("html,expected", [
     ("Line1<br>Line2", "Line1 • Line2"),
     ("<div>foo</div><p>bar</p>baz", "foo • bar • baz"),
-    ("<ul><li>foo</li><li>bar</li></ul>baz", "• foo • • bar • baz"),
-    ("<ul><li>Parent<br><ul><li>Child</li></ul></li></ul>End", "• Parent • • Child • End"),
+    ("<ul><li>foo</li><li>bar</li></ul>baz", "foo • bar • baz"),
+    ("<ul><li>Parent<br><ul><li>Child</li></ul></li></ul>End", "Parent • Child • End"),
+    ("<ul><li>foo</li><li>bar</li></ul>", "foo • bar"),
+    ("Start<ul><li>foo</li><li>bar</li></ul>End", "Start • foo • bar • End"),
 ])
 def test_html_to_text_examples(html, expected):
     assert html_to_text(html) == expected

--- a/tests/test_html_to_text.py
+++ b/tests/test_html_to_text.py
@@ -9,6 +9,7 @@ from src.utils.text import html_to_text
     ("<ul><li>Parent<br><ul><li>Child</li></ul></li></ul>End", "Parent • Child • End"),
     ("<ul><li>foo</li><li>bar</li></ul>", "foo • bar"),
     ("Start<ul><li>foo</li><li>bar</li></ul>End", "Start • foo • bar • End"),
+    ("<th>Head1</th><th>Head2</th>End", "Head1 • Head2 • End"),
 ])
 def test_html_to_text_examples(html, expected):
     assert html_to_text(html) == expected


### PR DESCRIPTION
## Summary
- Improve newline to bullet conversion to avoid duplicate bullets and strip leading bullets
- Expand tests for list conversions and adjust expectations

## Testing
- `pytest tests/test_html_to_text.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ed8d4fd8832ba701c2e956578f54