### PR TITLE
Use first_seen when expiring undated items

### DIFF
--- a/tests/test_build_feed_cache.py
+++ b/tests/test_build_feed_cache.py
@@ -184,7 +184,8 @@ def test_cache_iso_items_sorted_and_emit_pubdate(monkeypatch):
             assert isinstance(cache_items[idx][field], datetime)
             assert cache_items[idx][field].tzinfo is not None
 
-    filtered = build_feed._drop_old_items(cache_items, now)
+    state = {}
+    filtered = build_feed._drop_old_items(cache_items, now, state)
     assert {it["guid"] for it in filtered} == {"new-guid", "older-guid"}
 
     deduped = build_feed._dedupe_items(filtered)
@@ -192,7 +193,6 @@ def test_cache_iso_items_sorted_and_emit_pubdate(monkeypatch):
 
     assert [it["guid"] for it in deduped] == ["new-guid", "older-guid"]
 
-    state = {}
     monkeypatch.setattr(build_feed, "_save_state", lambda state: None)
     rss = build_feed._make_rss(deduped, now, state)
 

--- a/tests/test_drop_old_items_future.py
+++ b/tests/test_drop_old_items_future.py
@@ -42,5 +42,29 @@ def test_future_ends_at_skips_max_age(monkeypatch):
         "pubDate": now - timedelta(days=541),
         "ends_at": now + timedelta(days=1),
     }
-    res = build_feed._drop_old_items([future, no_end, too_old], now)
+    res = build_feed._drop_old_items([future, no_end, too_old], now, {})
     assert res == [future]
+
+
+def test_first_seen_used_when_no_dates(monkeypatch):
+    build_feed = _import_build_feed(
+        monkeypatch,
+        {"MAX_ITEM_AGE_DAYS": "2", "ABSOLUTE_MAX_AGE_DAYS": "10"},
+    )
+
+    now = datetime.now(timezone.utc)
+
+    old = {"title": "old", "source": "Test", "category": "Info"}
+    keep = {"title": "keep", "source": "Test", "category": "Info"}
+    new_item = {"title": "new", "source": "Test", "category": "Info"}
+
+    old_ident = build_feed._identity_for_item(old)
+    keep_ident = build_feed._identity_for_item(keep)
+
+    state = {
+        old_ident: {"first_seen": (now - timedelta(days=3)).isoformat()},
+        keep_ident: {"first_seen": (now - timedelta(days=1)).isoformat()},
+    }
+
+    res = build_feed._drop_old_items([old, keep, new_item], now, state)
+    assert res == [keep, new_item]


### PR DESCRIPTION
## Summary
- update `_drop_old_items` to accept the persisted state and fall back to `first_seen` when items lack date fields
- ensure the feed builder passes the loaded state into the expiry logic so undated entries age out correctly
- extend drop-old-item tests to cover the new behaviour and adjust cache tests to use the shared state object

## Testing
- pytest tests/test_drop_old_items_future.py tests/test_build_feed_cache.py tests/test_item_age.py

------
https://chatgpt.com/codex/tasks/task_e_68c9abec1a44832ba415287b31be7d2a