### PR TITLE
fix(stations): improve masking of generic suffixes for non-Vienna stations

### DIFF
--- a/src/utils/stations.py
+++ b/src/utils/stations.py
@@ -626,7 +626,14 @@ def _non_vienna_stations_regex() -> re.Pattern | None:
         return None
 
     sorted_terms = sorted(non_vienna, key=len, reverse=True)
-    pattern = r"(?<!\w)(?:" + "|".join(re.escape(t) for t in sorted_terms) + r")(?!\w)"
+
+    # Ergänze optionale generische Suffixe für Bahnhöfe
+    suffixes = (
+        r"(?:\s+(?:Hbf|Hauptbahnhof|Westbahnhof|Ostbahnhof|"
+        r"Südbahnhof|Nordbahnhof|Bahnhof|Bf|hl\.?\s*st\.?|"
+        r"hlavní\s+nádraží|Keleti|Nyugati|Déli)(?!\w))?"
+    )
+    pattern = r"(?<!\w)(?:" + "|".join(re.escape(t) for t in sorted_terms) + r")(?!\w)" + suffixes
     return re.compile(pattern, re.IGNORECASE)
 
 
@@ -672,15 +679,7 @@ def text_has_vienna_connection(text: str) -> bool:
 
     # 0a. Maskiere spezifische Nicht-Wien-Orte ohne generisches Suffix
     # Dies verhindert Verwechslungen wie Hadersdorf am Kamp (NÖ) vs. Wien Hadersdorf.
-    text = re.sub(r"Hadersdorf am Kamp", " ", text, flags=re.IGNORECASE)
-
-    # 0b. Maskiere ausländische/generische Suffixe nach dem dynamischen Orts-Matching
-    text_for_matching = re.sub(
-        r"\b\w[\w\s\-\.]{2,30}?\s+(?:hl\.?\s*st\.?|hlavní\s+nádraží|Keleti|Nyugati|Déli)(?!\w)",
-        " ",
-        text,
-        flags=re.IGNORECASE
-    )
+    text_for_matching = re.sub(r"Hadersdorf am Kamp", " ", text, flags=re.IGNORECASE)
 
     # 1. Pendler-Spezialfälle maskieren (verhindert False-Positive beim Wort "Wien")
     cleaned = re.sub(r"Flughafen Wien|Airport Vienna|Vienna Airport", " ", text_for_matching, flags=re.IGNORECASE)

--- a/tests/test_vienna_marchegg.py
+++ b/tests/test_vienna_marchegg.py
@@ -24,3 +24,16 @@ def test_bratislava_hl_st_is_false():
 def test_via_wien_regression_is_true():
     # MUST return True. (The text explicitly contains 'Wien').
     assert text_has_vienna_connection("REX 8: Marchegg ↔ Bratislava hl.st. via Wien") is True
+
+def test_villach_westbahnhof_is_false():
+    # MUST return False.
+    assert text_has_vienna_connection("Villach ↔ Villach Westbahnhof") is False
+
+def test_villach_rettungseinsatz_is_false():
+    # MUST return False. (Multiple instances of non-vienna station names with suffixes).
+    text = "Wegen eines Rettungseinsatzes sind zwischen Villach Hbf und Villach Westbahnhof keine Fahrten möglich."
+    assert text_has_vienna_connection(text) is False
+
+def test_st_poelten_hbf_is_false():
+    # MUST return False.
+    assert text_has_vienna_connection("St. Pölten Hbf ist groß.") is False


### PR DESCRIPTION
- Modified `_non_vienna_stations_regex()` to optionally match and mask generic station suffixes (e.g., `Hbf`, `Westbahnhof`, `hl.st.`) alongside the non-Vienna station name.
- Refactored `text_has_vienna_connection()` to remove redundant step 0b, as the new regex dynamically handles suffix masking across the entire text.
- Added regression tests for `Villach ↔ Villach Westbahnhof` and `St. Pölten Hbf` in `tests/test_vienna_marchegg.py`.

---
*PR created automatically by Jules for task [12130435224266947084](https://jules.google.com/task/12130435224266947084) started by @Origamihase*