### PR TITLE
Mask VOR accessId in stationboard errors

### DIFF
--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -134,6 +134,10 @@ def _fetch_stationboard(station_id: str, now_local: datetime) -> Optional[ET.Ele
             log.warning("VOR StationBoard %s -> HTTP %s", station_id, resp.status_code)
             return None
         return ET.fromstring(resp.content)
+    except requests.RequestException as e:
+        msg = re.sub(r"accessId=[^&]+", "accessId=***", str(e))
+        log.error("VOR StationBoard Fehler (%s): %s", station_id, msg)
+        return None
     except Exception as e:
         log.exception("VOR StationBoard Fehler (%s): %s", station_id, e)
         return None

--- a/tests/test_vor_accessid_not_logged.py
+++ b/tests/test_vor_accessid_not_logged.py
@@ -1,0 +1,34 @@
+import importlib
+import logging
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import requests
+import src.providers.vor as vor
+
+
+def test_accessid_not_logged(monkeypatch, caplog):
+    monkeypatch.setenv("VOR_ACCESS_ID", "secret")
+    importlib.reload(vor)
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, *args, **kwargs):
+            raise requests.RequestException(f"boom accessId={vor.VOR_ACCESS_ID}")
+
+    monkeypatch.setattr(vor, "_session", lambda: DummySession())
+    now_local = datetime.now(ZoneInfo("Europe/Vienna"))
+
+    with caplog.at_level(logging.ERROR):
+        vor._fetch_stationboard("123", now_local)
+
+    assert f"accessId={vor.VOR_ACCESS_ID}" not in caplog.text
+    assert "accessId=***" in caplog.text
+
+    monkeypatch.delenv("VOR_ACCESS_ID", raising=False)
+    importlib.reload(vor)


### PR DESCRIPTION
## Summary
- sanitize VOR station board error handling to hide accessId
- add regression test for accessId masking in logs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c81dedf6c0832b877cae685d8c97b0