### PR TITLE
Ensure provider cache loaders accept timeout

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import inspect
 import json
 import os
 import sys
@@ -56,10 +55,22 @@ PROVIDER_CACHE_KEYS: Dict[str, str] = {
     "VOR_ENABLE": "vor",
 }
 
+def read_cache_wl(timeout: int | None = None) -> List[Any]:
+    return read_cache("wl")
+
+
+def read_cache_oebb(timeout: int | None = None) -> List[Any]:
+    return read_cache("oebb")
+
+
+def read_cache_vor(timeout: int | None = None) -> List[Any]:
+    return read_cache("vor")
+
+
 PROVIDERS: List[Tuple[str, Any]] = [
-    ("WL_ENABLE", lambda: read_cache("wl")),
-    ("OEBB_ENABLE", lambda: read_cache("oebb")),
-    ("VOR_ENABLE", lambda: read_cache("vor")),
+    ("WL_ENABLE", read_cache_wl),
+    ("OEBB_ENABLE", read_cache_oebb),
+    ("VOR_ENABLE", read_cache_vor),
 ]
 
 for env, loader in PROVIDERS:
@@ -325,10 +336,7 @@ def _collect_items() -> List[Dict[str, Any]]:
     timed_out = False
     try:
         for fetch in active:
-            if "timeout" in inspect.signature(fetch).parameters:
-                futures[executor.submit(fetch, timeout=PROVIDER_TIMEOUT)] = fetch
-            else:
-                futures[executor.submit(fetch)] = fetch
+            futures[executor.submit(fetch, timeout=PROVIDER_TIMEOUT)] = fetch
         try:
             for future in as_completed(futures, timeout=PROVIDER_TIMEOUT):
                 fetch = futures[future]

--- a/tests/test_collect_items_bad_return.py
+++ b/tests/test_collect_items_bad_return.py
@@ -12,11 +12,11 @@ def _import_build_feed(monkeypatch):
     monkeypatch.syspath_prepend(str(root / "src"))
     providers = types.ModuleType("providers")
     wl = types.ModuleType("providers.wiener_linien")
-    wl.fetch_events = lambda: []
+    wl.fetch_events = lambda timeout=None: []
     oebb = types.ModuleType("providers.oebb")
-    oebb.fetch_events = lambda: []
+    oebb.fetch_events = lambda timeout=None: []
     vor = types.ModuleType("providers.vor")
-    vor.fetch_events = lambda: []
+    vor.fetch_events = lambda timeout=None: []
     monkeypatch.setitem(sys.modules, "providers", providers)
     monkeypatch.setitem(sys.modules, "providers.wiener_linien", wl)
     monkeypatch.setitem(sys.modules, "providers.oebb", oebb)
@@ -28,10 +28,10 @@ def _import_build_feed(monkeypatch):
 def test_collect_items_logs_and_skips_invalid_return(monkeypatch, caplog):
     build_feed = _import_build_feed(monkeypatch)
 
-    def good_provider():
+    def good_provider(timeout=None):
         return [{"p": "good"}]
 
-    def bad_provider():
+    def bad_provider(timeout=None):
         return {"p": "bad"}
 
     monkeypatch.setattr(

--- a/tests/test_collect_items_env.py
+++ b/tests/test_collect_items_env.py
@@ -12,11 +12,11 @@ def _import_build_feed(monkeypatch):
     monkeypatch.syspath_prepend(str(root / "src"))
     providers = types.ModuleType("providers")
     wl = types.ModuleType("providers.wiener_linien")
-    wl.fetch_events = lambda: []
+    wl.fetch_events = lambda timeout=None: []
     oebb = types.ModuleType("providers.oebb")
-    oebb.fetch_events = lambda: []
+    oebb.fetch_events = lambda timeout=None: []
     vor = types.ModuleType("providers.vor")
-    vor.fetch_events = lambda: []
+    vor.fetch_events = lambda timeout=None: []
     monkeypatch.setitem(sys.modules, "providers", providers)
     monkeypatch.setitem(sys.modules, "providers.wiener_linien", wl)
     monkeypatch.setitem(sys.modules, "providers.oebb", oebb)
@@ -40,9 +40,9 @@ def test_disabling_provider_suppresses_items(monkeypatch, disabled_env, expected
         build_feed,
         "PROVIDERS",
         [
-            ("WL_ENABLE", lambda: [{"p": "wl"}]),
-            ("OEBB_ENABLE", lambda: [{"p": "oebb"}]),
-            ("VOR_ENABLE", lambda: [{"p": "vor"}]),
+            ("WL_ENABLE", lambda timeout=None: [{"p": "wl"}]),
+            ("OEBB_ENABLE", lambda timeout=None: [{"p": "oebb"}]),
+            ("VOR_ENABLE", lambda timeout=None: [{"p": "vor"}]),
         ],
     )
 
@@ -65,7 +65,10 @@ def test_env_disabling_ignores_whitespace_and_case(monkeypatch, value):
     monkeypatch.setattr(
         build_feed,
         "PROVIDERS",
-        [("WL_ENABLE", lambda: [{"p": "wl"}]), ("OEBB_ENABLE", lambda: [{"p": "oebb"}])],
+        [
+            ("WL_ENABLE", lambda timeout=None: [{"p": "wl"}]),
+            ("OEBB_ENABLE", lambda timeout=None: [{"p": "oebb"}]),
+        ],
     )
 
     monkeypatch.setenv("WL_ENABLE", value)
@@ -82,9 +85,9 @@ def test_enabling_vor_yields_items(monkeypatch):
         build_feed,
         "PROVIDERS",
         [
-            ("WL_ENABLE", lambda: []),
-            ("OEBB_ENABLE", lambda: []),
-            ("VOR_ENABLE", lambda: [{"p": "vor"}]),
+            ("WL_ENABLE", lambda timeout=None: []),
+            ("OEBB_ENABLE", lambda timeout=None: []),
+            ("VOR_ENABLE", lambda timeout=None: [{"p": "vor"}]),
         ],
     )
 

--- a/tests/test_collect_items_timeout.py
+++ b/tests/test_collect_items_timeout.py
@@ -13,11 +13,11 @@ def _import_build_feed(monkeypatch):
     monkeypatch.syspath_prepend(str(root / "src"))
     providers = types.ModuleType("providers")
     wl = types.ModuleType("providers.wiener_linien")
-    wl.fetch_events = lambda: []
+    wl.fetch_events = lambda timeout=None: []
     oebb = types.ModuleType("providers.oebb")
-    oebb.fetch_events = lambda: []
+    oebb.fetch_events = lambda timeout=None: []
     vor = types.ModuleType("providers.vor")
-    vor.fetch_events = lambda: []
+    vor.fetch_events = lambda timeout=None: []
     monkeypatch.setitem(sys.modules, "providers", providers)
     monkeypatch.setitem(sys.modules, "providers.wiener_linien", wl)
     monkeypatch.setitem(sys.modules, "providers.oebb", oebb)
@@ -34,7 +34,7 @@ def test_slow_provider_does_not_block(monkeypatch):
         time.sleep(2)
         return [{"guid": "slow"}]
 
-    def fast_fetch():
+    def fast_fetch(timeout=None):
         return [{"guid": "fast"}]
 
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- wrap cache readers for each provider with a timeout-compatible signature
- always pass the configured timeout to provider fetches and drop reflection
- adjust collect items tests to use provider callables that accept a timeout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8a7e35e4c832b8b5832ee6dd16f9a