### PR TITLE
Fix ÖBB Seit time detection with range fallback

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -739,7 +739,10 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
         ends_at if isinstance(ends_at, datetime) else None,
     )
     normalized_time_line = (time_line or "").strip()
-    if date_range_line and (not normalized_time_line or normalized_time_line in {"Seit", "Ab"}):
+    if date_range_line and (
+        not normalized_time_line
+        or normalized_time_line.split(" ", 1)[0] in {"Seit", "Ab"}
+    ):
         time_line = date_range_line
     time_line = _sanitize_text(time_line)
     time_line = re.sub(r"[ \t\r\f\v]+", " ", time_line).strip()

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -196,6 +196,34 @@ def test_emit_item_uses_date_range_from_description(monkeypatch):
     ]
 
 
+def test_emit_item_since_line_replaced_by_description_range(monkeypatch):
+    bf = _load_build_feed(monkeypatch)
+    _freeze_vienna_now(
+        monkeypatch, bf, datetime(2025, 9, 20, tzinfo=bf._VIENNA_TZ)
+    )
+    now = datetime(2025, 9, 20, tzinfo=timezone.utc)
+    item = {
+        "title": "Ebenfurth",
+        "description": "06.12.2025 - 09.12.2025\nWegen Bauarbeiten",
+        "starts_at": bf.datetime(2025, 9, 16, 6, 0, tzinfo=timezone.utc),
+        "ends_at": bf.datetime(2025, 9, 16, 6, 0, tzinfo=timezone.utc),
+    }
+
+    _, xml = bf._emit_item(item, now, {})
+
+    desc_text = _extract_description(xml)
+    assert desc_text.splitlines() == [
+        "Wegen Bauarbeiten",
+        "06.12.2025 – 09.12.2025",
+    ]
+
+    content_html = _extract_content_encoded(xml)
+    assert content_html.split("<br/>") == [
+        "Wegen Bauarbeiten",
+        "06.12.2025 – 09.12.2025",
+    ]
+
+
 def test_emit_item_appends_since_time(monkeypatch):
     bf = _load_build_feed(monkeypatch)
     _freeze_vienna_now(


### PR DESCRIPTION
## Summary
- improve the RSS time line fallback so `Seit`/`Ab` strings with dates are treated as open and replaced by description date ranges
- add a regression test covering an ÖBB alert whose date range is only present in the description text

## Testing
- pytest tests/test_clip_and_escape.py

------
https://chatgpt.com/codex/tasks/task_e_68ca8ad2e5bc832b9540cd261228d0a6