### PR TITLE
Document VOR request counter helpers

### DIFF
--- a/tests/test_vor_request_limit.py
+++ b/tests/test_vor_request_limit.py
@@ -11,6 +11,9 @@ def test_fetch_events_respects_daily_limit(monkeypatch, caplog):
     monkeypatch.setattr(vor, "VOR_STATION_IDS", ["1"])
     monkeypatch.setattr(vor, "MAX_STATIONS_PER_RUN", 1)
 
+    # Die neuen Docstrings von ``load_request_count`` und
+    # ``save_request_count`` dokumentieren das zugrunde liegende Limit und die
+    # Persistenz, auf die sich dieser Test stützt.
     monkeypatch.setattr(
         vor,
         "_select_stations_round_robin",


### PR DESCRIPTION
## Summary
- add descriptive docstrings for the VOR request counter helper functions, including side effects and failure handling
- note in the request limit test that the persisted limit is documented in the helper docstrings

## Testing
- pytest tests/test_vor_request_limit.py

------
https://chatgpt.com/codex/tasks/task_e_68c8ad150024832baa393b3ae7094365