### PR TITLE
Fix feed merge and reporting bugs

### DIFF
--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -74,6 +74,8 @@ def _has_significant_overlap(name1: str, name2: str) -> bool:
         meaningful_union = union - _STOP_WORDS
         if meaningful_union:
             return False
+        else:
+            return True
 
     if len(intersection) / len(union) >= 0.4:
         return True
@@ -151,6 +153,8 @@ def deduplicate_fuzzy(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
                         # Update the list with the modified copy
                         merged_items[idx] = new_existing
+                        new_existing["_identity"] = new_existing.get("guid", "")
+                        new_existing.pop("_calculated_identity", None)
                         # Do NOT update GUID or Title from ÖBB (keep VOR master data)
                         merged = True
                         break
@@ -170,6 +174,8 @@ def deduplicate_fuzzy(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                             new_existing["description"] = f"{desc_vor}\n\n{desc_oebb}".strip()
 
                         merged_items[idx] = new_existing
+                        new_existing["_identity"] = new_existing.get("guid", "")
+                        new_existing.pop("_calculated_identity", None)
                         merged = True
                         break
 

--- a/src/feed/reporting.py
+++ b/src/feed/reporting.py
@@ -108,7 +108,7 @@ class _RunErrorCollector(logging.Handler):
         self.report = report
         self._formatter = logging.Formatter()
 
-    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - defensive
+    def emit(self, record: logging.LogRecord) -> None:
         try:
             msg = record.getMessage()
         except Exception:
@@ -144,6 +144,7 @@ class RunReport:
     finished_at: Optional[datetime] = None
     _error_collector: Optional[_RunErrorCollector] = None
     _lock: RLock = field(default_factory=RLock)
+    _issue_submitted: bool = False
 
     def __post_init__(self) -> None:
         for name, enabled in self.statuses:
@@ -210,6 +211,7 @@ class RunReport:
 
     def provider_error(self, name: str, message: str | None = None) -> None:
         """Record a provider failure with an error message."""
+        cleaned = ""
         with self._lock:
             entry = self.providers.get(name)
             if entry is None:
@@ -383,7 +385,9 @@ class RunReport:
                     "Hinweis: Fehler während des Feed-Laufs – Details siehe %s",
                     error_log_path,
                 )
-                _submit_github_issue(self)
+                if not self._issue_submitted:
+                    _submit_github_issue(self)
+                    self._issue_submitted = True
         finally:
             self.detach_error_collector()
 

--- a/tests/test_feed_merge_priority.py
+++ b/tests/test_feed_merge_priority.py
@@ -44,6 +44,10 @@ def test_fuzzy_merge_provider_priority_vor_wins_over_oebb():
     assert "Short VOR text." in item["description"]
     assert "Details from ÖBB" in item["description"]
 
+    # Verify identity update
+    assert item["_identity"] == "vor_guid_1"
+    assert "_calculated_identity" not in item
+
 def test_fuzzy_merge_provider_priority_vor_wins_reverse_order():
     """
     Same as above, but items are processed in reverse order (VOR exists, ÖBB comes later).
@@ -74,6 +78,10 @@ def test_fuzzy_merge_provider_priority_vor_wins_reverse_order():
     assert item["provider"] == "vor"
     assert "Short VOR text." in item["description"]
     assert "Details from ÖBB" in item["description"]
+
+    # Verify identity update
+    assert item["_identity"] == "vor_guid_1"
+    assert "_calculated_identity" not in item
 
 def test_fuzzy_merge_provider_priority_no_provider_field():
     """

--- a/tests/test_fuzzy_merge_stopwords.py
+++ b/tests/test_fuzzy_merge_stopwords.py
@@ -10,6 +10,9 @@ def test_has_significant_overlap_stopwords():
     # Should not merge.
     assert not _has_significant_overlap("Störung", "Störung am Schottentor")
 
+    # Exact same stopwords only
+    assert _has_significant_overlap("Störung", "Störung")
+
     # Meaningful overlap -> True
     # intersection: {'schottentor'}, union: {'schottentor', 'störung', 'info', 'ausfall'}
     # length: 1 / 4 = 0.25 (not >= 0.4) so this returns False. Let's make it >= 0.4

--- a/tests/test_provider_error.py
+++ b/tests/test_provider_error.py
@@ -1,0 +1,13 @@
+import pytest
+from unittest.mock import patch
+from src.feed.reporting import RunReport
+
+def test_provider_error_unbound_local_error_avoided():
+    report = RunReport([])
+
+    with patch("src.feed.reporting.clean_message", side_effect=Exception("Clean failed")):
+        with pytest.raises(Exception, match="Clean failed"):
+            report.provider_error("wl", "Some error")
+
+    # The key test is that an UnboundLocalError is NOT raised.
+    # The patch side_effect should propagate the Exception.

--- a/tests/test_reporting_github.py
+++ b/tests/test_reporting_github.py
@@ -33,6 +33,9 @@ def test_run_report_creates_github_issue(monkeypatch):
 
     report.log_results()
 
+    # Should not submit duplicate issue
+    report.log_results()
+
     assert len(responses.calls) == 1
     call = responses.calls[0]
     assert call.request.headers["Authorization"] == "Bearer secret-token"

--- a/tests/test_run_report_collector.py
+++ b/tests/test_run_report_collector.py
@@ -1,5 +1,5 @@
 import logging
-from src.feed.reporting import RunReport, _RunErrorCollector
+from src.feed.reporting import RunReport
 
 def test_run_error_collector_emits_error():
     report = RunReport([])

--- a/tests/test_run_report_collector.py
+++ b/tests/test_run_report_collector.py
@@ -1,0 +1,15 @@
+import logging
+from src.feed.reporting import RunReport, _RunErrorCollector
+
+def test_run_error_collector_emits_error():
+    report = RunReport([])
+    report.attach_error_collector()
+
+    logger = logging.getLogger("test_collector")
+    logger.error("Test error message")
+
+    assert report.has_errors()
+    errors = list(report.iter_error_messages())
+    assert any("Test error message" in msg for msg in errors)
+
+    report.detach_error_collector()


### PR DESCRIPTION
Fixes 5 requested bugs in `src/feed/merge.py` and `src/feed/reporting.py`:

**Bug 1 – merge.py: `_has_significant_overlap` missing explicit `return True` for stop-word-only union**
Fixed by adding `return True` when `meaningful_union` is empty.

**Bug 2 – reporting.py: `_submit_github_issue` called without deduplication guard**
Fixed by adding an `_issue_submitted` flag to `RunReport`.

**Bug 3 – reporting.py: `_RunErrorCollector.emit` must not be excluded from test coverage**
Fixed by removing `# pragma: no cover` and writing `test_run_report_collector.py`.

**Bug 4 – reporting.py: `provider_error` uses `cleaned` outside its defining scope safely but fragile**
Fixed by initializing `cleaned = ""` before entering the `with self._lock` block.

**Bug 5 – merge.py: VOR/ÖBB priority merge paths do not update `_identity`**
Fixed by manually updating `_identity` and removing `_calculated_identity`.

---
*PR created automatically by Jules for task [5226508558905923676](https://jules.google.com/task/5226508558905923676) started by @Origamihase*