### PR TITLE
Remove redundant pytest installation step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,4 @@ jobs:
         with:
           python-version: '3.11'
       - run: pip install -r requirements.txt
-      - run: pip install pytest
       - run: pytest -q


### PR DESCRIPTION
## Summary
- remove redundant `pip install pytest` from test workflow since pytest is already in `requirements.txt`

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c705177534832bb17ae3460891f0c9