### PR TITLE
fix: resolve concurrency, merge, and import bugs in feed processing

### DIFF
--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -231,6 +231,18 @@ def deduplicate_fuzzy(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                         elif desc2:
                             existing_copy["description"] = desc2
 
+                    for date_key in ("pubdate", "pub_date", "updated"):
+                        existing_date = existing_copy.get(date_key)
+                        item_date = item.get(date_key)
+                        if existing_date and item_date:
+                            try:
+                                if item_date > existing_date:
+                                    existing_copy[date_key] = item_date
+                            except TypeError:
+                                pass  # non-comparable types — leave existing unchanged
+                        elif item_date and not existing_date:
+                            existing_copy[date_key] = item_date
+
                     # 4. Update GUID
                     # We create a new deterministic GUID based on the new title.
                     # This ensures clients see it as a new/updated item.

--- a/src/feed/providers.py
+++ b/src/feed/providers.py
@@ -229,7 +229,6 @@ def read_cache_baustellen() -> List[Any]:
 
 
 register_default_providers()
-load_provider_plugins()
 
 
 __all__ = [

--- a/src/feed/reporting.py
+++ b/src/feed/reporting.py
@@ -107,8 +107,11 @@ class _RunErrorCollector(logging.Handler):
         super().__init__(level=logging.ERROR)
         self.report = report
         self._formatter = logging.Formatter()
+        self._detached = False
 
     def emit(self, record: logging.LogRecord) -> None:
+        if self._detached:
+            return
         try:
             msg = record.getMessage()
         except Exception:
@@ -278,6 +281,7 @@ class RunReport:
     def detach_error_collector(self) -> None:
         if self._error_collector is None:
             return
+        self._error_collector._detached = True
         logging.getLogger().removeHandler(self._error_collector)
         self._error_collector = None
 
@@ -385,9 +389,14 @@ class RunReport:
                     "Hinweis: Fehler während des Feed-Laufs – Details siehe %s",
                     error_log_path,
                 )
-                if not self._issue_submitted:
+                with self._lock:
+                    if not self._issue_submitted:
+                        self._issue_submitted = True
+                        submit_now = True
+                    else:
+                        submit_now = False
+                if submit_now:
                     _submit_github_issue(self)
-                    self._issue_submitted = True
         finally:
             self.detach_error_collector()
 

--- a/tests/test_feed_merge.py
+++ b/tests/test_feed_merge.py
@@ -35,6 +35,32 @@ def test_fuzzy_merge_silvester():
     assert item["guid"] != "guid1"
     assert item["guid"] != "guid2"
 
+def test_fuzzy_merge_pubdate_update():
+    items = [
+        {
+            "title": "U1: Störung",
+            "description": "Erste Meldung.",
+            "guid": "guid1",
+            "pubdate": "2023-01-01T10:00:00Z"
+        },
+        {
+            "title": "U1: Störung",
+            "description": "Zweite Meldung.",
+            "guid": "guid2",
+            "pubdate": "2023-01-01T10:30:00Z"
+        }
+    ]
+
+    merged = deduplicate_fuzzy(items)
+
+    assert len(merged) == 1
+    item = merged[0]
+
+    assert item["pubdate"] == "2023-01-01T10:30:00Z"
+    assert "Erste Meldung." in item["description"]
+    assert "Zweite Meldung." in item["description"]
+
+
 def test_fuzzy_no_merge_different_events():
     items = [
         {

--- a/tests/test_provider_plugins.py
+++ b/tests/test_provider_plugins.py
@@ -20,6 +20,38 @@ def _make_plugin_module(name: str, *, register_callable=None, providers=None) ->
     return module
 
 
+def test_load_provider_plugins_not_called_on_import():
+    # To properly test that importing doesn't call load_provider_plugins,
+    # we launch a subprocess that imports the module and exits without failure.
+    # We can inspect what it did by mocking it or checking side effects,
+    # but the simplest proof is verifying the code source doesn't contain the call at module level.
+    # We'll use a subprocess to run python -c "import src.feed.providers".
+    import subprocess
+    import sys
+
+    # Run the import in a clean environment to ensure no caching tricks us.
+    result = subprocess.run(
+        [sys.executable, "-c", "import sys; sys.path.insert(0, 'src'); import feed.providers; print('IMPORT SUCCESS')"],  # noqa: S603
+        capture_output=True,
+        text=True,
+        check=True
+    )
+
+    assert "IMPORT SUCCESS" in result.stdout
+    # Further ensure that load_provider_plugins() call is truly gone from the file text
+    import pathlib
+    providers_path = pathlib.Path("src/feed/providers.py")
+    content = providers_path.read_text()
+    # The string 'load_provider_plugins()' should not appear as a top-level call.
+    # It might appear in `__all__ = [...]`, so we look for the exact module-level call syntax.
+    # Or simply split lines and check.
+    lines = content.splitlines()
+    for line in lines:
+        # Check for unindented call
+        if line.startswith("load_provider_plugins()"):
+            assert False, "Found top-level call to load_provider_plugins()"
+
+
 def test_load_provider_plugins_via_callable(monkeypatch):
     from src.feed import providers as provider_mod
 

--- a/tests/test_run_report_collector.py
+++ b/tests/test_run_report_collector.py
@@ -13,3 +13,52 @@ def test_run_error_collector_emits_error():
     assert any("Test error message" in msg for msg in errors)
 
     report.detach_error_collector()
+
+
+def test_run_error_collector_no_op_when_detached():
+    report = RunReport([])
+    report.attach_error_collector()
+
+    logger = logging.getLogger("test_collector_detached")
+
+    # Detach immediately
+    report.detach_error_collector()
+
+    # Emit an error
+    logger.error("Test error message after detach")
+
+    # The error should not be captured
+    assert not report.has_errors()
+    errors = list(report.iter_error_messages())
+    assert not any("Test error message after detach" in msg for msg in errors)
+
+
+def test_run_report_log_results_concurrent_submission(monkeypatch):
+    import threading
+    import time
+    from src.feed import reporting
+
+    report = RunReport([])
+    report.add_error_message("Test Error")
+
+    submission_count = 0
+
+    def mock_submit_github_issue(rep):
+        nonlocal submission_count
+        # Simulate network delay to encourage race conditions
+        time.sleep(0.05)
+        submission_count += 1
+
+    monkeypatch.setattr(reporting, "_submit_github_issue", mock_submit_github_issue)
+
+    threads = []
+    for _ in range(5):
+        t = threading.Thread(target=report.log_results)
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join()
+
+    assert submission_count == 1
+    assert report._issue_submitted is True


### PR DESCRIPTION
This PR fixes 4 bugs in the feed processing pipeline:
1. Fixes a race condition in `src/feed/reporting.py` where concurrent `log_results()` calls could result in duplicate GitHub issues.
2. Fixes a logging bug in `src/feed/reporting.py` where `_RunErrorCollector.emit()` could run after being explicitly detached from the logger.
3. Fixes a loading issue in `src/feed/providers.py` where `load_provider_plugins()` was invoked at import time, ignoring dynamically populated env vars.
4. Fixes a merge behavior in `src/feed/merge.py` where standard peer merging would discard the newer item's `pubdate`.

Corresponding tests were added to `tests/test_run_report_collector.py`, `tests/test_provider_plugins.py`, and `tests/test_feed_merge.py`.

---
*PR created automatically by Jules for task [4712060986497155714](https://jules.google.com/task/4712060986497155714) started by @Origamihase*