### PR TITLE
Ensure feed build waits for cache workflows

### DIFF
--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -13,7 +13,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  update_wl_cache:
+    uses: ./.github/workflows/update-wl-cache.yml
+    secrets: inherit
+
+  update_oebb_cache:
+    uses: ./.github/workflows/update-oebb-cache.yml
+    secrets: inherit
+
+  update_vor_cache:
+    uses: ./.github/workflows/update-vor-cache.yml
+    secrets: inherit
+
   build:
+    needs:
+      - update_wl_cache
+      - update_oebb_cache
+      - update_vor_cache
     runs-on: ubuntu-latest
 
     env:
@@ -61,6 +77,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      - name: Sync repository
+        run: git pull --ff-only
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/update-oebb-cache.yml
+++ b/.github/workflows/update-oebb-cache.yml
@@ -1,6 +1,7 @@
 name: Update ÖBB cache
 
 on:
+  workflow_call:
   schedule:
     - cron: '*/30 * * * *'
   workflow_dispatch:

--- a/.github/workflows/update-vor-cache.yml
+++ b/.github/workflows/update-vor-cache.yml
@@ -1,6 +1,7 @@
 name: Update VOR cache
 
 on:
+  workflow_call:
   schedule:
     - cron: "*/30 * * * *"
   workflow_dispatch:

--- a/.github/workflows/update-wl-cache.yml
+++ b/.github/workflows/update-wl-cache.yml
@@ -1,6 +1,7 @@
 name: Update Wiener Linien cache
 
 on:
+  workflow_call:
   schedule:
     - cron: '*/30 * * * *'
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Der RSS-Feed deklariert den Namespace `ext` (`xmlns:ext="https://wien-oepnv.exam
 - `ext:starts_at`: Beginn der Störung bzw. Maßnahme.
 - `ext:ends_at`: Ende der Störung bzw. Maßnahme.
 
+## Cache-Dateien
+
+Drei GitHub Actions pflegen die Zwischenstände der Provider-Abfragen und legen sie im Repository ab:
+
+- [`.github/workflows/update-wl-cache.yml`](.github/workflows/update-wl-cache.yml) schreibt `cache/wl/events.json`.
+- [`.github/workflows/update-oebb-cache.yml`](.github/workflows/update-oebb-cache.yml) schreibt `cache/oebb/events.json`.
+- [`.github/workflows/update-vor-cache.yml`](.github/workflows/update-vor-cache.yml) schreibt `cache/vor/events.json`.
+
+Der Feed-Workflow wartet vor dem Build auf diese Jobs (`needs`) und kann dadurch direkt auf die aktuellen JSON-Dateien zugreifen. Da die Cache-Dateien versioniert im Repository liegen, steht der Feed auch dann zur Verfügung, wenn einer der Upstream-Dienste vorübergehend offline ist.
+
 ## Stationsverzeichnis
 
 `data/stations.json` enthält eine vereinfachte Zuordnung der ÖBB-Verkehrsstationen


### PR DESCRIPTION
## Summary
- call the cache update workflows from the feed pipeline and wait for them before building the feed
- refresh the README with details on the cache jobs and offline availability

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68c86a6a99e4832bbb1527374845e6e3