### PR TITLE
Use local session for ÖBB provider

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -53,8 +53,6 @@ def _session() -> requests.Session:
     s.headers.update({"User-Agent":"Origamihase-wien-oepnv/3.1 (+https://github.com/Origamihase/wien-oepnv)"})
     return s
 
-S = _session()
-
 # ---------------- Titel + Endpunkte ----------------
 BAHNHOF_TRIM_RE = re.compile(r"\s*(?:Bahnhof|Bahnhst|Hbf|Bf)(?:\s*\(U\))?", re.IGNORECASE)
 ARROW_ANY_RE    = re.compile(r"\s*(?:<=>|<->|<>|→|↔|=>|=|–|—|-)\s*")
@@ -196,9 +194,10 @@ def _keep_by_region(title: str, desc: str) -> bool:
 
 # ---------------- Fetch/Parse ----------------
 def _fetch_xml(url: str, timeout: int = 25) -> ET.Element:
-    r = S.get(url, timeout=timeout)
-    r.raise_for_status()
-    return ET.fromstring(r.content)
+    with _session() as s:
+        r = s.get(url, timeout=timeout)
+        r.raise_for_status()
+        return ET.fromstring(r.content)
 
 def _get_text(elem: Optional[ET.Element], tag: str) -> str:
     e = elem.find(tag) if elem is not None else None

--- a/tests/test_oebb_timeout.py
+++ b/tests/test_oebb_timeout.py
@@ -29,11 +29,16 @@ def test_fetch_xml_passes_timeout_to_session(monkeypatch):
             pass
 
     class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
         def get(self, url, timeout):
             recorded["timeout"] = timeout
             return DummyResponse()
-
-    monkeypatch.setattr(oebb, "S", DummySession())
+    monkeypatch.setattr(oebb, "_session", lambda: DummySession())
 
     oebb._fetch_xml("http://example.com", timeout=3)
     assert recorded["timeout"] == 3


### PR DESCRIPTION
## Summary
- ensure ÖBB provider creates and closes its own HTTP session for each request
- adjust timeout tests to patch the session factory instead of a global singleton

## Testing
- `pytest tests/test_oebb_timeout.py`


------
https://chatgpt.com/codex/tasks/task_e_68c72151b9c0832bbb50be9585cfd883