### PR TITLE
Narrow request error handling in Wiener Linien fetcher

### DIFF
--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -251,7 +251,7 @@ def fetch_events(timeout: int = 20) -> List[Dict[str, Any]]:
                     "_identity": identity,
                 }
             )
-    except Exception as e:  # pragma: no cover - network errors
+    except requests.RequestException as e:  # pragma: no cover - network errors
         log.exception("WL trafficInfoList fehlgeschlagen: %s", e)
 
     # B) News/Hinweise
@@ -344,7 +344,7 @@ def fetch_events(timeout: int = 20) -> List[Dict[str, Any]]:
                     "_identity": identity,
                 }
             )
-    except Exception as e:  # pragma: no cover - network errors
+    except requests.RequestException as e:  # pragma: no cover - network errors
         log.exception("WL newsList fehlgeschlagen: %s", e)
 
     # C) Bündelung: LINIEN-SET + TOPIC


### PR DESCRIPTION
## Summary
- Catch only network-related `requests.RequestException` during Wiener Linien fetches so other errors surface.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7ca025350832b94baf1ae8b8167c1