### PR TITLE
Use ordered preposition list for bullet stripping

### DIFF
--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -10,10 +10,11 @@ from html.parser import HTMLParser
 _WS_RE = re.compile(r"[ \t\r\f\v]+")
 
 # Common German prepositions that should not be followed by a bullet.
-PREPOSITIONS = {"bei", "in", "an", "auf"}
+PREPOSITIONS = ("bei", "in", "an", "auf")
 
 _PREP_BULLET_RE = re.compile(
-    rf"\b({'|'.join(map(re.escape, PREPOSITIONS))})\s*•\s*", re.IGNORECASE
+    rf"\b({'|'.join(re.escape(p) for p in PREPOSITIONS)})\s*•\s*",
+    re.IGNORECASE,
 )
 
 


### PR DESCRIPTION
## Summary
- switch PREPOSITIONS to an ordered tuple
- update regex compilation to use sequence order when matching bullets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c73c9b25fc832b8e9c7ec506465f31