### PR TITLE
ci: set PYTHONPATH in workflows to resolve src/ imports

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -30,6 +30,8 @@ jobs:
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
 
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: src
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -18,6 +18,8 @@ jobs:
     permissions:
       contents: write
     
+    env:
+      PYTHONPATH: src
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/test-vor-api.yml
+++ b/.github/workflows/test-vor-api.yml
@@ -15,6 +15,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
+      PYTHONPATH: src
       VOR_ACCESS_ID: ${{ secrets.VOR_ACCESS_ID }}
       VOR_BASE_URL: ${{ secrets.VOR_BASE_URL }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
     name: Run test suite
     runs-on: ubuntu-latest
 
+    env:
+      PYTHONPATH: src
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/update-google-places-stations.yml
+++ b/.github/workflows/update-google-places-stations.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
     env:
+      PYTHONPATH: src
       GOOGLE_ACCESS_ID: ${{ secrets.GOOGLE_ACCESS_ID }}
       PLACES_INCLUDED_TYPES: train_station,subway_station,bus_station
       PLACES_RADIUS_M: 2500

--- a/.github/workflows/update-oebb-cache.yml
+++ b/.github/workflows/update-oebb-cache.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: write
     env:
+      PYTHONPATH: src
       PIP_CACHE_DIR: /tmp/pip-cache
 
     steps:

--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -14,6 +14,8 @@ jobs:
     permissions:
       contents: write
 
+    env:
+      PYTHONPATH: src
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/update-vor-cache.yml
+++ b/.github/workflows/update-vor-cache.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
     env:
+      PYTHONPATH: src
       VOR_ACCESS_ID: ${{ secrets.VOR_ACCESS_ID }}
       VOR_BASE_URL: ${{ secrets.VOR_BASE_URL }}
       VOR_BASE: ${{ secrets.VOR_BASE }}

--- a/.github/workflows/update-wl-cache.yml
+++ b/.github/workflows/update-wl-cache.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      PYTHONPATH: src
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
This PR fixes a systemic `ModuleNotFoundError` issue across GitHub Actions workflows. It injects `PYTHONPATH: src` into the `env` block of the relevant jobs that execute Python scripts or run `pytest`. Tests have been run and verify the YAML files are syntactically valid.

---
*PR created automatically by Jules for task [10626483117665875406](https://jules.google.com/task/10626483117665875406) started by @Origamihase*