### PR TITLE
Refactor HTML to text conversion

### DIFF
--- a/tests/test_html_to_text.py
+++ b/tests/test_html_to_text.py
@@ -5,8 +5,8 @@ from src.utils.text import html_to_text
 @pytest.mark.parametrize("html,expected", [
     ("Line1<br>Line2", "Line1 • Line2"),
     ("<div>foo</div><p>bar</p>baz", "foo • bar • baz"),
-    ("<ul><li>foo</li><li>bar</li></ul>baz", "• foo • • bar • baz"),
-    ("<ul><li>Parent<br><ul><li>Child</li></ul></li></ul>End", "• Parent • • Child • End"),
+    ("<ul><li>foo</li><li>bar</li></ul>baz", "foo • bar • baz"),
+    ("<ul><li>Parent<br><ul><li>Child</li></ul></li></ul>End", "Parent • Child • End"),
     ("<th>Head1</th><th>Head2</th>End", "Head1 • Head2 • End"),
 ])
 def test_html_to_text_examples(html, expected):


### PR DESCRIPTION
## Summary
- Parse HTML fragments with `html.parser` instead of regexes
- Emit bullets only for `<li>` elements and normalize spacing
- Collapse duplicate bullets and strip leading or trailing separators

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f09517ac832b8081779640f64c33