### PR TITLE
Add CLI option for pendler station list path

### DIFF
--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -75,6 +75,12 @@ def parse_args() -> argparse.Namespace:
         help="Path to the JSON file that will be written",
     )
     parser.add_argument(
+        "--pendler",
+        type=Path,
+        default=DEFAULT_PENDLER_PATH,
+        help="Path to the JSON file containing pendler station IDs",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -236,7 +242,7 @@ def main() -> None:
     configure_logging(args.verbose)
     workbook_stream = download_workbook(args.source_url)
     stations = extract_stations(workbook_stream)
-    pendler_ids = load_pendler_station_ids(DEFAULT_PENDLER_PATH)
+    pendler_ids = load_pendler_station_ids(args.pendler)
     _annotate_station_flags(stations, pendler_ids)
     write_json(stations, args.output)
 


### PR DESCRIPTION
## Summary
- add a --pendler command line option to update_station_directory
- use the provided path when loading pendler station IDs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c88e1d12e4832b998dbc621784237e