### PR TITLE
Fix HTML unescaping, datetime normalization, logging, SSRF, and dead code

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import copy
-import html
 import inspect
 import json
 import logging
@@ -406,6 +405,7 @@ def format_local_times(
         end_local = _to_utc(end).astimezone(_VIENNA_TZ)
 
     if start_local and end_local and (end_local - start_local).days > 180:
+        log.warning("Enddatum liegt mehr als 180 Tage nach Startdatum. Setze Enddatum auf None.")
         end_local = None
 
     today = datetime.now(_VIENNA_TZ)
@@ -1260,7 +1260,7 @@ def _format_item_content(
     raw_title = it.get("title") or "Mitteilung"
     raw_desc  = it.get("description") or ""
     link = _build_canonical_link(it.get("link"), ident)
-    sanitized_link = validate_http_url(link, check_dns=False) if link else ""
+    sanitized_link = validate_http_url(link, check_dns=True) if link else ""
     if link and not sanitized_link:
         log.warning(
             "Item %s has potentially unsafe/invalid link %r; falling back to feed link.",
@@ -1306,7 +1306,7 @@ def _format_item_content(
         summary = summary[:175].rsplit(' ', 1)[0] + " …"
 
     # Für XML robust aufbereiten (CDATA schützt Sonderzeichen)
-    title_out = _sanitize_text(html.unescape(raw_title))
+    title_out = _sanitize_text(raw_title)
     if len(title_out) > feed_config.TITLE_CHAR_LIMIT:
         title_out = title_out[: feed_config.TITLE_CHAR_LIMIT].rstrip() + " …"
 
@@ -1525,7 +1525,6 @@ def lint() -> int:
     try:
         items = _invoke_collect_items(report)
         raw_count = len(items)
-        _normalize_item_datetimes(items)
 
         filtered_items, _ = _drop_old_items(items, now, state)
         filtered_count = len(filtered_items)
@@ -1673,11 +1672,6 @@ def main() -> int:
             collect_duration,
         )
 
-        normalize_start = perf_counter()
-        _normalize_item_datetimes(items)
-        normalize_duration = perf_counter() - normalize_start
-        log.debug("Zeitstempel normalisiert in %.2fs", normalize_duration)
-
         filter_start = perf_counter()
         items, dropped_ids = _drop_old_items(items, now, state)
         filter_duration = perf_counter() - filter_start
@@ -1767,7 +1761,6 @@ def main() -> int:
             final_items=len(items),
             durations={
                 "collect": collect_duration,
-                "normalize": normalize_duration,
                 "filter": filter_duration,
                 "dedupe": dedupe_duration,
                 "rss": rss_duration,

--- a/src/cli.py
+++ b/src/cli.py
@@ -12,12 +12,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     # mypy handling: assume package context or explicit import
-    try:
-        from src import build_feed as build_feed_module  # type: ignore
-        from src.utils.stations_validation import validate_stations  # type: ignore
-    except ImportError:
-        import build_feed as build_feed_module  # type: ignore
-        from utils.stations_validation import validate_stations  # type: ignore
+    from src import build_feed as build_feed_module  # type: ignore
+    from src.utils.stations_validation import validate_stations  # type: ignore
 elif __package__:
     from . import build_feed as build_feed_module
     from .utils.stations_validation import validate_stations

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import html
 import logging
 import os
 import re
@@ -127,6 +128,7 @@ def _clean_description(text: str) -> str:
 
 def _clean_title_keep_places(t: str) -> str:
     t = (t or "").strip()
+    t = html.unescape(t)
 
     # Redundanz-Check: Wenn Titel „Text: Station“ ist und Station im Text vorkommt,
     # dann nur Text nehmen (z.B. "Aufzug in X defekt: X").
@@ -414,7 +416,6 @@ def fetch_events(timeout: int = 25) -> List[FeedItem]:
     out: List[FeedItem] = []
     for item in channel.findall("item"):
         raw_title = _get_text(item, "title")
-        # html.unescape removed as per instruction
         title = _clean_title_keep_places(raw_title)
         link  = _get_text(item, "link").strip() or OEBB_URL
         raw_guid = _get_text(item, "guid").strip()


### PR DESCRIPTION
This PR addresses 5 specific issues in the codebase:
1.  **Inconsistent HTML Unescaping**: Moved `html.unescape` logic to `src/providers/oebb.py` and removed the central unescaping from `src/build_feed.py`.
2.  **Redundant Datetime Normalization**: Removed the redundant calls to `_normalize_item_datetimes` in `src/build_feed.py`.
3.  **Silent Discarding of End Dates > 180 Days**: Added a `log.warning` when this condition occurs in `src/build_feed.py`.
4.  **Disabled SSRF Protection**: Enabled `check_dns=True` in `validate_http_url` within `src/build_feed.py`.
5.  **Dead Code in Type Checking**: Removed a nonsensical `try/except ImportError` block under `if TYPE_CHECKING:` in `src/cli.py`.

All relevant static checks and unit tests have been run and passed.

---
*PR created automatically by Jules for task [10628884902994293692](https://jules.google.com/task/10628884902994293692) started by @Origamihase*