### PR TITLE
Add tests for VOR location and stationboard XML

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.32.0,<3
 python-dateutil>=2.9,<3
 defusedxml>=0.7.1,<1
 pytest>=8.0,<9
+responses>=0.25,<1

--- a/tests/test_vor_location_name.py
+++ b/tests/test_vor_location_name.py
@@ -1,0 +1,17 @@
+import requests
+import responses
+
+import src.providers.vor as vor
+
+
+@responses.activate
+def test_location_name_contains_stoplocation():
+    url = f"{vor.VOR_BASE}/{vor.VOR_VERSION}/location.name"
+    payload = {"StopLocation": [{"id": "1", "name": "Wien"}]}
+    responses.add(responses.GET, url, json=payload, status=200)
+
+    resp = requests.get(url)
+    data = resp.json()
+
+    assert isinstance(data.get("StopLocation"), list)
+    assert len(data["StopLocation"]) >= 1

--- a/tests/test_vor_stationboard_xml.py
+++ b/tests/test_vor_stationboard_xml.py
@@ -1,0 +1,17 @@
+from defusedxml import ElementTree as ET
+
+import src.providers.vor as vor
+
+
+def test_iter_messages_returns_element():
+    xml = """
+    <DepartureBoard>
+        <Messages>
+            <Message id="1" />
+        </Messages>
+    </DepartureBoard>
+    """
+    root = ET.fromstring(xml)
+    messages = list(vor._iter_messages(root))
+    assert len(messages) >= 1
+    assert messages[0].get("id") == "1"


### PR DESCRIPTION
## Summary
- add `responses` dependency for HTTP mocking
- test that mocked `location.name` returns a StopLocation
- ensure `_iter_messages` yields elements from a simple DepartureBoard XML

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c825810e78832bbc4e8eb5792824c8