### PR TITLE
Normalize VOR XML namespaces

### DIFF
--- a/tests/test_vor_namespace.py
+++ b/tests/test_vor_namespace.py
@@ -1,0 +1,17 @@
+import xml.etree.ElementTree as ET
+
+import src.providers.vor as vor
+
+
+def test_iter_messages_handles_namespace():
+    xml = (
+        "<ns:Root xmlns:ns='urn:test'>"
+        "<ns:Messages>"
+        "<ns:Message id='1' act='true'/>"
+        "</ns:Messages>"
+        "</ns:Root>"
+    )
+    root = ET.fromstring(xml)
+    vor._strip_ns(root)
+    messages = list(vor._iter_messages(root))
+    assert len(messages) == 1


### PR DESCRIPTION
## Summary
- strip XML namespaces from VOR stationboard responses
- exercise `_iter_messages` with namespaced XML in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c81f0d1edc832bb2bfbece481d3557