### PR TITLE
Refactor `_fmt_rfc2822` naive datetime handling

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -373,6 +373,9 @@ def _to_utc(dt: datetime) -> datetime:
 
 def _fmt_rfc2822(dt: datetime) -> str:
     """Format datetime as RFC-2822 string with Vienna offset."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+
     try:
         # Convert to Vienna time for output
         local_dt = _to_utc(dt).astimezone(_VIENNA_TZ)
@@ -382,13 +385,10 @@ def _fmt_rfc2822(dt: datetime) -> str:
             "Konnte Datum %r nicht per format_datetime formatieren – nutze strftime-Fallback.",
             dt,
         )
-        if dt.tzinfo is None:
-            local_dt = dt.replace(tzinfo=timezone.utc).astimezone(_VIENNA_TZ)
-        else:
-            try:
-                local_dt = dt.astimezone(_VIENNA_TZ)
-            except Exception:
-                local_dt = dt.astimezone(timezone.utc)
+        try:
+            local_dt = dt.astimezone(_VIENNA_TZ)
+        except Exception:
+            local_dt = dt.astimezone(timezone.utc)
 
         days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
         months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]


### PR DESCRIPTION
Refactor _fmt_rfc2822 to avoid exceptions for flow control

Moves the naive datetime check to the top of _fmt_rfc2822 as an early guard clause. If the datetime is naive, it explicitly sets the tzinfo to UTC before any other processing or try/except blocks. This avoids relying on the generic Exception block as a normal control flow path for handling naive datetimes, improving the function's readability and predictability.

---
*PR created automatically by Jules for task [7746739514354832300](https://jules.google.com/task/7746739514354832300) started by @Origamihase*