### PR TITLE
Limit ThreadPoolExecutor workers to providers

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -185,7 +185,7 @@ def _collect_items() -> List[Dict[str, Any]]:
     items: List[Dict[str, Any]] = []
     futures: Dict[Any, str] = {}
 
-    with ThreadPoolExecutor() as executor:
+    with ThreadPoolExecutor(max_workers=len(PROVIDERS)) as executor:
         for env_var, fetch in PROVIDERS:
             if os.getenv(env_var, "1").strip().lower() not in {"0", "false"}:
                 futures[executor.submit(fetch)] = env_var


### PR DESCRIPTION
## Summary
- Set ThreadPoolExecutor to use one worker per provider when collecting items

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c721333588832ba6e45f5e72bc6b11