### PR TITLE
Use Vienna timezone when parsing VOR dates

### DIFF
--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -77,8 +77,11 @@ def _parse_dt(date_str: str | None, time_str: str | None) -> Optional[datetime]:
     if not date_str: return None
     d = date_str.strip(); t = (time_str or "00:00:00").strip()
     if len(t)==5: t += ":00"
-    try: return datetime.fromisoformat(f"{d}T{t}").replace(tzinfo=timezone.utc)
-    except Exception: return None
+    try:
+        local = datetime.fromisoformat(f"{d}T{t}").replace(tzinfo=ZoneInfo("Europe/Vienna"))
+        return local.astimezone(timezone.utc)
+    except Exception:
+        return None
 
 def _normalize_spaces(s: str) -> str:
     return re.sub(r"\s{2,}", " ", s).strip()

--- a/tests/test_vor_parse_dt.py
+++ b/tests/test_vor_parse_dt.py
@@ -1,0 +1,11 @@
+from datetime import timezone
+
+import src.providers.vor as vor
+
+
+def test_parse_dt_converts_vienna_to_utc():
+    dt = vor._parse_dt("2024-07-01", "12:00")
+    assert dt is not None
+    assert dt.tzinfo == timezone.utc
+    assert dt.hour == 10
+    assert dt.minute == 0


### PR DESCRIPTION
## Summary
- parse VOR date/time using Europe/Vienna zoneinfo before converting to UTC
- add regression test for _parse_dt timezone conversion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c72c49c36c832b8a3cf212f46b9e0b