### PR TITLE
Adjust RSS description to use newlines

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -751,7 +751,7 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
     if time_line:
         desc_parts.append(time_line)
     desc_out = "\n".join(desc_parts)
-    desc_cdata = desc_out.replace("\n", "<br/>")
+    desc_html = desc_out.replace("\n", "<br/>")
 
     parts: List[str] = []
     parts.append("<item>")
@@ -767,8 +767,8 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
     if isinstance(ends_at, datetime):
         parts.append(f"<ext:ends_at>{_fmt_rfc2822(ends_at)}</ext:ends_at>")
 
-    parts.append(f"<description>{_cdata(desc_cdata)}</description>")
-    parts.append(f"<content:encoded>{_cdata(desc_cdata)}</content:encoded>")
+    parts.append(f"<description>{_cdata(desc_out)}</description>")
+    parts.append(f"<content:encoded>{_cdata(desc_html)}</content:encoded>")
     parts.append("</item>")
     return ident, "\n".join(parts)
 

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -159,7 +159,7 @@ def test_emit_item_oebb_multiline_sentence(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.split("<br/>") == [
+    assert desc_text.splitlines() == [
         "Wegen Bauarbeiten können in Ebenfurth Bahnhof von 06.12.2025 "
         "(06:10 Uhr) bis 09.12.2025 (04:40 Uhr) die S60-Züge nicht halten.",
         "06.12.2025 – 09.12.2025",
@@ -184,7 +184,7 @@ def test_emit_item_uses_date_range_from_description(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.split("<br/>") == [
+    assert desc_text.splitlines() == [
         "Wegen Bauarbeiten",
         "06.12.2025 – 09.12.2025",
     ]
@@ -211,7 +211,7 @@ def test_emit_item_appends_since_time(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Wegen Bauarbeiten<br/>Seit 05.01.2024"
+    assert desc_text == "Wegen Bauarbeiten\nSeit 05.01.2024"
 
     content_html = _extract_content_encoded(xml)
     assert content_html == "Wegen Bauarbeiten<br/>Seit 05.01.2024"
@@ -240,7 +240,7 @@ def test_emit_item_since_line_for_missing_or_nonadvancing_end(monkeypatch):
         _, xml = bf._emit_item(item, now, {})
 
         desc_text = _extract_description(xml)
-        assert desc_text.split("<br/>") == [
+        assert desc_text.splitlines() == [
             "Wegen Bauarbeiten",
             "Seit 05.01.2024",
         ]
@@ -268,7 +268,7 @@ def test_emit_item_same_day_shows_since(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.split("<br/>") == [
+    assert desc_text.splitlines() == [
         "Wegen Bauarbeiten",
         "Seit 10.01.2024",
     ]
@@ -295,7 +295,7 @@ def test_emit_item_future_start_without_end_shows_ab(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.split("<br/>") == [
+    assert desc_text.splitlines() == [
         "Eingeschränkter Betrieb",
         "Ab 20.01.2024",
     ]
@@ -338,7 +338,7 @@ def test_emit_item_long_range_treated_as_open(monkeypatch):
         _, xml = bf._emit_item(item, now, {})
 
         desc_text = _extract_description(xml)
-        assert desc_text.split("<br/>") == [
+        assert desc_text.splitlines() == [
             "Langer Zeitraum",
             expected_line,
         ]
@@ -366,7 +366,7 @@ def test_emit_item_same_day_range_shows_since(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.split("<br/>") == [
+    assert desc_text.splitlines() == [
         "Zug verkehrt nicht",
         "Seit 10.03.2024",
     ]
@@ -394,7 +394,7 @@ def test_emit_item_multi_day_range_still_shows_range(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.split("<br/>") == [
+    assert desc_text.splitlines() == [
         "Zug verkehrt eingeschränkt",
         "10.03.2024\u202f–\u202f12.03.2024",
     ]
@@ -419,7 +419,7 @@ def test_emit_item_appends_multi_day_range(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Ersatzverkehr eingerichtet<br/>01.06.2024\u202f–\u202f03.06.2024"
+    assert desc_text == "Ersatzverkehr eingerichtet\n01.06.2024\u202f–\u202f03.06.2024"
 
     content_html = _extract_content_encoded(xml)
     assert content_html == "Ersatzverkehr eingerichtet<br/>01.06.2024\u202f–\u202f03.06.2024"
@@ -438,7 +438,7 @@ def test_emit_item_description_two_lines(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.split("<br/>") == [
+    assert desc_text.splitlines() == [
         "Ersatzverkehr eingerichtet",
         "01.07.2024\u202f–\u202f02.07.2024",
     ]

--- a/tests/test_vor_title_prefix.py
+++ b/tests/test_vor_title_prefix.py
@@ -85,9 +85,8 @@ def test_vor_description_keeps_extra_lines():
     assert desc_match and content_match
     desc_html = desc_match.group(1)
     content_html = content_match.group(1)
-    assert desc_html == content_html
 
-    desc_lines = desc_html.split("<br/>")
+    desc_lines = desc_html.splitlines()
     assert desc_lines[0] == "Ersatzverkehr zwischen Floridsdorf und Praterstern."
     assert desc_lines[1] == "Linien: S1"
     assert (
@@ -95,3 +94,12 @@ def test_vor_description_keeps_extra_lines():
         == "Betroffene Haltestellen: Wien Floridsdorf, Wien Praterstern"
     )
     assert desc_lines[-1] == "Seit 15.07.2023"
+
+    content_lines = content_html.split("<br/>")
+    assert content_lines[0] == "Ersatzverkehr zwischen Floridsdorf und Praterstern."
+    assert content_lines[1] == "Linien: S1"
+    assert (
+        content_lines[2]
+        == "Betroffene Haltestellen: Wien Floridsdorf, Wien Praterstern"
+    )
+    assert content_lines[-1] == "Seit 15.07.2023"


### PR DESCRIPTION
## Summary
- ensure RSS `<description>` preserves newline separators while `<content:encoded>` keeps `<br/>` HTML output
- update VOR and feed generation tests to split descriptions on real newlines and keep verifying HTML formatting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca83ea7374832baaf528ffb315fe26