### PR TITLE
Refactor import structure in build_feed.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,4 @@ ignore_errors = false
 
 [tool.pytest.ini_options]
 addopts = "--timeout=60"
+pythonpath = ["src"]

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -30,67 +30,35 @@ from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union, cast,
 from urllib.parse import quote, urlparse
 from zoneinfo import ZoneInfo
 
-try:  # pragma: no cover - allow running as script or module
-    from feed_types import FeedItem
-    from feed import config as feed_config
-    from feed.merge import deduplicate_fuzzy
-    from feed.logging import configure_logging
-    from feed.providers import (
-        iter_providers,
-        load_provider_plugins,
-        provider_statuses,
-        register_provider,
-        resolve_provider_name,
-    )
-    from feed.reporting import (
-        DuplicateSummary,
-        FeedHealthMetrics,
-        RunReport,
-        clean_message,
-        write_feed_health_report,
-        write_feed_health_json,
-    )
-except ModuleNotFoundError:  # pragma: no cover
-    from .feed_types import FeedItem
-    from .feed import config as feed_config
-    from .feed.merge import deduplicate_fuzzy
-    from .feed.logging import configure_logging
-    from .feed.providers import (
-        iter_providers,
-        load_provider_plugins,
-        provider_statuses,
-        register_provider,
-        resolve_provider_name,
-    )
-    from .feed.reporting import (
-        DuplicateSummary,
-        FeedHealthMetrics,
-        RunReport,
-        clean_message,
-        write_feed_health_report,
-        write_feed_health_json,
-    )
+from feed_types import FeedItem
+from feed import config as feed_config
+from feed.merge import deduplicate_fuzzy
+from feed.logging import configure_logging
+from feed.providers import (
+    iter_providers,
+    load_provider_plugins,
+    provider_statuses,
+    register_provider,
+    resolve_provider_name,
+)
+from feed.reporting import (
+    DuplicateSummary,
+    FeedHealthMetrics,
+    RunReport,
+    clean_message,
+    write_feed_health_report,
+    write_feed_health_json,
+)
 
-try:  # pragma: no cover - allow running as script or package
-    from utils.cache import (
-        cache_modified_at,
-        read_cache as _core_read_cache,
-        register_cache_alert_hook,
-    )  # type: ignore
-    from utils.files import atomic_write
-    from utils.http import validate_http_url
-    from utils.locking import file_lock
-    from utils.text import html_to_text, truncate_html
-except ModuleNotFoundError:  # pragma: no cover
-    from .utils.cache import (
-        cache_modified_at,
-        read_cache as _core_read_cache,
-        register_cache_alert_hook,
-    )
-    from .utils.files import atomic_write
-    from .utils.http import validate_http_url
-    from .utils.locking import file_lock
-    from .utils.text import html_to_text, truncate_html
+from utils.cache import (
+    cache_modified_at,
+    read_cache as _core_read_cache,
+    register_cache_alert_hook,
+)  # type: ignore
+from utils.files import atomic_write
+from utils.http import validate_http_url
+from utils.locking import file_lock
+from utils.text import html_to_text, truncate_html
 
 
 # Register namespaces globally for thread-safe XML generation


### PR DESCRIPTION
Refactor import structure in build_feed.py

Removes the anti-pattern `try...except ModuleNotFoundError` blocks and fallback relative imports at the top of src/build_feed.py, preserving only clean absolute imports to prevent masking genuine import errors.

---
*PR created automatically by Jules for task [17795387437088897075](https://jules.google.com/task/17795387437088897075) started by @Origamihase*