### PR TITLE
Refactor integer env helper

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -18,34 +18,10 @@ from email.utils import format_datetime
 
 try:  # pragma: no cover - allow running as package and as script
     from utils.cache import read_cache
+    from utils.env import get_int_env
 except ModuleNotFoundError:  # pragma: no cover
     from .utils.cache import read_cache  # type: ignore
-
-# ---------------- Helpers: ENV ----------------
-
-def _get_int_env(name: str, default: int) -> int:
-    """Read integer environment variables safely.
-
-    Returns the provided default if the variable is unset or cannot be
-    converted to ``int``. On invalid values, a warning is logged using the
-    ``build_feed`` logger.
-    """
-
-    raw = os.getenv(name)
-    if raw is None:
-        return default
-    try:
-        return int(raw)
-    except (ValueError, TypeError) as e:
-        logging.getLogger("build_feed").warning(
-            "Ungültiger Wert für %s=%r – verwende Default %d (%s: %s)",
-            name,
-            raw,
-            default,
-            type(e).__name__,
-            e,
-        )
-        return default
+    from .utils.env import get_int_env  # type: ignore
 
 # ---------------- Logging ----------------
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").strip().upper()
@@ -54,8 +30,8 @@ if not isinstance(_level, int):
     _level = logging.INFO
 
 LOG_DIR = os.getenv("LOG_DIR", "log")
-LOG_MAX_BYTES = max(_get_int_env("LOG_MAX_BYTES", 1_000_000), 0)
-LOG_BACKUP_COUNT = max(_get_int_env("LOG_BACKUP_COUNT", 5), 0)
+LOG_MAX_BYTES = max(get_int_env("LOG_MAX_BYTES", 1_000_000), 0)
+LOG_BACKUP_COUNT = max(get_int_env("LOG_BACKUP_COUNT", 5), 0)
 
 os.makedirs(LOG_DIR, exist_ok=True)
 fmt = "%(asctime)s %(levelname)s %(name)s: %(message)s"
@@ -122,23 +98,23 @@ DEFAULT_FEED_TTL = 15
 DEFAULT_MAX_ITEM_AGE_DAYS = 365
 DEFAULT_ABSOLUTE_MAX_AGE_DAYS = 540
 
-FEED_TTL = max(_get_int_env("FEED_TTL", DEFAULT_FEED_TTL), 0)
+FEED_TTL = max(get_int_env("FEED_TTL", DEFAULT_FEED_TTL), 0)
 
-DESCRIPTION_CHAR_LIMIT = max(_get_int_env("DESCRIPTION_CHAR_LIMIT", 170), 0)
-FRESH_PUBDATE_WINDOW_MIN = _get_int_env("FRESH_PUBDATE_WINDOW_MIN", 5)
-MAX_ITEMS = max(_get_int_env("MAX_ITEMS", 10), 0)
+DESCRIPTION_CHAR_LIMIT = max(get_int_env("DESCRIPTION_CHAR_LIMIT", 170), 0)
+FRESH_PUBDATE_WINDOW_MIN = get_int_env("FRESH_PUBDATE_WINDOW_MIN", 5)
+MAX_ITEMS = max(get_int_env("MAX_ITEMS", 10), 0)
 MAX_ITEM_AGE_DAYS = max(
-    _get_int_env("MAX_ITEM_AGE_DAYS", DEFAULT_MAX_ITEM_AGE_DAYS), 0
+    get_int_env("MAX_ITEM_AGE_DAYS", DEFAULT_MAX_ITEM_AGE_DAYS), 0
 )
 ABSOLUTE_MAX_AGE_DAYS = max(
-    _get_int_env("ABSOLUTE_MAX_AGE_DAYS", DEFAULT_ABSOLUTE_MAX_AGE_DAYS), 0
+    get_int_env("ABSOLUTE_MAX_AGE_DAYS", DEFAULT_ABSOLUTE_MAX_AGE_DAYS), 0
 )
-ENDS_AT_GRACE_MINUTES = max(_get_int_env("ENDS_AT_GRACE_MINUTES", 10), 0)
-PROVIDER_TIMEOUT = max(_get_int_env("PROVIDER_TIMEOUT", 25), 0)
+ENDS_AT_GRACE_MINUTES = max(get_int_env("ENDS_AT_GRACE_MINUTES", 10), 0)
+PROVIDER_TIMEOUT = max(get_int_env("PROVIDER_TIMEOUT", 25), 0)
 
 STATE_FILE = Path(os.getenv("STATE_PATH", "data/first_seen.json"))  # nur Einträge aus *aktuellem* Feed
 STATE_FILE = _validate_path(STATE_FILE, "STATE_PATH")
