### PR TITLE
Retry ÖBB fetch after rate limit

### DIFF
--- a/tests/test_oebb_rate_limit.py
+++ b/tests/test_oebb_rate_limit.py
@@ -3,29 +3,41 @@ import logging
 import src.providers.oebb as oebb
 
 
-def test_rate_limit_logs_and_sleeps(monkeypatch, caplog):
-    class DummyResponse:
-        status_code = 429
-        headers = {"Retry-After": "1.5"}
-        content = b""
+class DummyResponse:
+    def __init__(self, status_code, headers=None, content=b""):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.content = content
 
-    class DummySession:
-        def __enter__(self):
-            return self
 
-        def __exit__(self, exc_type, exc, tb):
-            pass
+class DummySession:
+    def __init__(self, responses, calls):
+        self._responses = iter(responses)
+        self._calls = calls
 
-        def get(self, url, timeout):
-            return DummyResponse()
+    def __enter__(self):
+        return self
 
-    monkeypatch.setattr(oebb, "_session", lambda: DummySession())
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def get(self, url, timeout):
+        self._calls.append((url, timeout))
+        return next(self._responses)
+
+
+def test_rate_limit_retries_once_after_wait(monkeypatch, caplog):
+    responses = [
+        DummyResponse(429, {"Retry-After": "1.5"}),
+        DummyResponse(200, {}, b"<root></root>"),
+    ]
+    calls = []
+    monkeypatch.setattr(oebb, "_session", lambda: DummySession(responses, calls))
 
     slept = []
 
     def fake_sleep(seconds):
         slept.append(seconds)
-        raise RuntimeError("sleep failed")
 
     monkeypatch.setattr(oebb.time, "sleep", fake_sleep)
 
@@ -33,10 +45,34 @@ def test_rate_limit_logs_and_sleeps(monkeypatch, caplog):
 
     result = oebb._fetch_xml("https://example.com", timeout=1)
 
-    assert result is None
+    assert result is not None
+    assert result.tag == "root"
+    assert calls == [("https://example.com", 1), ("https://example.com", 1)]
     assert slept == [1.5]
 
     log_text = caplog.text
     assert "Rate-Limit" in log_text
     assert "https://example.com" not in log_text
     assert oebb.OEBB_URL not in log_text
+
+
+def test_rate_limit_returns_none_after_retry(monkeypatch):
+    responses = [
+        DummyResponse(429, {"Retry-After": "1.5"}),
+        DummyResponse(429, {"Retry-After": "2"}),
+    ]
+    calls = []
+    monkeypatch.setattr(oebb, "_session", lambda: DummySession(responses, calls))
+
+    slept = []
+
+    def fake_sleep(seconds):
+        slept.append(seconds)
+
+    monkeypatch.setattr(oebb.time, "sleep", fake_sleep)
+
+    result = oebb._fetch_xml("https://example.com", timeout=1)
+
+    assert result is None
+    assert calls == [("https://example.com", 1), ("https://example.com", 1)]
+    assert slept == [1.5]


### PR DESCRIPTION
## Summary
- retry the ÖBB RSS fetch once after encountering an HTTP 429 by reusing the existing wait handling and keeping other behavior intact
- guard against infinite retry loops by limiting attempts to two and only sleeping before the single retry
- extend the ÖBB rate limit tests to cover the retry path and the failure path after the retry

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c87445835c832b960bdfe7bc2c83b0