### PR TITLE
Fix quoting of commit message in update workflow

### DIFF
--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: chore: update stations directory
+          commit_message: "chore: update stations directory"
           file_pattern: data/stations.json


### PR DESCRIPTION
## Summary
- wrap the commit message string in quotes for the update-stations workflow

## Testing
- python - <<'PY'
import yaml
from pathlib import Path
path = Path('.github/workflows/update-stations.yml')
with path.open() as f:
    yaml.safe_load(f)
PY

------
https://chatgpt.com/codex/tasks/task_e_68c8429d665c832bb75f90a8fef3cc72