### PR TITLE
Normalize feed descriptions and limit to two lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Störungen und Einschränkungen für den Großraum Wien aus offiziellen Quellen.
 
+Die `<description>`-Elemente des Feeds enthalten höchstens zwei Zeilen; redundante Überschriften wie „Bauarbeiten“ oder das Label „Zeitraum:“ werden automatisch entfernt.
+
 ## Erweiterungen
 
 Der RSS-Feed deklariert den Namespace `ext` (`xmlns:ext="https://wien-oepnv.example/schema"`) für zusätzliche Metadaten:

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -506,6 +506,11 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
     desc_out = _clip_text_html(raw_desc, DESCRIPTION_CHAR_LIMIT)
     # Für XML robust aufbereiten (CDATA schützt Sonderzeichen)
     title_out = _sanitize_text(html.unescape(raw_title))
+    desc_lines = desc_out.split("\n")
+    if desc_lines and desc_lines[0].lower() in title_out.lower():
+        desc_lines = desc_lines[1:]
+    desc_lines = [l for l in desc_lines if l.strip().lower() != "zeitraum:"]
+    desc_out = "\n".join(desc_lines[:2])
     desc_out  = _sanitize_text(desc_out)
     title_out = re.sub(r"\s+", " ", title_out).strip()
     desc_out  = re.sub(r"[ \t\r\f\v]+", " ", desc_out).strip()

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -83,3 +83,21 @@ def test_emit_item_trims_wrapping_whitespace(monkeypatch):
     desc_match = re.search(r"<description><!\[CDATA\[(.*)]]></description>", xml)
     assert desc_match, xml
     assert desc_match.group(1) == "Foo bar"
+
+
+def test_emit_item_removes_category_and_limits_lines(monkeypatch):
+    bf = _load_build_feed(monkeypatch)
+    now = datetime(2024, 1, 1)
+    item = {
+        "title": "Bauarbeiten U6",
+        "description": "Bauarbeiten\nWegen …\nZeitraum:\nMontag …",
+    }
+
+    _, xml = bf._emit_item(item, now, {})
+
+    desc_match = re.search(r"<description><!\[CDATA\[(.*)]]></description>", xml)
+    assert desc_match, xml
+    desc_text = desc_match.group(1)
+    assert desc_text == "Wegen …<br/>Montag …"
+    assert "Bauarbeiten" not in desc_text
+    assert "Zeitraum" not in desc_text


### PR DESCRIPTION
## Summary
- remove redundant leading headings and the "Zeitraum:" label from feed descriptions while limiting them to two lines
- add a regression test that covers the new description normalization
- document the description cleanup in the README

## Testing
- pytest tests/test_clip_and_escape.py

------
https://chatgpt.com/codex/tasks/task_e_68c8a0c9938c832ba60346d8a5c25543