### PR TITLE
Refactor providers to use shared HTTP session helper

### DIFF
--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -1,0 +1,34 @@
+"""HTTP helpers for configuring :mod:`requests` sessions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+_DEFAULT_RETRY_OPTIONS: dict[str, Any] = {
+    "total": 4,
+    "backoff_factor": 0.6,
+    "status_forcelist": (429, 500, 502, 503, 504),
+    "allowed_methods": ("GET",),
+}
+
+
+def session_with_retries(user_agent: str, **retry_opts: Any) -> requests.Session:
+    """Return a :class:`requests.Session` pre-configured with retries.
+
+    Args:
+        user_agent: User-Agent header that should be sent with every request.
+        **retry_opts: Additional keyword arguments forwarded to
+            :class:`urllib3.util.retry.Retry`.
+    """
+
+    options = {**_DEFAULT_RETRY_OPTIONS, **retry_opts}
+    session = requests.Session()
+    retry = Retry(**options)
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("https://", adapter)
+    session.headers.update({"User-Agent": user_agent})
+    return session

--- a/tests/test_oebb_rate_limit.py
+++ b/tests/test_oebb_rate_limit.py
@@ -14,6 +14,7 @@ class DummySession:
     def __init__(self, responses, calls):
         self._responses = iter(responses)
         self._calls = calls
+        self.headers: dict[str, str] = {}
 
     def __enter__(self):
         return self
@@ -32,7 +33,7 @@ def test_rate_limit_retries_once_after_wait(monkeypatch, caplog):
         DummyResponse(200, {}, b"<root></root>"),
     ]
     calls = []
-    monkeypatch.setattr(oebb, "_session", lambda: DummySession(responses, calls))
+    monkeypatch.setattr(oebb, "session_with_retries", lambda *a, **kw: DummySession(responses, calls))
 
     slept = []
 
@@ -62,7 +63,7 @@ def test_rate_limit_returns_none_after_retry(monkeypatch):
         DummyResponse(429, {"Retry-After": "2"}),
     ]
     calls = []
-    monkeypatch.setattr(oebb, "_session", lambda: DummySession(responses, calls))
+    monkeypatch.setattr(oebb, "session_with_retries", lambda *a, **kw: DummySession(responses, calls))
 
     slept = []
 

--- a/tests/test_oebb_timeout.py
+++ b/tests/test_oebb_timeout.py
@@ -31,6 +31,9 @@ def test_fetch_xml_passes_timeout_to_session(monkeypatch):
             pass
 
     class DummySession:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
         def __enter__(self):
             return self
 
@@ -40,7 +43,7 @@ def test_fetch_xml_passes_timeout_to_session(monkeypatch):
         def get(self, url, timeout):
             recorded["timeout"] = timeout
             return DummyResponse()
-    monkeypatch.setattr(oebb, "_session", lambda: DummySession())
+    monkeypatch.setattr(oebb, "session_with_retries", lambda *a, **kw: DummySession())
 
     oebb._fetch_xml("http://example.com", timeout=3)
     assert recorded["timeout"] == 3

--- a/tests/test_vor_accessid_not_logged.py
+++ b/tests/test_vor_accessid_not_logged.py
@@ -12,6 +12,9 @@ def test_accessid_not_logged(monkeypatch, caplog):
     importlib.reload(vor)
 
     class DummySession:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
         def __enter__(self):
             return self
 
@@ -21,7 +24,7 @@ def test_accessid_not_logged(monkeypatch, caplog):
         def get(self, *args, **kwargs):
             raise requests.RequestException(f"boom accessId={vor.VOR_ACCESS_ID}")
 
-    monkeypatch.setattr(vor, "_session", lambda: DummySession())
+    monkeypatch.setattr(vor, "session_with_retries", lambda *a, **kw: DummySession())
     now_local = datetime.now(ZoneInfo("Europe/Vienna"))
 
     with caplog.at_level(logging.ERROR):

--- a/tests/test_vor_retry_after.py
+++ b/tests/test_vor_retry_after.py
@@ -11,6 +11,9 @@ def test_retry_after_invalid_value(monkeypatch, caplog):
         content = b""
 
     class DummySession:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
         def __enter__(self):
             return self
 
@@ -20,7 +23,7 @@ def test_retry_after_invalid_value(monkeypatch, caplog):
         def get(self, url, params, timeout):
             return DummyResponse()
 
-    monkeypatch.setattr(vor, "_session", lambda: DummySession())
+    monkeypatch.setattr(vor, "session_with_retries", lambda *a, **kw: DummySession())
 
     sleep_calls: list[float] = []
 
@@ -45,6 +48,9 @@ def test_retry_after_missing_header(monkeypatch, caplog):
         content = b""
 
     class DummySession:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
         def __enter__(self):
             return self
 
@@ -54,7 +60,7 @@ def test_retry_after_missing_header(monkeypatch, caplog):
         def get(self, url, params, timeout):
             return DummyResponse()
 
-    monkeypatch.setattr(vor, "_session", lambda: DummySession())
+    monkeypatch.setattr(vor, "session_with_retries", lambda *a, **kw: DummySession())
 
     sleep_calls: list[float] = []
 
@@ -80,6 +86,9 @@ def test_retry_after_numeric_value(monkeypatch):
         content = b""
 
     class DummySession:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
         def __enter__(self):
             return self
 
@@ -89,7 +98,7 @@ def test_retry_after_numeric_value(monkeypatch):
         def get(self, url, params, timeout):
             return DummyResponse()
 
-    monkeypatch.setattr(vor, "_session", lambda: DummySession())
+    monkeypatch.setattr(vor, "session_with_retries", lambda *a, **kw: DummySession())
 
     sleep_calls: list[float] = []
 
@@ -115,6 +124,9 @@ def test_retry_after_http_date(monkeypatch):
         content = b""
 
     class DummySession:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
         def __enter__(self):
             return self
 
@@ -130,7 +142,7 @@ def test_retry_after_http_date(monkeypatch):
             assert tz == timezone.utc
             return fixed_now
 
-    monkeypatch.setattr(vor, "_session", lambda: DummySession())
+    monkeypatch.setattr(vor, "session_with_retries", lambda *a, **kw: DummySession())
     monkeypatch.setattr(vor, "datetime", FixedDateTime)
 
     sleep_calls: list[float] = []
@@ -158,6 +170,9 @@ def test_fetch_stationboard_sends_products_param(monkeypatch):
             return {}
 
     class DummySession:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
         def __enter__(self):
             return self
 
@@ -168,7 +183,7 @@ def test_fetch_stationboard_sends_products_param(monkeypatch):
             captured_params.update(params)
             return DummyResponse()
 
-    monkeypatch.setattr(vor, "_session", lambda: DummySession())
+    monkeypatch.setattr(vor, "session_with_retries", lambda *a, **kw: DummySession())
     monkeypatch.setattr(vor, "ALLOW_BUS", False)
 
     result = vor._fetch_stationboard("123", datetime(2024, 1, 1, 12, 0))

--- a/tests/test_wl_fetch.py
+++ b/tests/test_wl_fetch.py
@@ -24,6 +24,9 @@ def test_fetch_events_handles_invalid_json(monkeypatch, caplog):
             raise ValueError("invalid JSON")
 
     class DummySession:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
         def __enter__(self):
             return self
 
@@ -33,7 +36,7 @@ def test_fetch_events_handles_invalid_json(monkeypatch, caplog):
         def get(self, url, params=None, timeout=None):
             return DummyResponse()
 
-    monkeypatch.setattr("src.providers.wl_fetch._session", lambda: DummySession())
+    monkeypatch.setattr("src.providers.wl_fetch.session_with_retries", lambda *a, **kw: DummySession())
 
     with caplog.at_level(logging.WARNING):
         events = fetch_events(timeout=0)


### PR DESCRIPTION
## Summary
- add a `session_with_retries` helper in `src/utils/http.py` for reusable retry-enabled sessions
- update the ÖBB, Wiener Linien, and VOR providers to rely on the shared session helper
- adjust tests to mock the new helper when providing dummy sessions

## Testing
- pytest tests/test_oebb_timeout.py tests/test_oebb_rate_limit.py tests/test_wl_fetch.py tests/test_vor_accessid_not_logged.py tests/test_vor_retry_after.py

------
https://chatgpt.com/codex/tasks/task_e_68c93f5296c4832b9d55eb0b1a9828b7