### PR TITLE
Expose fetch_events in provider modules

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -262,3 +262,7 @@ def fetch_events(timeout: int = 25) -> List[Dict[str, Any]]:
 
     log.info("ÖBB: %d Items nach Region/Titel-Kosmetik", len(out))
     return out
+
+
+__all__ = ["fetch_events"]
+

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -246,3 +246,7 @@ def fetch_events() -> List[Dict[str, Any]]:
 
     out.sort(key=lambda x: (0, x["pubDate"]) if x["pubDate"] else (1, x["guid"]))
     return out
+
+
+__all__ = ["fetch_events"]
+


### PR DESCRIPTION
## Summary
- export fetch_events via __all__ in ÖBB provider
- export fetch_events via __all__ in VOR provider

## Testing
- `pytest tests/test_collect_items_env.py::test_provider_env_disables` *(fails: not found)*
- `pytest tests/test_collect_items_env.py::test_disabling_provider_suppresses_items`

------
https://chatgpt.com/codex/tasks/task_e_68c7ea71dbb8832b9376a0cd7a7c6514