### PR TITLE
Handle timeframe formatting and parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Störungen und Einschränkungen für den Großraum Wien aus offiziellen Quellen.
 
-Die `<description>`-Elemente des Feeds enthalten höchstens zwei Zeilen; redundante Überschriften wie „Bauarbeiten“ oder das Label „Zeitraum:“ werden automatisch entfernt.
+Die `<description>`-Elemente des Feeds bestehen aus zwei Zeilen: Der erste Satz fasst den Inhalt zusammen, die zweite Zeile nennt den Zeitraum (z. B. „seit 05.01.2024“ oder „01.06.2024–03.06.2024“). Redundante Überschriften wie „Bauarbeiten“ oder das Label „Zeitraum:“ werden automatisch entfernt.
 
 ## Erweiterungen
 

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -167,13 +167,11 @@ def format_local_times(
         end_local = _to_utc(end).astimezone(_VIENNA_TZ)
 
     if start_local and end_local:
-        if start_local.date() == end_local.date():
-            return f"{start_local:%H:%M}-{end_local:%H:%M} {start_local:%d.%m.%Y}"
-        return f"{start_local:%d.%m.%Y %H:%M}-{end_local:%d.%m.%Y %H:%M}"
+        return f"{start_local:%d.%m.%Y}–{end_local:%d.%m.%Y}"
     if start_local:
-        return f"seit: {start_local:%d.%m.%Y %H:%M}"
+        return f"seit {start_local:%d.%m.%Y}"
     if end_local:
-        return f"bis: {end_local:%d.%m.%Y %H:%M}"
+        return f"bis {end_local:%d.%m.%Y}"
     return ""
 
 # Entfernt XML-unerlaubte Kontrollzeichen (außer \t, \n, \r)
@@ -528,6 +526,19 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
     pubDate   = it.get("pubDate")
     starts_at = it.get("starts_at")
     ends_at   = it.get("ends_at")
+
+    if isinstance(starts_at, str):
+        try:
+            starts_at = datetime.fromisoformat(starts_at)
+        except ValueError:
+            log.warning("starts_at Parsefehler: %r", starts_at)
+            starts_at = None
+    if isinstance(ends_at, str):
+        try:
+            ends_at = datetime.fromisoformat(ends_at)
+        except ValueError:
+            log.warning("ends_at Parsefehler: %r", ends_at)
+            ends_at = None
 
     if not isinstance(pubDate, datetime) and FRESH_PUBDATE_WINDOW_MIN > 0:
         age = _to_utc(now) - _to_utc(fs_dt)

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -119,7 +119,7 @@ def test_emit_item_appends_since_time(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Wegen Bauarbeiten<br/>seit: 05.01.2024 11:00"
+    assert desc_text == "Wegen Bauarbeiten<br/>seit 05.01.2024"
 
 
 def test_emit_item_appends_same_day_range(monkeypatch):
@@ -135,7 +135,7 @@ def test_emit_item_appends_same_day_range(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Zug verkehrt nicht<br/>09:00-13:30 10.03.2024"
+    assert desc_text == "Zug verkehrt nicht<br/>10.03.2024–10.03.2024"
 
 
 def test_emit_item_appends_multi_day_range(monkeypatch):
@@ -151,7 +151,26 @@ def test_emit_item_appends_multi_day_range(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Ersatzverkehr eingerichtet<br/>01.06.2024 14:00-03.06.2024 17:00"
+    assert desc_text == "Ersatzverkehr eingerichtet<br/>01.06.2024–03.06.2024"
+
+
+def test_emit_item_description_two_lines(monkeypatch):
+    bf = _load_build_feed(monkeypatch)
+    now = datetime(2024, 7, 1, tzinfo=timezone.utc)
+    item = {
+        "title": "Sperre",
+        "description": "Ersatzverkehr eingerichtet",
+        "starts_at": "2024-07-01T00:00:00+00:00",
+        "ends_at": "2024-07-02T00:00:00+00:00",
+    }
+
+    _, xml = bf._emit_item(item, now, {})
+
+    desc_text = _extract_description(xml)
+    assert desc_text.split("<br/>") == [
+        "Ersatzverkehr eingerichtet",
+        "01.07.2024–02.07.2024",
+    ]
 
 
 def test_emit_item_no_times_only_description(monkeypatch):


### PR DESCRIPTION
## Summary
- parse `starts_at`/`ends_at` ISO strings into datetimes before formatting feed items
- format timeframe lines with date-only "seit"/"bis"/"start–end" strings and document the two-line descriptions
- refresh clip-and-escape tests to cover the new formatting and ensure two-line descriptions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9272dfaf4832b8e2cd67f1ac6a567