### PR TITLE
ci: run tests before building feed

### DIFF
--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -73,6 +73,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Run tests
+        run: pytest -q
+
       # ------------------------------------------------------------
       # (Optional) VOR Stationen ermitteln – nur wenn Zugang vorhanden
       # ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- run `pytest -q` in build-feed workflow before feed generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c824a9f004832b86a9c3ab37898509