### PR TITLE
feat(vor): prefix titles with lines

### DIFF
--- a/tests/test_vor_title_prefix.py
+++ b/tests/test_vor_title_prefix.py
@@ -1,0 +1,16 @@
+import xml.etree.ElementTree as ET
+
+import src.providers.vor as vor
+
+
+def test_title_has_line_prefix():
+    xml = (
+        "<Root><Messages>"
+        "<Message id='1' act='true' head='Baustelle …'>"
+        "<products><Product catOutS='S' displayNumber='1'/></products>"
+        "</Message></Messages></Root>"
+    )
+    root = ET.fromstring(xml)
+    items = vor._collect_from_board("123", root)
+    assert len(items) == 1
+    assert items[0]["title"] == "S1: Baustelle …"


### PR DESCRIPTION
## Summary
- strip duplicates and bracketed extras from VOR lines
- prefix event titles with affected line numbers
- test title prefix for VOR events

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c82192f37c832bb925c8035a90763c