### PR TITLE
Remove redundant strip in html_to_text

### DIFF
--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -90,9 +90,8 @@ def html_to_text(s: str) -> str:
     # Collapse any repeated bullet separators before removing those after prepositions
     txt = re.sub(r"(?:\s*•\s*){2,}", " • ", txt)
     txt = normalize_bullets(txt)
-    txt = txt.strip()
-    txt = re.sub(r"^•\s*", "", txt)
-    txt = re.sub(r"\s*•$", "", txt)
+    txt = re.sub(r"^\s*•\s*", "", txt)
+    txt = re.sub(r"\s*•\s*$", "", txt)
     txt = _WS_RE.sub(" ", txt)
     txt = re.sub(r"\s{2,}", " ", txt).strip()
     return txt


### PR DESCRIPTION
## Summary
- simplify `html_to_text` by removing early `strip()` and letting final cleanup handle whitespace
- handle bullet trimming with regex tolerant of surrounding whitespace

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7c8fc6724832bbcaa685dbbda28b8