### PR TITLE
refactor: replace private logging level access

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -34,11 +34,12 @@ PROVIDERS: List[Tuple[str, Any]] = [
 
 # ---------------- Logging ----------------
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").strip().upper()
-if LOG_LEVEL not in logging._nameToLevel:
-    LOG_LEVEL = "INFO"
+_level = getattr(logging, LOG_LEVEL, logging.INFO)
+if not isinstance(_level, int):
+    _level = logging.INFO
 
 logging.basicConfig(
-    level=logging._nameToLevel.get(LOG_LEVEL, logging.INFO),
+    level=_level,
     format="%(asctime)s %(levelname)s %(name)s: %(message)s",
 )
 log = logging.getLogger("build_feed")


### PR DESCRIPTION
## Summary
- avoid private `logging._nameToLevel` by validating log level via `getattr`
- configure basic logging using public constants only

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7c4f3a8c8832ba09ccf7596140175