### PR TITLE
ci: fix nodejs 20 deprecation warnings by updating action tags and injecting node24 variable

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -31,12 +31,13 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -19,14 +19,15 @@ jobs:
       contents: write
     
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,9 +57,11 @@ jobs:
         # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
         # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
     - name: Checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@v4
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -35,8 +35,10 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: actions/checkout@v4
     - uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4
       with:
         dotnet-version: |

--- a/.github/workflows/seo-guard.yml
+++ b/.github/workflows/seo-guard.yml
@@ -19,11 +19,12 @@ jobs:
       contents: write
       pull-requests: write
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       SITE_BASE: https://origamihase.github.io/wien-oepnv
       DESC: Konsolidierter RSS-Feed für Störungen und Baustellenmeldungen im Wiener ÖPNV (WL/ÖBB/VOR), inkl. Doku & Open-Data-Workflows.
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test-vor-api.yml
+++ b/.github/workflows/test-vor-api.yml
@@ -15,13 +15,14 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
       VOR_ACCESS_ID: ${{ secrets.VOR_ACCESS_ID }}
       VOR_BASE_URL: ${{ secrets.VOR_BASE_URL }}
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
 
       - name: Validate required secrets
         shell: bash
@@ -35,7 +36,7 @@ jobs:
 
       - name: Set up Python
         if: ${{ success() }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,14 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: pip

--- a/.github/workflows/update-google-places-stations.yml
+++ b/.github/workflows/update-google-places-stations.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
       GOOGLE_ACCESS_ID: ${{ secrets.GOOGLE_ACCESS_ID }}
       PLACES_INCLUDED_TYPES: train_station,subway_station,bus_station
@@ -28,12 +29,12 @@ jobs:
       PLACES_QUOTA_STATE: data/places_quota.json
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/update-oebb-cache.yml
+++ b/.github/workflows/update-oebb-cache.yml
@@ -18,18 +18,19 @@ jobs:
     permissions:
       contents: write
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
       PIP_CACHE_DIR: /tmp/pip-cache
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
 
       - name: Ensure pip cache directory exists
         run: mkdir -p "$PIP_CACHE_DIR"
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -46,7 +47,7 @@ jobs:
         run: git pull --rebase --autostash
 
       - name: Commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'chore: update ÖBB cache'
           file_pattern: 'cache/oebb*/events.json'

--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -15,15 +15,16 @@ jobs:
       contents: write
 
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -49,7 +50,7 @@ jobs:
         run: git pull --rebase --autostash
 
       - name: Commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore(data): add VOR stations (900100, 900300) + CI harden"
           add_options: "-A"

--- a/.github/workflows/update-vor-cache.yml
+++ b/.github/workflows/update-vor-cache.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
       VOR_ACCESS_ID: ${{ secrets.VOR_ACCESS_ID }}
       VOR_BASE_URL: ${{ secrets.VOR_BASE_URL }}
@@ -28,7 +29,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
 
       - name: Ensure pip cache directory exists
         run: mkdir -p "$PIP_CACHE_DIR"
@@ -43,7 +44,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -84,7 +85,7 @@ jobs:
 
       - name: Commit and push changes
         if: ${{ github.ref_type == 'branch' }}
-        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'chore: update VOR cache [skip ci]'
           file_pattern: 'cache/vor*/events.json data/vor_request_count.json'

--- a/.github/workflows/update-wl-cache.yml
+++ b/.github/workflows/update-wl-cache.yml
@@ -18,10 +18,11 @@ jobs:
     permissions:
       contents: write
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@v4
 
       - name: Ensure pip cache directory exists
         shell: bash
@@ -35,7 +36,7 @@ jobs:
           echo "$EOF" >> "$GITHUB_ENV"
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -52,7 +53,7 @@ jobs:
         run: git pull --rebase --autostash
 
       - name: Commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'chore: update Wiener Linien cache'
           file_pattern: 'cache/wl*/events.json'


### PR DESCRIPTION
This PR resolves Node.js 20 deprecation warnings across all `.github/workflows/` files.
- Updates hardcoded commit hashes for `actions/checkout` to `@v4`.
- Updates hardcoded commit hashes for `actions/setup-python` to `@v5`.
- Updates hardcoded commit hashes for `stefanzweifel/git-auto-commit-action` to `@v7`.
- Injects `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` into workflow `env:` blocks to suppress deprecation warnings and force newer runtimes.
- Preserves existing variables such as `PYTHONPATH: src`.

---
*PR created automatically by Jules for task [9497135777583124775](https://jules.google.com/task/9497135777583124775) started by @Origamihase*