### PR TITLE
Improve robustness of feed state saving and item emission

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -597,7 +597,10 @@ def _save_state(state: Dict[str, Dict[str, Any]], deletions: Optional[Set[str]] 
                 ) as f:
                     json.dump(merged_state, f, ensure_ascii=False, indent=2, sort_keys=True)
     finally:
-        lock_path.unlink(missing_ok=True)
+        try:
+            lock_path.unlink(missing_ok=True)
+        except OSError as e:
+            log.debug("Konnte Lock-Datei nicht löschen (Windows-Lock): %s", e)
 
 
 def _identity_for_item(item: FeedItem) -> str:
@@ -1351,12 +1354,17 @@ def _emit_item(
     # Generate unique placeholders
     # We use a cryptographically secure random token to ensure uniqueness within the document
     # Ensure placeholder is not accidentally present in the original desc_html or raw_desc
+    max_attempts = 100
+    attempts = 0
     while True:
+        if attempts >= max_attempts:
+            raise RuntimeError("Konnte keinen eindeutigen Platzhalter generieren")
         uid = secrets.token_hex(16)
         PH_CONTENT = f"___CDATA_CONTENT_{uid}___"
         PH_TITLE = f"___CDATA_TITLE_{uid}___"
         if PH_CONTENT not in formatted.desc_html and PH_CONTENT not in formatted.raw_desc and PH_TITLE not in formatted.title_out:
             break
+        attempts += 1
 
     # --- ElementTree Construction ---
     item = ET.Element("item")


### PR DESCRIPTION
This change addresses two key stability improvements within `src/build_feed.py`:
1.  **Windows File Lock Handling**: In `_save_state`, the unlinking of `lock_path` inside the `finally` block could trigger a `PermissionError` (an `OSError`) on Windows if another process held the file open. The fix safely catches the `OSError` and logs a debug message, preventing an uncontrolled script crash.
2.  **Infinite Loop Prevention**: In `_emit_item`, the cryptographically secure token generation for CDATA placeholders relied on a bare `while True` loop. While collisions are exceptionally rare, an explicit `max_attempts` (100) limit has been implemented as a best practice for static code analysis. If the limit is reached, it securely aborts via a `RuntimeError`.

---
*PR created automatically by Jules for task [11983250669689005841](https://jules.google.com/task/11983250669689005841) started by @Origamihase*