### PR TITLE
Use GUID for deterministic sorting

### DIFF
--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -12,7 +12,7 @@ KEIN <pubDate> und ordnet solche Items hinter datierten ein.
 
 from __future__ import annotations
 
-import os, re, html, hashlib, logging
+import os, re, html, logging
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 from typing import Any, Dict, Iterable, List, Optional
@@ -244,5 +244,5 @@ def fetch_events() -> List[Dict[str, Any]]:
                 seen.add(it["guid"])
                 out.append(it)
 
-    out.sort(key=lambda x: (0, x["pubDate"]) if x["pubDate"] else (1, hashlib.md5(x["guid"].encode()).hexdigest()))
+    out.sort(key=lambda x: (0, x["pubDate"]) if x["pubDate"] else (1, x["guid"]))
     return out

--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 import re
@@ -459,7 +458,7 @@ def fetch_events(timeout: int = 20) -> List[Dict[str, Any]]:
         it.pop("_lines_set", None)
 
     filtered.sort(
-        key=lambda x: (0, x["pubDate"]) if x["pubDate"] else (1, hashlib.md5(x["guid"].encode()).hexdigest())
+        key=lambda x: (0, x["pubDate"]) if x["pubDate"] else (1, x["guid"])
     )
     log.info("WL: %d Items nach Filter/Dedupe", len(filtered))
     return filtered


### PR DESCRIPTION
## Summary
- Avoid MD5 in sort keys for VOR and WL providers by using each item's GUID directly
- Drop unused `hashlib` imports

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7ce8d9a84832bba07a78cb5f8fa82