### PR TITLE
Ignore emergency management archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ data/*.txt
 *.log
 *.tmp
 .DS_Store
+streckendaten_notfallmanagement.zip


### PR DESCRIPTION
## Summary
- confirm the `streckendaten_notfallmanagement.zip` archive is not present in the repository
- add the archive filename to `.gitignore` so future commits exclude it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8a20a2a78832b9c69b34745834682