### PR TITLE
Add wrapper script for station updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,19 @@ lädt monatlich (Cron `0 0 1 * *`) die aktuelle Excel-Datei und schreibt daraus 
 aktualisierte `data/stations.json`. Änderungen werden automatisch in den Hauptzweig
 committet.
 
+### Stationsverzeichnis komplett aktualisieren
+
+```bash
+python scripts/update_all_stations.py --verbose
+```
+
+Der Sammelbefehl führt nacheinander `update_station_directory.py`,
+`update_vor_stations.py` und `update_wl_stations.py` aus. Damit entsteht das
+vollständige `stations.json` in einem Durchlauf – Voraussetzung ist, dass die
+benötigten Quelldateien (VOR-Export sowie die Wiener-Linien-CSV-Dateien) wie in
+den folgenden Abschnitten beschrieben lokal vorliegen. Die Einzelskripte lassen
+sich weiterhin separat starten, um gezielt Teilmengen zu aktualisieren.
+
 ### Manuelle Aktualisierung
 
 ```bash

--- a/scripts/update_all_stations.py
+++ b/scripts/update_all_stations.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Convenience wrapper to refresh all station datasets."""
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+_SCRIPT_ORDER = (
+    "update_station_directory.py",
+    "update_vor_stations.py",
+    "update_wl_stations.py",
+)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run all station update scripts in sequence.",
+    )
+    parser.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Python interpreter used to invoke the update scripts (default: current interpreter).",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging output for the wrapper and update scripts.",
+    )
+    return parser.parse_args(argv)
+
+
+def configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(message)s")
+
+
+def run_script(python: str, script_path: Path, verbose: bool) -> None:
+    cmd = [python, str(script_path)]
+    if verbose:
+        cmd.append("--verbose")
+    logging.info("Running %s", script_path.name)
+    subprocess.run(cmd, check=True)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    configure_logging(args.verbose)
+
+    script_dir = Path(__file__).resolve().parent
+    for script_name in _SCRIPT_ORDER:
+        script_path = script_dir / script_name
+        if not script_path.exists():
+            logging.error("Script not found: %s", script_path)
+            return 1
+        try:
+            run_script(args.python, script_path, args.verbose)
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - thin wrapper
+            logging.error(
+                "Script %s failed with exit code %s", script_path.name, exc.returncode
+            )
+            return exc.returncode or 1
+
+    logging.info("All station update scripts completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an `update_all_stations.py` wrapper script that chains the ÖBB, VOR and Wiener Linien updates
- describe the new combined command in the README so manual runs cover all data sources

## Testing
- python -m compileall scripts/update_all_stations.py

------
https://chatgpt.com/codex/tasks/task_e_68c89dd36c5c832b8a8bd666aec0ddf0