### PR TITLE
Simplify product iteration in VOR provider

### DIFF
--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -158,11 +158,10 @@ def _collect_from_board(station_id: str, root: ET.Element) -> List[Dict[str, Any
 
         lines: List[str] = []
         affected_stops: List[str] = []
-        prods_el = m.find("./products")
-        if prods_el is not None:
-            for p in prods:
-                name = _text(p, "name") or (_text(p, "catOutS") + " " + _text(p, "displayNumber"))
-                if name: lines.append(name.strip())
+        for p in prods:
+            name = _text(p, "name") or (_text(p, "catOutS") + " " + _text(p, "displayNumber"))
+            if name:
+                lines.append(name.strip())
         aff = m.find("./affectedStops")
         if aff is not None:
             for st in aff.findall("./Stop"):


### PR DESCRIPTION
## Summary
- streamline `_collect_from_board` by iterating directly over accepted products
- drop redundant `prods_el` lookup in VOR provider

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c73a2323bc832b8d77d9c9e9db63ba