### PR TITLE
Refactor build_feed for better code quality

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -510,6 +510,7 @@ def _normalize_item_datetimes(
             _coerce_datetime_field(item, field_name)
     return items
 
+
 # ---------------- State (first_seen) ----------------
 
 def _load_state() -> Dict[str, Dict[str, Any]]:
@@ -562,6 +563,7 @@ def _load_state() -> Dict[str, Dict[str, Any]]:
         out[ident] = new_entry
     return out
 
+
 def _save_state(state: Dict[str, Dict[str, Any]], deletions: Optional[Set[str]] = None) -> None:
     path = validate_path(feed_config.STATE_FILE, "STATE_PATH")
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -596,6 +598,7 @@ def _save_state(state: Dict[str, Dict[str, Any]], deletions: Optional[Set[str]] 
                     json.dump(merged_state, f, ensure_ascii=False, indent=2, sort_keys=True)
     finally:
         lock_path.unlink(missing_ok=True)
+
 
 def _identity_for_item(item: FeedItem) -> str:
     """
@@ -1150,37 +1153,10 @@ def _sort_key(item: FeedItem) -> Tuple[int, float, str]:
     pd = item.get("pubDate")
     # Fix TypeError: Ensure guid is always a string, even if explicitly None
     guid_val = item.get("guid")
-    # Avoid mutating dictionary; use pre-calculated identity or compute it cleanly here
     if guid_val:
         guid_str = str(guid_val)
     else:
-        # Check if already calculated to avoid re-calculating, but do not mutate if not
-        if "_calculated_identity" in item:
-            guid_str = cast(str, item["_calculated_identity"])
-        else:
-            # We can use a simplified, non-mutating hash as fallback
-            # (or simply a string representation if identity isn't cached yet, which shouldn't happen here)
-            title = item.get("title") or ""
-            sa = item.get("starts_at")
-            ea = item.get("ends_at")
-            sa_str = _to_utc(sa).isoformat() if isinstance(sa, datetime) else "None"
-            ea_str = _to_utc(ea).isoformat() if isinstance(ea, datetime) else "None"
-            fuzzy_raw = f"{title}|{sa_str}|{ea_str}"
-            fuzzy_hash = hashlib.sha256(fuzzy_raw.encode("utf-8")).hexdigest()
-
-            source = (item.get("source") or "").lower()
-            category = (item.get("category") or "").lower()
-            lines = _parse_lines_from_title(title)
-            lines_part = "L=" + "/".join(lines) if lines else "L="
-            start_day = _ymd_or_none(sa)
-            base = f"{source}|{category}|{lines_part}|D={start_day}"
-
-            if title:
-                guid_str = f"{base}|T={title}|F={fuzzy_hash}"
-            else:
-                raw = json.dumps(item, sort_keys=True, default=str)
-                hashed = hashlib.sha256(raw.encode("utf-8")).hexdigest()
-                guid_str = f"{base}|H={hashed}|F={fuzzy_hash}"
+        guid_str = _identity_for_item(item)
 
     if isinstance(pd, datetime):
         return (0, -_to_utc(pd).timestamp(), guid_str)
@@ -1241,6 +1217,7 @@ def _update_item_state(it: FeedItem, now: datetime, state: Dict[str, Dict[str, A
         fs_dt = _to_utc(now)
         st["first_seen"] = fs_dt.isoformat()
     return ident, fs_dt
+
 
 def _format_item_content(
     it: FeedItem, ident: str, starts_at: Optional[datetime], ends_at: Optional[datetime]
@@ -1310,10 +1287,7 @@ def _format_item_content(
     time_line = _sanitize_text(time_line)
     time_line = _WHITESPACE_CLEANUP_RE.sub(" ", time_line).strip()
     if time_line:
-        if not time_line.startswith("["):
-            time_line = f"[{time_line}"
-        if not time_line.endswith("]"):
-            time_line = f"{time_line}]"
+        time_line = f"[{time_line.strip('[]')}]"
 
     # Combine
     desc_parts = []
@@ -1434,7 +1408,7 @@ def _make_rss(
     now: datetime,
     state: Dict[str, Dict[str, Any]],
     deletions: Optional[Set[str]] = None,
-) -> Tuple[str, Optional[Set[str]]]:
+) -> str:
     """
     Generate the full RSS XML document from a list of items using ElementTree.
 
@@ -1445,9 +1419,7 @@ def _make_rss(
         deletions: IDs to be removed from the state.
 
     Returns:
-        A tuple containing:
-        - The generated RSS XML string with CDATA sections.
-        - The deletions set.
+        The generated RSS XML string with CDATA sections.
     """
     if deletions is None:
         deletions = set()
@@ -1485,7 +1457,7 @@ def _make_rss(
     for placeholder, cdata in item_replacements.items():
         xml_str = xml_str.replace(placeholder, cdata)
 
-    return xml_str, deletions
+    return xml_str
 
 
 def lint() -> int:
@@ -1716,7 +1688,7 @@ def main() -> int:
         )
 
         rss_start = perf_counter()
-        rss, returned_deletions = _make_rss(items, now, state, deletions=dropped_ids)
+        rss = _make_rss(items, now, state, deletions=dropped_ids)
         rss_duration = perf_counter() - rss_start
 
         out_path = validate_path(Path(feed_config.OUT_PATH), "OUT_PATH")
@@ -1726,7 +1698,7 @@ def main() -> int:
             f.write(rss)
 
         try:
-            _save_state(state, deletions=returned_deletions)
+            _save_state(state, deletions=dropped_ids)
         except Exception as e:
             log.warning(
                 "State speichern fehlgeschlagen (%s) – Feed wurde geschrieben, State bleibt veraltet.",

--- a/tests/test_build_feed_cache.py
+++ b/tests/test_build_feed_cache.py
@@ -216,7 +216,7 @@ def test_cache_iso_items_sorted_and_emit_pubdate(monkeypatch):
     assert [it["guid"] for it in deduped] == ["new-guid", "older-guid"]
 
     monkeypatch.setattr(build_feed, "_save_state", lambda state: None)
-    rss, _ = build_feed._make_rss(deduped, now, state)
+    rss = build_feed._make_rss(deduped, now, state)
 
     assert rss.count("<item>") == 2
     assert rss.count("<pubDate>") == 2

--- a/tests/test_dedupe_items.py
+++ b/tests/test_dedupe_items.py
@@ -43,7 +43,7 @@ def test_main_dedupes_items(monkeypatch, tmp_path):
 
     def fake_make_rss(items, now, state, deletions=None):
         captured["items"] = items
-        return "", deletions
+        return ""
 
     monkeypatch.setattr(build_feed, "_collect_items", fake_collect)
     monkeypatch.setattr(build_feed, "_make_rss", fake_make_rss)

--- a/tests/test_ends_at.py
+++ b/tests/test_ends_at.py
@@ -35,7 +35,7 @@ def test_item_with_past_ends_at_is_dropped(monkeypatch, tmp_path):
 
     def fake_make_rss(items, now_param, state, deletions=None):
         captured["items"] = items
-        return "", deletions
+        return ""
 
     monkeypatch.setattr(build_feed, "_collect_items", fake_collect)
     monkeypatch.setattr(build_feed, "_make_rss", fake_make_rss)

--- a/tests/test_first_seen_fuzzy.py
+++ b/tests/test_first_seen_fuzzy.py
@@ -100,8 +100,8 @@ def test_first_seen_fuzzy_identity(monkeypatch, tmp_path):
     # Because `_identity_for_item` mutates the item and sets `_calculated_identity`.
     # Let's see how `item_c` is processed.
 
-    rss, deletions = build_feed._make_rss([item_c], now + timedelta(hours=2), state)
-    build_feed._save_state(state, deletions=deletions)
+    rss = build_feed._make_rss([item_c], now + timedelta(hours=2), state)
+    build_feed._save_state(state)
 
     state_after_third = build_feed._load_state()
 

--- a/tests/test_item_age.py
+++ b/tests/test_item_age.py
@@ -42,7 +42,7 @@ def test_main_filters_items_older_than_max(monkeypatch, tmp_path):
 
     def fake_make_rss(items, now_param, state, deletions=None):
         captured["items"] = items
-        return "", deletions
+        return ""
 
     monkeypatch.setattr(build_feed, "_collect_items", fake_collect)
     monkeypatch.setattr(build_feed, "_make_rss", fake_make_rss)
@@ -77,7 +77,7 @@ def test_main_filters_items_older_than_absolute(monkeypatch, tmp_path):
 
     def fake_make_rss(items, now_param, state, deletions=None):
         captured["items"] = items
-        return "", deletions
+        return ""
 
     monkeypatch.setattr(build_feed, "_collect_items", fake_collect)
     monkeypatch.setattr(build_feed, "_make_rss", fake_make_rss)

--- a/tests/test_max_items.py
+++ b/tests/test_max_items.py
@@ -38,7 +38,7 @@ def test_make_rss_ignores_items_when_max_is_zero(monkeypatch):
 
         now = datetime.now(timezone.utc)
         state = {}
-        rss, _ = build_feed._make_rss(
+        rss = build_feed._make_rss(
             [
                 {
                     "source": "test",

--- a/tests/test_state_save_readonly.py
+++ b/tests/test_state_save_readonly.py
@@ -40,7 +40,7 @@ def test_make_rss_logs_warning_when_state_readonly(monkeypatch, caplog):
     }
 
     with caplog.at_level(logging.WARNING):
-        rss, _ = build_feed._make_rss([item], now, {})
+        rss = build_feed._make_rss([item], now, {})
 
     assert "</rss>" in rss
 
@@ -57,7 +57,7 @@ def test_make_rss_saves_empty_state_when_no_identities(monkeypatch, caplog):
 
 
     with caplog.at_level(logging.WARNING):
-        rss, _ = build_feed._make_rss(
+        rss = build_feed._make_rss(
             [],
             datetime.now(timezone.utc),
             {"old": {"first_seen": datetime.now(timezone.utc).isoformat()}},

--- a/tests/test_xml_ends_at.py
+++ b/tests/test_xml_ends_at.py
@@ -25,7 +25,7 @@ class TestXmlEndsAt(unittest.TestCase):
         }
 
         # Execution
-        rss_xml, _ = _make_rss([item], now, {})
+        rss_xml = _make_rss([item], now, {})
 
         # Verification
         root = ET.fromstring(rss_xml)
@@ -60,7 +60,7 @@ class TestXmlEndsAt(unittest.TestCase):
             "category": "TestCat"
         }
 
-        rss_xml, _ = _make_rss([item], now, {})
+        rss_xml = _make_rss([item], now, {})
         root = ET.fromstring(rss_xml)
         rss_item = root.find("channel").find("item")
         ns = {"ext": "https://wien-oepnv.example/schema"}


### PR DESCRIPTION
This PR implements the requested code-quality refactor measures on `src/build_feed.py`.

Changes:
1. **DRY `_sort_key`**: Removes redundant duplicate hash/identity generation logic, correctly falling back to `_identity_for_item`.
2. **Clean `_make_rss` Signature**: Returns only `xml_str`, drops `deletions` from output tuple, directly mapping the locally scoped `dropped_ids` variable when saving state in `main`.
3. **Robust `time_line` Bracket Formatting**: Uses `.strip("[]")` to prevent edge-cases such as `]text[]`.
4. **PEP-8 Spacing**: Enforces exactly two blank lines around modules-level functions `_load_state`, `_save_state`, `_identity_for_item`, and `_format_item_content`.

All related unit tests were successfully run and updated to pass.

---
*PR created automatically by Jules for task [17739935020183582130](https://jules.google.com/task/17739935020183582130) started by @Origamihase*