### PR TITLE
Add brackets to time line output

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -749,6 +749,11 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
         time_line = date_range_line
     time_line = _sanitize_text(time_line)
     time_line = re.sub(r"[ \t\r\f\v]+", " ", time_line).strip()
+    if time_line:
+        if not time_line.startswith("["):
+            time_line = f"[{time_line}"
+        if not time_line.endswith("]"):
+            time_line = f"{time_line}]"
 
     desc_parts: List[str] = []
     if desc_line:

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -162,14 +162,14 @@ def test_emit_item_oebb_multiline_sentence(monkeypatch):
     assert desc_text.split("<br>") == [
         "Wegen Bauarbeiten können in Ebenfurth Bahnhof von 06.12.2025 "
         "(06:10 Uhr) bis 09.12.2025 (04:40 Uhr) die S60-Züge nicht halten.",
-        "06.12.2025 – 09.12.2025",
+        "[06.12.2025 – 09.12.2025]",
     ]
 
     content_html = _extract_content_encoded(xml)
     assert content_html.split("<br/>") == [
         "Wegen Bauarbeiten können in Ebenfurth Bahnhof von 06.12.2025 "
         "(06:10 Uhr) bis 09.12.2025 (04:40 Uhr) die S60-Züge nicht halten.",
-        "06.12.2025 – 09.12.2025",
+        "[06.12.2025 – 09.12.2025]",
     ]
 
 
@@ -186,13 +186,13 @@ def test_emit_item_uses_date_range_from_description(monkeypatch):
     desc_text = _extract_description(xml)
     assert desc_text.split("<br>") == [
         "Wegen Bauarbeiten",
-        "06.12.2025 – 09.12.2025",
+        "[06.12.2025 – 09.12.2025]",
     ]
 
     content_html = _extract_content_encoded(xml)
     assert content_html.split("<br/>") == [
         "Wegen Bauarbeiten",
-        "06.12.2025 – 09.12.2025",
+        "[06.12.2025 – 09.12.2025]",
     ]
 
 
@@ -214,13 +214,13 @@ def test_emit_item_since_line_replaced_by_description_range(monkeypatch):
     desc_text = _extract_description(xml)
     assert desc_text.split("<br>") == [
         "Wegen Bauarbeiten",
-        "06.12.2025 – 09.12.2025",
+        "[06.12.2025 – 09.12.2025]",
     ]
 
     content_html = _extract_content_encoded(xml)
     assert content_html.split("<br/>") == [
         "Wegen Bauarbeiten",
-        "06.12.2025 – 09.12.2025",
+        "[06.12.2025 – 09.12.2025]",
     ]
 
 
