### PR TITLE
Normalize VOR access id handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Der erzeugte Feed liegt unter `docs/feed.xml`.
 
 | Variable | Typ | Standardwert | Beschreibung |
 | --- | --- | --- | --- |
-| `VOR_ACCESS_ID` / `VAO_ACCESS_ID` | str | – | API-Zugangsschlüssel. Ohne Wert bleibt der Provider inaktiv. |
+| `VOR_ACCESS_ID` / `VAO_ACCESS_ID` | str | – | API-Zugangsschlüssel. Leere Werte werden ignoriert; ohne Wert bleibt der Provider inaktiv. |
 | `VOR_STATION_IDS` | Liste (kommagetrennt) | – | Stations-IDs für Abfragen. Ohne Angabe bleibt der Provider inaktiv. |
 | `VOR_BASE` | str | `"https://routenplaner.verkehrsauskunft.at/vao/restproxy"` | Basis-URL der VAO-API. |
 | `VOR_VERSION` | str | `"v1.3"` | API-Version. |

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -30,7 +30,7 @@ from urllib3.util.retry import Retry
 
 log = logging.getLogger(__name__)
 
-VOR_ACCESS_ID: str | None = os.getenv("VOR_ACCESS_ID") or os.getenv("VAO_ACCESS_ID")
+VOR_ACCESS_ID: str | None = (os.getenv("VOR_ACCESS_ID") or os.getenv("VAO_ACCESS_ID") or "").strip() or None
 VOR_STATION_IDS: List[str] = [s.strip() for s in (os.getenv("VOR_STATION_IDS") or "").split(",") if s.strip()]
 VOR_BASE = os.getenv("VOR_BASE", "https://routenplaner.verkehrsauskunft.at/vao/restproxy")
 VOR_VERSION = os.getenv("VOR_VERSION", "v1.3")

--- a/tests/test_vor_env.py
+++ b/tests/test_vor_env.py
@@ -1,0 +1,25 @@
+import importlib
+import src.providers.vor as vor
+
+
+def test_access_id_env_normalization(monkeypatch):
+    # VOR_ACCESS_ID mit Leerzeichen sollte als None interpretiert werden
+    monkeypatch.setenv("VOR_ACCESS_ID", "   ")
+    importlib.reload(vor)
+    assert vor.VOR_ACCESS_ID is None
+
+    # Fallback auf VAO_ACCESS_ID, ebenfalls Leerzeichen -> None
+    monkeypatch.delenv("VOR_ACCESS_ID", raising=False)
+    monkeypatch.setenv("VAO_ACCESS_ID", "   ")
+    importlib.reload(vor)
+    assert vor.VOR_ACCESS_ID is None
+
+    # VAO_ACCESS_ID mit zusätzlichen Leerzeichen wird getrimmt
+    monkeypatch.setenv("VAO_ACCESS_ID", " token ")
+    importlib.reload(vor)
+    assert vor.VOR_ACCESS_ID == "token"
+
+    # Aufräumen
+    monkeypatch.delenv("VAO_ACCESS_ID", raising=False)
+    importlib.reload(vor)
+


### PR DESCRIPTION
## Summary
- trim and ignore empty VOR/VAO access IDs
- document ignored empty access IDs
- add tests for environment variable normalization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c74240eb54832ba2af2deaa2061d5c