### PR TITLE
Document and configure log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ python -u src/build_feed.py  # erzeugt docs/feed.xml
 
 Der erzeugte Feed liegt unter `docs/feed.xml`.
 
+Fehlerprotokolle landen in `log/errors.log`. Das Verzeichnis `log/` wird bei Bedarf
+automatisch angelegt. Wird die Datei größer als `LOG_MAX_BYTES`, rotiert sie und
+ältere Versionen werden als `errors.log.1` usw. (max. `LOG_BACKUP_COUNT`) im selben
+Ordner abgelegt.
+
 ## Umgebungsvariablen
 
 ### Allgemein (`src/build_feed.py`)
@@ -27,6 +32,9 @@ Der erzeugte Feed liegt unter `docs/feed.xml`.
 | Variable | Typ | Standardwert | Beschreibung |
 | --- | --- | --- | --- |
 | `LOG_LEVEL` | str | `"INFO"` | Log-Level für Ausgaben. |
+| `LOG_DIR` | str | `"log"` | Basisverzeichnis für Log-Dateien. |
+| `LOG_MAX_BYTES` | int | `1000000` | Maximale Größe von `errors.log` bevor rotiert wird. |
+| `LOG_BACKUP_COUNT` | int | `5` | Anzahl der Vorversionen von `errors.log`, die behalten werden. |
 | `OUT_PATH` | str | `"docs/feed.xml"` | Zielpfad für den erzeugten Feed. |
 | `FEED_TITLE` | str | `"ÖPNV Störungen Wien & Umgebung"` | Titel des RSS-Feeds. |
 | `FEED_LINK` | str | `"https://github.com/Origamihase/wien-oepnv"` | Link zur Projektseite. |

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -45,14 +45,32 @@ _level = getattr(logging, LOG_LEVEL, logging.INFO)
 if not isinstance(_level, int):
     _level = logging.INFO
 
-os.makedirs("log", exist_ok=True)
+LOG_DIR = os.getenv("LOG_DIR", "log")
+try:
+    LOG_MAX_BYTES = int(os.getenv("LOG_MAX_BYTES", "1000000"))
+    if LOG_MAX_BYTES < 0:
+        LOG_MAX_BYTES = 0
+except (ValueError, TypeError):
+    LOG_MAX_BYTES = 1_000_000
+
+try:
+    LOG_BACKUP_COUNT = int(os.getenv("LOG_BACKUP_COUNT", "5"))
+    if LOG_BACKUP_COUNT < 0:
+        LOG_BACKUP_COUNT = 0
+except (ValueError, TypeError):
+    LOG_BACKUP_COUNT = 5
+
+os.makedirs(LOG_DIR, exist_ok=True)
 fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
 logging.basicConfig(
     level=_level,
     format=fmt,
 )
 error_handler = RotatingFileHandler(
-    "log/errors.log", maxBytes=1_000_000, backupCount=5, encoding="utf-8"
+    Path(LOG_DIR) / "errors.log",
+    maxBytes=LOG_MAX_BYTES,
+    backupCount=LOG_BACKUP_COUNT,
+    encoding="utf-8",
 )
 error_handler.setLevel(logging.ERROR)
 error_handler.setFormatter(logging.Formatter(fmt))


### PR DESCRIPTION
## Summary
- support configurable log directory and rotation size/count via environment variables
- document `log/` folder, `errors.log`, and log rotation behavior

## Testing
- `python -m pytest -q`
- `python -u src/build_feed.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7efdda71c832ba37d0a9a0c3074c0