@@ -242,13 +242,13 @@ def test_emit_item_since_line_replaced_by_description_range_after_text(monkeypat
     desc_text = _extract_description(xml)
     assert desc_text.split("<br>") == [
         "Wegen Bauarbeiten.",
-        "06.12.2025 – 09.12.2025",
+        "[06.12.2025 – 09.12.2025]",
     ]
 
     content_html = _extract_content_encoded(xml)
     assert content_html.split("<br/>") == [
         "Wegen Bauarbeiten.",
-        "06.12.2025 – 09.12.2025",
+        "[06.12.2025 – 09.12.2025]",
     ]
 
 
@@ -267,10 +267,10 @@ def test_emit_item_appends_since_time(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Wegen Bauarbeiten<br>Seit 05.01.2024"
+    assert desc_text == "Wegen Bauarbeiten<br>[Seit 05.01.2024]"
 
     content_html = _extract_content_encoded(xml)
-    assert content_html == "Wegen Bauarbeiten<br/>Seit 05.01.2024"
+    assert content_html == "Wegen Bauarbeiten<br/>[Seit 05.01.2024]"
 
 
 def test_emit_item_since_line_for_missing_or_nonadvancing_end(monkeypatch):
@@ -298,13 +298,13 @@ def test_emit_item_since_line_for_missing_or_nonadvancing_end(monkeypatch):
         desc_text = _extract_description(xml)
         assert desc_text.split("<br>") == [
             "Wegen Bauarbeiten",
-            "Seit 05.01.2024",
+            "[Seit 05.01.2024]",
         ]
 
         content_html = _extract_content_encoded(xml)
         assert content_html.split("<br/>") == [
             "Wegen Bauarbeiten",
-            "Seit 05.01.2024",
+            "[Seit 05.01.2024]",
         ]
 
 
@@ -326,13 +326,13 @@ def test_emit_item_same_day_shows_since(monkeypatch):
     desc_text = _extract_description(xml)
     assert desc_text.split("<br>") == [
         "Wegen Bauarbeiten",
-        "Seit 10.01.2024",
+        "[Seit 10.01.2024]",
     ]
 
     content_html = _extract_content_encoded(xml)
     assert content_html.split("<br/>") == [
         "Wegen Bauarbeiten",
-        "Seit 10.01.2024",
+        "[Seit 10.01.2024]",
     ]
 
 
@@ -353,13 +353,13 @@ def test_emit_item_future_start_without_end_shows_ab(monkeypatch):
     desc_text = _extract_description(xml)
     assert desc_text.split("<br>") == [
         "Eingeschränkter Betrieb",
-        "Ab 20.01.2024",
+        "[Ab 20.01.2024]",
     ]
 
     content_html = _extract_content_encoded(xml)
     assert content_html.split("<br/>") == [
         "Eingeschränkter Betrieb",
-        "Ab 20.01.2024",
+        "[Ab 20.01.2024]",
     ]
 
 
@@ -370,12 +370,12 @@ def test_emit_item_long_range_treated_as_open(monkeypatch):
         (
             datetime(2024, 1, 10, tzinfo=bf._VIENNA_TZ),
             (2024, 1, 5, 10, 0),
-            "Seit 05.01.2024",
+            "[Seit 05.01.2024]",
         ),
         (
             datetime(2024, 1, 1, tzinfo=bf._VIENNA_TZ),
             (2024, 1, 20, 6, 0),
-            "Ab 20.01.2024",
+            "[Ab 20.01.2024]",
         ),
     ]
 
@@ -424,13 +424,13 @@ def test_emit_item_same_day_range_shows_since(monkeypatch):
     desc_text = _extract_description(xml)
     assert desc_text.split("<br>") == [
         "Zug verkehrt nicht",
-        "Seit 10.03.2024",
+        "[Seit 10.03.2024]",
     ]
 
     content_html = _extract_content_encoded(xml)
     assert content_html.split("<br/>") == [
         "Zug verkehrt nicht",
-        "Seit 10.03.2024",
+        "[Seit 10.03.2024]",
     ]
 
 
@@ -452,13 +452,13 @@ def test_emit_item_multi_day_range_still_shows_range(monkeypatch):
     desc_text = _extract_description(xml)
     assert desc_text.split("<br>") == [
         "Zug verkehrt eingeschränkt",
-        "10.03.2024\u202f–\u202f12.03.2024",
+        "[10.03.2024\u202f–\u202f12.03.2024]",
     ]
 
     content_html = _extract_content_encoded(xml)
     assert content_html.split("<br/>") == [
         "Zug verkehrt eingeschränkt",
-        "10.03.2024\u202f–\u202f12.03.2024",
+        "[10.03.2024\u202f–\u202f12.03.2024]",
     ]
 
 
@@ -475,10 +475,10 @@ def test_emit_item_appends_multi_day_range(monkeypatch):
     _, xml = bf._emit_item(item, now, {})
 
     desc_text = _extract_description(xml)
-    assert desc_text == "Ersatzverkehr eingerichtet<br>01.06.2024\u202f–\u202f03.06.2024"
+    assert desc_text == "Ersatzverkehr eingerichtet<br>[01.06.2024\u202f–\u202f03.06.2024]"
 
     content_html = _extract_content_encoded(xml)
-    assert content_html == "Ersatzverkehr eingerichtet<br/>01.06.2024\u202f–\u202f03.06.2024"
+    assert content_html == "Ersatzverkehr eingerichtet<br/>[01.06.2024\u202f–\u202f03.06.2024]"
 
 
 def test_emit_item_description_two_lines(monkeypatch):
@@ -496,13 +496,13 @@ def test_emit_item_description_two_lines(monkeypatch):
     desc_text = _extract_description(xml)
     assert desc_text.split("<br>") == [
         "Ersatzverkehr eingerichtet",
-        "01.07.2024\u202f–\u202f02.07.2024",
+        "[01.07.2024\u202f–\u202f02.07.2024]",
     ]
 
     content_html = _extract_content_encoded(xml)
     assert content_html.split("<br/>") == [
         "Ersatzverkehr eingerichtet",
-        "01.07.2024\u202f–\u202f02.07.2024",
+        "[01.07.2024\u202f–\u202f02.07.2024]",
     ]
 
 

--- a/tests/test_vor_title_prefix.py
+++ b/tests/test_vor_title_prefix.py
@@ -101,4 +101,4 @@ def test_vor_description_keeps_extra_lines():
             lines[2]
             == "Betroffene Haltestellen: Wien Floridsdorf, Wien Praterstern"
         )
-        assert lines[-1] == "Seit 15.07.2023"
+        assert lines[-1] == "[Seit 15.07.2023]"


### PR DESCRIPTION
## Summary
- wrap sanitized `time_line` strings in `_emit_item` with square brackets when present
- adjust expectations in `tests/test_clip_and_escape.py` and `tests/test_vor_title_prefix.py` for the new bracketed output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd3c806184832bb67e238b9926c7e2