### PR TITLE
Add thin-spaced date range formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Störungen und Einschränkungen für den Großraum Wien aus offiziellen Quellen.
 
-Die `<description>`-Elemente des Feeds bestehen aus zwei Zeilen: Der erste Satz fasst den Inhalt zusammen, die zweite Zeile nennt den Zeitraum (z. B. „Seit 05.01.2024“, „Ab 20.01.2024“, „Am 10.01.2024“ oder „01.06.2024–03.06.2024“). Fehlt ein sinnvolles Enddatum oder liegt es nicht nach dem Beginn, erscheint abhängig vom Datum automatisch „Seit <Datum>“ (Vergangenheit) bzw. „Ab <Datum>“ (zukünftig). Für zukünftige eintägige Intervalle wird „Am <Datum>“ verwendet. Redundante Überschriften wie „Bauarbeiten“ oder das Label „Zeitraum:“ werden automatisch entfernt. Die `<description>`-Elemente enthalten rohe Zeilenumbrüche; wer HTML-Breaks benötigt, kann stattdessen `<content:encoded>` mit `<br/>`-Trennzeichen nutzen.
+Die `<description>`-Elemente des Feeds bestehen aus zwei Zeilen: Der erste Satz fasst den Inhalt zusammen, die zweite Zeile nennt den Zeitraum (z. B. „Seit 05.01.2024“, „Ab 20.01.2024“, „Am 10.01.2024“ oder „01.06.2024 – 03.06.2024“). Fehlt ein sinnvolles Enddatum oder liegt es nicht nach dem Beginn, erscheint abhängig vom Datum automatisch „Seit <Datum>“ (Vergangenheit) bzw. „Ab <Datum>“ (zukünftig). Für zukünftige eintägige Intervalle wird „Am <Datum>“ verwendet. Redundante Überschriften wie „Bauarbeiten“ oder das Label „Zeitraum:“ werden automatisch entfernt. Die `<description>`-Elemente enthalten rohe Zeilenumbrüche; wer HTML-Breaks benötigt, kann stattdessen `<content:encoded>` mit `<br/>`-Trennzeichen nutzen.
 
 ## Erweiterungen
 

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -195,7 +195,7 @@ def format_local_times(
                 if start_local.date() > today.date():
                     return f"Ab {start_local:%d.%m.%Y}"
                 return f"Seit {start_local:%d.%m.%Y}"
-            return f"{start_local:%d.%m.%Y}–{end_local:%d.%m.%Y}"
+            return f"{start_local:%d.%m.%Y} – {end_local:%d.%m.%Y}"
         if start_local.date() > today.date():
             return f"Ab {start_local:%d.%m.%Y}"
         return f"Seit {start_local:%d.%m.%Y}"

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -296,10 +296,10 @@ def test_emit_item_appends_same_day_range(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Zug verkehrt nicht<br/>10.03.2024–10.03.2024"
+    assert desc_text == "Zug verkehrt nicht<br/>10.03.2024\u202f–\u202f10.03.2024"
 
     content_html = _extract_content_encoded(xml)
-    assert content_html == "Zug verkehrt nicht<br/>10.03.2024–10.03.2024"
+    assert content_html == "Zug verkehrt nicht<br/>10.03.2024\u202f–\u202f10.03.2024"
 
 
 def test_emit_item_appends_multi_day_range(monkeypatch):
@@ -315,10 +315,10 @@ def test_emit_item_appends_multi_day_range(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Ersatzverkehr eingerichtet<br/>01.06.2024–03.06.2024"
+    assert desc_text == "Ersatzverkehr eingerichtet<br/>01.06.2024\u202f–\u202f03.06.2024"
 
     content_html = _extract_content_encoded(xml)
-    assert content_html == "Ersatzverkehr eingerichtet<br/>01.06.2024–03.06.2024"
+    assert content_html == "Ersatzverkehr eingerichtet<br/>01.06.2024\u202f–\u202f03.06.2024"
 
 
 def test_emit_item_description_two_lines(monkeypatch):
@@ -336,13 +336,13 @@ def test_emit_item_description_two_lines(monkeypatch):
     desc_text = _extract_description(xml)
     assert desc_text.split("<br/>") == [
         "Ersatzverkehr eingerichtet",
-        "01.07.2024–02.07.2024",
+        "01.07.2024\u202f–\u202f02.07.2024",
     ]
 
     content_html = _extract_content_encoded(xml)
     assert content_html.split("<br/>") == [
         "Ersatzverkehr eingerichtet",
-        "01.07.2024–02.07.2024",
+        "01.07.2024\u202f–\u202f02.07.2024",
     ]
 
 


### PR DESCRIPTION
## Summary
- ensure date range formatting uses thin non-breaking spaces in feed output
- adjust tests and README examples to match the new date range layout

## Testing
- pytest tests/test_clip_and_escape.py

------
https://chatgpt.com/codex/tasks/task_e_68c959a6ab34832bb94fca93c9381dd5