### PR TITLE
Handle save-state errors gracefully

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -342,7 +342,10 @@ def _make_rss(items: List[Dict[str, Any]], now: datetime, state: Dict[str, Dict[
 
     # State nur für *aktuelle* Items speichern (kein Anwachsen)
     pruned = {k: state[k] for k in identities_in_feed if k in state}
-    _save_state(pruned)
+    try:
+        _save_state(pruned)
+    except Exception as e:
+        log.warning("State speichern fehlgeschlagen (%s) – Feed wird trotzdem zurückgegeben.", e)
 
     return "\n".join(out)
 

--- a/tests/test_state_save_readonly.py
+++ b/tests/test_state_save_readonly.py
@@ -1,0 +1,39 @@
+import importlib
+import sys
+import types
+import logging
+from pathlib import Path
+from datetime import datetime, timezone
+
+
+def _import_build_feed(monkeypatch):
+    module_name = "src.build_feed"
+    root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(root))
+    monkeypatch.syspath_prepend(str(root / "src"))
+    providers = types.ModuleType("providers")
+    wl = types.ModuleType("providers.wiener_linien")
+    wl.fetch_events = lambda: []
+    oebb = types.ModuleType("providers.oebb")
+    oebb.fetch_events = lambda: []
+    monkeypatch.setitem(sys.modules, "providers", providers)
+    monkeypatch.setitem(sys.modules, "providers.wiener_linien", wl)
+    monkeypatch.setitem(sys.modules, "providers.oebb", oebb)
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_make_rss_logs_warning_when_state_readonly(monkeypatch, caplog):
+    build_feed = _import_build_feed(monkeypatch)
+
+    def fail_save(_):
+        raise PermissionError("read-only file system")
+
+    monkeypatch.setattr(build_feed, "_save_state", fail_save)
+
+    with caplog.at_level(logging.WARNING):
+        rss = build_feed._make_rss([], datetime.now(timezone.utc), {})
+
+    assert "</rss>" in rss
+    assert any("State speichern fehlgeschlagen" in r.message for r in caplog.records)
+


### PR DESCRIPTION
## Summary
- wrap `_save_state` in try/except and log warnings on failure
- add regression test simulating state save failure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c73878d8fc832bb6cefe6ba600d916