### PR TITLE
Replace bullet separators in feed items with newlines

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -388,7 +388,7 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
     desc_out = _clip_text_html(raw_desc, DESCRIPTION_CHAR_LIMIT)
     # Für XML robust aufbereiten (CDATA schützt Sonderzeichen)
     title_out = _sanitize_text(html.unescape(raw_title))
-    desc_out  = _sanitize_text(desc_out)
+    desc_out  = _sanitize_text(desc_out).replace(" • ", "\n")
 
     parts: List[str] = []
     parts.append("<item>")


### PR DESCRIPTION
## Summary
- replace bullet separators in build_feed descriptions with line breaks for better readability

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7fd652bc0832b9cad67640935307a