### PR TITLE
Accept line tokens with letter prefixes and add regression tests

### DIFF
--- a/tests/test_identity_no_lines.py
+++ b/tests/test_identity_no_lines.py
@@ -39,3 +39,28 @@ def test_identity_distinguishes_items_without_lines(monkeypatch):
     assert ident1.startswith("wl|störung|L=|D=2024-01-01|T=")
     assert ident2.startswith("wl|störung|L=|D=2024-01-01|T=")
 
+
+def test_identity_includes_line_tokens_and_is_cosmetic_stable(monkeypatch):
+    build_feed = _import_build_feed(monkeypatch)
+
+    day = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    base_item = {"source": "wl", "category": "störung", "starts_at": day}
+
+    s45 = {**base_item, "title": "S45: Baustelle"}
+    s45_ident = build_feed._identity_for_item(s45)
+    assert "|L=S45|" in s45_ident
+
+    def _identity_base(item: dict) -> str:
+        ident = build_feed._identity_for_item(item)
+        return ident.split("|F=", 1)[0]
+
+    assert _identity_base(s45) == _identity_base({**base_item, "title": "s45: Baustelle"})
+    assert _identity_base(s45) == _identity_base({**base_item, "title": "S45: Baustelle (Update)"})
+
+    rjx = {**base_item, "title": "RJX/RJ: Hinweis"}
+    rjx_ident = build_feed._identity_for_item(rjx)
+    assert "|L=RJX/RJ|" in rjx_ident
+
+    assert _identity_base(rjx) == _identity_base({**base_item, "title": "rjx/rj: Hinweis"})
+    assert _identity_base(rjx) == _identity_base({**base_item, "title": "RJX/RJ: Hinweis (Update)"})
+

--- a/tests/test_parse_lines_from_title.py
+++ b/tests/test_parse_lines_from_title.py
@@ -7,3 +7,11 @@ def test_parse_lines_from_title_ignores_non_line_prefix():
 
 def test_parse_lines_from_title_accepts_line_token():
     assert _parse_lines_from_title("N81: Rohrleitungsarbeiten") == ["N81"]
+
+
+def test_parse_lines_from_title_accepts_letter_digit_tokens():
+    assert _parse_lines_from_title("S45: Baustelle") == ["S45"]
+
+
+def test_parse_lines_from_title_accepts_multi_letter_tokens():
+    assert _parse_lines_from_title("RJX/RJ: Hinweis") == ["RJX", "RJ"]


### PR DESCRIPTION
## Summary
- expand the line token parser to accept multi-letter and letter-digit identifiers while normalising them to uppercase for identity building
- use the normalised tokens when composing `_identity_for_item` to keep the `L=` component stable
- add regression tests that cover new token shapes and confirm identity stability for S45 and RJX/RJ titles

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9d4ba210c832b89b1fe112811fca9