### PR TITLE
Cache station lookup results

### DIFF
--- a/src/utils/stations.py
+++ b/src/utils/stations.py
@@ -374,6 +374,7 @@ def _candidate_values(value: str) -> List[str]:
     return candidates
 
 
+@lru_cache(maxsize=2048)
 def canonical_name(name: str) -> str | None:
     """Return the canonical ÖBB station name for *name* or ``None`` if unknown."""
 
@@ -381,6 +382,7 @@ def canonical_name(name: str) -> str | None:
     return info.name if info else None
 
 
+@lru_cache(maxsize=2048)
 def station_info(name: str) -> StationInfo | None:
     """Return :class:`StationInfo` for *name* or ``None`` if the station is unknown."""
 


### PR DESCRIPTION
## Summary
- cache canonical_name and station_info lookups with lru_cache to speed up repeated station queries

## Testing
- pytest tests/test_station_alias_collision.py tests/test_vor_stations_directory.py tests/test_wl_stations_directory.py

------
https://chatgpt.com/codex/tasks/task_e_68c8a646093c832ba7fda47c0fc78c8f