### PR TITLE
chore: update VOR fallback version

### DIFF
--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -97,7 +97,7 @@ jobs:
           import requests
           ACCESS = os.environ.get("VOR_ACCESS_ID","").strip()
           BASE   = os.environ.get("VOR_BASE","").rstrip("/")
-          VER    = os.environ.get("VOR_VERSION","v1.3").strip()
+          VER    = os.environ.get("VOR_VERSION","v1.11.0").strip()
           OUT    = "data/vor_station_ids_wien.txt"
           if not ACCESS: sys.exit(0)
           session = requests.Session()

--- a/tests/test_vor_default_version.py
+++ b/tests/test_vor_default_version.py
@@ -1,0 +1,16 @@
+import importlib
+import os
+
+
+def test_default_vor_version():
+    module = importlib.import_module("src.providers.vor")
+    original_env = os.environ.pop("VOR_VERSION", None)
+    try:
+        reloaded = importlib.reload(module)
+        assert reloaded.VOR_VERSION == "v1.11.0"
+    finally:
+        if original_env is not None:
+            os.environ["VOR_VERSION"] = original_env
+        else:
+            os.environ.pop("VOR_VERSION", None)
+        importlib.reload(module)


### PR DESCRIPTION
## Summary
- update the workflow VOR discovery helper to default to v1.11.0 when no environment override is present
- add a pytest that reloads the VOR provider without VOR_VERSION to assert the fallback version stays at v1.11.0

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c83374ebe8832bbc6781c1018e5209