### PR TITLE
Fix 5 bugs in build_feed.py

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -430,7 +430,8 @@ def format_local_times(
         if end_local:
             if start_local.date() == end_local.date():
                 return f"Am {start_local:%d.%m.%Y}"
-            if end_local <= start_local:
+            if end_local < start_local:
+                log.warning("Enddatum liegt vor Startdatum")
                 if start_local.date() > today.date():
                     return f"Ab {start_local:%d.%m.%Y}"
                 return f"Seit {start_local:%d.%m.%Y}"
@@ -838,8 +839,6 @@ def _collect_items(report: Optional[RunReport] = None) -> List[FeedItem]:
                         timeout_arg = timeout_value if timeout_value >= 0 else None
 
                         if timeout_arg == 0:
-                            if report:
-                                report.provider_started(provider_name)
                             raise TimeoutError("Timeout value is 0, expiring immediately without acquiring semaphore.")
 
                         if semaphore is None:
@@ -943,26 +942,7 @@ def _collect_items(report: Optional[RunReport] = None) -> List[FeedItem]:
 
 
 def _invoke_collect_items(report: RunReport) -> List[FeedItem]:
-    collect_fn = _collect_items
-    try:
-        signature = inspect.signature(collect_fn)
-    except (TypeError, ValueError):  # pragma: no cover - defensive
-        signature = None
-    if signature is not None:
-        params = signature.parameters
-        if not params:
-            return collect_fn()
-        if "report" in params:
-            return collect_fn(report=report)
-        if all(
-            param.kind in (
-                inspect.Parameter.POSITIONAL_ONLY,
-                inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            )
-            for param in params.values()
-        ):
-            return collect_fn()
-    return collect_fn(report=report)
+    return _collect_items(report=report)
 
 
 def _drop_old_items(
@@ -1182,7 +1162,8 @@ def _dedupe_items(items: List[FeedItem]) -> List[FeedItem]:
 def _sort_key(item: FeedItem) -> Tuple[int, float, str]:
     pd = item.get("pubDate")
     # Fix TypeError: Ensure guid is always a string, even if explicitly None
-    guid_str = str(item.get("guid") or "")
+    guid_val = item.get("guid")
+    guid_str = str(guid_val) if guid_val else _identity_for_item(item)
     if isinstance(pd, datetime):
         return (0, -_to_utc(pd).timestamp(), guid_str)
     return (1, 0.0, guid_str)
@@ -1437,14 +1418,6 @@ def _make_rss(
         identities_in_feed.append(ident)
         emitted += 1
 
-    try:
-        _save_state(state, deletions=deletions)
-    except Exception as e:
-        log.warning(
-            "State speichern fehlgeschlagen (%s) – Feed wird trotzdem zurückgegeben.",
-            e,
-        )
-
     # Pretty print the tree
     if hasattr(ET, "indent"):
         ET.indent(rss, space="  ", level=0)
@@ -1456,6 +1429,14 @@ def _make_rss(
     # Inject CDATA
     for placeholder, cdata in item_replacements.items():
         xml_str = xml_str.replace(placeholder, cdata)
+
+    try:
+        _save_state(state, deletions=deletions)
+    except Exception as e:
+        log.warning(
+            "State speichern fehlgeschlagen (%s) – Feed wird trotzdem zurückgegeben.",
+            e,
+        )
 
     return xml_str
 

--- a/tests/test_build_feed_sort.py
+++ b/tests/test_build_feed_sort.py
@@ -67,10 +67,10 @@ def test_sort_key_handles_none_guid(monkeypatch, tmp_path):
 
     # Verify that the guid part of the key is a string
     assert isinstance(key1[2], str)
-    assert key1[2] == ""
+    assert len(key1[2]) > 0
 
     assert isinstance(key2[2], str)
-    assert key2[2] == ""
+    assert len(key2[2]) > 0
 
     assert isinstance(key3[2], str)
     assert key3[2] == "some-guid"

--- a/tests/test_dedupe_items.py
+++ b/tests/test_dedupe_items.py
@@ -36,7 +36,7 @@ def test_main_dedupes_items(monkeypatch, tmp_path):
         {"guid": "gc", "title": "C"},
     ]
 
-    def fake_collect():
+    def fake_collect(report=None):
         return list(sample_items)
 
     captured = {}

--- a/tests/test_ends_at.py
+++ b/tests/test_ends_at.py
@@ -28,7 +28,7 @@ def test_item_with_past_ends_at_is_dropped(monkeypatch, tmp_path):
     future = {"title": "future", "ends_at": now + timedelta(hours=1)}
     past = {"title": "past", "ends_at": now - timedelta(minutes=11)}
 
-    def fake_collect():
+    def fake_collect(report=None):
         return [future, past]
 
     captured = {}

--- a/tests/test_item_age.py
+++ b/tests/test_item_age.py
@@ -35,7 +35,7 @@ def test_main_filters_items_older_than_max(monkeypatch, tmp_path):
     recent = {"title": "recent", "pubDate": now - timedelta(days=2) + timedelta(minutes=1)}
     old = {"title": "old", "pubDate": now - timedelta(days=2) - timedelta(minutes=1)}
 
-    def fake_collect():
+    def fake_collect(report=None):
         return [recent, old]
 
     captured = {}
@@ -70,7 +70,7 @@ def test_main_filters_items_older_than_absolute(monkeypatch, tmp_path):
         "starts_at": now - timedelta(days=2) - timedelta(minutes=1),
     }
 
-    def fake_collect():
+    def fake_collect(report=None):
         return [within, too_old]
 
     captured = {}


### PR DESCRIPTION
This commit fixes 5 specific logic and architectural bugs in `src/build_feed.py` as requested:

1. **Fix Logical Error in `format_local_times`:** Modified the comparison from `<=` to `<` when checking if `end_local` is before `start_local`, and added a warning log `log.warning("Enddatum liegt vor Startdatum")` to catch anomalies.
2. **Prevent Premature State Saving in `_make_rss`:** Moved the `_save_state` logic to the end of the `_make_rss` function so it's not called if string serialization (`ET.tostring`) fails.
3. **Remove Over-engineered Introspection in `_invoke_collect_items`:** Removed the complex `inspect.signature(collect_fn)` fallback logic and simplified it to directly return `_collect_items(report=report)`. (Also updated test mocks that lacked the `report` parameter).
4. **Fix Duplicate Telemetry Logging in `_run_fetch` Closure:** Removed the explicit call to `report.provider_started(provider_name)` right before raising a `TimeoutError` when `timeout_arg == 0` since the main thread already records this event.
5. **Ensure Deterministic Sorting in `_sort_key`:** Changed the fallback sorting behavior for items missing a `guid`. Now, if `item.get("guid")` is empty or missing, it falls back to using `_identity_for_item(item)` to ensure deterministic ordering.

All tests have been run and pass. Static checks have been successful.

---
*PR created automatically by Jules for task [6243952266447723354](https://jules.google.com/task/6243952266447723354) started by @Origamihase*