### PR TITLE
Add cache utilities and provider cache directories

### DIFF
--- a/cache/oebb/.gitkeep
+++ b/cache/oebb/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep cache/oebb tracked.

--- a/cache/vor/.gitkeep
+++ b/cache/vor/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep cache/vor tracked.

--- a/cache/wl/.gitkeep
+++ b/cache/wl/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep cache/wl tracked.


### PR DESCRIPTION
## Summary
- create cache directories for wl, oebb, and vor providers
- add cache utility helpers to read and write provider cache JSON files atomically

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8624ebcb4832bb81bd45f36c0a443