### PR TITLE
Regenerate feed with updated defaults

### DIFF
--- a/docs/feed-validator-output.txt
+++ b/docs/feed-validator-output.txt
@@ -1,1 +1,3 @@
-curl: (7) Failed to connect to validator.w3.org port 443 after 230 ms: Couldn't connect to server
+bozo: False
+feed is well-formed
+entries: 32

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -4,23 +4,27 @@
 <title>ÖPNV Störungen Wien &amp; Umgebung</title>
 <link>https://github.com/Origamihase/wien-oepnv</link>
 <description>Aktive Störungen/Baustellen/Einschränkungen aus offiziellen Quellen</description>
-<lastBuildDate>Mon, 15 Sep 2025 11:34:19 +0000</lastBuildDate>
+<lastBuildDate>Mon, 15 Sep 2025 12:03:06 +0000</lastBuildDate>
 <ttl>15</ttl>
 <item>
 <title><![CDATA[Wien Nußdorf]]></title>
 <link>https://fahrplan.oebb.at/bin/help.exe/dn?L=vs_scotty&amp;tpl=showmap_external&amp;</link>
 <guid>https://fahrplan.oebb.at/bin/query.exe/dn?ujm=1&amp;mapType=TRACKINFO&amp;813955</guid>
 <pubDate>Mon, 15 Sep 2025 11:05:07 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Mon, 15 Sep 2025 11:05:07 +0000</ext:starts_at>
