### PR TITLE
Include source in fallback dedupe key

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -274,9 +274,12 @@ def _dedupe_items(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         elif it.get("guid"):
             key = it.get("guid")
         else:
-            raw = f"{it.get('title') or ''}|{it.get('description') or ''}"
+            raw = f"{it.get('source') or ''}|{it.get('title') or ''}|{it.get('description') or ''}"
             key = hashlib.sha1(raw.encode("utf-8")).hexdigest()
-            log.warning("Item ohne guid/_identity – Fallback-Schlüssel %s", key)
+            log.warning(
+                "Item ohne guid/_identity – Fallback-Schlüssel (source|title|description) %s",
+                key,
+            )
         if key in seen:
             continue
         seen.add(key)

--- a/tests/test_dedupe_items.py
+++ b/tests/test_dedupe_items.py
@@ -67,3 +67,14 @@ def test_items_without_identifier_are_unique(monkeypatch):
     ]
 
     assert build_feed._dedupe_items(items) == items
+
+
+def test_items_with_same_text_but_different_source(monkeypatch):
+    build_feed = _import_build_feed(monkeypatch)
+
+    items = [
+        {"title": "A", "description": "desc", "source": "S1"},
+        {"title": "A", "description": "desc", "source": "S2"},
+    ]
+
+    assert build_feed._dedupe_items(items) == items


### PR DESCRIPTION
## Summary
- incorporate source/provider into fallback dedupe hash
- clarify logging message for composite key
- test dedupe behavior with identical text from different sources

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c745baab88832bbeebe547a981aba1