### PR TITLE
Normalize provider enable env vars

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -215,7 +215,7 @@ def _collect_items() -> List[Dict[str, Any]]:
     active = [
         f
         for env, f in PROVIDERS
-        if os.getenv(env, "1").lower() not in {"0", "false"}
+        if os.getenv(env, "1").strip().lower() not in {"0", "false"}
     ]
     if not active:
         return []

--- a/tests/test_collect_items_env.py
+++ b/tests/test_collect_items_env.py
@@ -55,6 +55,26 @@ def test_disabling_provider_suppresses_items(monkeypatch, disabled_env, expected
     assert items == expected
 
 
+@pytest.mark.parametrize(
+    "value",
+    ["0", " 0 ", "false", " False ", "FALSE", "\t0\n", "\nfalse\t"],
+)
+def test_env_disabling_ignores_whitespace_and_case(monkeypatch, value):
+    build_feed = _import_build_feed(monkeypatch)
+
+    monkeypatch.setattr(
+        build_feed,
+        "PROVIDERS",
+        [("WL_ENABLE", lambda: [{"p": "wl"}]), ("OEBB_ENABLE", lambda: [{"p": "oebb"}])],
+    )
+
+    monkeypatch.setenv("WL_ENABLE", value)
+    monkeypatch.setenv("OEBB_ENABLE", "1")
+
+    items = build_feed._collect_items()
+    assert items == [{"p": "oebb"}]
+
+
 def test_enabling_vor_yields_items(monkeypatch):
     build_feed = _import_build_feed(monkeypatch)
 


### PR DESCRIPTION
## Summary
- Normalize provider enable environment variables with `strip().lower()` to treat values like `0` and `false` (with whitespace) as disabled
- Add tests ensuring whitespace and case are ignored when disabling providers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74cc9e8a4832b81ce93bc79c1380f