### PR TITLE
Ensure VOR cache updates persist at request limit

### DIFF
--- a/scripts/update_vor_cache.py
+++ b/scripts/update_vor_cache.py
@@ -21,7 +21,6 @@ from providers.vor import (  # noqa: E402  (import after path setup)
     MAX_REQUESTS_PER_DAY,
     fetch_events,
     load_request_count,
-    save_request_count,
 )
 from utils.cache import write_cache  # noqa: E402
 from utils.serialize import serialize_for_cache  # noqa: E402
@@ -88,13 +87,8 @@ def main() -> int:
         )
         return 1
 
-    now_local = _now_local()
-    if _limit_reached(now_local):
-        return 0
-
     serialized_items = [serialize_for_cache(item) for item in items]
     write_cache("vor", serialized_items)
-    save_request_count(now_local)
     logger.info("VOR: Cache mit %d Einträgen aktualisiert.", len(serialized_items))
     return 0
 

--- a/tests/test_update_vor_cache.py
+++ b/tests/test_update_vor_cache.py
@@ -1,0 +1,52 @@
+"""Tests for the VOR cache update script."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import Mock
+from zoneinfo import ZoneInfo
+
+from scripts import update_vor_cache
+
+
+def test_cache_written_when_limit_reached(monkeypatch) -> None:
+    """Ensure the cache is written even if the final request hits the limit."""
+
+    now = datetime(2024, 1, 1, 12, tzinfo=ZoneInfo("Europe/Vienna"))
+    remaining_state = {"count": update_vor_cache.MAX_REQUESTS_PER_DAY - 1}
+
+    monkeypatch.setattr(update_vor_cache, "_now_local", lambda: now)
+    monkeypatch.setattr(
+        update_vor_cache,
+        "_todays_request_count",
+        lambda current: remaining_state["count"],
+    )
+
+    calls: list[int] = []
+
+    def fake_fetch_events() -> list[dict[str, str]]:
+        remaining_state["count"] += 1
+        calls.append(remaining_state["count"])
+        return [{"id": "event"}]
+
+    monkeypatch.setattr(update_vor_cache, "fetch_events", fake_fetch_events)
+
+    write_cache_mock = Mock()
+    monkeypatch.setattr(update_vor_cache, "write_cache", write_cache_mock)
+    monkeypatch.setattr(update_vor_cache, "serialize_for_cache", lambda item: item)
+
+    save_request_count_mock = Mock()
+    monkeypatch.setattr(
+        update_vor_cache,
+        "save_request_count",
+        save_request_count_mock,
+        raising=False,
+    )
+
+    exit_code = update_vor_cache.main()
+
+    assert exit_code == 0
+    write_cache_mock.assert_called_once_with("vor", [{"id": "event"}])
+    assert calls == [update_vor_cache.MAX_REQUESTS_PER_DAY]
+    assert remaining_state["count"] == update_vor_cache.MAX_REQUESTS_PER_DAY
+    save_request_count_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- ensure the VOR cache update script persists fetched data even if the last request reaches the daily limit
- avoid incrementing the request counter from the script so only real HTTP calls are counted
- add a regression test covering the limit-reached scenario for the cache update script

## Testing
- pytest tests/test_update_vor_cache.py

------
https://chatgpt.com/codex/tasks/task_e_68c9cdf464bc832b851cb2a910545cff