### PR TITLE
Add tests for bullet normalization

### DIFF
--- a/tests/test_normalize_bullets.py
+++ b/tests/test_normalize_bullets.py
@@ -1,0 +1,21 @@
+import pytest
+
+from src.utils.text import normalize_bullets
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("bei • Station", "bei Station"),
+        ("In • der Station", "In der Station"),
+        ("An • der Haltestelle", "An der Haltestelle"),
+        ("auf • dem Bahnsteig", "auf dem Bahnsteig"),
+        ("Am • Rathaus", "Am Rathaus"),
+        ("Vom • Bahnsteig", "Vom Bahnsteig"),
+        ("zur • Station", "zur Station"),
+        ("zum • Ausgang", "zum Ausgang"),
+        ("Nach • Wien", "Nach Wien"),
+    ],
+)
+def test_normalize_bullets_prepositions(text, expected):
+    assert normalize_bullets(text) == expected


### PR DESCRIPTION
## Summary
- test that `normalize_bullets` removes bullets after common German prepositions

## Testing
- `pytest tests/test_normalize_bullets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7ec3e6990832ba65b9f1698b75943