### PR TITLE
Add VOR StationBoard request counter and daily limit enforcement

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,19 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 root = Path(__file__).resolve().parents[1]
 if str(root) not in sys.path:
     sys.path.insert(0, str(root))
+
+
+@pytest.fixture(autouse=True)
+def reset_vor_request_count(tmp_path, monkeypatch):
+    import src.providers.vor as vor
+
+    path = tmp_path / "vor_request_count.json"
+    monkeypatch.setattr(vor, "REQUEST_COUNT_FILE", path)
+    yield
+    if path.exists():
+        path.unlink()

--- a/tests/test_vor_request_limit.py
+++ b/tests/test_vor_request_limit.py
@@ -1,0 +1,37 @@
+import json
+from datetime import datetime
+
+from zoneinfo import ZoneInfo
+
+import src.providers.vor as vor
+
+
+def test_fetch_events_respects_daily_limit(monkeypatch, caplog):
+    monkeypatch.setattr(vor, "VOR_ACCESS_ID", "test")
+    monkeypatch.setattr(vor, "VOR_STATION_IDS", ["1"])
+    monkeypatch.setattr(vor, "MAX_STATIONS_PER_RUN", 1)
+
+    monkeypatch.setattr(
+        vor,
+        "_select_stations_round_robin",
+        lambda ids, chunk, period: ids[:chunk],
+    )
+    monkeypatch.setattr(vor, "_collect_from_board", lambda sid, root: [])
+
+    def fail_fetch(*args, **kwargs):
+        raise AssertionError("StationBoard request should not be triggered when limit reached")
+
+    monkeypatch.setattr(vor, "_fetch_stationboard", fail_fetch)
+
+    today = datetime.now().astimezone(ZoneInfo("Europe/Vienna")).date().isoformat()
+    vor.REQUEST_COUNT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    vor.REQUEST_COUNT_FILE.write_text(
+        json.dumps({"date": today, "count": vor.MAX_REQUESTS_PER_DAY}),
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("INFO"):
+        items = vor.fetch_events()
+
+    assert items == []
+    assert any("Tageslimit" in record.getMessage() for record in caplog.records)


### PR DESCRIPTION
## Summary
- add persistent daily counter for VOR StationBoard requests and abort fetching once the 100-call limit is reached
- persist successful StationBoard fetches and isolate the counter file during tests
- add a regression test ensuring the limit prevents additional requests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c85c0764fc832b808485ce2eb823c6