### PR TITLE
doc: describe ENDS_AT_GRACE_MINUTES in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Der erzeugte Feed liegt unter `docs/feed.xml`.
 | `MAX_ITEMS` | int | `60` | Maximale Anzahl an Items im Feed. |
 | `MAX_ITEM_AGE_DAYS` | int | `45` | Entfernt Items, die älter als diese Anzahl an Tagen sind. |
 | `ABSOLUTE_MAX_AGE_DAYS` | int | `365` | Harte Obergrenze für das Alter von Items. |
+| `ENDS_AT_GRACE_MINUTES` | int | `10` | Kulanzfenster (Minuten), in dem Meldungen nach `ends_at` noch gezeigt werden. |
 | `STATE_PATH` | str | `"data/first_seen.json"` | Speicherort der `first_seen`-Daten. |
 | `STATE_RETENTION_DAYS` | int | `60` | Aufbewahrungsdauer der `first_seen`-Daten. |
 | `WL_ENABLE` | bool (`"1"`/`"0"`) | `"1"` | Provider „Wiener Linien“ aktivieren/deaktivieren. |


### PR DESCRIPTION
## Summary
- document `ENDS_AT_GRACE_MINUTES` config option in README's general table

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71f0ec224832bbba1bd6f7920e22e