### PR TITLE
Handle multiple arrow variants in ÖBB endpoints

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -97,9 +97,14 @@ def _clean_title_keep_places(t: str) -> str:
 
 def _split_endpoints(title: str) -> Optional[List[str]]:
     """Extrahiert Endpunktnamen links/rechts (ohne Bahnhof/Hbf/Klammern)."""
-    if "↔" not in title and "<=>" not in title and "=>" not in title:
+    arrow_markers = (
+        "↔", "<=>", "<->", "→", "=>", "->", "—", "–",
+    )
+    if not any(a in title for a in arrow_markers):
         return None
-    parts = [p for p in re.split(r"\s*(?:↔|<=>|=>|<|->|—|-)\s*", title) if p.strip()]
+    parts = [
+        p for p in re.split(r"\s*(?:↔|<=>|<->|→|=>|->|—|–|-)\s*", title) if p.strip()
+    ]
     if len(parts) < 2:
         return None
     left, right = parts[0], parts[1]

--- a/tests/test_oebb_whitelist.py
+++ b/tests/test_oebb_whitelist.py
@@ -1,8 +1,10 @@
 import src.providers.oebb as oebb
+import pytest
 
 
-def test_whitelist_deutsch_wagram():
-    assert oebb._keep_by_region("Wien ↔ Deutsch Wagram Bahnhof", "")
+@pytest.mark.parametrize("arrow", ["↔", "<->", "->", "—", "–", "→"])
+def test_whitelist_deutsch_wagram(arrow: str) -> None:
+    assert oebb._keep_by_region(f"Wien {arrow} Deutsch Wagram Bahnhof", "")
 
 
 def test_whitelist_ebenfurth():


### PR DESCRIPTION
## Summary
- support additional arrow/separator variants when parsing ÖBB endpoint titles
- test `_keep_by_region` with different arrow variants

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c735ae4554832b93db30f05ce5ab4d