### PR TITLE
Mount retry adapter for http sessions

### DIFF
--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -29,6 +29,7 @@ def session_with_retries(user_agent: str, **retry_opts: Any) -> requests.Session
     session = requests.Session()
     retry = Retry(**options)
     adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
     session.mount("https://", adapter)
     session.headers.update({"User-Agent": user_agent})
     return session

--- a/tests/test_http_session.py
+++ b/tests/test_http_session.py
@@ -1,0 +1,19 @@
+from requests.adapters import HTTPAdapter
+
+from src.utils.http import session_with_retries
+
+
+def test_session_mounts_same_retry_adapter_for_http_and_https() -> None:
+    session = session_with_retries("pytest-agent")
+
+    http_adapter = session.adapters["http://"]
+    https_adapter = session.adapters["https://"]
+
+    assert isinstance(http_adapter, HTTPAdapter)
+    assert http_adapter is https_adapter
+
+    retry = http_adapter.max_retries
+    assert retry.total == 4
+    assert retry.backoff_factor == 0.6
+    assert retry.status_forcelist == (429, 500, 502, 503, 504)
+    assert retry.allowed_methods == ("GET",)


### PR DESCRIPTION
## Summary
- mount the retry-configured HTTPAdapter for both http and https sessions
- add coverage to ensure both schemes share the same adapter and retry settings

## Testing
- pytest tests/test_http_session.py

------
https://chatgpt.com/codex/tasks/task_e_68c94e2bf150832bb12505ff6d4a10eb