### PR TITLE
Strip bullet after colon in HTML text conversion

### DIFF
--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -95,6 +95,7 @@ def html_to_text(s: str) -> str:
     txt = "".join(parser.parts)
     txt = html.unescape(txt)
     txt = re.sub(r"\s*\n\s*", " • ", txt)
+    txt = re.sub(r":\s*•\s*", ": ", txt)
     txt = re.sub(r"(\d)([A-Za-zÄÖÜäöüß])", r"\1 \2", txt)
     txt = _WS_RE.sub(" ", txt)
     # Collapse any repeated bullet separators before removing those after prepositions

--- a/tests/test_html_to_text.py
+++ b/tests/test_html_to_text.py
@@ -13,6 +13,7 @@ from src.utils.text import html_to_text
         "A • B • C • D",
     ),
     ("<th>Head1</th><th>Head2</th>End", "Head1 • Head2 • End"),
+    ("Zeitraum:<br>Ab Montag", "Zeitraum: Ab Montag"),
 ])
 def test_html_to_text_examples(html, expected):
     assert html_to_text(html) == expected


### PR DESCRIPTION
## Summary
- avoid bullet insertion after colons in `html_to_text`
- add regression test covering colon handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7e7978c28832bb253ca9db6a15ec8