### PR TITLE
Fix provider plugins missing explicit auto-load in entrypoint

### DIFF
--- a/audit.md
+++ b/audit.md
@@ -1,0 +1,22 @@
+# Audit of load_provider_plugins call sites
+
+The following files and line numbers contain references or calls to `load_provider_plugins`:
+
+- `src/feed/providers.py`
+  - Line 178: `def load_provider_plugins(*, force: bool = False) -> List[str]:` (Definition)
+  - Line 238: `"load_provider_plugins",` (Export in `__all__`)
+
+- `src/build_feed.py`
+  - Line 43: `load_provider_plugins,` (Import)
+  - Line 63: `load_provider_plugins,` (Import fallback)
+  - Line 110: `load_provider_plugins(force=True)` (Call inside `refresh_from_env()`)
+
+- `tests/test_provider_plugins.py`
+  - Line 23: `def test_load_provider_plugins_not_called_on_import():` (Test definition)
+  - Line 24: `# To properly test that importing doesn't call load_provider_plugins,` (Comment)
+  - Line 41: `# Further ensure that load_provider_plugins() call is truly gone from the file text` (Comment)
+  - Line 45: `# The string 'load_provider_plugins()' should not appear as a top-level call.` (Comment)
+  - Line 51: `if line.startswith("load_provider_plugins()"):` (Test logic)
+  - Line 52: `assert False, "Found top-level call to load_provider_plugins()"` (Test assertion message)
+  - Line 55: `def test_load_provider_plugins_via_callable(monkeypatch):` (Test definition)
+  - Line 72: `loaded = provider_mod.load_provider_plugins(force=True)` (Call in test)

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -138,6 +138,10 @@ DEFAULT_PROVIDERS: Tuple[Tuple[str, Any], ...] = (
 
 PROVIDERS: List[Tuple[str, Any]] = list(DEFAULT_PROVIDERS)
 
+# Ensure plugins are loaded exactly once per process startup AFTER env vars are configured
+# and BEFORE the main provider registration loop.
+load_provider_plugins()
+
 for env_name, loader in PROVIDERS:
     register_provider(env_name, loader, cache_key=resolve_provider_name(loader, env_name))
 

--- a/tests/test_provider_plugins.py
+++ b/tests/test_provider_plugins.py
@@ -213,3 +213,45 @@ def test_main_generates_feed_and_health_with_plugin(monkeypatch, tmp_path):
         monkeypatch.delenv("WIEN_OEPNV_PROVIDER_PLUGINS", raising=False)
         sys.modules.pop(module_name, None)
         importlib.reload(build_feed)
+
+def test_full_build_loads_plugins_subprocess(tmp_path):
+    import subprocess
+    import sys
+    import os
+
+    # Create a temporary plugin module
+    plugin_path = tmp_path / "mock_plugin_entrypoint.py"
+    plugin_path.write_text("""
+def loader():
+    return []
+
+def register_providers(register_provider):
+    import sys
+    # Print a specific marker so we can detect it in stdout
+    print("MOCK_PLUGIN_REGISTERED")
+    register_provider("MOCK_PLUGIN_ENABLE", loader, cache_key="mock_plugin")
+""")
+
+    # We want to run a small python script that just imports build_feed
+    # and we verify it prints the marker.
+    # It must have the temp directory in PYTHONPATH to find the plugin.
+    test_script = tmp_path / "run_build.py"
+    test_script.write_text("""
+import sys
+sys.path.insert(0, 'src')
+import build_feed
+""")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"src{os.pathsep}{str(tmp_path)}"
+    env["WIEN_OEPNV_PROVIDER_PLUGINS"] = "mock_plugin_entrypoint"
+
+    result = subprocess.run(
+        [sys.executable, str(test_script)],  # noqa: S603
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True
+    )
+
+    assert "MOCK_PLUGIN_REGISTERED" in result.stdout


### PR DESCRIPTION
Fix provider plugins missing explicit auto-load in entrypoint

PR #1039 removed the module-level auto-call of `load_provider_plugins`
from `src/feed/providers.py` to prevent premature plugin loading during
imports. However, no explicit call site was added in the build process
itself.

This patch adds an explicit `load_provider_plugins()` call to the
entrypoint script (`src/build_feed.py`), ensuring that plugins are
loaded once per process startup exactly after environment configuration
and before the main provider registration loop. Additionally, a regression
test is added using subprocess isolation to ensure plugins trigger.

---
*PR created automatically by Jules for task [7980581709195149022](https://jules.google.com/task/7980581709195149022) started by @Origamihase*