### PR TITLE
Build feed entirely from cached provider data

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Drei GitHub Actions pflegen die Zwischenstände der Provider-Abfragen und legen 
 - [`.github/workflows/update-oebb-cache.yml`](.github/workflows/update-oebb-cache.yml) schreibt `cache/oebb/events.json`.
 - [`.github/workflows/update-vor-cache.yml`](.github/workflows/update-vor-cache.yml) schreibt `cache/vor/events.json`.
 
-Der Feed-Workflow wartet vor dem Build auf diese Jobs (`needs`) und kann dadurch direkt auf die aktuellen JSON-Dateien zugreifen. Da die Cache-Dateien versioniert im Repository liegen, steht der Feed auch dann zur Verfügung, wenn einer der Upstream-Dienste vorübergehend offline ist.
+Der Feed-Workflow wartet vor dem Build auf diese Jobs (`needs`) und kann dadurch direkt auf die aktuellen JSON-Dateien zugreifen.
+Der eigentliche Feed-Build liest ausschließlich diese Cache-Dateien; externe API-Abfragen finden beim Generieren des Feeds nicht statt.
+Da die Cache-Dateien versioniert im Repository liegen, steht der Feed auch dann zur Verfügung, wenn einer der Upstream-Dienste vorübergehend offline ist.
 
 ## Stationsverzeichnis
 


### PR DESCRIPTION
## Summary
- load all provider data via `utils.cache.read_cache` and drop the dynamic provider loader helper
- keep provider metadata for logging while adding a dedicated test to ensure the feed build consumes cached events
- document that the feed generation step works exclusively with the cached JSON files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c86c0775f0832bb21f423577b3611e