### PR TITLE
Fix environment variable write-back in config loader

### DIFF
--- a/src/feed/config.py
+++ b/src/feed/config.py
@@ -115,7 +115,6 @@ def resolve_env_path(env_name: str, default: str | Path, *, allow_fallback: bool
         validate_path(default_path, env_name)
         fallback_path = Path(default_path)
         return fallback_path
-    os.environ[env_name] = resolved.as_posix()
     return resolved
 
 

--- a/tests/test_resolve_env_path.py
+++ b/tests/test_resolve_env_path.py
@@ -30,7 +30,23 @@ def test_resolve_env_path_normalizes_valid_input(monkeypatch):
 
     expected = Path("log/custom.log").resolve()
     assert resolved == expected
-    assert os.getenv("CUSTOM_PATH") == expected.as_posix()
+    assert os.getenv("CUSTOM_PATH") == "  log/custom.log  "
+
+
+def test_resolve_env_path_does_not_overwrite_env_on_refresh(monkeypatch):
+    monkeypatch.setenv("CUSTOM_PATH", "data/feed.rss")
+    default = Path("data/default.rss")
+
+    # First call (simulating initial load)
+    resolved_1 = feed_config.resolve_env_path("CUSTOM_PATH", default)
+    # Second call (simulating refresh_from_env)
+    resolved_2 = feed_config.resolve_env_path("CUSTOM_PATH", default)
+
+    expected = Path("data/feed.rss").resolve()
+    assert resolved_1 == expected
+    assert resolved_2 == expected
+    # The environment variable should retain its original relative value
+    assert os.getenv("CUSTOM_PATH") == "data/feed.rss"
 
 
 def test_resolve_env_path_raises_for_invalid_without_fallback(monkeypatch):


### PR DESCRIPTION
Fix `os.environ` write-back inconsistency in `resolve_env_path` by making the function a pure reader/validator. Added regression test to verify `refresh_from_env()` preserves original relative path values.

---
*PR created automatically by Jules for task [2728211131568708632](https://jules.google.com/task/2728211131568708632) started by @Origamihase*