### PR TITLE
chore: run full station update in workflow

### DIFF
--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -25,7 +25,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Refresh station directory
-        run: python scripts/update_station_directory.py --verbose
+        run: python scripts/update_all_stations.py --verbose
 
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
## Summary
- adjust the update-stations workflow to call the aggregated station refresh script
- keep the auto-commit step focused on data/stations.json

## Testing
- python scripts/update_all_stations.py --verbose
- pytest tests/test_wl_stations_directory.py tests/test_vor_stations_directory.py

------
https://chatgpt.com/codex/tasks/task_e_68c923562cb0832b94701ec4f5903531