### PR TITLE
fix: align oebb deduplication key logic in build_feed

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -1034,7 +1034,11 @@ def _dedupe_key_for_item(
         return cast(str, it["_calculated_dedupe_key"]), False
 
     if it.get("guid"):
-        return str(it.get("guid")), False
+        guid_str = str(it.get("guid"))
+        source = (it.get("source") or "").lower()
+        if "öbb" in source or "oebb" in source:
+             guid_str = f"oebb|{guid_str}"
+        return guid_str, False
     raw = (
         f"{it.get('source') or ''}|{it.get('title') or ''}|{it.get('description') or ''}"
     )


### PR DESCRIPTION
Updated `_dedupe_key_for_item` in `src/build_feed.py` to prepend the `oebb|` prefix to ÖBB guid entries when generating deduplication keys. This resolves a structural issue where deduplication and state keys were inconsistent for identical feed entries, restoring identical prefix logic between `_dedupe_key_for_item` and `_identity_for_item`.

---
*PR created automatically by Jules for task [14324218763916487427](https://jules.google.com/task/14324218763916487427) started by @Origamihase*