### PR TITLE
Make OEBB_ONLY_VIENNA env var case-insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Der erzeugte Feed liegt unter `docs/feed.xml`.
 | Variable | Typ | Standardwert | Beschreibung |
 | --- | --- | --- | --- |
 | `OEBB_RSS_URL` | str | `"https://fahrplan.oebb.at/bin/help.exe/dnl?protocol=https:&tpl=rss_WI_oebb&"` | RSS-Quelle der ÖBB (kann über Secret überschrieben werden). |
-| `OEBB_ONLY_VIENNA` | bool (`"1"`/`"0"`) | `"0"` | Nur Meldungen mit Endpunkten in Wien behalten. |
+| `OEBB_ONLY_VIENNA` | bool (`"1"`/`"0"` oder `"true"`/`"false"`, case-insens) | `"0"` | Nur Meldungen mit Endpunkten in Wien behalten. |
 
 ### VOR / VAO (`src/providers/vor.py`)
 

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -41,8 +41,8 @@ OEBB_URL = (os.getenv("OEBB_RSS_URL", "").strip()
             or "https://fahrplan.oebb.at/bin/help.exe/dnl?protocol=https:&tpl=rss_WI_oebb&")
 
 # Optional strenger Filter: Nur Meldungen mit Endpunkten in Wien behalten.
-# Aktiviert durch Umgebungsvariable ``OEBB_ONLY_VIENNA`` ("1"/"0").
-OEBB_ONLY_VIENNA = os.getenv("OEBB_ONLY_VIENNA", "").strip() not in {"", "0", "false", "False"}
+# Aktiviert durch Umgebungsvariable ``OEBB_ONLY_VIENNA`` ("1"/"true" vs "0"/"false", case-insens).
+OEBB_ONLY_VIENNA = os.getenv("OEBB_ONLY_VIENNA", "").strip().lower() not in {"", "0", "false"}
 
 # ---------------- HTTP ----------------
 def _session() -> requests.Session:

--- a/tests/test_oebb_env_var.py
+++ b/tests/test_oebb_env_var.py
@@ -1,0 +1,15 @@
+import importlib
+
+import src.providers.oebb as oebb
+
+
+def test_oebb_only_vienna_env_var(monkeypatch):
+    monkeypatch.setenv("OEBB_ONLY_VIENNA", "FaLsE")
+    importlib.reload(oebb)
+    assert oebb.OEBB_ONLY_VIENNA is False
+    monkeypatch.setenv("OEBB_ONLY_VIENNA", "1")
+    importlib.reload(oebb)
+    assert oebb.OEBB_ONLY_VIENNA is True
+    monkeypatch.delenv("OEBB_ONLY_VIENNA", raising=False)
+    importlib.reload(oebb)
+


### PR DESCRIPTION
## Summary
- parse `OEBB_ONLY_VIENNA` environment variable in a case-insensitive way
- document accepted values for `OEBB_ONLY_VIENNA`
- test the environment variable parsing

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c741900afc832bba12e03f5780dc5c