### PR TITLE
Handle empty titles in WL line prefixes

### DIFF
--- a/src/providers/wl_lines.py
+++ b/src/providers/wl_lines.py
@@ -55,9 +55,10 @@ def _ensure_line_prefix(title: str, lines_disp: List[str]) -> str:
         return title
     wanted = "/".join(lines_disp)
     if re.match(rf"^\s*{re.escape(wanted)}\s*:\s*", title, re.IGNORECASE):
-        return title
-    stripped = _strip_existing_line_block(title)
-    return f"{wanted}: {stripped}".strip()
+        rest = re.sub(rf"^\s*{re.escape(wanted)}\s*:\s*", "", title, flags=re.IGNORECASE).strip()
+        return title if rest else wanted
+    stripped = _strip_existing_line_block(title).strip()
+    return f"{wanted}: {stripped}" if stripped else wanted
 
 
 # Fallback-Linien aus Titeltext — vorher Datum/Zeit/Adressen maskieren

--- a/tests/test_wl_title.py
+++ b/tests/test_wl_title.py
@@ -59,6 +59,11 @@ def test_line_prefix_and_house_number_false_positive():
     assert _detect_line_pairs_from_text("Neubaugasse 69") == []
 
 
+def test_line_prefix_empty_title():
+    assert _ensure_line_prefix("5:", ["5"]) == "5"
+    assert _ensure_line_prefix("5: ", ["5"]) == "5"
+
+
 def test_tidy_title_wl_strips_label():
     assert _tidy_title_wl("Störung: U1 steht") == "U1 steht"
 


### PR DESCRIPTION
## Summary
- Avoid trailing colon when `_ensure_line_prefix` strips an empty title
- Cover empty-title behavior for Wiener Linien line prefixes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7c817915c832bb8701930f775f883