### PR TITLE
Deduplicate ÖBB endpoints

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -118,7 +118,9 @@ def _split_endpoints(title: str) -> Optional[List[str]]:
             if n:
                 names.append(n)
         return names
-    return explode(left) + explode(right)
+    # Links/Rechts zusammenführen und Duplikate entfernen
+    endpoints = explode(left) + explode(right)
+    return list(dict.fromkeys(endpoints))
 
 # ---------------- Pendler-Region (Whitelist) ----------------
 def _norm(s: str) -> str:

--- a/tests/test_oebb_split_endpoints.py
+++ b/tests/test_oebb_split_endpoints.py
@@ -1,0 +1,7 @@
+import src.providers.oebb as oebb
+
+
+def test_split_endpoints_deduplicates():
+    title = "Wien Hbf ↔ Wien Hbf"
+    assert oebb._split_endpoints(title) == ["Wien"]
+


### PR DESCRIPTION
## Summary
- remove duplicate endpoint names when parsing ÖBB titles
- add test to ensure endpoint deduplication

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c74a47bba0832b9701f9d33bca9c48