### PR TITLE
Fix whitespace indentation for TimeoutError

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -852,7 +852,7 @@ def _collect_items(report: Optional[RunReport] = None) -> List[FeedItem]:
                         # If timeout_arg is None, acquire(timeout=None) will wait indefinitely.
                         acquired = semaphore.acquire(timeout=timeout_arg)
                         if not acquired:
-                             raise TimeoutError(f"Semaphore acquisition timed out after {timeout_value}s")
+                            raise TimeoutError(f"Semaphore acquisition timed out after {timeout_value}s")
 
                         # Task 3: Subtract wait time from timeout
                         try:


### PR DESCRIPTION
Fixes an extra indentation space on `raise TimeoutError` inside `_run_fetch` in `src/build_feed.py`.

---
*PR created automatically by Jules for task [16756798364825261100](https://jules.google.com/task/16756798364825261100) started by @Origamihase*