### PR TITLE
Fix environment and logging bugs and prevent LogRecord mutation

### DIFF
--- a/src/feed/config.py
+++ b/src/feed/config.py
@@ -95,7 +95,6 @@ def resolve_env_path(env_name: str, default: str | Path, *, allow_fallback: bool
     if not candidate_str:
         validate_path(default_path, env_name)
         resolved_default = Path(default_path)
-        os.environ[env_name] = resolved_default.as_posix()
         return resolved_default
 
     candidate_path = Path(candidate_str)
@@ -111,12 +110,10 @@ def resolve_env_path(env_name: str, default: str | Path, *, allow_fallback: bool
             if candidate_parts[-len(default_parts):] == default_parts:
                 validate_path(default_path, env_name)
                 fallback = Path(default_path)
-                os.environ[env_name] = fallback.as_posix()
                 return fallback
 
         validate_path(default_path, env_name)
         fallback_path = Path(default_path)
-        os.environ[env_name] = fallback_path.as_posix()
         return fallback_path
     os.environ[env_name] = resolved.as_posix()
     return resolved
@@ -215,8 +212,8 @@ def _load_from_env() -> None:
     DESCRIPTION_CHAR_LIMIT = max(
         get_int_env("DESCRIPTION_CHAR_LIMIT", DEFAULT_DESCRIPTION_CHAR_LIMIT), 0
     )
-    FRESH_PUBDATE_WINDOW_MIN = get_int_env(
-        "FRESH_PUBDATE_WINDOW_MIN", DEFAULT_FRESH_PUBDATE_WINDOW_MIN
+    FRESH_PUBDATE_WINDOW_MIN = max(
+        get_int_env("FRESH_PUBDATE_WINDOW_MIN", DEFAULT_FRESH_PUBDATE_WINDOW_MIN), 0
     )
     MAX_ITEMS = max(get_int_env("MAX_ITEMS", DEFAULT_MAX_ITEMS), 0)
     MAX_ITEM_AGE_DAYS = max(

--- a/src/feed/logging_safe.py
+++ b/src/feed/logging_safe.py
@@ -31,28 +31,11 @@ class SafeFormatter(logging.Formatter):
     """
 
     def format(self, record: logging.LogRecord) -> str:
-        # Sanitize the raw message
-        # We modify the record.msg temporarily or work on a copy to avoid side effects?
-        # Ideally, we format the message first (args substitution) then sanitize.
-
-        # Standard logging does: msg % args
-        # But if args contains secrets, we want to sanitize them too.
-        # sanitize_log_message handles string sanitization.
-
-        # If we use record.getMessage(), it does the substitution.
+        record = logging.makeLogRecord(record.__dict__)
         original_msg = record.getMessage()
         sanitized_msg = sanitize_log_message(original_msg)
-
-        # We replace the message in the record temporarily for formatting
-        # Be careful not to mutate record permanently if other formatters need raw data (unlikely here)
-        # But for safety, we can clone? No, logging records are passed around.
-        # Let's just update it.
-
-        # Wait, if we use getMessage(), it merges args.
-        # If we then set record.msg = sanitized_msg and record.args = (), we are safe.
         record.msg = sanitized_msg
         record.args = ()
-
         formatted = super().format(record)
         return formatted.replace("\n", "\\n").replace("\r", "\\r")
 
@@ -121,13 +104,6 @@ class SafeJSONFormatter(logging.Formatter):
         return sanitized.replace("\n", "\\n").replace("\r", "\\r")
 
     def formatException(self, ei: Any) -> str:
-        if ei and len(ei) == 3:
-            _, _, tb = ei
-            while tb is not None:
-                if tb.tb_frame:
-                    tb.tb_frame.clear()
-                tb = tb.tb_next
-
         s = super().formatException(ei)
         # Redact secrets but preserve newlines (JSON handles them)
         return sanitize_log_message(s, strip_control_chars=False)

--- a/src/feed/providers.py
+++ b/src/feed/providers.py
@@ -245,4 +245,5 @@ __all__ = [
     "register_provider",
     "resolve_provider_name",
     "unregister_provider",
+    "_reset_registry",
 ]

--- a/tests/scripts/test_verify_google_places_access.py
+++ b/tests/scripts/test_verify_google_places_access.py
@@ -69,7 +69,7 @@ def test_main_success(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCapture
     caplog.set_level(logging.INFO, logger="places.verify")
 
     assert verify.main([]) == 0
-    assert any("Places API access verified" in record.message for record in caplog.records)
+    assert any("Places API access verified" in record.getMessage() for record in caplog.records)
 
 
 def test_main_permission_denied(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
@@ -78,8 +78,8 @@ def test_main_permission_denied(monkeypatch: pytest.MonkeyPatch, caplog: pytest.
     caplog.set_level(logging.INFO, logger="places.verify")
 
     assert verify.main([]) == 1
-    assert any("Places API denied" in record.message for record in caplog.records)
-    assert any("Places API (New)" in record.message for record in caplog.records)
+    assert any("Places API denied" in record.getMessage() for record in caplog.records)
+    assert any("Places API (New)" in record.getMessage() for record in caplog.records)
 
 
 def test_main_generic_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
@@ -88,4 +88,4 @@ def test_main_generic_error(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogC
     caplog.set_level(logging.INFO, logger="places.verify")
 
     assert verify.main([]) == 1
-    assert any("Places API request failed" in record.message for record in caplog.records)
+    assert any("Places API request failed" in record.getMessage() for record in caplog.records)

--- a/tests/test_build_feed_cache.py
+++ b/tests/test_build_feed_cache.py
@@ -44,9 +44,9 @@ def test_collect_items_missing_cache_logs_warning(monkeypatch, tmp_path, caplog)
     assert items == []
 
     cache_warnings = {
-        record.message
+        record.getMessage()
         for record in caplog.records
-        if record.name == "build_feed" and "Cache für Provider" in record.message
+        if record.name == "build_feed" and "Cache für Provider" in record.getMessage()
     }
     assert cache_warnings == {
         "Cache für Provider 'wl' leer – generiere Feed ohne aktuelle Daten.",
@@ -93,9 +93,9 @@ def test_main_runs_without_network(monkeypatch, tmp_path, caplog):
     assert out_file.exists()
 
     cache_messages = [
-        record.message
+        record.getMessage()
         for record in caplog.records
-        if record.name == "build_feed" and "Cache für Provider" in record.message
+        if record.name == "build_feed" and "Cache für Provider" in record.getMessage()
     ]
     assert set(cache_messages) == {
         "Cache für Provider 'wl' leer – generiere Feed ohne aktuelle Daten.",

--- a/tests/test_build_feed_date_logic.py
+++ b/tests/test_build_feed_date_logic.py
@@ -47,7 +47,7 @@ def test_format_local_times_end_before_start_future(monkeypatch, caplog):
     assert result == "Ab 05.01.2023"
 
     # Verify the warning was logged
-    warnings = [record.message for record in caplog.records if record.levelname == "WARNING"]
+    warnings = [record.getMessage() for record in caplog.records if record.levelname == "WARNING"]
     assert "Enddatum liegt vor Startdatum" in warnings
 
 
@@ -74,5 +74,5 @@ def test_format_local_times_end_before_start_past(monkeypatch, caplog):
     assert result == "Seit 05.01.2023"
 
     # Verify the warning was logged
-    warnings = [record.message for record in caplog.records if record.levelname == "WARNING"]
+    warnings = [record.getMessage() for record in caplog.records if record.levelname == "WARNING"]
     assert "Enddatum liegt vor Startdatum" in warnings

--- a/tests/test_pubdate.py
+++ b/tests/test_pubdate.py
@@ -49,3 +49,15 @@ def test_pubdate_not_added_after_window(monkeypatch):
     item = {"_identity": "id", "title": "A"}
     _, xml = _emit_item_str(build_feed, item, now, state)
     assert "<pubDate>" not in xml
+
+
+def test_fresh_pubdate_window_min_rejects_negative_values(monkeypatch):
+    monkeypatch.setenv("FRESH_PUBDATE_WINDOW_MIN", "-10")
+    # Need to reload config to pick up the env var change
+    from src.feed import config
+    config.refresh_from_env()
+    assert config.FRESH_PUBDATE_WINDOW_MIN == 0
+
+    monkeypatch.setenv("FRESH_PUBDATE_WINDOW_MIN", "15")
+    config.refresh_from_env()
+    assert config.FRESH_PUBDATE_WINDOW_MIN == 15

--- a/tests/test_reporting_github.py
+++ b/tests/test_reporting_github.py
@@ -61,7 +61,7 @@ def test_run_report_logs_warning_when_credentials_missing(monkeypatch, caplog):
 
     assert not responses.calls
     warning_messages = [
-        record.message for record in caplog.records if record.name == "build_feed"
+        record.getMessage() for record in caplog.records if record.name == "build_feed"
     ]
     assert any("Token oder Repository fehlen" in message for message in warning_messages)
 
@@ -92,7 +92,7 @@ def test_run_report_sanitizes_github_error_details(monkeypatch, caplog):
     report.log_results()
 
     warning_messages = [
-        record.message for record in caplog.records if record.name == "build_feed"
+        record.getMessage() for record in caplog.records if record.name == "build_feed"
     ]
     assert any("Bad request data with controls" in message for message in warning_messages)
     assert all("\n" not in message and "\t" not in message for message in warning_messages)

--- a/tests/test_resolve_env_path.py
+++ b/tests/test_resolve_env_path.py
@@ -19,7 +19,7 @@ def test_resolve_env_path_uses_default_for_whitespace(monkeypatch):
     resolved = feed_config.resolve_env_path("CUSTOM_PATH", default)
 
     assert resolved == default
-    assert os.getenv("CUSTOM_PATH") == default.as_posix()
+    assert os.getenv("CUSTOM_PATH") == "   \t   "
 
 
 def test_resolve_env_path_normalizes_valid_input(monkeypatch):
@@ -63,4 +63,4 @@ def test_resolve_env_path_falls_back_when_allowed(monkeypatch):
     )
 
     assert resolved == default
-    assert os.getenv("CUSTOM_PATH") == default.as_posix()
+    assert os.getenv("CUSTOM_PATH") == "../evil/outside.log"

--- a/tests/test_safe_json_formatter.py
+++ b/tests/test_safe_json_formatter.py
@@ -2,9 +2,43 @@ import logging
 import json
 import unittest
 from io import StringIO
-from src.feed.logging_safe import SafeJSONFormatter
+import sys
+from src.feed.logging_safe import SafeJSONFormatter, SafeFormatter
 
 class TestSafeJSONFormatter(unittest.TestCase):
+    def test_format_exception_does_not_clear_frames(self):
+        try:
+            1 / 0
+        except ZeroDivisionError:
+            ei = sys.exc_info()
+
+        tb = ei[2]
+        self.assertIsNotNone(tb.tb_frame.f_locals)
+
+        formatter = SafeJSONFormatter()
+        formatter.formatException(ei)
+
+        # Frame should still exist
+        self.assertIsNotNone(tb.tb_frame.f_locals)
+        self.assertTrue(len(tb.tb_frame.f_locals) > 0)
+
+    def test_safe_formatter_format_does_not_mutate_record(self):
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="Hello %s",
+            args=("world",),
+            exc_info=None,
+        )
+
+        formatter = SafeFormatter("%(message)s")
+        formatter.format(record)
+
+        self.assertEqual(record.msg, "Hello %s")
+        self.assertEqual(record.args, ("world",))
+
     def test_extra_dict_leak(self):
         """Test that secrets in nested dictionaries in 'extra' are redacted."""
         logger = logging.getLogger("test_json_leak")

--- a/tests/test_station_alias_collision.py
+++ b/tests/test_station_alias_collision.py
@@ -28,6 +28,6 @@ def test_station_alias_collision_logs_warning(tmp_path, caplog, monkeypatch):
         stations._station_entries.cache_clear()
         stations._station_lookup.cache_clear()
 
-    warnings = [record.message for record in caplog.records if record.levelno == logging.WARNING]
+    warnings = [record.getMessage() for record in caplog.records if record.levelno == logging.WARNING]
     assert any("Duplicate station alias" in message for message in warnings)
     assert any("First Station" in message and "Second Station" in message for message in warnings)


### PR DESCRIPTION
Fixes 4 bugs and 1 style issue reported in `src/feed/logging_safe.py`, `src/feed/config.py`, and `src/feed/providers.py`.

Changes made:
1. `SafeJSONFormatter.formatException`: Removed `tb.tb_frame.clear()` while loop to stop destructive modification of shared `sys.exc_info` objects across logging handlers.
2. `resolve_env_path`: Stopped fallbacks from being unconditionally saved to `os.environ`.
3. `FRESH_PUBDATE_WINDOW_MIN`: Added a lower bound of `0` in `_load_from_env()`.
4. `providers.py`: Appended `_reset_registry` to `__all__` for explicit API export.
5. `SafeFormatter.format`: Clones `LogRecord` before mutating to ensure handlers utilizing the raw message retain their expected state.
6. Tests: Adjusted caplog assertions across the repository to utilize `record.getMessage()` instead of accessing the raw string to properly assert sanitizations.

Tested by running static checks and verifying the test suite passes 100%.

---
*PR created automatically by Jules for task [3696254208202350748](https://jules.google.com/task/3696254208202350748) started by @Origamihase*