### PR TITLE
Validate provider return types

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -199,10 +199,14 @@ def _collect_items() -> List[Dict[str, Any]]:
             futures[executor.submit(fetch)] = fetch
         for future in as_completed(futures):
             fetch = futures[future]
+            name = getattr(fetch, "__name__", str(fetch))
             try:
-                items += future.result()
+                result = future.result()
+                if not isinstance(result, list):
+                    log.error("%s fetch gab keine Liste zurück: %r", name, result)
+                    continue
+                items += result
             except Exception as e:
-                name = getattr(fetch, "__name__", str(fetch))
                 log.exception("%s fetch fehlgeschlagen: %s", name, e)
 
     return items

--- a/tests/test_collect_items_bad_return.py
+++ b/tests/test_collect_items_bad_return.py
@@ -1,0 +1,53 @@
+import importlib
+import sys
+from pathlib import Path
+import types
+import pytest
+
+
+def _import_build_feed(monkeypatch):
+    module_name = "src.build_feed"
+    root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(root))
+    monkeypatch.syspath_prepend(str(root / "src"))
+    providers = types.ModuleType("providers")
+    wl = types.ModuleType("providers.wiener_linien")
+    wl.fetch_events = lambda: []
+    oebb = types.ModuleType("providers.oebb")
+    oebb.fetch_events = lambda: []
+    vor = types.ModuleType("providers.vor")
+    vor.fetch_events = lambda: []
+    monkeypatch.setitem(sys.modules, "providers", providers)
+    monkeypatch.setitem(sys.modules, "providers.wiener_linien", wl)
+    monkeypatch.setitem(sys.modules, "providers.oebb", oebb)
+    monkeypatch.setitem(sys.modules, "providers.vor", vor)
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_collect_items_logs_and_skips_invalid_return(monkeypatch, caplog):
+    build_feed = _import_build_feed(monkeypatch)
+
+    def good_provider():
+        return [{"p": "good"}]
+
+    def bad_provider():
+        return {"p": "bad"}
+
+    monkeypatch.setattr(
+        build_feed,
+        "PROVIDERS",
+        [
+            ("GOOD_ENABLE", good_provider),
+            ("BAD_ENABLE", bad_provider),
+        ],
+    )
+
+    monkeypatch.setenv("GOOD_ENABLE", "1")
+    monkeypatch.setenv("BAD_ENABLE", "1")
+
+    with caplog.at_level("ERROR"):
+        items = build_feed._collect_items()
+
+    assert items == [{"p": "good"}]
+    assert any("bad_provider" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- ensure `_collect_items` logs and skips non-list provider results
- add regression test for invalid provider output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c737d32958832b981352a4dffb4a66