### PR TITLE
Read GTFS stops from extracted stops.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ entpackten GTFS-Dateien (z. B. aus dem ÖBB- oder WL-Export) parallel in
 GTFS-Dateien verknüpfen, und die WGS84-Koordinaten aus den CSVs erleichtern das
 Matching mit Streckendaten oder dem GeoNetz.
 
+Für automatisierte Tests liegt im Repository eine stark verkleinerte GTFS-Datei
+`data/gtfs/stops.txt`, die nur einige Wiener Beispiele enthält. Wer mit dem
+vollständigen GTFS-Export arbeiten möchte, lädt das ZIP-Archiv
+„Fahrplandaten GTFS“ aus dem ÖBB-Open-Data-Portal herunter (kostenlose Anmeldung
+erforderlich) und entpackt die benötigten Dateien nach `data/gtfs/`, zum Beispiel:
+
+```bash
+mkdir -p data/gtfs
+# heruntergeladenes Archiv ablegen, z. B. data/gtfs/oebb-gtfs.zip
+unzip data/gtfs/oebb-gtfs.zip "stops.txt" "routes.txt" "trips.txt" "stop_times.txt" -d data/gtfs
+```
+
+Damit stehen die vollständigen Stop-Informationen für lokale Experimente zur
+Verfügung.
+
 ### Pendlerstationen
 
 Die Datei `data/pendler_bst_ids.json` enthält eine manuell gepflegte Liste an

--- a/data/gtfs/stops.txt
+++ b/data/gtfs/stops.txt
@@ -1,0 +1,6 @@
+stop_id,stop_code,stop_name,stop_lat,stop_lon,location_type,parent_station,platform_code
+8103000,,Wien Hbf (Bahnsteige 1-2),48.185013,16.374582,1,,
+8103000:1,1299,Wien Hbf (Bahnsteig 1),48.185750,16.375120,0,8103000,1
+8103000:2,1300,Wien Hbf (Bahnsteig 2),48.185820,16.375330,0,8103000,2
+8103001,,Wien Quartier Belvedere,48.186719,16.377046,1,,
+8103001:1,,Quartier Belvedere Gleis 1,48.186950,16.377240,,8103001,1

--- a/scripts/gtfs.py
+++ b/scripts/gtfs.py
@@ -1,0 +1,105 @@
+"""Utilities for reading GTFS reference data used in tests."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import csv
+from pathlib import Path
+from typing import Dict
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_GTFS_STOP_PATH = BASE_DIR / "data" / "gtfs" / "stops.txt"
+
+
+@dataclass(frozen=True, slots=True)
+class GTFSStop:
+    """Representation of a single row from ``stops.txt``."""
+
+    stop_id: str
+    stop_name: str
+    stop_code: str | None
+    stop_lat: float | None
+    stop_lon: float | None
+    location_type: int | None
+    parent_station: str | None
+    platform_code: str | None
+
+
+def _strip(text: str | None) -> str:
+    if text is None:
+        return ""
+    return text.strip()
+
+
+def _optional(text: str | None) -> str | None:
+    value = _strip(text)
+    return value or None
+
+
+def _coerce_float(text: str | None) -> float | None:
+    value = _strip(text)
+    if not value:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _coerce_int(text: str | None) -> int | None:
+    value = _strip(text)
+    if not value:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def read_gtfs_stops(path: Path | None = None) -> Dict[str, GTFSStop]:
+    """Read GTFS stop entries from ``stops.txt``.
+
+    Parameters
+    ----------
+    path:
+        Optional override for the ``stops.txt`` file that should be read.  If no
+        path is provided the file placed at ``data/gtfs/stops.txt`` is used.
+
+    Returns
+    -------
+    dict
+        A mapping keyed by ``stop_id`` where each value contains a
+        :class:`GTFSStop` with the parsed data.
+
+    Raises
+    ------
+    ValueError
+        If the file does not provide the mandatory ``stop_id`` column.
+    """
+
+    stop_path = Path(path) if path is not None else DEFAULT_GTFS_STOP_PATH
+
+    with stop_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None or "stop_id" not in reader.fieldnames:
+            raise ValueError("GTFS stops.txt file is missing the 'stop_id' column")
+
+        stops: Dict[str, GTFSStop] = {}
+        for row in reader:
+            stop_id = _strip(row.get("stop_id"))
+            if not stop_id:
+                continue
+            stop_name = _strip(row.get("stop_name"))
+            stops[stop_id] = GTFSStop(
+                stop_id=stop_id,
+                stop_name=stop_name,
+                stop_code=_optional(row.get("stop_code")),
+                stop_lat=_coerce_float(row.get("stop_lat")),
+                stop_lon=_coerce_float(row.get("stop_lon")),
+                location_type=_coerce_int(row.get("location_type")),
+                parent_station=_optional(row.get("parent_station")),
+                platform_code=_optional(row.get("platform_code")),
+            )
+    return stops
+
+
+__all__ = ["GTFSStop", "DEFAULT_GTFS_STOP_PATH", "read_gtfs_stops"]

--- a/tests/test_gtfs_read_stops.py
+++ b/tests/test_gtfs_read_stops.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.gtfs import DEFAULT_GTFS_STOP_PATH, GTFSStop, read_gtfs_stops
+
+
+def test_read_gtfs_stops_reads_sample_file():
+    stops = read_gtfs_stops()
+
+    assert DEFAULT_GTFS_STOP_PATH.exists()
+    assert "8103000" in stops
+    assert isinstance(stops["8103000"], GTFSStop)
+
+    station = stops["8103000"]
+    assert station.stop_name == "Wien Hbf (Bahnsteige 1-2)"
+    assert station.stop_code is None
+    assert station.location_type == 1
+    assert station.parent_station is None
+
+    platform = stops["8103000:1"]
+    assert platform.parent_station == "8103000"
+    assert platform.platform_code == "1"
+    assert platform.stop_lat == pytest.approx(48.185750)
+    assert platform.stop_lon == pytest.approx(16.375120)
+
+    child_without_location = stops["8103001:1"]
+    assert child_without_location.location_type is None
+    assert child_without_location.platform_code == "1"
+
+
+def test_read_gtfs_stops_handles_custom_path(tmp_path: Path):
+    sample = tmp_path / "stops.txt"
+    sample.write_text(
+        "stop_id,stop_name,stop_lat,stop_lon,location_type,parent_station,platform_code\n"
+        "child,Example,48.0,16.0,0,parent,\n"
+        " ,Missing,,,,,\n",
+        encoding="utf-8",
+    )
+
+    stops = read_gtfs_stops(sample)
+
+    assert list(stops.keys()) == ["child"]
+    assert stops["child"].stop_name == "Example"
+    assert stops["child"].location_type == 0
+    assert stops["child"].parent_station == "parent"
+    assert stops["child"].platform_code is None
+
+
+def test_read_gtfs_stops_requires_stop_id_column(tmp_path: Path):
+    sample = tmp_path / "stops.txt"
+    sample.write_text("stop_name\nFoo\n", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        read_gtfs_stops(sample)


### PR DESCRIPTION
## Summary
- add a small extracted data/gtfs/stops.txt sample for tests
- implement scripts.gtfs.read_gtfs_stops to parse stops.txt entries
- document how to download and extract a full GTFS archive when needed

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c881100898832b88e043fc525b081b