### PR TITLE
Handle invalid VOR bus regex patterns

### DIFF
--- a/tests/test_vor_env.py
+++ b/tests/test_vor_env.py
@@ -57,3 +57,21 @@ def test_invalid_int_env_uses_defaults(monkeypatch, caplog):
         monkeypatch.delenv(name, raising=False)
     importlib.reload(vor)
 
+
+def test_invalid_bus_regex_falls_back_to_defaults(monkeypatch, caplog):
+    monkeypatch.setenv("VOR_BUS_INCLUDE_REGEX", "(")
+    monkeypatch.setenv("VOR_BUS_EXCLUDE_REGEX", "(")
+
+    with caplog.at_level(logging.WARNING):
+        importlib.reload(vor)
+
+    assert vor.BUS_INCLUDE_RE.pattern == vor.DEFAULT_BUS_INCLUDE_PATTERN
+    assert vor.BUS_EXCLUDE_RE.pattern == vor.DEFAULT_BUS_EXCLUDE_PATTERN
+
+    assert any("VOR_BUS_INCLUDE_REGEX" in record.getMessage() for record in caplog.records)
+    assert any("VOR_BUS_EXCLUDE_REGEX" in record.getMessage() for record in caplog.records)
+
+    monkeypatch.delenv("VOR_BUS_INCLUDE_REGEX", raising=False)
+    monkeypatch.delenv("VOR_BUS_EXCLUDE_REGEX", raising=False)
+    importlib.reload(vor)
+


### PR DESCRIPTION
## Summary
- guard the VOR bus regex compilation against invalid patterns and warn before falling back to defaults
- expose the default bus regex patterns for reuse and testing
- cover the behaviour with a regression test that injects invalid regexes

## Testing
- pytest tests/test_vor_env.py

------
https://chatgpt.com/codex/tasks/task_e_68c94e4101f8832ba125c5b00ae5070b