### PR TITLE
feat(oebb): add Vienna-only filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Der erzeugte Feed liegt unter `docs/feed.xml`.
 | Variable | Typ | Standardwert | Beschreibung |
 | --- | --- | --- | --- |
 | `OEBB_RSS_URL` | str | `"https://fahrplan.oebb.at/bin/help.exe/dnl?protocol=https:&tpl=rss_WI_oebb&"` | RSS-Quelle der ÖBB (kann über Secret überschrieben werden). |
+| `OEBB_ONLY_VIENNA` | bool (`"1"`/`"0"`) | `"0"` | Nur Meldungen mit Endpunkten in Wien behalten. |
 
 ### VOR / VAO (`src/providers/vor.py`)
 

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -40,6 +40,10 @@ log = logging.getLogger(__name__)
 OEBB_URL = (os.getenv("OEBB_RSS_URL", "").strip()
             or "https://fahrplan.oebb.at/bin/help.exe/dnl?protocol=https:&tpl=rss_WI_oebb&")
 
+# Optional strenger Filter: Nur Meldungen mit Endpunkten in Wien behalten.
+# Aktiviert durch Umgebungsvariable ``OEBB_ONLY_VIENNA`` ("1"/"0").
+OEBB_ONLY_VIENNA = os.getenv("OEBB_ONLY_VIENNA", "").strip() not in {"", "0", "false", "False"}
+
 # ---------------- HTTP ----------------
 def _session() -> requests.Session:
     s = requests.Session()
@@ -171,6 +175,8 @@ def _is_near(name: str) -> bool:
     n = _norm(name)
     if not n:
         return False
+    if OEBB_ONLY_VIENNA:
+        return n in W_VIENNA or n.startswith("wien ")
     return n in W_VIENNA or n in W_NEAR or n.startswith("wien ")
 
 def _keep_by_region(title: str, desc: str) -> bool:

--- a/tests/test_oebb_whitelist.py
+++ b/tests/test_oebb_whitelist.py
@@ -1,9 +1,15 @@
-from src.providers.oebb import _keep_by_region
+import src.providers.oebb as oebb
 
 
 def test_whitelist_deutsch_wagram():
-    assert _keep_by_region("Wien ↔ Deutsch Wagram Bahnhof", "")
+    assert oebb._keep_by_region("Wien ↔ Deutsch Wagram Bahnhof", "")
 
 
 def test_whitelist_ebenfurth():
-    assert _keep_by_region("Wien ↔ Ebenfurth Bahnhof", "")
+    assert oebb._keep_by_region("Wien ↔ Ebenfurth Bahnhof", "")
+
+
+def test_only_vienna_env(monkeypatch):
+    monkeypatch.setattr(oebb, "OEBB_ONLY_VIENNA", True)
+    assert not oebb._keep_by_region("Wien ↔ Deutsch Wagram Bahnhof", "")
+    assert oebb._keep_by_region("Wien Floridsdorf ↔ Wien Mitte", "")


### PR DESCRIPTION
## Summary
- support optional Vienna-only filter for ÖBB events via `OEBB_ONLY_VIENNA`
- document `OEBB_ONLY_VIENNA` setting
- cover Vienna-only filtering in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c71cac2254832b82d3f7d9e578508b