### PR TITLE
Prevent emitting RSS items when MAX_ITEMS is zero

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -748,14 +748,14 @@ def _make_rss(items: List[Dict[str, Any]], now: datetime, state: Dict[str, Dict[
 
     body_parts: List[str] = []
     identities_in_feed: List[str] = []
-    count = 0
+    emitted = 0
     for it in items:
+        if emitted >= MAX_ITEMS:
+            break
         ident, xml_item = _emit_item(it, now, state)
         body_parts.append(xml_item)
         identities_in_feed.append(ident)
-        count += 1
-        if count >= MAX_ITEMS:
-            break
+        emitted += 1
 
     out.extend(body_parts)
     out.append("</channel>")

--- a/tests/test_max_items.py
+++ b/tests/test_max_items.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -11,3 +12,47 @@ def test_max_items_non_negative(monkeypatch):
     sys.modules.pop(module_name, None)
     build_feed = importlib.import_module(module_name)
     assert build_feed.MAX_ITEMS == 0
+
+
+def test_make_rss_ignores_items_when_max_is_zero(monkeypatch):
+    module_name = "src.build_feed"
+    monkeypatch.setenv("MAX_ITEMS", "0")
+    monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1] / "src"))
+    sys.modules.pop(module_name, None)
+    build_feed = importlib.import_module(module_name)
+    try:
+        captured_state = {"value": None}
+
+        def capture_state(state):
+            captured_state["value"] = state
+
+        monkeypatch.setattr(build_feed, "_save_state", capture_state)
+
+        def fail_emit(*_args, **_kwargs):  # pragma: no cover - should not be called
+            raise AssertionError("_emit_item should not run when MAX_ITEMS is 0")
+
+        monkeypatch.setattr(build_feed, "_emit_item", fail_emit)
+
+        now = datetime.now(timezone.utc)
+        state = {}
+        rss = build_feed._make_rss(
+            [
+                {
+                    "source": "test",
+                    "category": "cat",
+                    "title": "Test",
+                    "description": "Desc",
+                    "link": "https://example.test",
+                    "guid": "guid-1",
+                    "pubDate": now,
+                }
+            ],
+            now,
+            state,
+        )
+
+        assert "<item>" not in rss
+        assert state == {}
+        assert captured_state["value"] == {}
+    finally:
+        sys.modules.pop(module_name, None)


### PR DESCRIPTION
## Summary
- stop iterating through feed items once the configured MAX_ITEMS limit is reached so zero disables emissions without touching state
- add a regression test that exercises MAX_ITEMS=0 and checks that no RSS items are produced and no state is recorded

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9cc0d6750832ba85c0ebe2185a036