### PR TITLE
Clear state on empty feed

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -435,16 +435,16 @@ def _make_rss(items: List[Dict[str, Any]], now: datetime, state: Dict[str, Dict[
     out.append("</channel>")
     out.append("</rss>")
 
-    # State nur für *aktuelle* Items speichern (kein Anwachsen)
-    if identities_in_feed:
-        pruned = {k: state[k] for k in identities_in_feed if k in state}
-        try:
-            _save_state(pruned)
-        except Exception as e:
-            log.warning(
-                "State speichern fehlgeschlagen (%s) – Feed wird trotzdem zurückgegeben.",
-                e,
-            )
+    # State nur für *aktuelle* Items speichern (kein Anwachsen). Ist der Feed
+    # leer, speichern wir einen leeren State, um veraltete GUIDs zu entfernen.
+    pruned = {k: state[k] for k in identities_in_feed if k in state} if identities_in_feed else {}
+    try:
+        _save_state(pruned)
+    except Exception as e:
+        log.warning(
+            "State speichern fehlgeschlagen (%s) – Feed wird trotzdem zurückgegeben.",
+            e,
+        )
 
     return "\n".join(out)
 

--- a/tests/test_state_save_readonly.py
+++ b/tests/test_state_save_readonly.py
@@ -46,20 +46,24 @@ def test_make_rss_logs_warning_when_state_readonly(monkeypatch, caplog):
     assert any("State speichern fehlgeschlagen" in r.message for r in caplog.records)
 
 
-def test_make_rss_skips_state_save_when_no_identities(monkeypatch, caplog):
+def test_make_rss_saves_empty_state_when_no_identities(monkeypatch, caplog):
     build_feed = _import_build_feed(monkeypatch)
 
-    called = {"val": False}
+    captured = {"state": None}
 
-    def marker(_):  # pragma: no cover - trivial
-        called["val"] = True
+    def marker(state):  # pragma: no cover - trivial
+        captured["state"] = state
 
     monkeypatch.setattr(build_feed, "_save_state", marker)
 
     with caplog.at_level(logging.WARNING):
-        rss = build_feed._make_rss([], datetime.now(timezone.utc), {})
+        rss = build_feed._make_rss(
+            [],
+            datetime.now(timezone.utc),
+            {"old": {"first_seen": datetime.now(timezone.utc).isoformat()}},
+        )
 
     assert "</rss>" in rss
-    assert called["val"] is False
+    assert captured["state"] == {}
     assert not any("State speichern fehlgeschlagen" in r.message for r in caplog.records)
 


### PR DESCRIPTION
## Summary
- always save empty state when feed has no items to remove stale GUIDs
- test that empty feed clears stored state
- update tests to expect state save on empty feed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c80277cc78832bb24db6b19e85b0c6