### PR TITLE
Handle ÖBB rate limiting

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from email.utils import parsedate_to_datetime
@@ -202,10 +203,38 @@ def _keep_by_region(title: str, desc: str) -> bool:
     return False
 
 # ---------------- Fetch/Parse ----------------
-def _fetch_xml(url: str, timeout: int = 25) -> ET.Element:
+def _fetch_xml(url: str, timeout: int = 25) -> Optional[ET.Element]:
     with _session() as s:
         r = s.get(url, timeout=timeout)
-        r.raise_for_status()
+        status = getattr(r, "status_code", None)
+        headers = getattr(r, "headers", {}) or {}
+        if status == 429:
+            retry_after = headers.get("Retry-After")
+            log.warning("ÖBB RSS Rate-Limit (Retry-After: %s)", retry_after)
+            if retry_after:
+                wait_seconds: Optional[float] = None
+                try:
+                    wait_seconds = float(retry_after)
+                except (TypeError, ValueError):
+                    try:
+                        retry_dt = parsedate_to_datetime(str(retry_after))
+                    except (TypeError, ValueError, OverflowError):
+                        wait_seconds = None
+                    else:
+                        if retry_dt is not None:
+                            if retry_dt.tzinfo is None:
+                                retry_dt = retry_dt.replace(tzinfo=timezone.utc)
+                            delta = (retry_dt - datetime.now(timezone.utc)).total_seconds()
+                            wait_seconds = max(0.0, delta)
+                if wait_seconds and wait_seconds > 0:
+                    try:
+                        time.sleep(wait_seconds)
+                    except Exception as sleep_err:
+                        log.warning("ÖBB RSS Wartezeit fehlgeschlagen: %s", sleep_err)
+            return None
+        if status is not None and status >= 400:
+            log.warning("ÖBB RSS HTTP-Fehler: Status %s", status)
+            return None
         return ET.fromstring(r.content)
 
 def _get_text(elem: Optional[ET.Element], tag: str) -> str:
@@ -226,7 +255,11 @@ def fetch_events(timeout: int = 25) -> List[Dict[str, Any]]:
     try:
         root = _fetch_xml(OEBB_URL, timeout=timeout)
     except Exception as e:
-        log.exception("ÖBB RSS abruf fehlgeschlagen: %s", e)
+        msg = str(e).replace(OEBB_URL, "***")
+        log.exception("ÖBB RSS abruf fehlgeschlagen: %s", msg)
+        return []
+
+    if root is None:
         return []
 
     channel = root.find("channel")

--- a/tests/test_oebb_rate_limit.py
+++ b/tests/test_oebb_rate_limit.py
@@ -1,0 +1,42 @@
+import logging
+
+import src.providers.oebb as oebb
+
+
+def test_rate_limit_logs_and_sleeps(monkeypatch, caplog):
+    class DummyResponse:
+        status_code = 429
+        headers = {"Retry-After": "1.5"}
+        content = b""
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, url, timeout):
+            return DummyResponse()
+
+    monkeypatch.setattr(oebb, "_session", lambda: DummySession())
+
+    slept = []
+
+    def fake_sleep(seconds):
+        slept.append(seconds)
+        raise RuntimeError("sleep failed")
+
+    monkeypatch.setattr(oebb.time, "sleep", fake_sleep)
+
+    caplog.set_level(logging.WARNING, logger=oebb.log.name)
+
+    result = oebb._fetch_xml("https://example.com", timeout=1)
+
+    assert result is None
+    assert slept == [1.5]
+
+    log_text = caplog.text
+    assert "Rate-Limit" in log_text
+    assert "https://example.com" not in log_text
+    assert oebb.OEBB_URL not in log_text

--- a/tests/test_oebb_timeout.py
+++ b/tests/test_oebb_timeout.py
@@ -24,6 +24,8 @@ def test_fetch_xml_passes_timeout_to_session(monkeypatch):
 
     class DummyResponse:
         content = b"<rss/>"
+        status_code = 200
+        headers = {}
 
         def raise_for_status(self):
             pass


### PR DESCRIPTION
## Summary
- extend the ÖBB RSS fetcher to handle HTTP errors gracefully, including waiting on 429 Retry-After values
- sanitise logging and return early when no XML was fetched
- cover the new behaviour with a dedicated rate-limit test and adjust the timeout test harness

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c82fda4238832b974394e37f003217