### PR TITLE
Warn on duplicate station aliases

### DIFF
--- a/src/utils/stations.py
+++ b/src/utils/stations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 import unicodedata
 from functools import lru_cache
@@ -10,6 +11,9 @@ from pathlib import Path
 from typing import Dict, Iterable, List, NamedTuple, Sequence, Tuple
 
 __all__ = ["canonical_name", "is_in_vienna", "is_pendler", "station_info"]
+
+
+logger = logging.getLogger(__name__)
 
 
 class WLStop(NamedTuple):
@@ -325,8 +329,19 @@ def _station_lookup() -> Dict[str, StationInfo]:
             key = _normalize_token(alias)
             if not key:
                 continue
-            if key not in mapping:
+            existing = mapping.get(key)
+            if existing is None:
                 mapping[key] = record
+                continue
+            if existing is record or existing.name == record.name:
+                continue
+            logger.warning(
+                "Duplicate station alias %r normalized to %r for %s conflicts with %s",
+                alias,
+                key,
+                record.name,
+                existing.name,
+            )
     return mapping
 
 

--- a/tests/test_station_alias_collision.py
+++ b/tests/test_station_alias_collision.py
@@ -1,0 +1,31 @@
+import json
+import logging
+
+from src.utils import stations
+
+
+def test_station_alias_collision_logs_warning(tmp_path, caplog, monkeypatch):
+    data = [
+        {
+            "name": "First Station",
+            "aliases": ["Collision"],
+        },
+        {
+            "name": "Second Station",
+            "aliases": ["Collision"],
+        },
+    ]
+    temp_file = tmp_path / "stations.json"
+    temp_file.write_text(json.dumps(data), encoding="utf-8")
+
+    monkeypatch.setattr(stations, "_STATIONS_PATH", temp_file)
+    stations._station_lookup.cache_clear()
+    try:
+        with caplog.at_level(logging.WARNING):
+            stations._station_lookup()
+    finally:
+        stations._station_lookup.cache_clear()
+
+    warnings = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+    assert any("Duplicate station alias" in message for message in warnings)
+    assert any("First Station" in message and "Second Station" in message for message in warnings)


### PR DESCRIPTION
## Summary
- log a warning when station alias normalization collides with an existing entry
- add a regression test covering the duplicate alias warning

## Testing
- pytest tests/test_station_alias_collision.py


------
https://chatgpt.com/codex/tasks/task_e_68c895324220832bac4b3227f8a5adbd