### PR TITLE
Avoid splitting transit line codes in text utilities

### DIFF
--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -84,7 +84,7 @@ def html_to_text(s: str) -> str:
     txt = "".join(parser.parts)
     txt = html.unescape(txt)
     txt = re.sub(r"\s*\n\s*", " • ", txt)
-    txt = re.sub(r"(\d)([A-Za-zÄÖÜäöüß])", r"\1 \2", txt)
+    txt = re.sub(r"(\d)([a-zäöüß])", r"\1 \2", txt)
     txt = _WS_RE.sub(" ", txt)
     # Collapse any repeated bullet separators before removing those after prepositions
     txt = re.sub(r"(?:\s*•\s*){2,}", " • ", txt)

--- a/tests/test_html_to_text.py
+++ b/tests/test_html_to_text.py
@@ -36,3 +36,12 @@ def test_html_to_text_edge_cases(html, expected):
 ])
 def test_preposition_bullet_stripping(html, expected):
     assert html_to_text(html) == expected
+
+
+@pytest.mark.parametrize("html,expected", [
+    ("10A", "10A"),
+    ("U6", "U6"),
+    ("2m", "2 m"),
+])
+def test_line_codes_and_units(html, expected):
+    assert html_to_text(html) == expected


### PR DESCRIPTION
## Summary
- Prevent `html_to_text` from inserting spaces in transit line codes like `10A`
- Add regression tests for line codes and number-unit spacing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6f6834550832bb1cc3f89b54c7bff