### PR TITLE
fix: close if block in build-feed workflow

### DIFF
--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -124,6 +124,7 @@ jobs:
             echo "VOR_STATION_IDS=$IDS" >> "$GITHUB_ENV"
           else
             echo "VOR_STATION_IDS=" >> "$GITHUB_ENV"
+          fi
 
       - name: Commit discovered VOR stations (if any)
         if: ${{ env.VOR_ACCESS_ID != '' }}


### PR DESCRIPTION
## Summary
- close if/else block for VOR station file detection in build-feed workflow

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71c9e27dc832b85101b536210e21a