### PR TITLE
Stop blocking on provider timeout

### DIFF
--- a/tests/test_collect_items_timeout.py
+++ b/tests/test_collect_items_timeout.py
@@ -44,7 +44,9 @@ def test_slow_provider_does_not_block(monkeypatch):
     )
     monkeypatch.setenv("SLOW", "1")
     monkeypatch.setenv("FAST", "1")
-
+    start = time.time()
     items = build_feed._collect_items()
+    elapsed = time.time() - start
 
+    assert elapsed < 1.5, f"_collect_items blocked for {elapsed:.2f}s"
     assert items == [{"guid": "fast"}]


### PR DESCRIPTION
## Summary
- stop awaiting unfinished provider threads on timeout in `_collect_items`
- test that slow providers no longer block when exceeding timeout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7df0b6e48832bb747f1b0d2980ae7