### PR TITLE
Trim description whitespace when emitting items

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -508,7 +508,7 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
     title_out = _sanitize_text(html.unescape(raw_title))
     desc_out  = _sanitize_text(desc_out)
     title_out = re.sub(r"\s+", " ", title_out).strip()
-    desc_out  = re.sub(r"[ \t\r\f\v]+", " ", desc_out)
+    desc_out  = re.sub(r"[ \t\r\f\v]+", " ", desc_out).strip()
     desc_cdata = desc_out.replace("\n", "<br/>")
 
     parts: List[str] = []

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -56,9 +56,30 @@ def test_emit_item_collapses_whitespace(monkeypatch):
     assert title_match, xml
     assert "  " not in title_match.group(1)
     assert "\t" not in title_match.group(1)
+    assert title_match.group(1) == title_match.group(1).strip()
 
     desc_match = re.search(r"<description><!\[CDATA\[(.*)]]></description>", xml)
     assert desc_match, xml
     desc_text = desc_match.group(1)
     assert "  " not in desc_text
     assert "\t" not in desc_text
+    assert desc_text == desc_text.strip()
+
+
+def test_emit_item_trims_wrapping_whitespace(monkeypatch):
+    bf = _load_build_feed(monkeypatch)
+    now = datetime(2024, 1, 1)
+    item = {
+        "title": "\t  Foo  ",
+        "description": " \t Foo  bar \n ",
+    }
+
+    _, xml = bf._emit_item(item, now, {})
+
+    title_match = re.search(r"<title><!\[CDATA\[(.*)]]></title>", xml)
+    assert title_match, xml
+    assert title_match.group(1) == "Foo"
+
+    desc_match = re.search(r"<description><!\[CDATA\[(.*)]]></description>", xml)
+    assert desc_match, xml
+    assert desc_match.group(1) == "Foo bar"


### PR DESCRIPTION
## Summary
- strip leading and trailing whitespace from sanitized description text before emitting RSS items
- expand clip and escape tests to assert trimmed output and cover wrapping whitespace inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c89ca2ff1c832b9a42aaef8a85414e