### PR TITLE
Ensure RSS description preserves HTML line breaks

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -757,8 +757,8 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
     if time_line:
         desc_parts.append(time_line)
     desc_out = "\n".join(desc_parts)
-    desc_cdata = desc_out
     desc_html = desc_out.replace("\n", "<br/>")
+    desc_cdata = desc_html
 
     parts: List[str] = []
     parts.append("<item>")

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -159,7 +159,7 @@ def test_emit_item_oebb_multiline_sentence(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.splitlines() == [
+    assert desc_text.split("<br/>") == [
         "Wegen Bauarbeiten können in Ebenfurth Bahnhof von 06.12.2025 "
         "(06:10 Uhr) bis 09.12.2025 (04:40 Uhr) die S60-Züge nicht halten.",
         "06.12.2025 – 09.12.2025",
@@ -184,7 +184,7 @@ def test_emit_item_uses_date_range_from_description(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.splitlines() == [
+    assert desc_text.split("<br/>") == [
         "Wegen Bauarbeiten",
         "06.12.2025 – 09.12.2025",
     ]
@@ -212,7 +212,7 @@ def test_emit_item_since_line_replaced_by_description_range(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.splitlines() == [
+    assert desc_text.split("<br/>") == [
         "Wegen Bauarbeiten",
         "06.12.2025 – 09.12.2025",
     ]
@@ -240,7 +240,7 @@ def test_emit_item_since_line_replaced_by_description_range_after_text(monkeypat
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.splitlines() == [
+    assert desc_text.split("<br/>") == [
         "Wegen Bauarbeiten.",
         "06.12.2025 – 09.12.2025",
     ]
@@ -267,7 +267,7 @@ def test_emit_item_appends_since_time(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Wegen Bauarbeiten\nSeit 05.01.2024"
+    assert desc_text == "Wegen Bauarbeiten<br/>Seit 05.01.2024"
 
     content_html = _extract_content_encoded(xml)
     assert content_html == "Wegen Bauarbeiten<br/>Seit 05.01.2024"
@@ -296,7 +296,7 @@ def test_emit_item_since_line_for_missing_or_nonadvancing_end(monkeypatch):
         _, xml = bf._emit_item(item, now, {})
 
         desc_text = _extract_description(xml)
-        assert desc_text.splitlines() == [
+        assert desc_text.split("<br/>") == [
             "Wegen Bauarbeiten",
             "Seit 05.01.2024",
         ]
@@ -324,7 +324,7 @@ def test_emit_item_same_day_shows_since(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.splitlines() == [
+    assert desc_text.split("<br/>") == [
         "Wegen Bauarbeiten",
         "Seit 10.01.2024",
     ]
@@ -351,7 +351,7 @@ def test_emit_item_future_start_without_end_shows_ab(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.splitlines() == [
+    assert desc_text.split("<br/>") == [
         "Eingeschränkter Betrieb",
         "Ab 20.01.2024",
     ]
@@ -394,7 +394,7 @@ def test_emit_item_long_range_treated_as_open(monkeypatch):
         _, xml = bf._emit_item(item, now, {})
 
         desc_text = _extract_description(xml)
-        assert desc_text.splitlines() == [
+        assert desc_text.split("<br/>") == [
             "Langer Zeitraum",
             expected_line,
         ]
@@ -422,7 +422,7 @@ def test_emit_item_same_day_range_shows_since(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.splitlines() == [
+    assert desc_text.split("<br/>") == [
         "Zug verkehrt nicht",
         "Seit 10.03.2024",
     ]
@@ -450,7 +450,7 @@ def test_emit_item_multi_day_range_still_shows_range(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.splitlines() == [
+    assert desc_text.split("<br/>") == [
         "Zug verkehrt eingeschränkt",
         "10.03.2024\u202f–\u202f12.03.2024",
     ]
@@ -475,7 +475,7 @@ def test_emit_item_appends_multi_day_range(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Ersatzverkehr eingerichtet\n01.06.2024\u202f–\u202f03.06.2024"
+    assert desc_text == "Ersatzverkehr eingerichtet<br/>01.06.2024\u202f–\u202f03.06.2024"
 
     content_html = _extract_content_encoded(xml)
     assert content_html == "Ersatzverkehr eingerichtet<br/>01.06.2024\u202f–\u202f03.06.2024"
@@ -494,7 +494,7 @@ def test_emit_item_description_two_lines(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text.splitlines() == [
+    assert desc_text.split("<br/>") == [
         "Ersatzverkehr eingerichtet",
         "01.07.2024\u202f–\u202f02.07.2024",
     ]


### PR DESCRIPTION
## Summary
- ensure the RSS `<description>` CDATA uses the HTML version with `<br/>` line breaks
- update clip/escape tests to assert `<br/>` separators in descriptions

## Testing
- pytest tests/test_clip_and_escape.py

------
https://chatgpt.com/codex/tasks/task_e_68cbe6bfdd4c832b835cf3f7eac5ea36