### PR TITLE
Ensure _iso returns UTC-aware datetime

### DIFF
--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -81,7 +81,10 @@ def _iso(s: Optional[str]) -> Optional[datetime]:
     s = s.replace("Z", "+00:00")
     if len(s) >= 5 and (s[-5] in "+-") and s[-3] != ":":
         s = s[:-2] + ":" + s[-2:]
-    return dtparser.isoparse(s)
+    dt = dtparser.isoparse(s)
+    if not dt.tzinfo:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 def _best_ts(obj: Dict[str, Any]) -> Optional[datetime]:

--- a/tests/test_wl_iso_timezone.py
+++ b/tests/test_wl_iso_timezone.py
@@ -1,0 +1,9 @@
+from datetime import timezone
+
+from src.providers.wl_fetch import _iso
+
+
+def test_iso_returns_utc_aware():
+    dt = _iso("2024-07-01T12:00:00")
+    assert dt is not None
+    assert dt.tzinfo == timezone.utc


### PR DESCRIPTION
## Summary
- handle ISO strings lacking timezone by defaulting to UTC
- add regression test for `_iso` timezone awareness

## Testing
- `pytest` *(fails: test_fetch_events_parallel)*

------
https://chatgpt.com/codex/tasks/task_e_68c72f950684832bbf19284f13a52151