### PR TITLE
Add unit test for _sanitize_text control char removal

### DIFF
--- a/tests/test_sanitize_text.py
+++ b/tests/test_sanitize_text.py
@@ -1,0 +1,5 @@
+from src.build_feed import _sanitize_text
+
+
+def test_sanitize_text_removes_control_characters():
+    assert _sanitize_text("\x07test\x1F") == "test"


### PR DESCRIPTION
## Summary
- add regression test ensuring `_sanitize_text` strips ASCII control characters

## Testing
- `pytest tests/test_sanitize_text.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7ebb0838c832bab8bd91ab941fc29