### PR TITLE
Normalize bullets after collapse for prepositions

### DIFF
--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -86,8 +86,9 @@ def html_to_text(s: str) -> str:
     txt = re.sub(r"\s*\n\s*", " • ", txt)
     txt = re.sub(r"(\d)([A-Za-zÄÖÜäöüß])", r"\1 \2", txt)
     txt = _WS_RE.sub(" ", txt)
-    txt = normalize_bullets(txt)
+    # Collapse any repeated bullet separators before removing those after prepositions
     txt = re.sub(r"(?:\s*•\s*){2,}", " • ", txt)
+    txt = normalize_bullets(txt)
     txt = txt.strip()
     txt = re.sub(r"^•\s*", "", txt)
     txt = re.sub(r"\s*•$", "", txt)

--- a/tests/test_html_to_text.py
+++ b/tests/test_html_to_text.py
@@ -7,6 +7,10 @@ from src.utils.text import html_to_text
     ("<div>foo</div><p>bar</p>baz", "foo • bar • baz"),
     ("<ul><li>foo</li><li>bar</li></ul>baz", "foo • bar • baz"),
     ("<ul><li>Parent<br><ul><li>Child</li></ul></li></ul>End", "Parent • Child • End"),
+    (
+        "<ul><li>A<ul><li>B</li><li>C</li></ul></li><li>D</li></ul>",
+        "A • B • C • D",
+    ),
     ("<th>Head1</th><th>Head2</th>End", "Head1 • Head2 • End"),
 ])
 def test_html_to_text_examples(html, expected):
@@ -18,6 +22,7 @@ def test_html_to_text_examples(html, expected):
     ("   ", ""),
     ("Tom &amp; Jerry", "Tom & Jerry"),
     ("<div>&nbsp; A &nbsp; &amp; B  </div>End", "A & B • End"),
+    ("• foo • • bar •", "foo • bar"),
 ])
 def test_html_to_text_edge_cases(html, expected):
     assert html_to_text(html) == expected
@@ -26,6 +31,8 @@ def test_html_to_text_edge_cases(html, expected):
 @pytest.mark.parametrize("html,expected", [
     ("bei<br>Station", "bei Station"),
     ("An<br>der Haltestelle", "An der Haltestelle"),
+    ("bei<br>• foo", "bei foo"),
+    ("In<br>• der Station", "In der Station"),
 ])
 def test_preposition_bullet_stripping(html, expected):
     assert html_to_text(html) == expected


### PR DESCRIPTION
## Summary
- add tests covering nested bullet lists, start/end bullet trimming, and prepositions after line breaks
- collapse duplicate bullet separators before stripping those after prepositions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f307a3d0832b9303f985901a4176