### PR TITLE
Split build_feed imports into separate lines

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -2,7 +2,13 @@
 # -*- coding: utf-8 -*-
 
 import inspect
-import json, os, sys, html, logging, re, hashlib
+import json
+import os
+import sys
+import html
+import logging
+import re
+import hashlib
 from concurrent.futures import ThreadPoolExecutor, as_completed, TimeoutError
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple


### PR DESCRIPTION
## Summary
- split combined imports into individual lines in build_feed

## Testing
- `flake8 src/build_feed.py` *(fails: E731, E302, E305, E501, E741, W293, E221)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ecdc95b0832bacac677a3af3ff50