### PR TITLE
Filter line tokens parsed from titles

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -165,6 +165,8 @@ _CONTROL_RE = re.compile(
 )
 
 # Prefix pattern for line identifiers like "U1/U2: "
+_LINE_TOKEN_RE = re.compile(r"^(?:N\d{1,2}|\d{1,3}[A-Z]?|[A-Z])$")
+
 _LINE_PREFIX_RE = re.compile(
     r"^\s*([A-Za-z0-9]+(?:/[A-Za-z0-9]+){0,20})\s*:\s*"
 )
@@ -191,7 +193,11 @@ def _parse_lines_from_title(title: str) -> List[str]:
     m = _LINE_PREFIX_RE.match(title or "")
     if not m:
         return []
-    return m.group(1).split("/")
+    return [
+        token
+        for token in m.group(1).split("/")
+        if _LINE_TOKEN_RE.match(token)
+    ]
 
 def _ymd_or_none(dt: Optional[datetime]) -> str:
     if isinstance(dt, datetime):

--- a/tests/test_parse_lines_from_title.py
+++ b/tests/test_parse_lines_from_title.py
@@ -1,0 +1,9 @@
+from src.build_feed import _parse_lines_from_title
+
+
+def test_parse_lines_from_title_ignores_non_line_prefix():
+    assert _parse_lines_from_title("Neubaugasse 69: Sperre") == []
+
+
+def test_parse_lines_from_title_accepts_line_token():
+    assert _parse_lines_from_title("N81: Rohrleitungsarbeiten") == ["N81"]


### PR DESCRIPTION
## Summary
- add a regex to validate individual line tokens parsed from titles
- filter tokens using that regex before returning them from `_parse_lines_from_title`
- add regression tests that cover non-line prefixes and valid N-lines

## Testing
- pytest tests/test_parse_lines_from_title.py

------
https://chatgpt.com/codex/tasks/task_e_68c830f05528832ba131a9bd3d09da7d