### PR TITLE
Handle uppercase units in html_to_text

### DIFF
--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -85,7 +85,7 @@ def html_to_text(s: str) -> str:
     txt = "".join(parser.parts)
     txt = html.unescape(txt)
     txt = re.sub(r"\s*\n\s*", " • ", txt)
-    txt = re.sub(r"(\d)([a-zäöüß])", r"\1 \2", txt)
+    txt = re.sub(r"(\d)([A-Za-zÄÖÜäöüß])", r"\1 \2", txt)
     txt = _WS_RE.sub(" ", txt)
     # Collapse any repeated bullet separators before removing those after prepositions
     txt = re.sub(r"(?:\s*•\s*){2,}", " • ", txt)

--- a/tests/test_html_to_text.py
+++ b/tests/test_html_to_text.py
@@ -40,7 +40,8 @@ def test_preposition_bullet_stripping(html, expected):
 
 
 @pytest.mark.parametrize("html,expected", [
-    ("10A", "10A"),
+    ("10A", "10 A"),
+    ("12A", "12 A"),
     ("U6", "U6"),
     ("2m", "2 m"),
 ])


### PR DESCRIPTION
## Summary
- Expand html_to_text regex to separate digits from uppercase letters (e.g. `12A` -> `12 A`)
- Extend tests to cover uppercase unit separation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c749099b88832b94cc83dff8f8b918