### PR TITLE
Add Deutsch Wagram and Ebenfurth stations to whitelist

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -135,6 +135,8 @@ W_NEAR_RAW = [
     # Nutzerwunsch (alphabetisch gruppiert)
     "Baden bei Wien",
     "Bruck an der Leitha",            # deckt „Bruck/Leitha Bahnhof“
+    "Deutsch Wagram Bahnhof",
+    "Ebenfurth Bahnhof",
     "Ebreichsdorf",
     "Eisenstadt",
     "Flughafen Wien",

--- a/tests/test_oebb_whitelist.py
+++ b/tests/test_oebb_whitelist.py
@@ -1,0 +1,9 @@
+from src.providers.oebb import _keep_by_region
+
+
+def test_whitelist_deutsch_wagram():
+    assert _keep_by_region("Wien ↔ Deutsch Wagram Bahnhof", "")
+
+
+def test_whitelist_ebenfurth():
+    assert _keep_by_region("Wien ↔ Ebenfurth Bahnhof", "")


### PR DESCRIPTION
## Summary
- extend ÖBB region whitelist with Deutsch Wagram Bahnhof and Ebenfurth Bahnhof
- cover the new stations with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6efb0dc90832bb1ec8f8b0e930b72