### PR TITLE
feat: update feed defaults

### DIFF
--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -22,12 +22,12 @@ jobs:
       FEED_TITLE: "ÖPNV Störungen Wien & Umgebung"
       FEED_LINK: "https://github.com/${{ github.repository }}"
       FEED_DESC: "Aktive Störungen/Baustellen/Einschränkungen aus offiziellen Quellen"
-      FEED_TTL: "15"
+      FEED_TTL: "15"               # Cache-Haltbarkeit in Minuten
       LOG_LEVEL: INFO
       DESCRIPTION_CHAR_LIMIT: "170"
       MAX_ITEMS: "60"
-      MAX_ITEM_AGE_DAYS: "365"
-      ABSOLUTE_MAX_AGE_DAYS: "540"
+      MAX_ITEM_AGE_DAYS: "365"     # Entferne Items älter als diese Tage
+      ABSOLUTE_MAX_AGE_DAYS: "540" # Harte Obergrenze für Item-Alter
 
       # --- Persistenter State ---
       STATE_PATH: "data/first_seen.json"

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -97,13 +97,22 @@ OUT_PATH = os.getenv("OUT_PATH", "docs/feed.xml")
 FEED_TITLE = os.getenv("FEED_TITLE", "ÖPNV Störungen Wien & Umgebung")
 FEED_LINK = os.getenv("FEED_LINK", "https://github.com/Origamihase/wien-oepnv")
 FEED_DESC = os.getenv("FEED_DESC", "Aktive Störungen/Baustellen/Einschränkungen aus offiziellen Quellen")
-FEED_TTL = max(_get_int_env("FEED_TTL", 15), 0)
+# Defaultwerte für die Feed-Erzeugung
+DEFAULT_FEED_TTL = 15
+DEFAULT_MAX_ITEM_AGE_DAYS = 365
+DEFAULT_ABSOLUTE_MAX_AGE_DAYS = 540
+
+FEED_TTL = max(_get_int_env("FEED_TTL", DEFAULT_FEED_TTL), 0)
 
 DESCRIPTION_CHAR_LIMIT = max(_get_int_env("DESCRIPTION_CHAR_LIMIT", 170), 0)
 FRESH_PUBDATE_WINDOW_MIN = _get_int_env("FRESH_PUBDATE_WINDOW_MIN", 5)
 MAX_ITEMS = max(_get_int_env("MAX_ITEMS", 60), 0)
-MAX_ITEM_AGE_DAYS = max(_get_int_env("MAX_ITEM_AGE_DAYS", 365), 0)
-ABSOLUTE_MAX_AGE_DAYS = max(_get_int_env("ABSOLUTE_MAX_AGE_DAYS", 540), 0)
+MAX_ITEM_AGE_DAYS = max(
+    _get_int_env("MAX_ITEM_AGE_DAYS", DEFAULT_MAX_ITEM_AGE_DAYS), 0
+)
+ABSOLUTE_MAX_AGE_DAYS = max(
+    _get_int_env("ABSOLUTE_MAX_AGE_DAYS", DEFAULT_ABSOLUTE_MAX_AGE_DAYS), 0
+)
 ENDS_AT_GRACE_MINUTES = max(_get_int_env("ENDS_AT_GRACE_MINUTES", 10), 0)
 PROVIDER_TIMEOUT = max(_get_int_env("PROVIDER_TIMEOUT", 25), 0)
 

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -2,6 +2,7 @@ import importlib
 import sys
 from pathlib import Path
 import types
+import pytest
 
 
 def _import_build_feed(monkeypatch):
@@ -24,11 +25,17 @@ def _import_build_feed(monkeypatch):
     return importlib.import_module(module_name)
 
 
-def test_default_age_and_ttl(monkeypatch):
+@pytest.mark.parametrize(
+    "attr, expected",
+    [
+        ("FEED_TTL", 15),
+        ("MAX_ITEM_AGE_DAYS", 365),
+        ("ABSOLUTE_MAX_AGE_DAYS", 540),
+    ],
+)
+def test_default_age_and_ttl(monkeypatch, attr, expected):
     monkeypatch.delenv("FEED_TTL", raising=False)
     monkeypatch.delenv("MAX_ITEM_AGE_DAYS", raising=False)
     monkeypatch.delenv("ABSOLUTE_MAX_AGE_DAYS", raising=False)
     build_feed = _import_build_feed(monkeypatch)
-    assert build_feed.FEED_TTL == 15
-    assert build_feed.MAX_ITEM_AGE_DAYS == 365
-    assert build_feed.ABSOLUTE_MAX_AGE_DAYS == 540
+    assert getattr(build_feed, attr) == expected


### PR DESCRIPTION
## Summary
- centralize default constants for feed TTL and item age
- document feed defaults in build workflow
- parametrize tests for new default values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c80166b56c832ba7fae1e8c0beabfd