### PR TITLE
Handle VAO rate limiting

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -49,8 +49,13 @@ OEBB_ONLY_VIENNA = os.getenv("OEBB_ONLY_VIENNA", "").strip().lower() not in {"",
 # ---------------- HTTP ----------------
 def _session() -> requests.Session:
     s = requests.Session()
-    retry = Retry(total=4, backoff_factor=0.6, status_forcelist=(429,500,502,503,504),
-                  allowed_methods=("GET",))
+    retry = Retry(
+        total=4,
+        backoff_factor=0.6,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=("GET",),
+        raise_on_status=False,
+    )
     s.mount("https://", HTTPAdapter(max_retries=retry))
     s.headers.update({"User-Agent":"Origamihase-wien-oepnv/3.1 (+https://github.com/Origamihase/wien-oepnv)"})
     return s
@@ -256,7 +261,7 @@ def fetch_events(timeout: int = 25) -> List[Dict[str, Any]]:
         root = _fetch_xml(OEBB_URL, timeout=timeout)
     except Exception as e:
         msg = str(e).replace(OEBB_URL, "***")
-        log.exception("ÖBB RSS abruf fehlgeschlagen: %s", msg)
+        log.error("ÖBB RSS abruf fehlgeschlagen: %s", msg, exc_info=False)
         return []
 
     if root is None:

--- a/tests/test_oebb_rate_limit.py
+++ b/tests/test_oebb_rate_limit.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timedelta, timezone
 
 import src.providers.oebb as oebb
 
@@ -40,3 +41,41 @@ def test_rate_limit_logs_and_sleeps(monkeypatch, caplog):
     assert "Rate-Limit" in log_text
     assert "https://example.com" not in log_text
     assert oebb.OEBB_URL not in log_text
+
+
+def test_rate_limit_http_date(monkeypatch):
+    now_utc = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    class DummyDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return now_utc
+
+    retry_dt = now_utc + timedelta(seconds=3)
+    header = retry_dt.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    class DummyResponse:
+        status_code = 429
+        headers = {"Retry-After": header}
+        content = b""
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def get(self, url, timeout):
+            return DummyResponse()
+
+    monkeypatch.setattr(oebb, "datetime", DummyDateTime)
+    monkeypatch.setattr(oebb, "_session", lambda: DummySession())
+
+    slept = []
+    monkeypatch.setattr(oebb.time, "sleep", lambda s: slept.append(s))
+
+    result = oebb._fetch_xml("https://example.com", timeout=1)
+
+    assert result is None
+    assert slept == [3.0]

--- a/tests/test_oebb_secret_not_logged.py
+++ b/tests/test_oebb_secret_not_logged.py
@@ -1,0 +1,24 @@
+import importlib
+import logging
+import requests
+
+import src.providers.oebb as oebb
+
+
+def test_oebb_url_masked_in_error_log(monkeypatch, caplog):
+    monkeypatch.setenv("OEBB_RSS_URL", "https://secret.example/?token=abc")
+    importlib.reload(oebb)
+
+    def failing_fetch(url, timeout):
+        raise requests.RequestException(f"boom {oebb.OEBB_URL}")
+
+    monkeypatch.setattr(oebb, "_fetch_xml", failing_fetch)
+
+    with caplog.at_level(logging.ERROR, logger=oebb.log.name):
+        oebb.fetch_events()
+
+    assert oebb.OEBB_URL not in caplog.text
+    assert "***" in caplog.text
+
+    monkeypatch.delenv("OEBB_RSS_URL", raising=False)
+    importlib.reload(oebb)

--- a/tests/test_vor_retry_after.py
+++ b/tests/test_vor_retry_after.py
@@ -1,15 +1,10 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 import src.providers.vor as vor
 
 
-def test_retry_after_invalid_value(monkeypatch, caplog):
-    class DummyResponse:
-        status_code = 429
-        headers = {"Retry-After": "not-a-number"}
-        content = b""
-
+def _dummy_session(response):
     class DummySession:
         def __enter__(self):
             return self
@@ -18,9 +13,63 @@ def test_retry_after_invalid_value(monkeypatch, caplog):
             pass
 
         def get(self, url, params, timeout):
-            return DummyResponse()
+            return response
 
-    monkeypatch.setattr(vor, "_session", lambda: DummySession())
+    return DummySession()
+
+
+def test_retry_after_seconds(monkeypatch):
+    class DummyResponse:
+        status_code = 429
+        headers = {"Retry-After": "2.5"}
+        content = b""
+
+    monkeypatch.setattr(vor, "_session", lambda: _dummy_session(DummyResponse()))
+
+    slept = []
+    monkeypatch.setattr(vor.time, "sleep", lambda s: slept.append(s))
+
+    result = vor._fetch_stationboard("123", datetime(2024, 1, 1, 12, 0))
+
+    assert result is None
+    assert slept == [2.5]
+
+
+def test_retry_after_http_date(monkeypatch):
+    now_utc = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    class DummyDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return now_utc
+
+    retry_dt = now_utc + timedelta(seconds=5)
+    header = retry_dt.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+    class DummyResponse:
+        status_code = 429
+        headers = {"Retry-After": header}
+        content = b""
+
+    monkeypatch.setattr(vor, "datetime", DummyDateTime)
+    monkeypatch.setattr(vor, "_session", lambda: _dummy_session(DummyResponse()))
+
+    slept = []
+    monkeypatch.setattr(vor.time, "sleep", lambda s: slept.append(s))
+
+    result = vor._fetch_stationboard("123", now_utc)
+
+    assert result is None
+    assert slept == [5.0]
+
+
+def test_retry_after_invalid_value(monkeypatch, caplog):
+    class DummyResponse:
+        status_code = 429
+        headers = {"Retry-After": "not-a-number"}
+        content = b""
+
+    monkeypatch.setattr(vor, "_session", lambda: _dummy_session(DummyResponse()))
 
     def fake_sleep(seconds):
         raise AssertionError("sleep should not be called")


### PR DESCRIPTION
## Summary
- prevent retry adapter from raising on HTTP errors and mask RSS URL in ÖBB provider logs
- improve VOR stationboard rate limiting by parsing `Retry-After` seconds or HTTP dates and backing off accordingly
- expand test suite for rate limiting and secret masking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c83682da4c832b83e6c348a9a0b052