### PR TITLE
Clip descriptions at natural word boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ LOG_MAX_BYTES=2097152 LOG_BACKUP_COUNT=10 python -u src/build_feed.py
 | `FEED_LINK` | str | `"https://github.com/Origamihase/wien-oepnv"` | Link zur Projektseite. |
 | `FEED_DESC` | str | `"Aktive Störungen/Baustellen/Einschränkungen aus offiziellen Quellen"` | Beschreibung des RSS-Feeds. |
 | `FEED_TTL` | int | `15` | Minuten, die Clients den Feed im Cache halten dürfen. |
-| `DESCRIPTION_CHAR_LIMIT` | int | `170` | Maximale Länge der Item-Beschreibung. |
+| `DESCRIPTION_CHAR_LIMIT` | int | `170` | Maximale Länge der Item-Beschreibung (Kürzung erfolgt an Wort-/Satzgrenzen, danach `…`). |
 | `FRESH_PUBDATE_WINDOW_MIN` | int | `5` | Zeitfenster (Minuten), in dem Meldungen ohne Datum als „frisch“ gelten und mit aktuellem `pubDate` versehen werden. |
 | `MAX_ITEMS` | int | `60` | Maximale Anzahl an Items im Feed. |
 | `MAX_ITEM_AGE_DAYS` | int | `365` | Entfernt Items, die älter als diese Anzahl an Tagen sind. |

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -15,7 +15,14 @@ def test_clip_text_html_plain_and_clips(monkeypatch):
     bf = _load_build_feed(monkeypatch)
     html_in = "<b>foo &amp; bar</b>"
     assert bf._clip_text_html(html_in, 100) == "foo & bar"
-    assert bf._clip_text_html(html_in, 7) == "foo & b …"
+    assert bf._clip_text_html(html_in, 7) == "foo & …"
+
+
+def test_clip_text_html_avoids_half_words(monkeypatch):
+    bf = _load_build_feed(monkeypatch)
+    assert bf._clip_text_html("foo bar baz", 8) == "foo bar …"
+    assert bf._clip_text_html("Tom & Jerry", 5) == "Tom & …"
+    assert bf._clip_text_html("Satz eins. Satz zwei.", 12) == "Satz eins. …"
 
 
 def test_emit_item_sanitizes_description(monkeypatch):


### PR DESCRIPTION
## Summary
- update `_clip_text_html` to prefer sentence and word boundaries when shortening descriptions
- extend clipping tests to cover whole-word truncation cases
- document the new `DESCRIPTION_CHAR_LIMIT` behaviour in the README

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68c882a67c0c832bb86ba065ca3dbe87