### PR TITLE
Extract shared serialization helper

### DIFF
--- a/scripts/update_oebb_cache.py
+++ b/scripts/update_oebb_cache.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
-from typing import Any
 
 from requests.exceptions import RequestException
 
@@ -19,24 +17,10 @@ if str(SRC_DIR) not in sys.path:
 
 from providers.oebb import fetch_events  # noqa: E402  (import after path setup)
 from utils.cache import write_cache  # noqa: E402
+from utils.serialize import serialize_for_cache  # noqa: E402
 
 
 logger = logging.getLogger("update_oebb_cache")
-
-
-def _serialize(value: Any) -> Any:
-    """Recursively convert unsupported types into JSON serializable values."""
-
-    if isinstance(value, datetime):
-        return value.isoformat()
-    if isinstance(value, dict):
-        return {key: _serialize(val) for key, val in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_serialize(item) for item in value]
-    if isinstance(value, set):
-        serialized = [_serialize(item) for item in value]
-        return sorted(serialized, key=str)
-    return value
 
 
 def configure_logging() -> None:
@@ -71,7 +55,7 @@ def main() -> int:
         )
         return 1
 
-    serialized_items = [_serialize(item) for item in items]
+    serialized_items = [serialize_for_cache(item) for item in items]
     write_cache("oebb", serialized_items)
     logger.info("Updated ÖBB cache with %d events.", len(serialized_items))
     return 0

--- a/scripts/update_wl_cache.py
+++ b/scripts/update_wl_cache.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 
 import logging
 import sys
-from datetime import datetime
 from pathlib import Path
-from typing import Any
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -17,24 +15,10 @@ if str(SRC_DIR) not in sys.path:
 
 from providers.wiener_linien import fetch_events  # noqa: E402  (import after path setup)
 from utils.cache import write_cache  # noqa: E402
+from utils.serialize import serialize_for_cache  # noqa: E402
 
 
 logger = logging.getLogger("update_wl_cache")
-
-
-def _serialize(value: Any) -> Any:
-    """Recursively convert unsupported types into JSON serializable values."""
-
-    if isinstance(value, datetime):
-        return value.isoformat()
-    if isinstance(value, dict):
-        return {key: _serialize(val) for key, val in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_serialize(item) for item in value]
-    if isinstance(value, set):
-        serialized = [_serialize(item) for item in value]
-        return sorted(serialized, key=str)
-    return value
 
 
 def configure_logging() -> None:
@@ -63,7 +47,7 @@ def main() -> int:
         )
         return 1
 
-    serialized_items = [_serialize(item) for item in items]
+    serialized_items = [serialize_for_cache(item) for item in items]
     write_cache("wl", serialized_items)
     logger.info("Updated Wiener Linien cache with %d events.", len(serialized_items))
     return 0

--- a/src/utils/serialize.py
+++ b/src/utils/serialize.py
@@ -1,0 +1,24 @@
+"""Utilities for serializing provider data structures for caching."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
+__all__ = ["serialize_for_cache"]
+
+
+def serialize_for_cache(value: Any) -> Any:
+    """Recursively convert *value* into a JSON-serializable structure."""
+
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {key: serialize_for_cache(val) for key, val in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [serialize_for_cache(item) for item in value]
+    if isinstance(value, set):
+        serialized = [serialize_for_cache(item) for item in value]
+        return sorted(serialized, key=str)
+    return value


### PR DESCRIPTION
## Summary
- add `utils.serialize.serialize_for_cache` to centralize cache serialization logic
- update the update scripts to reuse the shared helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8711e11cc832b8a4246e2fc4ddd74