### PR TITLE
Add WL title context fallback when lines missing

### DIFF
--- a/tests/test_wl_fetch.py
+++ b/tests/test_wl_fetch.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timezone
 
 from src.providers.wl_fetch import _stop_names_from_related, fetch_events
 
@@ -43,3 +44,88 @@ def test_fetch_events_handles_invalid_json(monkeypatch, caplog):
 
     assert events == []
     assert any("Ungültige JSON-Antwort" in message for message in caplog.messages)
+
+
+class DummySession:
+    def __init__(self):
+        self.headers: dict[str, str] = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def _setup_fetch(monkeypatch, traffic_infos=None, news=None):
+    monkeypatch.setattr(
+        "src.providers.wl_fetch._fetch_traffic_infos",
+        lambda *a, **kw: traffic_infos or [],
+    )
+    monkeypatch.setattr(
+        "src.providers.wl_fetch._fetch_news",
+        lambda *a, **kw: news or [],
+    )
+    monkeypatch.setattr(
+        "src.providers.wl_fetch.session_with_retries",
+        lambda *a, **kw: DummySession(),
+    )
+
+
+def _base_event(**overrides):
+    now = datetime.now(timezone.utc).isoformat()
+    base = {
+        "title": "Sperre Museumsquartier",
+        "description": "Testbeschreibung",
+        "time": {"start": now},
+        "attributes": {},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_fetch_events_adds_stop_context_when_no_lines(monkeypatch):
+    rel_stops = [
+        {"name": "Karlsplatz"},
+        {"name": "Museumsquartier"},
+    ]
+    traffic_info = _base_event(
+        attributes={
+            "station": "Museumsquartier (U2)",
+            "relatedStops": rel_stops,
+        }
+    )
+
+    _setup_fetch(monkeypatch, traffic_infos=[traffic_info], news=[])
+
+    events = fetch_events(timeout=0)
+
+    assert len(events) == 1
+    title = events[0]["title"]
+    assert " – " in title
+    assert "Karlsplatz" in title
+    assert "Museumsquartier" in title
+    assert title.endswith("(2 Halte)")
+    assert "Station: Museumsquartier (U2)" in events[0]["description"]
+
+
+def test_fetch_events_uses_extra_context_when_no_stops(monkeypatch):
+    traffic_info = _base_event(
+        attributes={
+            "station": "Karlsplatz",
+            "location": "Ausgang Oper",
+        }
+    )
+
+    _setup_fetch(monkeypatch, traffic_infos=[traffic_info], news=[])
+
+    events = fetch_events(timeout=0)
+
+    assert len(events) == 1
+    title = events[0]["title"]
+    assert "Halte" not in title  # keine Halteanzahl bei fehlenden Stopps
+    assert " – Karlsplatz" in title
+    assert "Ausgang Oper" in title
+    desc = events[0]["description"]
+    assert "Station: Karlsplatz" not in desc
+    assert "Location: Ausgang Oper" not in desc


### PR DESCRIPTION
## Summary
- build reusable helpers that derive stop or extra based context for WL titles when no line display is available
- append the derived context to titles and drop the consumed extras from descriptions to avoid duplication
- add regression tests covering stop-name and extra-based context handling for WL events

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce810904d0832bae112a226be3ff0d