### PR TITLE
Handle Retry-After HTTP-date headers

### DIFF
--- a/tests/test_vor_retry_after.py
+++ b/tests/test_vor_retry_after.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 import src.providers.vor as vor
 
@@ -33,3 +33,76 @@ def test_retry_after_invalid_value(monkeypatch, caplog):
 
     assert result is None
     assert any("ungültiges Retry-After" in message for message in caplog.messages)
+
+
+def test_retry_after_numeric_value(monkeypatch):
+    class DummyResponse:
+        status_code = 429
+        headers = {"Retry-After": "3.5"}
+        content = b""
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, url, params, timeout):
+            return DummyResponse()
+
+    monkeypatch.setattr(vor, "_session", lambda: DummySession())
+
+    sleep_calls: list[float] = []
+
+    def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(vor.time, "sleep", fake_sleep)
+
+    result = vor._fetch_stationboard("123", datetime(2024, 1, 1, 12, 0))
+
+    assert result is None
+    assert sleep_calls == [3.5]
+
+
+def test_retry_after_http_date(monkeypatch):
+    fixed_now = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    delay = timedelta(seconds=7)
+    retry_dt = fixed_now + delay
+
+    class DummyResponse:
+        status_code = 429
+        headers = {"Retry-After": retry_dt.strftime("%a, %d %b %Y %H:%M:%S GMT")}
+        content = b""
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, url, params, timeout):
+            return DummyResponse()
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            assert tz == timezone.utc
+            return fixed_now
+
+    monkeypatch.setattr(vor, "_session", lambda: DummySession())
+    monkeypatch.setattr(vor, "datetime", FixedDateTime)
+
+    sleep_calls: list[float] = []
+
+    def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+
+    monkeypatch.setattr(vor.time, "sleep", fake_sleep)
+
+    result = vor._fetch_stationboard("123", datetime(2024, 1, 1, 12, 0))
+
+    assert result is None
+    assert sleep_calls == [delay.total_seconds()]


### PR DESCRIPTION
## Summary
- parse VOR Retry-After responses supporting both delta seconds and HTTP-date values
- compute sleep duration from parsed HTTP-date headers while still logging invalid values
- extend retry-after tests to cover numeric and date-based headers

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c8378cbb1c832b9c30683b19a00229