### PR TITLE
Clarify preferred ÖBB RSS source in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,12 +318,13 @@ Weitere Details folgen …]]></description>
 | `OEBB_RSS_URL` | str | `"https://fahrplan.oebb.at/bin/help.exe/dnl?protocol=https:&tpl=rss_WI_oebb&"` | RSS-Quelle der ÖBB (kann über Secret überschrieben werden). |
 | `OEBB_ONLY_VIENNA` | bool (`"1"`/`"0"` oder `"true"`/`"false"`, case-insens) | `"0"` | Nur Meldungen mit Endpunkten in Wien behalten. |
 
-> **Hinweis:** Bevorzugt wird der RSS-Endpunkt unter `https://fahrplan.oebb.at`,
-> da der bisher genutzte Host `https://verkehrsauskunft.oebb.at` aus manchen
-> Netzen (u. a. den GitHub-Actions-Runnern) nur eingeschränkt erreichbar ist.
-> Falls eigene Deployments weiterhin Zugriff auf `verkehrsauskunft.oebb.at`
-> haben, kann die Umgebungsvariable `OEBB_RSS_URL` auf den alternativen Host
-> zeigen.
+> **Hinweis:** Als bevorzugte Standardquelle dient der RSS-Endpunkt unter
+> `https://fahrplan.oebb.at`, der den zuvor verwendeten Host
+> `https://verkehrsauskunft.oebb.at` ersetzt, da dieser aus manchen Netzen
+> (u. a. den GitHub-Actions-Runnern) nur eingeschränkt erreichbar ist. Falls
+> eigene Deployments weiterhin Zugriff auf `verkehrsauskunft.oebb.at` haben,
+> kann die Umgebungsvariable `OEBB_RSS_URL` auf den alternativen Host zeigen,
+> um den Feed bei Bedarf zu ergänzen.
 
 ### VOR / VAO (`src/providers/vor.py`)
 


### PR DESCRIPTION
## Summary
- update the README to call out https://fahrplan.oebb.at as the preferred ÖBB RSS feed source
- explain that the new endpoint replaces the previous https://verkehrsauskunft.oebb.at host due to accessibility issues
- review related documentation to ensure the ÖBB RSS feed references remain consistent

## Testing
- not run (documentation change)

------
https://chatgpt.com/codex/tasks/task_e_68c97a56d2f8832b87552ff0c4f8aa76