### PR TITLE
Refactor bullet normalization in text utils

### DIFF
--- a/tests/test_html_to_text.py
+++ b/tests/test_html_to_text.py
@@ -21,3 +21,11 @@ def test_html_to_text_examples(html, expected):
 ])
 def test_html_to_text_edge_cases(html, expected):
     assert html_to_text(html) == expected
+
+
+@pytest.mark.parametrize("html,expected", [
+    ("bei<br>Station", "bei Station"),
+    ("An<br>der Haltestelle", "An der Haltestelle"),
+])
+def test_preposition_bullet_stripping(html, expected):
+    assert html_to_text(html) == expected


### PR DESCRIPTION
## Summary
- move bullet stripping after prepositions into new `normalize_bullets` helper
- store prepositions in `PREPOSITIONS` constant used by regex
- apply helper in HTML-to-text conversion and add tests for prepositions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f1c65110832ba9a2263edfd94b6a