### PR TITLE
Skip leading date lines in feed descriptions

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -667,7 +667,10 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
         for line in desc_lines
         if line.strip() and line.strip().lower() != "zeitraum:"
     ]
-    desc_line = desc_lines[0] if desc_lines else ""
+    desc_line = next(
+        (line for line in desc_lines if any(ch.isalpha() for ch in line)),
+        desc_lines[0] if desc_lines else "",
+    )
     desc_line = _sanitize_text(desc_line)
     title_out = re.sub(r"\s+", " ", title_out).strip()
     desc_line = re.sub(r"[ \t\r\f\v]+", " ", desc_line).strip()

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -126,6 +126,20 @@ def test_emit_item_removes_category_and_limits_lines(monkeypatch):
     assert "Zeitraum" not in desc_text
 
 
+def test_emit_item_skips_leading_date_line(monkeypatch):
+    bf = _load_build_feed(monkeypatch)
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    item = {
+        "title": "Info",
+        "description": "24.01.2024\nErsatzverkehr eingerichtet",
+    }
+
+    _, xml = bf._emit_item(item, now, {})
+
+    desc_text = _extract_description(xml)
+    assert desc_text == "Ersatzverkehr eingerichtet"
+
+
 def test_emit_item_appends_since_time(monkeypatch):
     bf = _load_build_feed(monkeypatch)
     _freeze_vienna_now(


### PR DESCRIPTION
## Summary
- pick the first description line containing letters when generating feed entries so date headers are skipped
- add a regression test covering descriptions that start with a date line

## Testing
- pytest tests/test_clip_and_escape.py

------
https://chatgpt.com/codex/tasks/task_e_68c9b64e3f0c832b8404fdead78a348c