### PR TITLE
Skip max-age for future-ended items

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -343,7 +343,11 @@ def _drop_old_items(items: List[Dict[str, Any]], now: datetime) -> List[Dict[str
             if age_days > ABSOLUTE_MAX_AGE_DAYS:
                 continue
             if age_days > MAX_ITEM_AGE_DAYS:
-                continue
+                if not (
+                    isinstance(ends_at, datetime)
+                    and _to_utc(ends_at) > _to_utc(now)
+                ):
+                    continue
         out.append(it)
     return out
 

--- a/tests/test_drop_old_items_future.py
+++ b/tests/test_drop_old_items_future.py
@@ -1,0 +1,46 @@
+import importlib
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import types
+
+
+def _import_build_feed(monkeypatch, env=None):
+    module_name = "src.build_feed"
+    root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(root))
+    monkeypatch.syspath_prepend(str(root / "src"))
+    providers = types.ModuleType("providers")
+    wl = types.ModuleType("providers.wiener_linien")
+    wl.fetch_events = lambda: []
+    oebb = types.ModuleType("providers.oebb")
+    oebb.fetch_events = lambda: []
+    monkeypatch.setitem(sys.modules, "providers", providers)
+    monkeypatch.setitem(sys.modules, "providers.wiener_linien", wl)
+    monkeypatch.setitem(sys.modules, "providers.oebb", oebb)
+    env = env or {}
+    for k, v in env.items():
+        monkeypatch.setenv(k, str(v))
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_future_ends_at_skips_max_age(monkeypatch):
+    build_feed = _import_build_feed(
+        monkeypatch,
+        {"MAX_ITEM_AGE_DAYS": "365", "ABSOLUTE_MAX_AGE_DAYS": "540"},
+    )
+    now = datetime.now(timezone.utc)
+    future = {
+        "title": "future",
+        "pubDate": now - timedelta(days=400),
+        "ends_at": now + timedelta(days=1),
+    }
+    no_end = {"title": "no_end", "pubDate": now - timedelta(days=400)}
+    too_old = {
+        "title": "too_old",
+        "pubDate": now - timedelta(days=541),
+        "ends_at": now + timedelta(days=1),
+    }
+    res = build_feed._drop_old_items([future, no_end, too_old], now)
+    assert res == [future]


### PR DESCRIPTION
## Summary
- Skip MAX_ITEM_AGE_DAYS check when an item's `ends_at` is in the future
- Add regression test covering future `ends_at`, missing `ends_at`, and over-age items

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c80b046128832ba93b472675118b5c