### PR TITLE
Skip state save when RSS feed has no items

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -391,11 +391,15 @@ def _make_rss(items: List[Dict[str, Any]], now: datetime, state: Dict[str, Dict[
     out.append("</rss>")
 
     # State nur für *aktuelle* Items speichern (kein Anwachsen)
-    pruned = {k: state[k] for k in identities_in_feed if k in state}
-    try:
-        _save_state(pruned)
-    except Exception as e:
-        log.warning("State speichern fehlgeschlagen (%s) – Feed wird trotzdem zurückgegeben.", e)
+    if identities_in_feed:
+        pruned = {k: state[k] for k in identities_in_feed if k in state}
+        try:
+            _save_state(pruned)
+        except Exception as e:
+            log.warning(
+                "State speichern fehlgeschlagen (%s) – Feed wird trotzdem zurückgegeben.",
+                e,
+            )
 
     return "\n".join(out)
 


### PR DESCRIPTION
## Summary
- call `_save_state` only when current RSS feed contains identities
- adjust readonly state test and add coverage for no-item case

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7d5909e08832b816f8875861cac5e