### PR TITLE
Preserve line breaks in text conversion and feed descriptions

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -507,6 +507,7 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
     # Für XML robust aufbereiten (CDATA schützt Sonderzeichen)
     title_out = _sanitize_text(html.unescape(raw_title))
     desc_out  = _sanitize_text(desc_out)
+    desc_cdata = desc_out.replace("\n", "<br/>")
 
     parts: List[str] = []
     parts.append("<item>")
@@ -522,7 +523,7 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
     if isinstance(ends_at, datetime):
         parts.append(f"<ext:ends_at>{_fmt_rfc2822(ends_at)}</ext:ends_at>")
 
-    parts.append(f"<description>{_cdata(desc_out)}</description>")
+    parts.append(f"<description>{_cdata(desc_cdata)}</description>")
     parts.append("</item>")
     return ident, "\n".join(parts)
 

--- a/tests/test_html_to_text.py
+++ b/tests/test_html_to_text.py
@@ -4,16 +4,16 @@ from src.utils.text import html_to_text
 
 
 @pytest.mark.parametrize("html,expected", [
-    ("Line1<br>Line2", "Line1 • Line2"),
-    ("<div>foo</div><p>bar</p>baz", "foo • bar • baz"),
-    ("<ul><li>foo</li><li>bar</li></ul>baz", "foo • bar • baz"),
-    ("<ul><li>Parent<br><ul><li>Child</li></ul></li></ul>End", "Parent • Child • End"),
+    ("Line1<br>Line2", "Line1\nLine2"),
+    ("<div>foo</div><p>bar</p>baz", "foo\nbar\nbaz"),
+    ("<ul><li>foo</li><li>bar</li></ul>baz", "• foo\n• bar\nbaz"),
+    ("<ul><li>Parent<br><ul><li>Child</li></ul></li></ul>End", "• Parent\n• Child\nEnd"),
     (
         "<ul><li>A<ul><li>B</li><li>C</li></ul></li><li>D</li></ul>",
-        "A • B • C • D",
+        "• A\n• B\n• C\n• D",
     ),
-    ("<th>Head1</th><th>Head2</th>End", "Head1 • Head2 • End"),
-    ("Zeitraum:<br>Ab Montag", "Zeitraum: Ab Montag"),
+    ("<th>Head1</th><th>Head2</th>End", "Head1\nHead2\nEnd"),
+    ("Zeitraum:<br>Ab Montag", "Zeitraum:\nAb Montag"),
 ])
 def test_html_to_text_examples(html, expected):
     assert html_to_text(html) == expected
@@ -23,7 +23,7 @@ def test_html_to_text_examples(html, expected):
     ("", ""),
     ("   ", ""),
     ("Tom &amp; Jerry", "Tom & Jerry"),
-    ("<div>&nbsp; A &nbsp; &amp; B  </div>End", "A & B • End"),
+    ("<div>&nbsp; A &nbsp; &amp; B  </div>End", "A & B\nEnd"),
     ("• foo • • bar •", "foo • bar"),
 ])
 def test_html_to_text_edge_cases(html, expected):
@@ -31,15 +31,15 @@ def test_html_to_text_edge_cases(html, expected):
 
 
 @pytest.mark.parametrize("html,expected", [
-    ("bei<br>Station", "bei Station"),
-    ("An<br>der Haltestelle", "An der Haltestelle"),
-    ("bei<br>• foo", "bei foo"),
-    ("In<br>• der Station", "In der Station"),
-    ("Am<br>Bahnhof", "Am Bahnhof"),
-    ("Vom<br>• Bahnsteig", "Vom Bahnsteig"),
-    ("Zur<br>• Station", "Zur Station"),
-    ("Zum<br>• Ausgang", "Zum Ausgang"),
-    ("Nach<br>• Wien", "Nach Wien"),
+    ("bei<br>Station", "bei\nStation"),
+    ("An<br>der Haltestelle", "An\nder Haltestelle"),
+    ("bei<br>• foo", "bei\nfoo"),
+    ("In<br>• der Station", "In\nder Station"),
+    ("Am<br>Bahnhof", "Am\nBahnhof"),
+    ("Vom<br>• Bahnsteig", "Vom\nBahnsteig"),
+    ("Zur<br>• Station", "Zur\nStation"),
+    ("Zum<br>• Ausgang", "Zum\nAusgang"),
+    ("Nach<br>• Wien", "Nach\nWien"),
 ])
 def test_preposition_bullet_stripping(html, expected):
     assert html_to_text(html) == expected

--- a/tests/test_normalize_bullets.py
+++ b/tests/test_normalize_bullets.py
@@ -15,6 +15,8 @@ from src.utils.text import normalize_bullets
         ("zur • Station", "zur Station"),
         ("zum • Ausgang", "zum Ausgang"),
         ("Nach • Wien", "Nach Wien"),
+        ("bei\n• Station", "bei\nStation"),
+        ("In •\n der Station", "In\nder Station"),
     ],
 )
 def test_normalize_bullets_prepositions(text, expected):


### PR DESCRIPTION
## Summary
- keep line breaks emitted by html_to_text while still allowing the old collapsing behaviour via a flag and adjust preposition bullet stripping accordingly
- normalise non-breaking spaces and ensure newline-aware bullet handling stays intact for providers
- replace newlines with <br/> in RSS descriptions and update the unit tests for the revised text formatting behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8858aeb74832b88863b617af0724b