### PR TITLE
refactor: Relocate `_VIENNA_TZ` constant to top of `src/build_feed.py`

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -97,6 +97,8 @@ log = logging.getLogger("build_feed")
 # Expose validate_path for tests that patch it or use it
 validate_path = feed_config.validate_path
 
+_VIENNA_TZ = ZoneInfo("Europe/Vienna")
+
 
 def refresh_from_env() -> None:
     """Refresh configuration values and reload provider plugins."""
@@ -398,9 +400,6 @@ def _fmt_rfc2822(dt: datetime) -> str:
             f"{day_name}, {local_dt.day:02d} {month_name} {local_dt.year:04d} "
             f"{local_dt.hour:02d}:{local_dt.minute:02d}:{local_dt.second:02d} {offset_str}"
         )
-
-
-_VIENNA_TZ = ZoneInfo("Europe/Vienna")
 
 
 def format_local_times(


### PR DESCRIPTION
This PR resolves a minor PEP-8 and code quality issue in `src/build_feed.py` by moving the global constant `_VIENNA_TZ = ZoneInfo("Europe/Vienna")` to the top of the file, immediately after the `validate_path` declaration and before the `refresh_from_env` function. It also removes the extraneous blank lines that were left behind at its original location, maintaining clean separation between the surrounding functions `_fmt_rfc2822` and `format_local_times`. All tests have been executed and passed.

---
*PR created automatically by Jules for task [16789257865074083318](https://jules.google.com/task/16789257865074083318) started by @Origamihase*