### PR TITLE
Handle spaced hyphens as endpoint separators

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -56,7 +56,8 @@ def _session() -> requests.Session:
 
 # ---------------- Titel + Endpunkte ----------------
 BAHNHOF_TRIM_RE = re.compile(r"\s*(?:Bahnhof|Bahnhst|Hbf|Bf)(?:\s*\(U\))?", re.IGNORECASE)
-ARROW_ANY_RE    = re.compile(r"\s*(?:<=>|<->|<>|→|↔|=>|=|–|—|-)\s*")
+# treat simple hyphen as separator only when surrounded by spaces
+ARROW_ANY_RE    = re.compile(r"\s*(?:<=>|<->|<>|→|↔|=>|=|–|—|\s-\s)\s*")
 COLON_PREFIX_RE = re.compile(
     r"""^\s*(?:Update\s*\d+\s*\([^)]*\)\s*)?
         (?:DB\s*↔\s*)?
@@ -99,12 +100,12 @@ def _clean_title_keep_places(t: str) -> str:
 def _split_endpoints(title: str) -> Optional[List[str]]:
     """Extrahiert Endpunktnamen links/rechts (ohne Bahnhof/Hbf/Klammern)."""
     arrow_markers = (
-        "↔", "<=>", "<->", "→", "=>", "->", "—", "–", "-",
-    )  # treat hyphen as arrow indicator as well
-    if not any(a in title for a in arrow_markers):
+        "↔", "<=>", "<->", "→", "=>", "->", "—", "–",
+    )
+    if not any(a in title for a in arrow_markers) and not re.search(r"\s-\s", title):
         return None
     parts = [
-        p for p in re.split(r"\s*(?:↔|<=>|<->|→|=>|->|—|–|-)\s*", title) if p.strip()
+        p for p in re.split(r"\s*(?:↔|<=>|<->|→|=>|->|—|–|\s-\s)\s*", title) if p.strip()
     ]
     if len(parts) < 2:
         return None

--- a/tests/test_oebb_split_endpoints.py
+++ b/tests/test_oebb_split_endpoints.py
@@ -10,3 +10,8 @@ def test_split_endpoints_hyphen():
     title = "Wien - Linz"
     assert oebb._split_endpoints(title) == ["Wien", "Linz"]
 
+
+def test_split_endpoints_inner_hyphen():
+    title = "Graz Ostbahnhof-Messe - Wien"
+    assert oebb._split_endpoints(title) == ["Graz Ost-Messe", "Wien"]
+


### PR DESCRIPTION
## Summary
- Treat ASCII hyphen as arrow only when surrounded by spaces in ARROW_ANY_RE and endpoint splitting
- Add regression test for station names containing inner hyphen

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7e8aee420832bb079856a6e06ad53