### PR TITLE
Add W3C validator diagnostics

### DIFF
--- a/docs/feed-validator-output.txt
+++ b/docs/feed-validator-output.txt
@@ -1,0 +1,1 @@
+curl: (7) Failed to connect to validator.w3.org port 443 after 230 ms: Couldn't connect to server


### PR DESCRIPTION
## Summary
- Capture W3C feed validator attempt for `docs/feed.xml`.
- Store diagnostic output showing the validator could not be reached.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7fb735348832ba753593fb8788ccc