-<description><![CDATA[31.10.2025 - 17.11.2025 • Wegen Bauarbeiten können • in Wien Nußdorf Bahnhst • von 31.10.2025 (22:00 Uhr) bis 03.11.2025 (02:00 Uhr) und • von 14.11.2025 (22:00 Uhr) bis …]]></description>
+<description><![CDATA[31.10.2025 - 17.11.2025
+Wegen Bauarbeiten können
+in Wien Nußdorf Bahnhst
+von 31.10.2025 (22:00 Uhr) bis 03.11.2025 (02:00 Uhr) und
+von 14.11.2025 (22:00 Uhr) bis …]]></description>
 </item>
 <item>
 <title><![CDATA[80A: Polizeieinsatz]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>004ddbf538374883daf43e1fbe6447619cae191baab3faeb8c93f9eeb85fac8a</guid>
 <pubDate>Mon, 15 Sep 2025 10:35:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Mon, 15 Sep 2025 10:35:00 +0000</ext:starts_at>
 <ext:ends_at>Mon, 15 Sep 2025 21:55:00 +0000</ext:ends_at>
 <description><![CDATA[Nach einer Fahrtbehinderung kommt es auf der Linie 80 A zu unterschiedlichen Intervallen.]]></description>
@@ -30,7 +34,7 @@
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>b3799ddddf61cd5c6404f1e8b07bf577d21dbd25d292c9833575d0f1f823d0c6</guid>
 <pubDate>Mon, 15 Sep 2025 10:25:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Mon, 15 Sep 2025 10:25:00 +0000</ext:starts_at>
 <ext:ends_at>Mon, 15 Sep 2025 21:55:00 +0000</ext:ends_at>
 <description><![CDATA[Nach einer Fahrtbehinderung kommt es auf der Linie O zu unterschiedlichen Intervallen.]]></description>
@@ -40,7 +44,7 @@
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>156d90f1fcb0c74f4bce3fbf47a7aa6473974e0501109186dc9f43f15805f3c3</guid>
 <pubDate>Mon, 15 Sep 2025 02:45:08 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Mon, 15 Sep 2025 02:45:08 +0000</ext:starts_at>
 <ext:ends_at>Mon, 15 Sep 2025 22:35:00 +0000</ext:ends_at>
 <description><![CDATA[Bauarbeiten Busse halten Breitenfurter Straße 236-238]]></description>
@@ -50,7 +54,7 @@
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>79d70b60ea9f3f396e403123459bbed9393be2edbbbdc2b1e066ec622d9f9339</guid>
 <pubDate>Mon, 15 Sep 2025 02:45:03 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Mon, 15 Sep 2025 02:45:03 +0000</ext:starts_at>
 <ext:ends_at>Mon, 15 Sep 2025 22:00:00 +0000</ext:ends_at>
 <description><![CDATA[Bauarbeiten Züge halten Alszeile 126]]></description>
@@ -60,7 +64,7 @@
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>c6b1998ef7f34abd716aca5b6a9e1eff4f901b6489602bf2863cfb4a83cf741c</guid>
 <pubDate>Mon, 15 Sep 2025 02:30:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Mon, 15 Sep 2025 02:30:00 +0000</ext:starts_at>
 <ext:ends_at>Thu, 02 Oct 2025 02:00:00 +0000</ext:ends_at>
 <description><![CDATA[Die Linie 5 fährt nur zwischen Praterstern und Josefstädter Straße. Die Störung dauert voraussichtlich bis 02. Oktober 2025, 04:00 Uhr. Grund dafür sind Bauarbeiten im Be …]]></description>
@@ -70,7 +74,7 @@
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>0a6a987a32b38d85f3d0dcaceba01b7e03ecd4a1b44249076de8bb39e7c3f35b</guid>
 <pubDate>Sun, 14 Sep 2025 22:00:24 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Sun, 14 Sep 2025 22:00:24 +0000</ext:starts_at>
 <ext:ends_at>Mon, 15 Sep 2025 21:59:59 +0000</ext:ends_at>
 <description><![CDATA[Bauarbeiten Busse halten bei Liechtensteinstr. 68-72]]></description>
@@ -80,7 +84,7 @@
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>2664a84bd7bb35a6f0aba982e3c561700607eccff2b9b90413246f273c30c1cd</guid>
 <pubDate>Sun, 14 Sep 2025 22:00:20 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Sun, 14 Sep 2025 22:00:20 +0000</ext:starts_at>
 <ext:ends_at>Mon, 15 Sep 2025 21:59:59 +0000</ext:ends_at>
 <description><![CDATA[Bauarbeiten Busse halten Währinger Straße 48-50]]></description>
@@ -90,7 +94,7 @@
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>78e25f4709a0c5e27cab79b249f85b38898f9b4660c45314e351f1aef4f9f2e7</guid>
 <pubDate>Sun, 14 Sep 2025 22:00:10 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Sun, 14 Sep 2025 22:00:10 +0000</ext:starts_at>
 <ext:ends_at>Mon, 15 Sep 2025 21:59:59 +0000</ext:ends_at>
 <description><![CDATA[Gleisbauarbeiten Betrieb ab St. Marx]]></description>
@@ -100,76 +104,94 @@
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>2b36bd83c76e9b3875ef8db91fdcf612018122efc252eefcfaa4627f1b8fb247</guid>
 <pubDate>Thu, 11 Sep 2025 11:00:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Thu, 11 Sep 2025 11:00:00 +0000</ext:starts_at>
 <ext:ends_at>Fri, 11 Sep 2026 09:11:00 +0000</ext:ends_at>
-<description><![CDATA[Straßenbauarbeiten • Wegen Bauarbeiten im Bereich Pfalzgasse werden die Linien 95 A und 97 A umgeleitet. • Zeitraum: Ab Montag, 22. September 2025, etwa 07:00 Uhr auf Dau …]]></description>
+<description><![CDATA[Straßenbauarbeiten
+Wegen Bauarbeiten im Bereich Pfalzgasse werden die Linien 95 A und 97 A umgeleitet.
+Zeitraum: Ab Montag, 22. September 2025, etwa 07:00 Uhr auf Dau …]]></description>
 </item>
 <item>
 <title><![CDATA[14A: Straßenbauarbeiten]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>a1cb8bd7ea1775b815cfa7161da7efc4dec722b2e99f3e3fb3ed9416380eaf0c</guid>
 <pubDate>Wed, 10 Sep 2025 14:00:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Wed, 10 Sep 2025 14:00:00 +0000</ext:starts_at>
 <ext:ends_at>Thu, 10 Sep 2026 09:11:00 +0000</ext:ends_at>
-<description><![CDATA[Straßenbauarbeiten • Wegen Bauarbeiten im Bereich Gudrunstraße wird die Linie 14 A umgeleitet. • Zeitraum: Ab Dienstag, 30. September 2025, etwa 07:00 Uhr auf Dauer von e …]]></description>
+<description><![CDATA[Straßenbauarbeiten
+Wegen Bauarbeiten im Bereich Gudrunstraße wird die Linie 14 A umgeleitet.
+Zeitraum: Ab Dienstag, 30. September 2025, etwa 07:00 Uhr auf Dauer von e …]]></description>
 </item>
 <item>
 <title><![CDATA[24A: Umleitung ab 17.09.2025]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>696de635b40d0fab3ebaebd9b92bde822bd58a70218936d9493d2e3d31633367</guid>
 <pubDate>Tue, 09 Sep 2025 12:00:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Tue, 09 Sep 2025 12:00:00 +0000</ext:starts_at>
 <ext:ends_at>Wed, 24 Sep 2025 15:00:00 +0000</ext:ends_at>
-<description><![CDATA[Straßenbauarbeiten • Wegen Bauarbeiten im Bereich Breitenleer Straße wird die Linie 24 A umgeleitet. • Zeitraum: Am Mittwoch, 17. September 2025, etwa 20:00 Uhr bis Betri …]]></description>
+<description><![CDATA[Straßenbauarbeiten
+Wegen Bauarbeiten im Bereich Breitenleer Straße wird die Linie 24 A umgeleitet.
+Zeitraum: Am Mittwoch, 17. September 2025, etwa 20:00 Uhr bis Betri …]]></description>
 </item>
 <item>
 <title><![CDATA[40/41: Währinger Straßenfest]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>8d0572101e7b7279d06f36b41d98c79e78e11243162604a070f1d6b69451c057</guid>
 <pubDate>Fri, 05 Sep 2025 15:00:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Fri, 05 Sep 2025 15:00:00 +0000</ext:starts_at>
 <ext:ends_at>Fri, 19 Sep 2025 21:00:00 +0000</ext:ends_at>
-<description><![CDATA[Veranstaltung • Wegen Abhaltung des Währinger Straßenfestes kommt es zu einer Umleitung der Linien 40 und 41 in beiden Fahrtrichtungen. • Zeitraum: Freitag, 19. September …]]></description>
+<description><![CDATA[Veranstaltung
+Wegen Abhaltung des Währinger Straßenfestes kommt es zu einer Umleitung der Linien 40 und 41 in beiden Fahrtrichtungen.
+Zeitraum: Freitag, 19. September …]]></description>
 </item>
 <item>
 <title><![CDATA[73A/73B: Pantucekgasse Straßenbauarbeiten]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>2303367fff580a248c65ce744ec4c1248c455c28bd8d0a516fe7e3aad5729a5e</guid>
 <pubDate>Fri, 05 Sep 2025 07:15:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Fri, 05 Sep 2025 07:15:00 +0000</ext:starts_at>
 <ext:ends_at>Sat, 05 Sep 2026 09:11:00 +0000</ext:ends_at>
-<description><![CDATA[Straßenbauarbeiten • Wegen Bauarbeiten im Bereich Pantucekgasse werden die Linien 73 A und 73 B umgeleitet. • Zeitraum: Ab Mittwoch, 10. September 2025, etwa 07:00 Uhr au …]]></description>
+<description><![CDATA[Straßenbauarbeiten
+Wegen Bauarbeiten im Bereich Pantucekgasse werden die Linien 73 A und 73 B umgeleitet.
+Zeitraum: Ab Mittwoch, 10. September 2025, etwa 07:00 Uhr au …]]></description>
 </item>
 <item>
 <title><![CDATA[Wien Autoreisezug]]></title>
 <link>https://fahrplan.oebb.at/bin/help.exe/dn?L=vs_scotty&amp;tpl=showmap_external&amp;</link>
 <guid>https://fahrplan.oebb.at/bin/query.exe/dn?ujm=1&amp;mapType=TRACKINFO&amp;812807</guid>
 <pubDate>Tue, 02 Sep 2025 14:56:34 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Tue, 02 Sep 2025 14:56:34 +0000</ext:starts_at>
-<description><![CDATA[08.10.2025 - 12.10.2025 • Wegen Bauarbeiten kann • in Wien Autoreisezug • von 08. auf 09.10.2025 • von 10. auf 11.10.2025 • der Zug EN 1153 nicht halten. • Zwischen Wien …]]></description>
+<description><![CDATA[08.10.2025 - 12.10.2025
+Wegen Bauarbeiten kann
+in Wien Autoreisezug
+von 08. auf 09.10.2025
+von 10. auf 11.10.2025
+der Zug EN 1153 nicht halten.
+Zwischen Wien …]]></description>
 </item>
 <item>
 <title><![CDATA[5: Gleisbauarbeiten ab 15.09.2025]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>bde6f98157c57b5ee943d88257d2347232c3a4f8f6c9a520d7288ac12214bc8a</guid>
 <pubDate>Mon, 01 Sep 2025 05:00:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Mon, 01 Sep 2025 05:00:00 +0000</ext:starts_at>
 <ext:ends_at>Thu, 02 Oct 2025 02:00:00 +0000</ext:ends_at>
-<description><![CDATA[Gleisbauarbeiten • Wegen umfangreicher Gleisbauarbeiten in der Blindengasse wird die Linie 5 kurz geführt. • Zeitraum: Montag, 15. September 2025, 04:00 Uhr bis Donnersta …]]></description>
+<description><![CDATA[Gleisbauarbeiten
+Wegen umfangreicher Gleisbauarbeiten in der Blindengasse wird die Linie 5 kurz geführt.
+Zeitraum: Montag, 15. September 2025, 04:00 Uhr bis Donnersta …]]></description>
 </item>
 <item>
 <title><![CDATA[18: Gleisbauarbeiten]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>3d33b89f825f14e61970e398aae1b19308c5bf34b1160f0a9de15bbd537d8d65</guid>
 <pubDate>Mon, 01 Sep 2025 03:30:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Mon, 01 Sep 2025 03:30:00 +0000</ext:starts_at>
 <ext:ends_at>Wed, 31 Dec 2025 21:55:00 +0000</ext:ends_at>
 <description><![CDATA[Die Linie 18 fährt bis Ende des Jahres nur zwischen Burggasse, Stadthalle und St. Marx. Weichen Sie auf die Linien U3, O, 71, 74 A, 77 A und die S-Bahn aus. Grund dafür s …]]></description>
@@ -179,97 +201,117 @@
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>4ead97e3caab804664057055348bb18eea92fe5f1b788b6168be11c8792edbd0</guid>
 <pubDate>Thu, 28 Aug 2025 10:00:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Thu, 28 Aug 2025 10:00:00 +0000</ext:starts_at>
 <ext:ends_at>Fri, 28 Aug 2026 09:11:00 +0000</ext:ends_at>
-<description><![CDATA[Straßenbauarbeiten • Wegen Bauarbeiten im Bereich Leo-Mathauser-Gasse wird die Linie 61 A umgeleitet. • Zeitraum: Ab Dienstag, 2. September 2025, etwa 07:00 Uhr auf Dauer …]]></description>
+<description><![CDATA[Straßenbauarbeiten
+Wegen Bauarbeiten im Bereich Leo-Mathauser-Gasse wird die Linie 61 A umgeleitet.
+Zeitraum: Ab Dienstag, 2. September 2025, etwa 07:00 Uhr auf Dauer …]]></description>
 </item>
 <item>
 <title><![CDATA[49A: Kurzführung ab 26.08.2025]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>212c9d4d39aa141b9d061920d3dc5ad6ac16c097b0c2a5658d3d67a9cf06fda8</guid>
 <pubDate>Wed, 20 Aug 2025 12:20:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Wed, 20 Aug 2025 12:20:00 +0000</ext:starts_at>
 <ext:ends_at>Thu, 20 Aug 2026 09:11:00 +0000</ext:ends_at>
-<description><![CDATA[Kurzführung / Haltestellenverlegung • Wegen Straßenbauarbeiten in der Salzwiesengasse wird die Linie 49 A umgeleitet. • Zeitraum: Ab 26. August 2025, etwa 07:00 Uhr für v …]]></description>
+<description><![CDATA[Kurzführung / Haltestellenverlegung
+Wegen Straßenbauarbeiten in der Salzwiesengasse wird die Linie 49 A umgeleitet.
+Zeitraum: Ab 26. August 2025, etwa 07:00 Uhr für v …]]></description>
 </item>
 <item>
 <title><![CDATA[11A: Umleitung Engerthstraße ab 23.08.2025]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>7458cad6f053dd22fb8d797e6870a19d692061d5248ab03e9d7d5b465a46a021</guid>
 <pubDate>Mon, 18 Aug 2025 12:30:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Mon, 18 Aug 2025 12:30:00 +0000</ext:starts_at>
 <ext:ends_at>Tue, 18 Aug 2026 09:11:00 +0000</ext:ends_at>
-<description><![CDATA[Bauarbeiten • Wegen Rohrlegungsarbeiten in der Engethstraße 213 wird diese zur Einbahnstraße umgewandelt und die Linie 11 A umgeleitet. • Zeitraum: Ab Samstag, 23. August …]]></description>
+<description><![CDATA[Bauarbeiten
+Wegen Rohrlegungsarbeiten in der Engethstraße 213 wird diese zur Einbahnstraße umgewandelt und die Linie 11 A umgeleitet.
+Zeitraum: Ab Samstag, 23. August …]]></description>
 </item>
 <item>
 <title><![CDATA[N20: Umleitung Schlosshofer Straße ab 11.08.2025]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>1726b0d02537732189d424e1d32801336b1f8a815bde9413b64e4062d8d8a61b</guid>
 <pubDate>Mon, 04 Aug 2025 10:30:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Mon, 04 Aug 2025 10:30:00 +0000</ext:starts_at>
 <ext:ends_at>Tue, 04 Aug 2026 09:11:00 +0000</ext:ends_at>
-<description><![CDATA[Umleitung • Wegen Gleisbauarbeiten in der Schlosshofer Straße müssen die Busse der Linie N20 umgeleitet werden. • Zeitraum: Ab 11. August 2025 (Nacht von 10. auf 11. Augu …]]></description>
+<description><![CDATA[Umleitung
+Wegen Gleisbauarbeiten in der Schlosshofer Straße müssen die Busse der Linie N20 umgeleitet werden.
+Zeitraum: Ab 11. August 2025 (Nacht von 10. auf 11. Augu …]]></description>
 </item>
 <item>
 <title><![CDATA[29A/29B: Umleitung ab 04.08.2025]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>6e4177e16bcc0a2b04b0dc1cfd337a16495b81def430bbc4f8018d760528e3c7</guid>
 <pubDate>Mon, 28 Jul 2025 12:40:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Mon, 28 Jul 2025 12:40:00 +0000</ext:starts_at>
 <ext:ends_at>Tue, 28 Jul 2026 09:11:00 +0000</ext:ends_at>
-<description><![CDATA[Straßenbauarbeiten • Wegen Straßenbauarbeiten in der Leopoldauer Straße müssen die Busse neuerlich umgeleitet werden. • Zeitraum: Montag, 4. August 2025 Betriebsbeginn bi …]]></description>
+<description><![CDATA[Straßenbauarbeiten
+Wegen Straßenbauarbeiten in der Leopoldauer Straße müssen die Busse neuerlich umgeleitet werden.
+Zeitraum: Montag, 4. August 2025 Betriebsbeginn bi …]]></description>
 </item>
 <item>
 <title><![CDATA[27A/28A/29A: Erntedankfest 2025 am 28.09.2025]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>adfefef3364504c7fe78c9764c622a358206286461637423dc807dbcbf98b85f</guid>
 <pubDate>Fri, 25 Jul 2025 04:05:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Fri, 25 Jul 2025 04:05:00 +0000</ext:starts_at>
 <ext:ends_at>Sun, 28 Sep 2025 14:00:00 +0000</ext:ends_at>
-<description><![CDATA[Veranstaltung • Wegen Abhaltung des Erntedankfestes am Leopoldauer Platz müssen die Autobuslinien im genannten Bereich umgeleitet werden. • Zeitraum: Sonntag, den 28. Sep …]]></description>
+<description><![CDATA[Veranstaltung
+Wegen Abhaltung des Erntedankfestes am Leopoldauer Platz müssen die Autobuslinien im genannten Bereich umgeleitet werden.
+Zeitraum: Sonntag, den 28. Sep …]]></description>
 </item>
 <item>
 <title><![CDATA[1/1A/2/2A/31/3A/71/74A/D: Vienna Night Run am 25.09.2025]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>21a4b95df14ea5792c7b8f93440e57bc726c599ee02eec407e794de996587897</guid>
 <pubDate>Wed, 09 Jul 2025 12:00:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Wed, 09 Jul 2025 12:00:00 +0000</ext:starts_at>
 <ext:ends_at>Thu, 25 Sep 2025 19:00:00 +0000</ext:ends_at>
-<description><![CDATA[Veranstaltung • Wegen einer Laufveranstaltung kommt es zu Einschränkungen bei den Linien D, 1, 2, 31, 71, 1 A, 2 A, 3 A und 74 A. • Zeitraum: Donnerstag, 25. September 20 …]]></description>
+<description><![CDATA[Veranstaltung
+Wegen einer Laufveranstaltung kommt es zu Einschränkungen bei den Linien D, 1, 2, 31, 71, 1 A, 2 A, 3 A und 74 A.
+Zeitraum: Donnerstag, 25. September 20 …]]></description>
 </item>
 <item>
 <title><![CDATA[2A: Bauarbeiten Renngasse ab 14.07.2025]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>01c9f4ff8e2a95c1daa67093e9fb371618e5d7c7d3cc36a78465221712a0ca86</guid>
 <pubDate>Mon, 07 Jul 2025 11:16:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Mon, 07 Jul 2025 11:16:00 +0000</ext:starts_at>
 <ext:ends_at>Tue, 07 Jul 2026 09:11:00 +0000</ext:ends_at>
-<description><![CDATA[Bauarbeiten • Wegen Rohrlegungsarbeiten in der Renngasse wir die Linie 2 A umgeleitet. • Zeitraum: Montag, 14. Juli 2025, 06:30 Uhr bis voraussichtlich Ende November 2025 …]]></description>
+<description><![CDATA[Bauarbeiten
+Wegen Rohrlegungsarbeiten in der Renngasse wir die Linie 2 A umgeleitet.
+Zeitraum: Montag, 14. Juli 2025, 06:30 Uhr bis voraussichtlich Ende November 2025 …]]></description>
 </item>
 <item>
 <title><![CDATA[77A: Bauarbeiten, Umleitung über A23]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>d1297817ee10718651d484a8940d921a33ea574775f089682c8b7548d336d46d</guid>
 <pubDate>Tue, 24 Jun 2025 22:00:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Tue, 24 Jun 2025 22:00:00 +0000</ext:starts_at>
 <ext:ends_at>Sat, 01 Aug 2026 09:11:00 +0000</ext:ends_at>
-<description><![CDATA[Bauarbeiten • Wegen großräumigen Bauarbeiten wird die Linie 77 A umgeleitet. • Update (25.06.2025)! • Über die Sommermonate kommt es zu einer geänderten Umleitung. • Zeit …]]></description>
+<description><![CDATA[Bauarbeiten
+Wegen großräumigen Bauarbeiten wird die Linie 77 A umgeleitet.
+Update (25.06.2025)!
+Über die Sommermonate kommt es zu einer geänderten Umleitung.
+Zeit …]]></description>
 </item>
 <item>
 <title><![CDATA[77A: Gleisbauarbeiten]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>3dcf0210270641b46748f117a05cae54687efe642e0a4fa99f7baa012c5385a0</guid>
 <pubDate>Wed, 11 Jun 2025 10:10:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Wed, 11 Jun 2025 10:10:00 +0000</ext:starts_at>
 <ext:ends_at>Fri, 04 Sep 2026 23:00:00 +0000</ext:ends_at>
 <description><![CDATA[Die Linie 77 A wird in Richtung Lusthaus zwischen Ludwig-Koeßler-Platz und Donaumarina über die Südosttangente A23 umgeleitet. In Richtung Rennweg wird über die normale R …]]></description>
@@ -279,37 +321,43 @@
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>03219c6c88ffc4859d5f0fb6813dba10dcd3af2f62b275944cae2f51ff065c22</guid>
 <pubDate>Tue, 03 Jun 2025 11:00:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Tue, 03 Jun 2025 11:00:00 +0000</ext:starts_at>
 <ext:ends_at>Mon, 22 Sep 2025 03:00:00 +0000</ext:ends_at>
-<description><![CDATA[Gleisbauarbeiten • Wegen Gleisbauarbeiten im Bereich Jörgerstraße wird die Linie N43 umgeleitet. • Zeitraum: Ab Mittwoch, 11. Juni 2025 Betriebsbeginn (Nacht von 10. auf …]]></description>
+<description><![CDATA[Gleisbauarbeiten
+Wegen Gleisbauarbeiten im Bereich Jörgerstraße wird die Linie N43 umgeleitet.
+Zeitraum: Ab Mittwoch, 11. Juni 2025 Betriebsbeginn (Nacht von 10. auf …]]></description>
 </item>
 <item>
 <title><![CDATA[N38: Umleitung über Liechtensteinstraße bis Ende September 2025]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>79dd50bb6ad0010930215eaac1ffd42f90299ec3830d9d137602ec7bccb252f4</guid>
 <pubDate>Wed, 28 May 2025 08:45:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Wed, 28 May 2025 08:45:00 +0000</ext:starts_at>
 <ext:ends_at>Thu, 28 May 2026 09:11:00 +0000</ext:ends_at>
-<description><![CDATA[Bauarbeiten • Wegen Rohrlegungsarbeiten und den darauffolgenden Instandsetzungsarbeiten muss die Linie N38 umgeleitet werden. • Zeitraum: Ab Donnerstag, 5. Juni 2025 bis …]]></description>
+<description><![CDATA[Bauarbeiten
+Wegen Rohrlegungsarbeiten und den darauffolgenden Instandsetzungsarbeiten muss die Linie N38 umgeleitet werden.
+Zeitraum: Ab Donnerstag, 5. Juni 2025 bis …]]></description>
 </item>
 <item>
 <title><![CDATA[40A: Umleitung über Währinger Straße bis Ende September 2025]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>273be19ba4a7384577da847d6b90c251b11283f483b8950af18ea9fb2f2e232b</guid>
 <pubDate>Mon, 26 May 2025 11:15:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Mon, 26 May 2025 11:15:00 +0000</ext:starts_at>
 <ext:ends_at>Tue, 26 May 2026 09:11:00 +0000</ext:ends_at>
-<description><![CDATA[Bauarbeiten • Wegen Rohrlegungsarbeiten und Instandsetzungsarbeiten in der Alserbachstraße muss die Linie 40 A umgeleitet werden. • Zeitraum: Ab Mittwoch, 4. Juni 2025 Be …]]></description>
+<description><![CDATA[Bauarbeiten
+Wegen Rohrlegungsarbeiten und Instandsetzungsarbeiten in der Alserbachstraße muss die Linie 40 A umgeleitet werden.
+Zeitraum: Ab Mittwoch, 4. Juni 2025 Be …]]></description>
 </item>
 <item>
 <title><![CDATA[U6: Bauarbeiten]]></title>
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>c8fe425d7242fb213ce8416c7e36d3307750aef3cd584dd26b6b881c88e54d42</guid>
 <pubDate>Sun, 11 May 2025 22:55:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Sun, 11 May 2025 22:55:00 +0000</ext:starts_at>
 <ext:ends_at>Wed, 31 Dec 2025 21:55:00 +0000</ext:ends_at>
 <description><![CDATA[Wegen Bauarbeiten kann die Station Tscherttegasse U in Fahrtrichtung Floridsdorf S U nicht eingehalten werden. Um die Station Tscherttegasse U zu erreichen, fahren Sie ei …]]></description>
@@ -319,10 +367,13 @@
 <link>https://www.wienerlinien.at/ogd_realtime</link>
 <guid>ee448e1c1219fb2329c135f6b8016a2c3ebe008a7dad51da62f93b910442a352</guid>
 <pubDate>Wed, 02 Apr 2025 12:00:00 +0000</pubDate>
-<ext:first_seen>Mon, 15 Sep 2025 11:34:19 +0000</ext:first_seen>
+<ext:first_seen>Mon, 15 Sep 2025 12:03:06 +0000</ext:first_seen>
 <ext:starts_at>Wed, 02 Apr 2025 12:00:00 +0000</ext:starts_at>
 <ext:ends_at>Thu, 02 Apr 2026 09:11:00 +0000</ext:ends_at>
-<description><![CDATA[Rohrleitungsarbeiten im Bereich Engerthstraße • Zeitraum: Ab Donnerstag, den 17. April 2025, etwa 07:00 Uhr auf Dauer von etwa zehn Wochen • Maßnahmen: Linie N81 • Umleit …]]></description>
+<description><![CDATA[Rohrleitungsarbeiten im Bereich Engerthstraße
+Zeitraum: Ab Donnerstag, den 17. April 2025, etwa 07:00 Uhr auf Dauer von etwa zehn Wochen
+Maßnahmen: Linie N81
+Umleit …]]></description>
 </item>
 </channel>
 </rss>


### PR DESCRIPTION
## Summary
- Regenerate `docs/feed.xml` using current defaults
- Update validator output after verifying RSS and GUID uniqueness

## Testing
- `rg '<guid>.*</guid>' -o docs/feed.xml | sed -E 's/<guid>(.*)<\/guid>/\1/' | sort | uniq -d`
- `python - <<'PY'
import xml.etree.ElementTree as ET
root = ET.parse('docs/feed.xml').getroot()
guids = [g.text for g in root.findall('.//guid')]
print('total', len(guids), 'unique', len(set(guids)))
PY`
- `xmllint --noout docs/feed.xml`
- `python - <<'PY'
import feedparser
feed = feedparser.parse('docs/feed.xml')
print(f'bozo: {feed.bozo}')
if feed.bozo:
    print(f'bozo_exception: {feed.bozo_exception}')
else:
    print('feed is well-formed')
print(f'entries: {len(feed.entries)}')
PY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c800245818832babba2afef6ca05aa