### PR TITLE
Return plaintext clipping and escape descriptions in feed

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -127,14 +127,11 @@ def _strip_html(s: str) -> str:
     return re.sub(r"<[^>]*>", "", s or "")
 
 def _clip_text_html(text: str, limit: int) -> str:
-    """Für TV knapper machen. Wenn HTML enthalten ist, clippen wir auf Plaintext und escapen."""
-    if limit <= 0:
-        return text or ""
-    plain = _strip_html(text)
-    if len(plain) <= limit:
-        return text or ""
-    clipped = plain[:limit].rstrip() + " …"
-    return html.escape(clipped)
+    """Für TV knapper machen. Gibt immer Plaintext zurück und kürzt falls nötig."""
+    plain = html.unescape(_strip_html(text or ""))
+    if limit <= 0 or len(plain) <= limit:
+        return plain
+    return plain[:limit].rstrip() + " …"
 
 def _parse_lines_from_title(title: str) -> List[str]:
     m = re.match(r"^\s*([A-Za-z0-9]+(?:/[A-Za-z0-9]+){0,20})\s*:\s*", title or "")
@@ -352,7 +349,7 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
     desc_out = _clip_text_html(raw_desc, DESCRIPTION_CHAR_LIMIT)
     # Für XML robust aufbereiten
     title_out = _sanitize_text(html.unescape(raw_title))
-    desc_out  = _sanitize_text(html.unescape(desc_out))
+    desc_out  = html.escape(_sanitize_text(desc_out))
 
     parts: List[str] = []
     parts.append("<item>")

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -1,0 +1,27 @@
+import importlib
+import sys
+from pathlib import Path
+from datetime import datetime
+
+
+def _load_build_feed(monkeypatch):
+    module_name = "src.build_feed"
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1] / "src"))
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_clip_text_html_plain_and_clips(monkeypatch):
+    bf = _load_build_feed(monkeypatch)
+    html_in = "<b>foo &amp; bar</b>"
+    assert bf._clip_text_html(html_in, 100) == "foo & bar"
+    assert bf._clip_text_html(html_in, 7) == "foo & b …"
+
+
+def test_emit_item_escapes_description(monkeypatch):
+    bf = _load_build_feed(monkeypatch)
+    monkeypatch.setattr(bf, "DESCRIPTION_CHAR_LIMIT", 5)
+    now = datetime(2024, 1, 1)
+    ident, xml = bf._emit_item({"title": "X", "description": "<b>Tom & Jerry</b>"}, now, {})
+    assert "<description><![CDATA[Tom &amp; …]]></description>" in xml
+    assert "Jerry" not in xml


### PR DESCRIPTION
## Summary
- ensure `_clip_text_html` always returns plain text and clips if needed
- escape sanitized description in `_emit_item` before wrapping in CDATA
- add tests for clipping logic and HTML-safe description output

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7d7ba3848832ba71c05a0a7b09e26