### PR TITLE
Fix false negative in OEBB route filter for titles with multiple colons

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -233,8 +233,8 @@ def _is_relevant(title: str, description: str) -> bool:
         parts = [p.strip() for p in title.split("↔")]
         if len(parts) >= 2:
             # Entferne eventuelle Präfixe wie "REX 51: " aus den Stationsnamen
-            part0 = parts[0].split(":", 1)[-1].strip() if ":" in parts[0] else parts[0]
-            part1 = parts[1].split(":", 1)[-1].strip() if ":" in parts[1] else parts[1]
+            part0 = parts[0].split(":")[-1].strip() if ":" in parts[0] else parts[0]
+            part1 = parts[1].split(":")[-1].strip() if ":" in parts[1] else parts[1]
 
             info0 = station_info(part0)
             info1 = station_info(part1)

--- a/tests/test_oebb_title_prefix.py
+++ b/tests/test_oebb_title_prefix.py
@@ -1,0 +1,8 @@
+from src.providers.oebb import _is_relevant
+
+def test_rex_51_multiple_colons():
+    # REX 51: Störung: Wien Meidling ↔ Mödling
+    title = "REX 51: Störung: Wien Meidling ↔ Mödling"
+    description = "Wegen einer Störung..."
+    # Should be True because Wien Meidling is in Vienna
+    assert _is_relevant(title, description) is True


### PR DESCRIPTION
Removed the `, 1` limit in `split(":", 1)` within `_is_relevant()` for OEBB provider to correctly isolate station names when the title prefix contains multiple colons (e.g., `REX 51: Störung: Wien Meidling`).

Also added a new test `test_rex_51_multiple_colons` to verify this behavior.

---
*PR created automatically by Jules for task [16370692485389288505](https://jules.google.com/task/16370692485389288505) started by @Origamihase*