### PR TITLE
Expand German preposition handling in text utilities

### DIFF
--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -10,7 +10,17 @@ from html.parser import HTMLParser
 _WS_RE = re.compile(r"[ \t\r\f\v]+")
 
 # Common German prepositions that should not be followed by a bullet.
-PREPOSITIONS = ("bei", "in", "an", "auf")
+PREPOSITIONS = (
+    "bei",
+    "in",
+    "an",
+    "auf",
+    "am",
+    "vom",
+    "zur",
+    "zum",
+    "nach",
+)
 
 _PREP_BULLET_RE = re.compile(
     rf"\b({'|'.join(re.escape(p) for p in PREPOSITIONS)})\s*•\s*",

--- a/tests/test_html_to_text.py
+++ b/tests/test_html_to_text.py
@@ -34,6 +34,11 @@ def test_html_to_text_edge_cases(html, expected):
     ("An<br>der Haltestelle", "An der Haltestelle"),
     ("bei<br>• foo", "bei foo"),
     ("In<br>• der Station", "In der Station"),
+    ("Am<br>Bahnhof", "Am Bahnhof"),
+    ("Vom<br>• Bahnsteig", "Vom Bahnsteig"),
+    ("Zur<br>• Station", "Zur Station"),
+    ("Zum<br>• Ausgang", "Zum Ausgang"),
+    ("Nach<br>• Wien", "Nach Wien"),
 ])
 def test_preposition_bullet_stripping(html, expected):
     assert html_to_text(html) == expected


### PR DESCRIPTION
## Summary
- broaden list of German prepositions that suppress bullets
- cover new prepositions with additional html_to_text tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7cf4acc08832bbebdd866601ee177