### PR TITLE
Avoid NONE tokens in line parsing

### DIFF
--- a/src/providers/wl_lines.py
+++ b/src/providers/wl_lines.py
@@ -14,7 +14,11 @@ def _clean_line_token(s: str) -> str:
 
 
 def _tok(v: Any) -> str:
-    return _clean_line_token(re.sub(r"[^A-Za-z0-9+]", "", str(v)))
+    if v is None:
+        return ""
+    token = re.sub(r"[^A-Za-z0-9+]", "", str(v))
+    token = _clean_line_token(token)
+    return token if token else ""
 
 
 def _display_line(s: str) -> str:

--- a/tests/test_wl_lines_pairs.py
+++ b/tests/test_wl_lines_pairs.py
@@ -1,0 +1,11 @@
+from src.providers.wl_lines import _tok, _make_line_pairs_from_related
+
+
+def test_tok_returns_empty_for_none_and_empty():
+    assert _tok(None) == ""
+    assert _tok("") == ""
+
+
+def test_make_line_pairs_from_related_ignores_none():
+    pairs = _make_line_pairs_from_related(["5", None, "U1", ""])
+    assert pairs == [("5", "5"), ("U1", "U1")]


### PR DESCRIPTION
## Summary
- return empty string from `_tok` for `None` or empty tokens
- ensure `_make_line_pairs_from_related` ignores such entries
- add regression tests for `_tok` and `_make_line_pairs_from_related`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7e06a48f8832b87752691ff7cf5fb