### PR TITLE
Reduce default MAX_ITEMS to 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ LOG_MAX_BYTES=2097152 LOG_BACKUP_COUNT=10 python -u src/build_feed.py
 | `FEED_TTL` | int | `15` | Minuten, die Clients den Feed im Cache halten dürfen. |
 | `DESCRIPTION_CHAR_LIMIT` | int | `170` | Maximale Länge der Item-Beschreibung. Die Kürzung achtet auf Wort-/Satzgrenzen und ergänzt eine Ellipsis (`…`), damit keine halben Wörter im Feed landen. |
 | `FRESH_PUBDATE_WINDOW_MIN` | int | `5` | Zeitfenster (Minuten), in dem Meldungen ohne Datum als „frisch“ gelten und mit aktuellem `pubDate` versehen werden. |
-| `MAX_ITEMS` | int | `60` | Maximale Anzahl an Items im Feed. |
+| `MAX_ITEMS` | int | `10` | Maximale Anzahl an Items im Feed. |
 | `MAX_ITEM_AGE_DAYS` | int | `365` | Entfernt Items, die älter als diese Anzahl an Tagen sind. |
 | `ABSOLUTE_MAX_AGE_DAYS` | int | `540` | Harte Obergrenze für das Alter von Items. |
 | `ENDS_AT_GRACE_MINUTES` | int | `10` | Kulanzfenster (Minuten), in dem Meldungen nach `ends_at` noch gezeigt werden. |

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -126,7 +126,7 @@ FEED_TTL = max(_get_int_env("FEED_TTL", DEFAULT_FEED_TTL), 0)
 
 DESCRIPTION_CHAR_LIMIT = max(_get_int_env("DESCRIPTION_CHAR_LIMIT", 170), 0)
 FRESH_PUBDATE_WINDOW_MIN = _get_int_env("FRESH_PUBDATE_WINDOW_MIN", 5)
-MAX_ITEMS = max(_get_int_env("MAX_ITEMS", 60), 0)
+MAX_ITEMS = max(_get_int_env("MAX_ITEMS", 10), 0)
 MAX_ITEM_AGE_DAYS = max(
     _get_int_env("MAX_ITEM_AGE_DAYS", DEFAULT_MAX_ITEM_AGE_DAYS), 0
 )


### PR DESCRIPTION
## Summary
- set the default MAX_ITEMS environment fallback to 10 in the feed builder
- document the updated default in the environment variable reference

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c89d0f92f8832bab0b61603d898428