### PR TITLE
fix: resolve structural edge cases and infinite loops

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -78,7 +78,7 @@ try:  # pragma: no cover - allow running as script or package
     )  # type: ignore
     from utils.files import atomic_write
     from utils.http import validate_http_url
-    from utils.locking import file_lock, clear_stale_lock
+    from utils.locking import file_lock
     from utils.text import html_to_text, truncate_html
 except ModuleNotFoundError:  # pragma: no cover
     from .utils.cache import (
@@ -88,7 +88,7 @@ except ModuleNotFoundError:  # pragma: no cover
     )
     from .utils.files import atomic_write
     from .utils.http import validate_http_url
-    from .utils.locking import file_lock, clear_stale_lock
+    from .utils.locking import file_lock
     from .utils.text import html_to_text, truncate_html
 
 log = logging.getLogger("build_feed")
@@ -379,7 +379,10 @@ def _fmt_rfc2822(dt: datetime) -> str:
         try:
             local_dt = _to_utc(dt).astimezone(_VIENNA_TZ)
         except Exception:
-            local_dt = dt.replace(tzinfo=timezone.utc)
+            if dt.tzinfo is None:
+                local_dt = dt.replace(tzinfo=timezone.utc)
+            else:
+                local_dt = dt.astimezone(timezone.utc)
         days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
         months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
 
@@ -542,7 +545,6 @@ def _load_state() -> Dict[str, Dict[str, Any]]:
     path = validate_path(feed_config.STATE_FILE, "STATE_PATH")
     try:
         lock_path = path.with_suffix(".lock")
-        clear_stale_lock(lock_path)
         with lock_path.open("a+", encoding="utf-8") as lock_file:
             with file_lock(lock_file, exclusive=False):
                 with path.open("r", encoding="utf-8") as f:
@@ -592,7 +594,6 @@ def _save_state(state: Dict[str, Dict[str, Any]], deletions: Optional[Set[str]] 
     path.parent.mkdir(parents=True, exist_ok=True)
     # Windows-fix: Use a separate lock file to avoid permission errors when atomic_write replaces the target
     lock_path = path.with_suffix(".lock")
-    clear_stale_lock(lock_path)
     with lock_path.open("a+", encoding="utf-8") as lock_file:
         with file_lock(lock_file, exclusive=True):
             # Safe merge: read existing state to avoid overwriting parallel updates
@@ -835,6 +836,10 @@ def _collect_items(report: Optional[RunReport] = None) -> List[FeedItem]:
                         semaphore: Optional[BoundedSemaphore] = semaphore,
                     ) -> Any:
                         timeout_arg = timeout_value if timeout_value >= 0 else None
+
+                        if timeout_arg == 0:
+                            raise TimeoutError("Timeout value is 0, expiring immediately without acquiring semaphore.")
+
                         if semaphore is None:
                             return _call_fetch_with_timeout(fetch, timeout_arg, supports)
 

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -40,7 +40,7 @@ from ..utils.env import read_secret
 from ..utils.files import atomic_write
 from ..utils.http import session_with_retries, validate_http_url, fetch_content_safe
 from ..utils.ids import make_guid
-from ..utils.locking import file_lock, clear_stale_lock
+from ..utils.locking import file_lock
 from ..utils.logging import sanitize_log_arg, sanitize_log_message
 from ..utils.stations import vor_station_ids, station_info, text_has_vienna_connection
 
@@ -1169,7 +1169,6 @@ def save_request_count(now_ignored: datetime | None = None) -> int:
             REQUEST_COUNT_FILE.parent.mkdir(parents=True, exist_ok=True)
 
             lock_path = REQUEST_COUNT_FILE.with_suffix(".lock")
-            clear_stale_lock(lock_path)
 
             try:
                 with lock_path.open("a+", encoding="utf-8") as lock_file:

--- a/src/utils/locking.py
+++ b/src/utils/locking.py
@@ -69,6 +69,9 @@ def _lock_length(fileobj: Any) -> int:
 
 
 def _acquire_file_lock(fileobj: Any, exclusive: bool) -> None:
+    timeout = 15.0  # Hard timeout of 15 seconds
+    start_time = time.time()
+
     if fcntl is not None:  # pragma: no branch - simple POSIX case
         flag = (fcntl.LOCK_EX | fcntl.LOCK_NB) if exclusive else (fcntl.LOCK_SH | fcntl.LOCK_NB)
         while True:
@@ -77,13 +80,14 @@ def _acquire_file_lock(fileobj: Any, exclusive: bool) -> None:
                 return
             except OSError as exc:  # pragma: no cover - rare EINTR handling
                 if exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+                    if time.time() - start_time >= timeout:
+                        raise TimeoutError(f"Could not acquire file lock within {timeout} seconds.")
                     time.sleep(0.1)
                 elif exc.errno != errno.EINTR:
                     raise
     elif msvcrt is not None:  # pragma: no cover - Windows fallback
         length = _lock_length(fileobj)
-        shared_flag = getattr(msvcrt, "LK_NBRLCK", getattr(msvcrt, "LK_NBLCK", getattr(msvcrt, "LK_LOCK")))
-        mode = getattr(msvcrt, "LK_NBLCK", getattr(msvcrt, "LK_LOCK")) if exclusive else shared_flag
+        mode = msvcrt.LK_NBLCK if hasattr(msvcrt, "LK_NBLCK") else msvcrt.LK_LOCK
         current = None
         try:
             current = fileobj.tell()
@@ -96,6 +100,10 @@ def _acquire_file_lock(fileobj: Any, exclusive: bool) -> None:
                 break
             except OSError as exc:
                 if exc.errno in (errno.EACCES, errno.EAGAIN):
+                    if time.time() - start_time >= timeout:
+                        if current is not None:
+                            fileobj.seek(current)
+                        raise TimeoutError(f"Could not acquire file lock within {timeout} seconds.")
                     time.sleep(0.1)
                 else:
                     if current is not None:
@@ -167,9 +175,4 @@ def file_lock(fileobj: Any, *, exclusive: bool) -> Iterator[None]:
             if path:
                 _release_thread_lock_ref(path)
 
-def clear_stale_lock(path: str | os.PathLike[str], ttl_seconds: int = 1200) -> None:
-    """Proactively clear a lock file if it is older than ttl_seconds."""
-    pass
-
-
-__all__ = ["file_lock", "clear_stale_lock"]
+__all__ = ["file_lock"]


### PR DESCRIPTION
Fixes the timezone fallback in `src/build_feed.py` so that it doesn't try to use `dt.replace(tzinfo=timezone.utc)` unconditionally.
Fixes the semaphore timeout execution so that it bypasses the semaphore completely and raises `TimeoutError` if `timeout_value == 0`.
Updates the `_acquire_file_lock` in `src/utils/locking.py` to have a hard timeout instead of an infinite loop, and simplifies the Windows fallback.
Deletes the unnecessary `clear_stale_lock` logic from the codebase.

---
*PR created automatically by Jules for task [1988618806978790552](https://jules.google.com/task/1988618806978790552) started by @Origamihase*