### PR TITLE
Ensure WL identical descriptions retain fallback

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -680,7 +680,9 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
             date_range_line = f"{match.group(1)} – {match.group(2)}"
             break
 
+    removed_title_line: Optional[str] = None
     if desc_lines_raw and desc_lines_raw[0].lower() in title_out.lower():
+        removed_title_line = desc_lines_raw[0]
         desc_lines_raw = desc_lines_raw[1:]
     filtered_lines = [
         line.strip()
@@ -700,7 +702,13 @@ def _emit_item(it: Dict[str, Any], now: datetime, state: Dict[str, Dict[str, Any
 
     first_alpha_idx: Optional[int] = None
     fallback_candidates = desc_lines if desc_lines else extra_lines_raw
-    fallback_line = fallback_candidates[0] if fallback_candidates else ""
+    if fallback_candidates:
+        fallback_line = fallback_candidates[0]
+    else:
+        sanitized_removed = (
+            _sanitize_text(removed_title_line) if removed_title_line else ""
+        )
+        fallback_line = sanitized_removed or title_out
     for idx, line in enumerate(desc_lines):
         if any(ch.isalpha() for ch in line):
             first_alpha_idx = idx

--- a/tests/test_clip_and_escape.py
+++ b/tests/test_clip_and_escape.py
@@ -140,6 +140,20 @@ def test_emit_item_skips_leading_date_line(monkeypatch):
     assert desc_text == "Ersatzverkehr eingerichtet"
 
 
+def test_emit_item_wl_identical_title_description_fallback(monkeypatch):
+    bf = _load_build_feed(monkeypatch)
+    now = datetime(2024, 1, 1)
+    item = {
+        "title": "WL Störung auf Linie U2",
+        "description": "WL Störung auf Linie U2",
+    }
+
+    _, xml = bf._emit_item(item, now, {})
+
+    desc_text = _extract_description(xml)
+    assert desc_text == "WL Störung auf Linie U2"
+
+
 def test_emit_item_oebb_multiline_sentence(monkeypatch):
     bf = _load_build_feed(monkeypatch)
     now = datetime(2024, 1, 1)


### PR DESCRIPTION
## Summary
- ensure `_emit_item` reuses the removed title line as a fallback description when no other lines remain
- add a regression test covering Wiener Linien incidents with identical title and description

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce8a7d4a08832b96ce417ebc4282c8