### PR TITLE
Flush and sync state file writes

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -184,6 +184,8 @@ def _save_state(state: Dict[str, Dict[str, Any]]) -> None:
     tmp = STATE_FILE.with_suffix(".tmp")
     with tmp.open("w", encoding="utf-8") as f:
         json.dump(pruned, f, ensure_ascii=False, indent=2, sort_keys=True)
+        f.flush()
+        os.fsync(f.fileno())
     tmp.replace(STATE_FILE)
 
 def _identity_for_item(item: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- ensure state file writes are flushed and fsynced to disk to avoid data loss

## Testing
- `pytest tests/test_state.py::test_save_state` *(fails: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e9d96db0832b83ce05982f49490c