### PR TITLE
Reuse Wiener Linien session across API calls

### DIFF
--- a/tests/test_wl_aggregate_removal.py
+++ b/tests/test_wl_aggregate_removal.py
@@ -23,9 +23,13 @@ def test_aggregate_removed_when_all_singles_present(monkeypatch):
     single2 = _make_event("Single2", ["U2"])
 
     monkeypatch.setattr(
-        wl_fetch, "_fetch_traffic_infos", lambda timeout=20: [aggregate, single1, single2]
+        wl_fetch,
+        "_fetch_traffic_infos",
+        lambda timeout=20, session=None: [aggregate, single1, single2],
     )
-    monkeypatch.setattr(wl_fetch, "_fetch_news", lambda timeout=20: [])
+    monkeypatch.setattr(
+        wl_fetch, "_fetch_news", lambda timeout=20, session=None: []
+    )
 
     items = wl_fetch.fetch_events()
     titles = [it["title"] for it in items]
@@ -40,9 +44,13 @@ def test_aggregate_retained_when_single_missing(monkeypatch):
     single1 = _make_event("Single1", ["U1"])
 
     monkeypatch.setattr(
-        wl_fetch, "_fetch_traffic_infos", lambda timeout=20: [aggregate, single1]
+        wl_fetch,
+        "_fetch_traffic_infos",
+        lambda timeout=20, session=None: [aggregate, single1],
     )
-    monkeypatch.setattr(wl_fetch, "_fetch_news", lambda timeout=20: [])
+    monkeypatch.setattr(
+        wl_fetch, "_fetch_news", lambda timeout=20, session=None: []
+    )
 
     items = wl_fetch.fetch_events()
     titles = [it["title"] for it in items]


### PR DESCRIPTION
## Summary
- reuse a single retry-configured session across Wiener Linien fetches
- allow `_get_json`, `_fetch_traffic_infos`, and `_fetch_news` to accept an optional session
- update the Wiener Linien aggregation test doubles for the new call signature

## Testing
- pytest tests/test_wl_aggregate_removal.py

------
https://chatgpt.com/codex/tasks/task_e_68c871eec2d4832b84f65ca60c6ca78f