### PR TITLE
Handle missing or non-advancing end dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Störungen und Einschränkungen für den Großraum Wien aus offiziellen Quellen.
 
-Die `<description>`-Elemente des Feeds bestehen aus zwei Zeilen: Der erste Satz fasst den Inhalt zusammen, die zweite Zeile nennt den Zeitraum (z. B. „seit 05.01.2024“ oder „01.06.2024–03.06.2024“). Redundante Überschriften wie „Bauarbeiten“ oder das Label „Zeitraum:“ werden automatisch entfernt.
+Die `<description>`-Elemente des Feeds bestehen aus zwei Zeilen: Der erste Satz fasst den Inhalt zusammen, die zweite Zeile nennt den Zeitraum (z. B. „seit 05.01.2024“ oder „01.06.2024–03.06.2024“). Fehlt ein sinnvolles Enddatum oder liegt es nicht nach dem Beginn, erscheint dort automatisch „seit <Datum>“. Redundante Überschriften wie „Bauarbeiten“ oder das Label „Zeitraum:“ werden automatisch entfernt.
 
 ## Erweiterungen
 

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -166,10 +166,10 @@ def format_local_times(
     if isinstance(end, datetime):
         end_local = _to_utc(end).astimezone(_VIENNA_TZ)
 
-    if start_local and end_local:
-        return f"{start_local:%d.%m.%Y}–{end_local:%d.%m.%Y}"
     if start_local:
-        return f"seit {start_local:%d.%m.%Y}"
+        if not end_local or end_local <= start_local:
+            return f"seit {start_local:%d.%m.%Y}"
+        return f"{start_local:%d.%m.%Y}–{end_local:%d.%m.%Y}"
     if end_local:
         return f"bis {end_local:%d.%m.%Y}"
     return ""

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -122,6 +122,32 @@ def test_emit_item_appends_since_time(monkeypatch):
     assert desc_text == "Wegen Bauarbeiten<br/>seit 05.01.2024"
 
 
+def test_emit_item_since_line_for_missing_or_nonadvancing_end(monkeypatch):
+    bf = _load_build_feed(monkeypatch)
+    now = datetime(2024, 1, 10, tzinfo=timezone.utc)
+    base_item = {
+        "title": "Störung",
+        "description": "Wegen Bauarbeiten",
+        "starts_at": datetime(2024, 1, 5, 10, 0, tzinfo=timezone.utc),
+    }
+
+    scenarios = [
+        {},
+        {"ends_at": datetime(2024, 1, 5, 10, 0, tzinfo=timezone.utc)},
+    ]
+
+    for extra in scenarios:
+        item = dict(base_item)
+        item.update(extra)
+        _, xml = bf._emit_item(item, now, {})
+
+        desc_text = _extract_description(xml)
+        assert desc_text.split("<br/>") == [
+            "Wegen Bauarbeiten",
+            "seit 05.01.2024",
+        ]
+
+
 def test_emit_item_appends_same_day_range(monkeypatch):
     bf = _load_build_feed(monkeypatch)
     now = datetime(2024, 3, 10, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- treat end times that are missing or not after the start as ongoing when formatting local dates
- add a regression test ensuring identical start and end dates emit a "seit" line
- document that events without a meaningful end date produce a "seit" line in the feed

## Testing
- pytest tests/test_clip_and_escape.py

------
https://chatgpt.com/codex/tasks/task_e_68c92e7c20c0832ba2feb416a74ef8fd