### PR TITLE
Document VOR lock timeout and station names

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,10 +332,12 @@ Weitere Details folgen …]]></description>
 | --- | --- | --- | --- |
 | `VOR_ACCESS_ID` / `VAO_ACCESS_ID` | str | – | API-Zugangsschlüssel. Leere Werte werden ignoriert; ohne Wert bleibt der Provider inaktiv. |
 | `VOR_STATION_IDS` | Liste (kommagetrennt) | – | Stations-IDs für Abfragen. Ohne Angabe bleibt der Provider inaktiv. |
+| `VOR_STATION_NAMES` | Liste (kommagetrennt) | – | Stationsnamen für Abfragen. Löst Stationen anhand ihrer Namen auf, wenn keine `VOR_STATION_IDS` gesetzt sind; ansonsten erfolgt die Abfrage über IDs. |
 | `VOR_BASE` | str | `"https://routenplaner.verkehrsauskunft.at/vao/restproxy"` | Basis-URL der VAO-API. |
 | `VOR_VERSION` | str | `"v1.11.0"` | API-Version. |
 | `VOR_BOARD_DURATION_MIN` | int | `60` | Zeitraum (Minuten) für die DepartureBoard-Abfrage. |
 | `VOR_HTTP_TIMEOUT` | int | `15` | Timeout (Sekunden) für HTTP-Anfragen. |
+| `VOR_REQUEST_LOCK_TIMEOUT_SEC` | int | `10` | Timeout (Sekunden), nach dem eine Lock-Datei als veraltet gilt und übernommen bzw. entfernt wird. |
 | `VOR_MAX_STATIONS_PER_RUN` | int | `2` | Anzahl der Stations-IDs pro Durchlauf. |
 | `VOR_ROTATION_INTERVAL_SEC` | int | `1800` | Zeitraum (Sekunden) für Round-Robin der Stationsauswahl. |
 | `VOR_ALLOW_BUS` | bool (`"1"`/`"0"`) | `"0"` | Auch Buslinien berücksichtigen. |


### PR DESCRIPTION
## Summary
- document the VOR request lock timeout environment variable
- add documentation for resolving VOR stations by name

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68ce973b0b30832b92931024934196a0