### PR TITLE
Sanitize LOG_LEVEL env var for build_feed logging

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -33,9 +33,12 @@ PROVIDERS: List[Tuple[str, Any]] = [
 ]
 
 # ---------------- Logging ----------------
-LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").strip().upper()
+if LOG_LEVEL not in logging._nameToLevel:
+    LOG_LEVEL = "INFO"
+
 logging.basicConfig(
-    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    level=logging._nameToLevel.get(LOG_LEVEL, logging.INFO),
     format="%(asctime)s %(levelname)s %(name)s: %(message)s",
 )
 log = logging.getLogger("build_feed")


### PR DESCRIPTION
## Summary
- Trim and validate LOG_LEVEL env var before configuring logging
- Default to INFO if LOG_LEVEL is missing or invalid

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74d820e00832b93232e3c3e144e25