### PR TITLE
chore: bump VOR API version to v1.11.0

### DIFF
--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -48,7 +48,7 @@ jobs:
       # --- VOR/VAO Zugang (Discovery nur wenn gesetzt) ---
       VOR_ACCESS_ID: ${{ secrets.VOR_ACCESS_ID }}
       VOR_BASE: "https://routenplaner.verkehrsauskunft.at/vao/restproxy"
-      VOR_VERSION: "v1.3"
+      VOR_VERSION: "v1.11.0"
 
       # --- VOR Feintuning ---
       VOR_ALLOW_BUS: "1"

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -44,7 +44,7 @@ def _get_int_env(name: str, default: int) -> int:
 VOR_ACCESS_ID: str | None = (os.getenv("VOR_ACCESS_ID") or os.getenv("VAO_ACCESS_ID") or "").strip() or None
 VOR_STATION_IDS: List[str] = [s.strip() for s in (os.getenv("VOR_STATION_IDS") or "").split(",") if s.strip()]
 VOR_BASE = os.getenv("VOR_BASE", "https://routenplaner.verkehrsauskunft.at/vao/restproxy")
-VOR_VERSION = os.getenv("VOR_VERSION", "v1.3")
+VOR_VERSION = os.getenv("VOR_VERSION", "v1.11.0")
 BOARD_DURATION_MIN = _get_int_env("VOR_BOARD_DURATION_MIN", 60)
 HTTP_TIMEOUT = _get_int_env("VOR_HTTP_TIMEOUT", 15)
 MAX_STATIONS_PER_RUN = _get_int_env("VOR_MAX_STATIONS_PER_RUN", 2)


### PR DESCRIPTION
## Summary
- update default VOR API version to v1.11.0
- align build-feed workflow with new VOR API version

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c82aaaeb04832ba572c084b261a9cb