### PR TITLE
workflow: use defusedxml for XML parsing

### DIFF
--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -88,7 +88,8 @@ jobs:
             exit 0
           fi
           python - <<'PY'
-          import os, sys, time, xml.etree.ElementTree as ET
+          import os, sys, time
+          from defusedxml import ElementTree as ET
           import requests
           ACCESS = os.environ.get("VOR_ACCESS_ID","").strip()
           BASE   = os.environ.get("VOR_BASE","").rstrip("/")
@@ -170,7 +171,8 @@ jobs:
       - name: Validate feed (XML + GUID uniqueness)
         run: |
           python - <<'PY'
-          import sys, xml.etree.ElementTree as ET
+          import sys
+          from defusedxml import ElementTree as ET
           p = "docs/feed.xml"
           try:
               tree = ET.parse(p)


### PR DESCRIPTION
## Summary
- use defusedxml's ElementTree in build-feed workflow scripts

## Testing
- `pytest`
- ⚠️ `act -n build` *(missing Docker; cannot run workflow locally)*

------
https://chatgpt.com/codex/tasks/task_e_68c726ccacc8832ba4dd4b0d4da7d9ee