### PR TITLE
Add process-safe locking for VOR request counter

### DIFF
--- a/tests/test_vor_request_limit.py
+++ b/tests/test_vor_request_limit.py
@@ -1,10 +1,28 @@
 import json
+import multiprocessing
 import os
+import threading
 from datetime import datetime
 
 from zoneinfo import ZoneInfo
 
 import src.providers.vor as vor
+
+
+def _save_request_count_worker(path_str: str, iterations: int, start_event) -> None:
+    """Helper for multiprocessing test to increment the counter."""
+
+    from pathlib import Path
+
+    import src.providers.vor as child_vor
+
+    child_vor.REQUEST_COUNT_FILE = Path(path_str)
+    child_vor.REQUEST_COUNT_LOCK = threading.Lock()
+
+    now = datetime(2023, 1, 2, tzinfo=ZoneInfo("Europe/Vienna"))
+    start_event.wait()
+    for _ in range(iterations):
+        child_vor.save_request_count(now)
 
 
 def test_fetch_events_respects_daily_limit(monkeypatch, caplog):
@@ -48,11 +66,11 @@ def test_save_request_count_flushes_and_fsyncs(monkeypatch, tmp_path):
     flush_called = False
     fsync_called = False
 
-    original_fdopen = os.fdopen
     original_fsync = os.fsync
+    original_open = vor.Path.open
 
-    def tracking_fdopen(*args, **kwargs):
-        file_obj = original_fdopen(*args, **kwargs)
+    def tracking_open(self, *args, **kwargs):
+        file_obj = original_open(self, *args, **kwargs)
 
         class TrackingFile:
             def __init__(self, wrapped):
@@ -80,10 +98,45 @@ def test_save_request_count_flushes_and_fsyncs(monkeypatch, tmp_path):
         fsync_called = True
         return original_fsync(fd)
 
-    monkeypatch.setattr(vor.os, "fdopen", tracking_fdopen)
+    monkeypatch.setattr(vor.Path, "open", tracking_open)
     monkeypatch.setattr(vor.os, "fsync", tracking_fsync)
 
     vor.save_request_count(datetime(2023, 1, 2, tzinfo=ZoneInfo("Europe/Vienna")))
 
     assert flush_called
     assert fsync_called
+
+
+def test_request_count_file_is_process_safe(monkeypatch, tmp_path):
+    target_file = tmp_path / "vor_request_count.json"
+    monkeypatch.setattr(vor, "REQUEST_COUNT_FILE", target_file)
+    monkeypatch.setattr(vor, "REQUEST_COUNT_LOCK", threading.Lock())
+
+    ctx = multiprocessing.get_context("spawn")
+    start_event = ctx.Event()
+    iterations_per_process = 3
+    processes = [
+        ctx.Process(
+            target=_save_request_count_worker,
+            args=(str(target_file), iterations_per_process, start_event),
+        )
+        for _ in range(4)
+    ]
+
+    for proc in processes:
+        proc.start()
+
+    start_event.set()
+
+    for proc in processes:
+        proc.join(10)
+        assert proc.exitcode == 0
+
+    data = json.loads(target_file.read_text(encoding="utf-8"))
+    expected_count = iterations_per_process * len(processes)
+    assert data["count"] == expected_count
+    assert data["date"] == datetime(2023, 1, 2, tzinfo=ZoneInfo("Europe/Vienna")).date().isoformat()
+
+    loaded_date, loaded_count = vor.load_request_count()
+    assert loaded_date == data["date"]
+    assert loaded_count == expected_count


### PR DESCRIPTION
## Summary
- add a cross-process lock for the VOR request counter with platform-specific handling for Unix and Windows
- update the request counter write path to truncate and rewrite the file while the lock is held
- extend the VOR request count tests to instrument flush/fsync and verify multiprocessing safety

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c97c8a8948832b874113be1f8dcef0