### PR TITLE
Normalize RSS description HTML line breaks

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -586,8 +586,7 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
     time_line = re.sub(r"[ \t\r\f\v]+", " ", time_line).strip()
 
     desc_out = "\n".join(filter(None, [desc_line, time_line]))
-    desc_cdata = desc_out
-    desc_html = desc_out.replace("\n", "<br/>")
+    desc_cdata = desc_out.replace("\n", "<br/>")
 
     parts: List[str] = []
     parts.append("<item>")
@@ -604,7 +603,7 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
         parts.append(f"<ext:ends_at>{_fmt_rfc2822(ends_at)}</ext:ends_at>")
 
     parts.append(f"<description>{_cdata(desc_cdata)}</description>")
-    parts.append(f"<content:encoded>{_cdata(desc_html)}</content:encoded>")
+    parts.append(f"<content:encoded>{_cdata(desc_cdata)}</content:encoded>")
     parts.append("</item>")
     return ident, "\n".join(parts)
 

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -141,7 +141,7 @@ def test_emit_item_appends_since_time(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Wegen Bauarbeiten\nSeit 05.01.2024"
+    assert desc_text == "Wegen Bauarbeiten<br/>Seit 05.01.2024"
 
     content_html = _extract_content_encoded(xml)
     assert content_html == "Wegen Bauarbeiten<br/>Seit 05.01.2024"
@@ -170,7 +170,7 @@ def test_emit_item_since_line_for_missing_or_nonadvancing_end(monkeypatch):
         _, xml = bf._emit_item(item, now, {})
 
         desc_text = _extract_description(xml)
-        assert desc_text.split("\n") == [
+        assert desc_text.split("<br/>") == [
             "Wegen Bauarbeiten",
             "Seit 05.01.2024",
         ]
@@ -198,7 +198,7 @@ def test_emit_item_future_same_day_shows_am(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.split("\n") == [
+    assert desc_text.split("<br/>") == [
         "Wegen Bauarbeiten",
         "Am 10.01.2024",
     ]
@@ -225,7 +225,7 @@ def test_emit_item_future_start_without_end_shows_ab(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.split("\n") == [
+    assert desc_text.split("<br/>") == [
         "Eingeschränkter Betrieb",
         "Ab 20.01.2024",
     ]
@@ -253,7 +253,7 @@ def test_emit_item_appends_same_day_range(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Zug verkehrt nicht\n10.03.2024–10.03.2024"
+    assert desc_text == "Zug verkehrt nicht<br/>10.03.2024–10.03.2024"
 
     content_html = _extract_content_encoded(xml)
     assert content_html == "Zug verkehrt nicht<br/>10.03.2024–10.03.2024"
@@ -272,7 +272,7 @@ def test_emit_item_appends_multi_day_range(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Ersatzverkehr eingerichtet\n01.06.2024–03.06.2024"
+    assert desc_text == "Ersatzverkehr eingerichtet<br/>01.06.2024–03.06.2024"
 
     content_html = _extract_content_encoded(xml)
     assert content_html == "Ersatzverkehr eingerichtet<br/>01.06.2024–03.06.2024"
@@ -291,7 +291,7 @@ def test_emit_item_description_two_lines(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.split("\n") == [
+    assert desc_text.split("<br/>") == [
         "Ersatzverkehr eingerichtet",
         "01.07.2024–02.07.2024",
     ]


### PR DESCRIPTION
## Summary
- convert RSS description CDATA to use `<br/>` elements instead of newlines
- reuse the HTML-friendly description for both description and content:encoded
- update clip and escape tests to assert `<description>` uses `<br/>`

## Testing
- pytest tests/test_clip_and_escape.py

------
https://chatgpt.com/codex/tasks/task_e_68c94b7e1c04832b9f86671169ddb9eb