### PR TITLE
Handle VAO rate limiting

### DIFF
--- a/tests/test_oebb_rate_limit.py
+++ b/tests/test_oebb_rate_limit.py
@@ -1,0 +1,33 @@
+import logging
+
+import src.providers.oebb as oebb
+
+
+def test_oebb_fetch_events_handles_rate_limit(monkeypatch, caplog):
+    sleep_calls = []
+
+    class DummyResponse:
+        status_code = 429
+        headers = {"Retry-After": "2.5"}
+        content = b""
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, timeout):
+            return DummyResponse()
+
+    monkeypatch.setattr(oebb, "_session", lambda: DummySession())
+    monkeypatch.setattr(oebb.time, "sleep", lambda delay: sleep_calls.append(delay))
+
+    with caplog.at_level(logging.DEBUG):
+        items = oebb.fetch_events(timeout=3)
+
+    assert items == []
+    assert sleep_calls == [2.5]
+    for rec in caplog.records:
+        assert oebb.OEBB_URL not in rec.getMessage()

--- a/tests/test_oebb_timeout.py
+++ b/tests/test_oebb_timeout.py
@@ -23,10 +23,9 @@ def test_fetch_xml_passes_timeout_to_session(monkeypatch):
     recorded = {}
 
     class DummyResponse:
+        status_code = 200
+        headers = {}
         content = b"<rss/>"
-
-        def raise_for_status(self):
-            pass
 
     class DummySession:
         def __enter__(self):

--- a/tests/test_vor_retry_after.py
+++ b/tests/test_vor_retry_after.py
@@ -1,0 +1,34 @@
+import logging
+from datetime import datetime
+
+import src.providers.vor as vor
+
+
+def test_vor_retry_after_invalid_header(monkeypatch, caplog):
+    sleep_calls = []
+
+    class DummyResponse:
+        status_code = 429
+        headers = {"Retry-After": "n/a"}
+        content = b""
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, params, timeout):
+            return DummyResponse()
+
+    monkeypatch.setattr(vor, "_session", lambda: DummySession())
+    monkeypatch.setattr(vor.time, "sleep", lambda delay: sleep_calls.append(delay))
+
+    now = datetime(2024, 1, 1, 8, 0, 0)
+    with caplog.at_level(logging.WARNING):
+        result = vor._fetch_stationboard("123", now)
+
+    assert result is None
+    assert sleep_calls == []
+    assert any("ungültiges Retry-After" in rec.getMessage() for rec in caplog.records)


### PR DESCRIPTION
## Summary
- respect Retry-After on the ÖBB RSS feed, mask secrets in error logs, and avoid raising on HTTP errors
- tolerate invalid Retry-After headers from the VOR stationboard endpoint while still backing off when possible
- extend the test-suite with rate-limit coverage and adjust existing timeout helpers

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c81d13c070832bba6829e5f7d69068