### PR TITLE
Add fuzzy identity hash to preserve first_seen across GUID changes

### DIFF
--- a/tests/test_first_seen_fuzzy.py
+++ b/tests/test_first_seen_fuzzy.py
@@ -1,0 +1,62 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+from datetime import datetime, timezone, timedelta
+
+
+def _import_build_feed(monkeypatch, tmp_path):
+    module_name = "src.build_feed"
+    root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(root))
+    monkeypatch.syspath_prepend(str(root / "src"))
+    providers = types.ModuleType("providers")
+    wl = types.ModuleType("providers.wiener_linien")
+    wl.fetch_events = lambda: []
+    oebb = types.ModuleType("providers.oebb")
+    oebb.fetch_events = lambda: []
+    vor = types.ModuleType("providers.vor")
+    vor.fetch_events = lambda: []
+    monkeypatch.setitem(sys.modules, "providers", providers)
+    monkeypatch.setitem(sys.modules, "providers.wiener_linien", wl)
+    monkeypatch.setitem(sys.modules, "providers.oebb", oebb)
+    monkeypatch.setitem(sys.modules, "providers.vor", vor)
+    sys.modules.pop(module_name, None)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("STATE_PATH", "data/state.json")
+    return importlib.import_module(module_name)
+
+
+def test_first_seen_fuzzy_identity(monkeypatch, tmp_path):
+    build_feed = _import_build_feed(monkeypatch, tmp_path)
+    now = datetime.now(timezone.utc)
+    item_a = {
+        "source": "oebb",
+        "category": "test",
+        "guid": "A",
+        "title": "Störung",
+        "starts_at": now,
+        "ends_at": now,
+    }
+    item_b = {
+        "source": "oebb",
+        "category": "test",
+        "guid": "B",
+        "title": "Störung",
+        "starts_at": now,
+        "ends_at": now,
+    }
+
+    state = build_feed._load_state()
+    build_feed._make_rss([item_a], now, state)
+    state_after_first = build_feed._load_state()
+    assert len(state_after_first) == 1
+    ident = next(iter(state_after_first.keys()))
+    first_seen = state_after_first[ident]["first_seen"]
+
+    state = build_feed._load_state()
+    build_feed._make_rss([item_b], now + timedelta(hours=1), state)
+    state_after_second = build_feed._load_state()
+    assert len(state_after_second) == 1
+    assert ident in state_after_second
+    assert state_after_second[ident]["first_seen"] == first_seen


### PR DESCRIPTION
## Summary
- Build a fuzzy identity hash from title and times to make item identities stable across GUID changes
- Test that first_seen remains unchanged when items only differ in GUID

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8237d1280832bb44023416ec59563