### PR TITLE
Do not escape description contents before wrapping in CDATA

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -361,9 +361,9 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
 
     # TV-freundliche Kürzung (Beschreibung darf HTML enthalten)
     desc_out = _clip_text_html(raw_desc, DESCRIPTION_CHAR_LIMIT)
-    # Für XML robust aufbereiten
+    # Für XML robust aufbereiten (CDATA schützt Sonderzeichen)
     title_out = _sanitize_text(html.unescape(raw_title))
-    desc_out  = html.escape(_sanitize_text(desc_out))
+    desc_out  = _sanitize_text(desc_out)
 
     parts: List[str] = []
     parts.append("<item>")

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -18,10 +18,10 @@ def test_clip_text_html_plain_and_clips(monkeypatch):
     assert bf._clip_text_html(html_in, 7) == "foo & b …"
 
 
-def test_emit_item_escapes_description(monkeypatch):
+def test_emit_item_sanitizes_description(monkeypatch):
     bf = _load_build_feed(monkeypatch)
     monkeypatch.setattr(bf, "DESCRIPTION_CHAR_LIMIT", 5)
     now = datetime(2024, 1, 1)
     ident, xml = bf._emit_item({"title": "X", "description": "<b>Tom & Jerry</b>"}, now, {})
-    assert "<description><![CDATA[Tom &amp; …]]></description>" in xml
+    assert "<description><![CDATA[Tom & …]]></description>" in xml
     assert "Jerry" not in xml


### PR DESCRIPTION
## Summary
- Ensure description is only sanitized (no HTML escaping) before CDATA in `_emit_item`
- Update test to expect unescaped special characters in description

## Testing
- `pytest -q`
- `python - <<'PY'
from datetime import datetime
from src.build_feed import _emit_item
ident, xml = _emit_item({'title': 'X', 'description': 'A & B'}, datetime(2024, 1, 1), {})
print(xml)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c7e421e2e0832bbb5909a1bb881b07