-STATE_RETENTION_DAYS = max(_get_int_env("STATE_RETENTION_DAYS", 60), 0)
+STATE_RETENTION_DAYS = max(get_int_env("STATE_RETENTION_DAYS", 60), 0)
 
 RFC = "%a, %d %b %Y %H:%M:%S %z"
 

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -27,6 +27,11 @@ try:  # pragma: no cover - support both package layouts
 except ModuleNotFoundError:  # pragma: no cover
     from src.utils.ids import make_guid  # type: ignore
 
+try:  # pragma: no cover - support both package layouts
+    from utils.env import get_int_env
+except ModuleNotFoundError:  # pragma: no cover
+    from src.utils.env import get_int_env  # type: ignore
+
 try:
     from utils.text import html_to_text
 except ModuleNotFoundError:
@@ -90,27 +95,17 @@ def save_request_count(now_local: datetime) -> int:
             log.warning("VOR: Konnte Request-Zähler nicht speichern: %s", exc)
         return new_count
 
-def _get_int_env(name: str, default: int) -> int:
-    val = os.getenv(name)
-    if val is None:
-        return default
-    try:
-        return int(val)
-    except ValueError:
-        log.warning("%s='%s' ist kein int – verwende %s", name, val, default)
-        return default
-
 
 VOR_ACCESS_ID: str | None = (os.getenv("VOR_ACCESS_ID") or os.getenv("VAO_ACCESS_ID") or "").strip() or None
 VOR_STATION_IDS: List[str] = [s.strip() for s in (os.getenv("VOR_STATION_IDS") or "").split(",") if s.strip()]
 VOR_STATION_NAMES: List[str] = [s.strip() for s in (os.getenv("VOR_STATION_NAMES") or "").split(",") if s.strip()]
 VOR_BASE = os.getenv("VOR_BASE", "https://routenplaner.verkehrsauskunft.at/vao/restproxy")
 VOR_VERSION = os.getenv("VOR_VERSION", "v1.11.0")
-BOARD_DURATION_MIN = _get_int_env("VOR_BOARD_DURATION_MIN", 60)
-HTTP_TIMEOUT = _get_int_env("VOR_HTTP_TIMEOUT", 15)
+BOARD_DURATION_MIN = get_int_env("VOR_BOARD_DURATION_MIN", 60)
+HTTP_TIMEOUT = get_int_env("VOR_HTTP_TIMEOUT", 15)
 DEFAULT_MAX_STATIONS_PER_RUN = 2
-MAX_STATIONS_PER_RUN = _get_int_env("VOR_MAX_STATIONS_PER_RUN", DEFAULT_MAX_STATIONS_PER_RUN)
-ROTATION_INTERVAL_SEC = _get_int_env("VOR_ROTATION_INTERVAL_SEC", 1800)
+MAX_STATIONS_PER_RUN = get_int_env("VOR_MAX_STATIONS_PER_RUN", DEFAULT_MAX_STATIONS_PER_RUN)
+ROTATION_INTERVAL_SEC = get_int_env("VOR_ROTATION_INTERVAL_SEC", 1800)
 RETRY_AFTER_FALLBACK_SEC = 5.0
 
 ALLOW_BUS = (os.getenv("VOR_ALLOW_BUS", "0").strip() == "1")

--- a/src/utils/env.py
+++ b/src/utils/env.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Helpers for reading environment variables in a safe way."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+__all__ = ["get_int_env"]
+
+
+def get_int_env(name: str, default: int) -> int:
+    """Read integer environment variables safely.
+
+    Returns the provided default if the variable is unset or cannot be
+    converted to ``int``. On invalid values, a warning is logged using the
+    ``build_feed`` logger.
+    """
+
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (ValueError, TypeError) as e:
+        logging.getLogger("build_feed").warning(
+            "Ungültiger Wert für %s=%r – verwende Default %d (%s: %s)",
+            name,
+            raw,
+            default,
+            type(e).__name__,
+            e,
+        )
+        return default
+


### PR DESCRIPTION
## Summary
- add a shared `get_int_env` helper in `utils.env`
- use the shared helper in `build_feed` and the VOR provider

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8a4b3561c832b83e0d835c2386fcc