### PR TITLE
Handle invalid VOR Retry-After header

### DIFF
--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -155,7 +155,14 @@ def _fetch_stationboard(station_id: str, now_local: datetime) -> Optional[ET.Ele
         retry_after = resp.headers.get("Retry-After")
         if resp.status_code == 429 and retry_after:
             log.warning("VOR StationBoard %s -> HTTP 429, Retry-After %s", station_id, retry_after)
-            time.sleep(int(retry_after))
+            try:
+                delay = float(retry_after)
+            except ValueError:
+                log.warning(
+                    "VOR StationBoard %s -> ungültiges Retry-After '%s'", station_id, retry_after
+                )
+            else:
+                time.sleep(delay)
             return None
         if resp.status_code >= 400:
             log.warning("VOR StationBoard %s -> HTTP %s", station_id, resp.status_code)

--- a/tests/test_vor_retry_after.py
+++ b/tests/test_vor_retry_after.py
@@ -1,0 +1,35 @@
+import logging
+from datetime import datetime
+
+import src.providers.vor as vor
+
+
+def test_retry_after_invalid_value(monkeypatch, caplog):
+    class DummyResponse:
+        status_code = 429
+        headers = {"Retry-After": "not-a-number"}
+        content = b""
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, url, params, timeout):
+            return DummyResponse()
+
+    monkeypatch.setattr(vor, "_session", lambda: DummySession())
+
+    def fake_sleep(seconds):
+        raise AssertionError("sleep should not be called")
+
+    monkeypatch.setattr(vor.time, "sleep", fake_sleep)
+
+    caplog.set_level(logging.WARNING, logger=vor.log.name)
+
+    result = vor._fetch_stationboard("123", datetime(2024, 1, 1, 12, 0))
+
+    assert result is None
+    assert any("ungültiges Retry-After" in message for message in caplog.messages)


### PR DESCRIPTION
## Summary
- parse Retry-After headers in the VOR stationboard fetch as floats and skip sleeping on invalid values
- add a regression test ensuring invalid Retry-After headers do not trigger exceptions

## Testing
- pytest tests/test_vor_retry_after.py

------
https://chatgpt.com/codex/tasks/task_e_68c8313b64c8832ba6522fce1e8293fc