### PR TITLE
Validate LOG_DIR against allowed roots

### DIFF
--- a/tests/test_path_guard.py
+++ b/tests/test_path_guard.py
@@ -40,3 +40,12 @@ def test_state_path_rejects_outside_whitelist(monkeypatch, tmp_path):
     with pytest.raises(ValueError):
         _import_build_feed(monkeypatch)
 
+
+def test_log_dir_outside_whitelist_falls_back(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("LOG_DIR", "../evil")
+    build_feed = _import_build_feed(monkeypatch)
+
+    assert build_feed.LOG_DIR == "log"
+    assert (tmp_path / "log").is_dir()
+


### PR DESCRIPTION
## Summary
- allow the logging directory to pass path validation and reuse the shared whitelist
- validate the LOG_DIR environment value and fall back to the default when it points outside allowed roots
- extend the path guard tests to cover rejection of invalid logging directories

## Testing
- pytest tests/test_path_guard.py

------
https://chatgpt.com/codex/tasks/task_e_68c95071b37c832bb18549a89f2f9796