### PR TITLE
Add helper for boolean environment variables

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -18,10 +18,10 @@ from zoneinfo import ZoneInfo
 
 try:  # pragma: no cover - allow running as package and as script
     from utils.cache import read_cache
-    from utils.env import get_int_env
+    from utils.env import get_int_env, get_bool_env
 except ModuleNotFoundError:  # pragma: no cover
     from .utils.cache import read_cache  # type: ignore
-    from .utils.env import get_int_env  # type: ignore
+    from .utils.env import get_int_env, get_bool_env  # type: ignore
 
 # ---------------- Logging ----------------
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").strip().upper()
@@ -349,11 +349,7 @@ def _collect_items() -> List[Dict[str, Any]]:
     items: List[Dict[str, Any]] = []
     futures: Dict[Any, Any] = {}
 
-    active = [
-        f
-        for env, f in PROVIDERS
-        if os.getenv(env, "1").strip().lower() not in {"0", "false"}
-    ]
+    active = [f for env, f in PROVIDERS if get_bool_env(env, True)]
     if not active:
         return []
 

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -26,6 +26,11 @@ from typing import Any, Dict, List, Optional
 from email.utils import parsedate_to_datetime
 
 try:  # pragma: no cover - support both package layouts
+    from utils.env import get_bool_env
+except ModuleNotFoundError:  # pragma: no cover
+    from src.utils.env import get_bool_env  # type: ignore
+
+try:  # pragma: no cover - support both package layouts
     from utils.ids import make_guid
     from utils.text import html_to_text
     from utils.stations import canonical_name, is_in_vienna, is_pendler
