### PR TITLE
refactor: centralize GUID generation

### DIFF
--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -18,6 +18,11 @@ from zoneinfo import ZoneInfo
 from typing import Any, Dict, Iterable, List, Optional
 from defusedxml import ElementTree as ET
 
+try:  # pragma: no cover - support both package layouts
+    from utils.ids import make_guid
+except ModuleNotFoundError:  # pragma: no cover
+    from src.utils.ids import make_guid  # type: ignore
+
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -63,9 +68,6 @@ def _parse_dt(date_str: str | None, time_str: str | None) -> Optional[datetime]:
     if len(t)==5: t += ":00"
     try: return datetime.fromisoformat(f"{d}T{t}").replace(tzinfo=timezone.utc)
     except Exception: return None
-
-def _guid(*parts: str) -> str:
-    return hashlib.md5("|".join(p or "" for p in parts).encode("utf-8")).hexdigest()
 
 def _normalize_spaces(s: str) -> str:
     return re.sub(r"\s{2,}", " ", s).strip()
@@ -159,7 +161,7 @@ def _collect_from_board(station_id: str, root: ET.Element) -> List[Dict[str, Any
         description_html = text or head
         if extras: description_html += "<br/>" + "<br/>".join(extras)
 
-        guid = _guid("vao", msg_id)
+        guid = make_guid("vao", msg_id)
         items.append({
             "source": "VOR/VAO",
             "category": "Störung",

--- a/src/providers/wiener_linien.py
+++ b/src/providers/wiener_linien.py
@@ -31,6 +31,11 @@ try:  # pragma: no cover - support both package layouts
 except ModuleNotFoundError:  # pragma: no cover
     from src.utils.text import html_to_text  # type: ignore
 
+try:  # pragma: no cover - support both package layouts
+    from utils.ids import make_guid
+except ModuleNotFoundError:  # pragma: no cover
+    from src.utils.ids import make_guid  # type: ignore
+
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -522,7 +527,7 @@ def fetch_events(timeout: int = 20) -> List[Dict[str, Any]]:
     buckets: Dict[str, Dict[str, Any]] = {}
     for ev in raw:
         line_toks_sorted = ",".join(sorted(_line_tokens_from_pairs(ev["lines_pairs"])))
-        key = _guid(
+        key = make_guid(
             "wl",
             ev["category"],
             ev["topic_key"],
@@ -586,7 +591,7 @@ def fetch_events(timeout: int = 20) -> List[Dict[str, Any]]:
         desc = re.sub(r"[<>]+", "", desc)
         desc = re.sub(r"\s{2,}", " ", desc).strip()
 
-        guid = _guid(
+        guid = make_guid(
             "wl",
             b["category"],
             b["topic_key"],
@@ -632,7 +637,3 @@ def fetch_events(timeout: int = 20) -> List[Dict[str, Any]]:
     return filtered
 
 
-# ---------------- Hilfsfunktionen ----------------
-
-def _guid(*parts: str) -> str:
-    return hashlib.md5("|".join(p or "" for p in parts).encode("utf-8")).hexdigest()

--- a/src/utils/ids.py
+++ b/src/utils/ids.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""ID utilities."""
+
+import hashlib
+
+__all__ = ["make_guid"]
+
+
+def make_guid(*parts: str) -> str:
+    """Return a stable MD5-based GUID for the given parts."""
+    return hashlib.md5("|".join(p or "" for p in parts).encode("utf-8")).hexdigest()

--- a/tests/test_wl_title.py
+++ b/tests/test_wl_title.py
@@ -1,4 +1,5 @@
 from src.providers import wiener_linien as wl
+from src.utils.ids import make_guid
 
 
 def test_dedupe_topic_shorter_title():
@@ -31,7 +32,7 @@ def test_dedupe_topic_shorter_title():
 
     buckets = {}
     for ev in (ev1, ev2):
-        key = wl._guid(
+        key = make_guid(
             "wl",
             ev["category"],
             ev["topic_key"],


### PR DESCRIPTION
## Summary
- add `make_guid` helper to `utils` module
- switch VOR and Wiener Linien providers to use shared GUID helper
- update tests to import `make_guid`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f77c19ec832b823b5e8eb5fc4da4