### PR TITLE
fix(stations): Make U1-U6 regex context-sensitive

### DIFF
--- a/src/utils/stations.py
+++ b/src/utils/stations.py
@@ -688,11 +688,23 @@ def text_has_vienna_connection(text: str) -> bool:
     if re.search(r"\b(flughafen wien|airport vienna|vienna airport)\b", text_for_matching, re.IGNORECASE):
         return True
 
-    # 2. Prüfe auf das eigenständige Wort "Wien" (z.B. als Richtungshinweis) oder U-Bahn Linien
-    if re.search(r"\b(wien|vienna|u[1-6]|u-bahn)\b", cleaned, re.IGNORECASE):
+    # 2. Prüfe auf das eigenständige Wort "Wien" (z.B. als Richtungshinweis) oder U-Bahn
+    if re.search(r"\b(wien|vienna|u-bahn)\b", cleaned, re.IGNORECASE):
         return True
 
-    # 3. Abgleich gegen Wiener Stationen und Aliase aus dem Verzeichnis
+    # 3. Kontextsensitive Erkennung für U1-U6:
+    # Matcht nur, wenn U1-U6 in typischen Mustern auftritt (z.B. "Linie U6", "der U6", "U1:", "(U2)")
+    # oder wenn typische Öffi-Wörter nahestehen, um False-Positives ("Zürich U4") zu vermeiden.
+    u_bahn_pattern = (
+        r"(?:\b(?:linie|der|die|auf|mit|von|zur)\s+u[1-6]\b|"
+        r"\bu[1-6]\b\s*[:(]|"
+        r"\(\s*u[1-6]\s*\)|"
+        r"\bu[1-6]\b(?=\s*(?:steht|fährt|ersatz|halt|störung|gesperrt|unterbrochen)))"
+    )
+    if re.search(u_bahn_pattern, cleaned, re.IGNORECASE):
+        return True
+
+    # 4. Abgleich gegen Wiener Stationen und Aliase aus dem Verzeichnis
     rx = _vienna_stations_regex()
     if rx.search(cleaned):
         return True

--- a/tests/test_vienna_marchegg.py
+++ b/tests/test_vienna_marchegg.py
@@ -15,6 +15,7 @@ from src.utils.stations import text_has_vienna_connection
         "Zugausfall: Bruck an der Leitha",
         "Zugausfall: Bratislava hl.st.",
         "St. Pölten Hbf ist groß.",
+        "Zürich U4 Betrieb",
     ],
 )
 def test_text_has_vienna_connection_false(text: str) -> None:
@@ -27,11 +28,11 @@ def test_text_has_vienna_connection_false(text: str) -> None:
         "S-Bahn Wien: Störung zwischen Wien Mitte und Floridsdorf",
         "REX: Marchegg ↔ Wien Praterstern",
         "Meidling gesperrt",
-        "Störung auf der U6",
         "Flughafen Wien: Zubringerbus ausgefallen",
         "Stockerau ↔ Wien Franz-Josefs-Bahnhof",
         "Zugausfall: Bruck an der Leitha ↔ Wien",
         "REX 8: Marchegg ↔ Bratislava hl.st. via Wien",
+        "Störung auf der U6",
     ],
 )
 def test_text_has_vienna_connection_true(text: str) -> None:


### PR DESCRIPTION
Fixes an issue in `text_has_vienna_connection` where strings like "Zürich U4 Betrieb" would incorrectly trigger a Vienna location match due to an overly broad regex. The matching logic for `u[1-6]` has been moved to a separate, context-sensitive block requiring specific prefixes, suffixes, or bounding punctuations. Included regression tests to prevent future false positives and confirm intended behavior.

---
*PR created automatically by Jules for task [14139311945142873505](https://jules.google.com/task/14139311945142873505) started by @Origamihase*