### PR TITLE
feat: make feed TTL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Der erzeugte Feed liegt unter `docs/feed.xml`.
 | `FEED_TITLE` | str | `"ÖPNV Störungen Wien & Umgebung"` | Titel des RSS-Feeds. |
 | `FEED_LINK` | str | `"https://github.com/Origamihase/wien-oepnv"` | Link zur Projektseite. |
 | `FEED_DESC` | str | `"Aktive Störungen/Baustellen/Einschränkungen aus offiziellen Quellen"` | Beschreibung des RSS-Feeds. |
+| `FEED_TTL` | int | `30` | Minuten, die Clients den Feed im Cache halten dürfen. |
 | `DESCRIPTION_CHAR_LIMIT` | int | `170` | Maximale Länge der Item-Beschreibung. |
 | `FRESH_PUBDATE_WINDOW_MIN` | int | `5` | Zeitfenster (Minuten), in dem Meldungen ohne Datum als „frisch“ gelten und mit aktuellem `pubDate` versehen werden. |
 | `MAX_ITEMS` | int | `60` | Maximale Anzahl an Items im Feed. |

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -44,6 +44,7 @@ OUT_PATH = os.getenv("OUT_PATH", "docs/feed.xml")
 FEED_TITLE = os.getenv("FEED_TITLE", "ÖPNV Störungen Wien & Umgebung")
 FEED_LINK = os.getenv("FEED_LINK", "https://github.com/Origamihase/wien-oepnv")
 FEED_DESC = os.getenv("FEED_DESC", "Aktive Störungen/Baustellen/Einschränkungen aus offiziellen Quellen")
+FEED_TTL = max(int(os.getenv("FEED_TTL", "30")), 0)
 
 DESCRIPTION_CHAR_LIMIT = max(int(os.getenv("DESCRIPTION_CHAR_LIMIT", "170")), 0)
 FRESH_PUBDATE_WINDOW_MIN = int(os.getenv("FRESH_PUBDATE_WINDOW_MIN", "5"))
@@ -247,7 +248,7 @@ def _emit_channel_header(now: datetime) -> List[str]:
     h.append(f"<link>{html.escape(FEED_LINK)}</link>")
     h.append(f"<description>{html.escape(FEED_DESC)}</description>")
     h.append(f"<lastBuildDate>{_fmt_rfc2822(now)}</lastBuildDate>")
-    h.append("<ttl>15</ttl>")
+    h.append(f"<ttl>{FEED_TTL}</ttl>")
     return h
 
 def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any]]) -> Tuple[str, str]:


### PR DESCRIPTION
## Summary
- make RSS TTL configurable via new FEED_TTL env var
- document FEED_TTL in README

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7015d20f0832bb5cb39edda8ff135