### PR TITLE
Fix OEBB geographic route filter logic for false positives

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -251,16 +251,13 @@ def _is_relevant(title: str, description: str) -> bool:
                 if (info0 and not info0.in_vienna) or (info1 and not info1.in_vienna):
                     return False
 
-            if (info0 and info0.in_vienna) or (info1 and info1.in_vienna):
-                return True
+            # Neuer, strikter Streckenabgleich:
+            # Wenn mindestens ein Endpunkt bekannt ist, MUSS mindestens einer in Wien liegen.
+            at_least_one_known = (info0 is not None) or (info1 is not None)
+            vienna_endpoint = (info0 and info0.in_vienna) or (info1 and info1.in_vienna)
 
-            is_outer0 = info0 is not None and not info0.in_vienna
-            is_outer1 = info1 is not None and not info1.in_vienna
-
-            if is_outer0 and is_outer1:
-                # Verbindung zwischen zwei reinen Pendlerbahnhöfen (z.B. Himberg ↔ Kledering)
-                # Sofort verwerfen, da nicht mindestens ein Bahnhof in Wien liegt.
-                return False
+            if at_least_one_known:
+                return bool(vienna_endpoint)
 
     return text_has_vienna_connection(text)
 


### PR DESCRIPTION
Fix logic error in OEBB geographic route filter

Replaced the old fallback logic in `_is_relevant` with a strict validation block. Now, if at least one station in the disruption title is known from the directory, the code explicitly enforces that at least one of the known stations must be located in Vienna. This prevents foreign or unmapped stations (e.g. Bratislava, Budapest) from leaking through to the fallback freetext parser and causing false positive inclusions in the feed.

---
*PR created automatically by Jules for task [1888498025076405696](https://jules.google.com/task/1888498025076405696) started by @Origamihase*