### PR TITLE
Add provider fetch timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Der erzeugte Feed liegt unter `docs/feed.xml`.
 | `MAX_ITEM_AGE_DAYS` | int | `45` | Entfernt Items, die älter als diese Anzahl an Tagen sind. |
 | `ABSOLUTE_MAX_AGE_DAYS` | int | `365` | Harte Obergrenze für das Alter von Items. |
 | `ENDS_AT_GRACE_MINUTES` | int | `10` | Kulanzfenster (Minuten), in dem Meldungen nach `ends_at` noch gezeigt werden. |
+| `PROVIDER_TIMEOUT` | float | `10` | Timeout (Sekunden) pro Provider-Fetch. |
 | `STATE_PATH` | str | `"data/first_seen.json"` | Speicherort der `first_seen`-Daten. |
 | `STATE_RETENTION_DAYS` | int | `60` | Aufbewahrungsdauer der `first_seen`-Daten. |
 | `WL_ENABLE` | bool (`"1"`/`"0"`) | `"1"` | Provider „Wiener Linien“ aktivieren/deaktivieren. |

--- a/tests/test_collect_items_timeout.py
+++ b/tests/test_collect_items_timeout.py
@@ -1,0 +1,56 @@
+import importlib
+import sys
+import time
+from pathlib import Path
+import types
+import pytest
+
+
+def _import_build_feed(monkeypatch):
+    module_name = "src.build_feed"
+    root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(root))
+    monkeypatch.syspath_prepend(str(root / "src"))
+    providers = types.ModuleType("providers")
+    wl = types.ModuleType("providers.wiener_linien")
+    wl.fetch_events = lambda: []
+    oebb = types.ModuleType("providers.oebb")
+    oebb.fetch_events = lambda: []
+    vor = types.ModuleType("providers.vor")
+    vor.fetch_events = lambda: []
+    monkeypatch.setitem(sys.modules, "providers", providers)
+    monkeypatch.setitem(sys.modules, "providers.wiener_linien", wl)
+    monkeypatch.setitem(sys.modules, "providers.oebb", oebb)
+    monkeypatch.setitem(sys.modules, "providers.vor", vor)
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_collect_items_timeout(monkeypatch, caplog):
+    monkeypatch.setenv("PROVIDER_TIMEOUT", "0.01")
+    build_feed = _import_build_feed(monkeypatch)
+
+    def slow_provider():
+        time.sleep(0.5)
+        return [{"p": "slow"}]
+
+    def fast_provider():
+        return [{"p": "fast"}]
+
+    monkeypatch.setattr(
+        build_feed,
+        "PROVIDERS",
+        [
+            ("SLOW_ENABLE", slow_provider),
+            ("FAST_ENABLE", fast_provider),
+        ],
+    )
+
+    monkeypatch.setenv("SLOW_ENABLE", "1")
+    monkeypatch.setenv("FAST_ENABLE", "1")
+
+    with caplog.at_level("WARNING"):
+        items = build_feed._collect_items()
+
+    assert items == [{"p": "fast"}]
+    assert any("Timeout" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- allow configuring provider fetch timeouts via `PROVIDER_TIMEOUT`
- log and skip providers that exceed the timeout
- document `PROVIDER_TIMEOUT` environment variable and add coverage test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74077090c832b9092d872fac58bb9