### PR TITLE
Adjust VOR description newline handling in tests

### DIFF
--- a/tests/test_vor_title_prefix.py
+++ b/tests/test_vor_title_prefix.py
@@ -89,7 +89,10 @@ def test_vor_description_keeps_extra_lines():
     desc_lines = desc_html.split("\n")
     content_lines = content_html.split("<br/>")
 
-    assert content_html == desc_html.replace("\n", "<br/>")
+    expected_content_html = desc_html.replace("\n", "<br/>")
+
+    assert content_html == expected_content_html
+    assert content_lines == desc_lines
 
     for lines in (desc_lines, content_lines):
         assert lines[0] == "Ersatzverkehr zwischen Floridsdorf und Praterstern."


### PR DESCRIPTION
## Summary
- update the VOR description test to derive expected HTML using newline splitting
- assert that the `<content:encoded>` block matches the newline-replaced expectation and that per-line content stays consistent

## Testing
- pytest tests/test_clip_and_escape.py tests/test_vor_title_prefix.py

------
https://chatgpt.com/codex/tasks/task_e_68cc150fd1f4832bafeda689ad4f3f86