### PR TITLE
Refactor `text_has_vienna_connection` for dynamic masking

### DIFF
--- a/data/stations.json
+++ b/data/stations.json
@@ -3367,6 +3367,166 @@
       "pendler": true,
       "source": "oebb",
       "vor_id": "430527400"
+    },
+    {
+      "name": "Innsbruck",
+      "bst_id": 900001,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Salzburg",
+      "bst_id": 900002,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Linz",
+      "bst_id": 900003,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Graz",
+      "bst_id": 900004,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Klagenfurt",
+      "bst_id": 900005,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Villach",
+      "bst_id": 900006,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Bregenz",
+      "bst_id": 900007,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Wels",
+      "bst_id": 900008,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Steyr",
+      "bst_id": 900009,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Feldkirch",
+      "bst_id": 900010,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Dornbirn",
+      "bst_id": 900011,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "St. Pölten",
+      "bst_id": 900012,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Leoben",
+      "bst_id": 900013,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "München",
+      "bst_id": 900014,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Passau",
+      "bst_id": 900015,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Frankfurt",
+      "bst_id": 900016,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Berlin",
+      "bst_id": 900017,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Bratislava",
+      "bst_id": 900018,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Prag",
+      "bst_id": 900019,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
+    },
+    {
+      "name": "Budapest",
+      "bst_id": 900020,
+      "in_vienna": false,
+      "pendler": false,
+      "aliases": [],
+      "source": "manual_foreign_city"
     }
   ]
 }

--- a/src/utils/stations.py
+++ b/src/utils/stations.py
@@ -605,6 +605,40 @@ def vor_station_ids() -> tuple[str, ...]:
 
 
 @lru_cache(maxsize=1)
+def _non_vienna_stations_regex() -> re.Pattern | None:
+    """Kompiliert einen Regex-Ausdruck mit allen bekannten Nicht-Wien/Nicht-Pendler Stationen."""
+    non_vienna = set()
+    for entry in _station_entries():
+        if entry.get("in_vienna") or entry.get("pendler"):
+            continue
+
+        name = str(entry.get("name", "")).strip()
+        if name and not name.isdigit() and len(name) >= 4:
+            non_vienna.add(name)
+
+        for alias in entry.get("aliases", []):
+            if alias:
+                alias_str = str(alias).strip()
+                if alias_str and not alias_str.isdigit() and len(alias_str) >= 4:
+                    non_vienna.add(alias_str)
+
+    if not non_vienna:
+        return None
+
+    sorted_terms = sorted(non_vienna, key=len, reverse=True)
+    pattern = r"(?<!\w)(?:" + "|".join(re.escape(t) for t in sorted_terms) + r")(?!\w)"
+    return re.compile(pattern, re.IGNORECASE)
+
+
+def _mask_non_vienna_stations(text: str) -> str:
+    """Maskiert bekannte Nicht-Wien/Nicht-Pendler Stationen im Text."""
+    regex = _non_vienna_stations_regex()
+    if regex:
+        return regex.sub(" ", text)
+    return text
+
+
+@lru_cache(maxsize=1)
 def _vienna_stations_regex() -> re.Pattern:
     """Kompiliert einen Regex-Ausdruck mit allen bekannten Wiener Stationen."""
     vienna = set()
@@ -633,20 +667,20 @@ def text_has_vienna_connection(text: str) -> bool:
     if not text:
         return False
 
+    # 0. Dynamically mask specific non-Vienna/non-commuter locations
+    text = _mask_non_vienna_stations(text)
+
     # 0a. Maskiere spezifische Nicht-Wien-Orte ohne generisches Suffix
     # Dies verhindert Verwechslungen wie Hadersdorf am Kamp (NÖ) vs. Wien Hadersdorf.
     text = re.sub(r"Hadersdorf am Kamp", " ", text, flags=re.IGNORECASE)
 
-    # 0b. Maskiere bekannte Nicht-Wien-Bahnhöfe mit generischen Suffixen (inkl. Bratislava/Prag)
-    # Nutzt (?!\w) statt \b am Ende, damit Abkürzungen wie hl.st. korrekt erkannt werden.
-    cities = (
-        r"(?:Innsbruck|Salzburg|Linz|Graz|Klagenfurt|Villach|Bregenz|"
-        r"Wels|Steyr|Feldkirch|Dornbirn|St\. Pölten|Wiener Neustadt|"
-        r"Bruck|Leoben|München|Passau|Frankfurt|Berlin|Bratislava|Prag|Budapest)"
+    # 0b. Maskiere ausländische/generische Suffixe nach dem dynamischen Orts-Matching
+    text_for_matching = re.sub(
+        r"\b\w[\w\s\-\.]{2,30}?\s+(?:hl\.?\s*st\.?|hlavní\s+nádraží|Keleti|Nyugati|Déli)\b",
+        " ",
+        text,
+        flags=re.IGNORECASE
     )
-    suffixes = r"(?:Westbahnhof|Ostbahnhof|Südbahnhof|Nordbahnhof|Mitte|Hbf|Hauptbahnhof|Flughafen|Airport|hl\.?\s*st\.?)"
-
-    text_for_matching = re.sub(rf"\b{cities}[\s\-]+{suffixes}(?!\w)", " ", text, flags=re.IGNORECASE)
 
     # 1. Pendler-Spezialfälle maskieren (verhindert False-Positive beim Wort "Wien")
     cleaned = re.sub(r"Flughafen Wien|Airport Vienna|Vienna Airport", " ", text_for_matching, flags=re.IGNORECASE)

--- a/tests/test_vienna_marchegg.py
+++ b/tests/test_vienna_marchegg.py
@@ -7,3 +7,20 @@ def test_marchegg_bratislava_is_false():
 def test_hadersdorf_am_kamp_is_false():
     text = "Hadersdorf am Kamp"
     assert text_has_vienna_connection(text) is False
+
+def test_bruck_an_der_leitha_is_false():
+    # MUST return False. (It is a commuter station, not a Vienna station, and 'Wien' is not in the text).
+    assert text_has_vienna_connection("Zugausfall: Bruck an der Leitha") is False
+
+def test_bruck_an_der_leitha_with_wien_is_true():
+    # MUST return True. (It remains unmasked, and the word 'Wien' triggers the true condition).
+    assert text_has_vienna_connection("Zugausfall: Bruck an der Leitha ↔ Wien") is True
+
+def test_bratislava_hl_st_is_false():
+    # MUST return False. (Marchegg is left untouched, Bratislava is masked out, no Vienna station or 'Wien' word is found).
+    assert text_has_vienna_connection("REX 8: Marchegg ↔ Bratislava hl.st.") is False
+    assert text_has_vienna_connection("Zugausfall: Bratislava hl.st.") is False
+
+def test_via_wien_regression_is_true():
+    # MUST return True. (The text explicitly contains 'Wien').
+    assert text_has_vienna_connection("REX 8: Marchegg ↔ Bratislava hl.st. via Wien") is True


### PR DESCRIPTION
Refactors `text_has_vienna_connection` in `src/utils/stations.py` to use a data-driven approach for identifying and masking non-Vienna stations, removing the brittle hardcoded city blacklist. Also updates the relevant tests to ensure accurate tracking of valid Vienna connections versus commuter station exemptions.

---
*PR created automatically by Jules for task [1110093988746728492](https://jules.google.com/task/1110093988746728492) started by @Origamihase*