### PR TITLE
Improve WL bucket merge heuristics

### DIFF
--- a/tests/test_wl_title.py
+++ b/tests/test_wl_title.py
@@ -1,57 +1,72 @@
+from datetime import datetime, timezone
+
+from src.providers.wl_fetch import fetch_events
 from src.providers.wl_lines import (
     _detect_line_pairs_from_text,
     _ensure_line_prefix,
-    _line_tokens_from_pairs,
 )
-from src.providers.wl_text import _tidy_title_wl, _topic_key_from_title
-from src.utils.ids import make_guid
+from src.providers.wl_text import _tidy_title_wl
 
 
-def test_dedupe_topic_shorter_title():
-    ev1 = {
-        "category": "Störung",
-        "title": "5: Falschparker",
-        "topic_key": _topic_key_from_title("Falschparker"),
-        "lines_pairs": [("5", "5")],
-        "desc": "",
-        "extras": [],
-        "stop_names": set(),
-        "pubDate": None,
-        "starts_at": None,
-        "ends_at": None,
-        "_identity": "1",
-    }
-    ev2 = {
-        "category": "Störung",
-        "title": "5: Fahrtbehinderung Falschparker",
-        "topic_key": _topic_key_from_title("Fahrtbehinderung Falschparker"),
-        "lines_pairs": [("5", "5")],
-        "desc": "",
-        "extras": [],
-        "stop_names": set(),
-        "pubDate": None,
-        "starts_at": None,
-        "ends_at": None,
-        "_identity": "2",
+def test_bucket_merge_prefers_informative_title_and_description(monkeypatch):
+    now_iso = datetime.now(timezone.utc).isoformat()
+    detailed_desc = (
+        "Störung zwischen Siebenhirten und Perfektastraße. Ersatzverkehr im Einsatz."
+    )
+
+    generic = {
+        "title": "Falschparker",
+        "description": "Störung",
+        "time": {"start": now_iso},
+        "attributes": {"relatedLines": ["U6"]},
     }
 
-    buckets = {}
-    for ev in (ev1, ev2):
-        key = make_guid(
-            "wl",
-            ev["category"],
-            ev["topic_key"],
-            ",".join(sorted(_line_tokens_from_pairs(ev["lines_pairs"]))),
-        )
-        b = buckets.get(key)
-        if not b:
-            buckets[key] = dict(ev)
-        else:
-            if len(ev["title"]) < len(b["title"]):
-                b["title"] = ev["title"]
+    detailed = {
+        "title": "Falschparker blockiert Linie U6 bei Siebenhirten",
+        "description": detailed_desc,
+        "time": {"start": now_iso},
+        "attributes": {
+            "relatedLines": ["U6"],
+            "relatedStops": [
+                {"name": "Siebenhirten"},
+                {"name": "Perfektastraße"},
+            ],
+            "station": "Siebenhirten (U6)",
+            "location": "Bereich Perfektastraße",
+        },
+    }
 
-    assert len(buckets) == 1
-    assert list(buckets.values())[0]["title"] == "5: Falschparker"
+    class DummySession:
+        def __init__(self):
+            self.headers = {}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(
+        "src.providers.wl_fetch._fetch_traffic_infos",
+        lambda *a, **kw: [generic, detailed],
+    )
+    monkeypatch.setattr(
+        "src.providers.wl_fetch._fetch_news",
+        lambda *a, **kw: [],
+    )
+    monkeypatch.setattr(
+        "src.providers.wl_fetch.session_with_retries",
+        lambda *a, **kw: DummySession(),
+    )
+
+    events = fetch_events(timeout=0)
+
+    assert len(events) == 1
+    event = events[0]
+    assert "blockiert Linie U6 bei Siebenhirten" in event["title"]
+    assert event["description"].startswith(detailed_desc)
+    assert "Perfektastraße" in event["description"]
+    assert len(event["description"]) > len("Störung")
 
 
 def test_line_prefix_and_house_number_false_positive():


### PR DESCRIPTION
## Summary
- add heuristics to prefer informative titles and descriptions when merging Wiener Linien events
- add regression coverage ensuring detailed WL events survive bucket merges

## Testing
- pytest tests/test_wl_title.py tests/test_wl_fetch.py

------
https://chatgpt.com/codex/tasks/task_e_68ce82bb6ff8832bb413e9104653924e