### PR TITLE
Handle int env conversion errors explicitly

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -54,8 +54,15 @@ def _get_int_env(name: str, default: int) -> int:
         return default
     try:
         return int(raw)
-    except Exception:
-        log.warning("Ungültiger Wert für %s=%r – verwende Default %d", name, raw, default)
+    except (ValueError, TypeError) as e:
+        log.warning(
+            "Ungültiger Wert für %s=%r – verwende Default %d (%s: %s)",
+            name,
+            raw,
+            default,
+            type(e).__name__,
+            e,
+        )
         return default
 
 # ---------------- ENV ----------------


### PR DESCRIPTION
## Summary
- Handle invalid integer environment variables with explicit ValueError/TypeError handling
- Log detailed error type/message when falling back to default values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c749b1e948832bb718db8d8c856b60