### PR TITLE
Fix WL fetch event descriptions

### DIFF
--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -724,6 +724,16 @@ def fetch_events(timeout: int = 20) -> List[Dict[str, Any]]:
 
         # Beschreibung aufbauen (ohne „Linien: …“ in extras)
         desc = b["desc_base"]
+
+        if b["stop_names"]:
+            stops_formatted = ", ".join(sorted(b["stop_names"]))
+            desc += f" | Haltestelle: {stops_formatted}"
+        elif b["extras"]:
+            locations = [x for x in b["extras"] if x.lower().startswith("station:") or x.lower().startswith("location:")]
+            if locations:
+                locations_formatted = " / ".join(locations)
+                desc += f" | {locations_formatted}"
+
         # Keine Extras oder Haltestellen mehr anhängen (Task: Strict 2-line Layout)
         # Keine aggressive HTML-Entfernung mehr (Task: Fix h2Artifacts)
         desc = re.sub(r"\s{2,}", " ", desc).strip()

--- a/tests/test_wl_fetch.py
+++ b/tests/test_wl_fetch.py
@@ -158,8 +158,8 @@ def test_fetch_events_adds_stop_context_when_no_lines(monkeypatch):
     assert "Karlsplatz" in title
     assert "Museumsquartier" in title
     assert title.endswith("(2 Halte)")
-    # New logic: Description is just the summary, no extras
-    assert events[0]["description"] == "Testbeschreibung"
+    # New logic: Description includes stop names if present
+    assert events[0]["description"] == "Testbeschreibung | Haltestelle: Karlsplatz, Museumsquartier"
 
 
 def test_fetch_events_uses_extra_context_when_no_stops(monkeypatch):
@@ -180,5 +180,5 @@ def test_fetch_events_uses_extra_context_when_no_stops(monkeypatch):
     assert " – Karlsplatz" in title
     assert "Ausgang Oper" in title
     desc = events[0]["description"]
-    assert "Station: Karlsplatz" not in desc
-    assert "Location: Ausgang Oper" not in desc
+    assert "Station: Karlsplatz" in desc
+    assert "Location: Ausgang Oper" in desc


### PR DESCRIPTION
Updates `src/providers/wl_fetch.py` to append `stop_names` (formatted with ` | Haltestelle: `) or location-based `extras` (formatted with ` | `) to event descriptions. The whitespace normalization cleanup step at the end of description building is preserved. Includes passing updated unit tests.

---
*PR created automatically by Jules for task [3888391831183078856](https://jules.google.com/task/3888391831183078856) started by @Origamihase*