@@ -46,7 +51,7 @@ OEBB_URL = (os.getenv("OEBB_RSS_URL", "").strip()
 
 # Optional strenger Filter: Nur Meldungen mit Endpunkten in Wien behalten.
 # Aktiviert durch Umgebungsvariable ``OEBB_ONLY_VIENNA`` ("1"/"true" vs "0"/"false", case-insens).
-OEBB_ONLY_VIENNA = os.getenv("OEBB_ONLY_VIENNA", "").strip().lower() not in {"", "0", "false"}
+OEBB_ONLY_VIENNA = get_bool_env("OEBB_ONLY_VIENNA", False)
 
 # ---------------- HTTP ----------------
 def _session() -> requests.Session:

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -28,9 +28,9 @@ except ModuleNotFoundError:  # pragma: no cover
     from src.utils.ids import make_guid  # type: ignore
 
 try:  # pragma: no cover - support both package layouts
-    from utils.env import get_int_env
+    from utils.env import get_int_env, get_bool_env
 except ModuleNotFoundError:  # pragma: no cover
-    from src.utils.env import get_int_env  # type: ignore
+    from src.utils.env import get_int_env, get_bool_env  # type: ignore
 
 try:
     from utils.text import html_to_text
@@ -123,7 +123,7 @@ MAX_STATIONS_PER_RUN = get_int_env("VOR_MAX_STATIONS_PER_RUN", DEFAULT_MAX_STATI
 ROTATION_INTERVAL_SEC = get_int_env("VOR_ROTATION_INTERVAL_SEC", 1800)
 RETRY_AFTER_FALLBACK_SEC = 5.0
 
-ALLOW_BUS = (os.getenv("VOR_ALLOW_BUS", "0").strip() == "1")
+ALLOW_BUS = get_bool_env("VOR_ALLOW_BUS", False)
 BUS_INCLUDE_RE = re.compile(os.getenv("VOR_BUS_INCLUDE_REGEX", r"(?:\b[2-9]\d{2,4}\b)"))
 BUS_EXCLUDE_RE = re.compile(os.getenv("VOR_BUS_EXCLUDE_REGEX", r"^(?:N?\d{1,2}[A-Z]?)$"))
 

--- a/src/utils/env.py
+++ b/src/utils/env.py
@@ -8,7 +8,44 @@ from __future__ import annotations
 import logging
 import os
 
-__all__ = ["get_int_env"]
+__all__ = ["get_int_env", "get_bool_env"]
+
+_TRUE_VALUES = {"1", "true", "t", "yes", "y", "on"}
+_FALSE_VALUES = {"0", "false", "f", "no", "n", "off"}
+
+
+def get_bool_env(name: str, default: bool) -> bool:
+    """Read boolean environment variables safely.
+
+    Supported truthy values are ``1``, ``true``, ``t``, ``yes``, ``y`` and
+    ``on`` (case-insensitive).  Falsy values are ``0``, ``false``, ``f``,
+    ``no``, ``n`` and ``off``.  Unset variables or values consisting solely of
+    whitespace result in the provided default.  All other values trigger a
+    warning and also fall back to the default.
+    """
+
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+
+    stripped = raw.strip()
+    if not stripped:
+        return default
+
+    lowered = stripped.casefold()
+    if lowered in _TRUE_VALUES:
+        return True
+    if lowered in _FALSE_VALUES:
+        return False
+
+    logging.getLogger("build_feed").warning(
+        "Ungültiger boolescher Wert für %s=%r – verwende Default %s "
+        "(erlaubt: 1/0, true/false, yes/no, on/off)",
+        name,
+        raw,
+        default,
+    )
+    return default
 
 
 def get_int_env(name: str, default: int) -> int:

--- a/tests/test_oebb_env_var.py
+++ b/tests/test_oebb_env_var.py
@@ -10,6 +10,9 @@ def test_oebb_only_vienna_env_var(monkeypatch):
     monkeypatch.setenv("OEBB_ONLY_VIENNA", "1")
     importlib.reload(oebb)
     assert oebb.OEBB_ONLY_VIENNA is True
+    monkeypatch.setenv("OEBB_ONLY_VIENNA", "yes")
+    importlib.reload(oebb)
+    assert oebb.OEBB_ONLY_VIENNA is True
     monkeypatch.delenv("OEBB_ONLY_VIENNA", raising=False)
     importlib.reload(oebb)
 

--- a/tests/test_utils_env.py
+++ b/tests/test_utils_env.py
@@ -1,0 +1,42 @@
+import logging
+
+import pytest
+
+from src.utils.env import get_bool_env
+
+
+def test_get_bool_env_default(monkeypatch):
+    monkeypatch.delenv("BOOL_TEST", raising=False)
+    assert get_bool_env("BOOL_TEST", True) is True
+    assert get_bool_env("BOOL_TEST", False) is False
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["1", "true", "True", " YES ", "on", "Y", "t"],
+)
+def test_get_bool_env_truthy(monkeypatch, value):
+    monkeypatch.setenv("BOOL_TEST", value)
+    assert get_bool_env("BOOL_TEST", False) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["0", "false", "False", " no ", "OFF", "n", "F"],
+)
+def test_get_bool_env_falsy(monkeypatch, value):
+    monkeypatch.setenv("BOOL_TEST", value)
+    assert get_bool_env("BOOL_TEST", True) is False
+
+
+def test_get_bool_env_empty_uses_default(monkeypatch):
+    monkeypatch.setenv("BOOL_TEST", "   ")
+    assert get_bool_env("BOOL_TEST", True) is True
+    assert get_bool_env("BOOL_TEST", False) is False
+
+
+def test_get_bool_env_invalid_logs_warning(monkeypatch, caplog):
+    monkeypatch.setenv("BOOL_TEST", "maybe")
+    with caplog.at_level(logging.WARNING, logger="build_feed"):
+        assert get_bool_env("BOOL_TEST", False) is False
+    assert "Ungültiger boolescher Wert" in caplog.text


### PR DESCRIPTION
## Summary
- add a `get_bool_env` helper that normalises boolean environment variables and warns on invalid input
- switch build_feed and the ÖBB/VOR providers to use the new helper
- extend tests to cover boolean env parsing and broaden the ÖBB env-var test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8acfdfc2c832b9adff570fe0ce6c9