### PR TITLE
🛡️ Sentinel: [Enhancement] Add Zero Trust payload validation for upstream APIs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -122,3 +122,8 @@
 **Vulnerability:** Generic high-entropy detection lacked specificity for common high-value secrets like Google API Keys and Telegram Bot Tokens.
 **Learning:** Specific regex patterns improve triage and remediation speed by identifying the exact type of secret exposed.
 **Prevention:** Added specific regexes to `_KNOWN_TOKENS` in `src/utils/secret_scanner.py`.
+
+## 2025-04-24 - Zero Trust Upstream Payload Validation
+**Vulnerability:** Upstream provider API integrations (`src/providers/vor.py` and `src/providers/wl_fetch.py`) parsed JSON directly via `json.loads` without validating the returned data type. A compromised or misconfigured API returning unexpected JSON structures (like a list instead of a dict) could cause runtime crashes or inject malformed data into downstream parsing logic that assumes dictionary methods (like `.get()`).
+**Learning:** Even "trusted" official external APIs must be treated as untrusted boundaries in a Zero Trust architecture. Just because data parses successfully as JSON doesn't mean it conforms to the expected shape or type for the application state.
+**Prevention:** Always follow up `json.loads` with explicit type and schema validation (e.g., `if not isinstance(data, dict): return safe_fallback`) before passing the deserialized payload to application logic, ensuring the application fails securely and drops malformed data at the network boundary.

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -1057,6 +1057,11 @@ def resolve_station_ids(names: Iterable[str]) -> List[str]:
                     allowed_content_types=("application/json",),
                 )
                 payload = json.loads(content)
+                if not isinstance(payload, dict):
+                    _log_warning(
+                        "VOR location.name für '%s' gab unerwartetes Format zurück (Zero Trust)", name
+                    )
+                    continue
             except (ValueError, json.JSONDecodeError) as exc:
                 _log_warning(
                     "VOR location.name für '%s' ungültig/zu groß: %s", name, exc
@@ -1336,7 +1341,13 @@ def _fetch_departure_board_for_station(
                 with counter["lock"]:
                     counter["consecutive_5xx"] = 0
 
-            return json.loads(content)
+            data = json.loads(content)
+            if not isinstance(data, dict):
+                _log_warning(
+                    "VOR DepartureBoard %s gab unerwartetes Format zurück: dict erwartet (Zero Trust)", station_id
+                )
+                return None
+            return data
 
         except (ValueError, json.JSONDecodeError) as exc:
             _log_warning(

--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -353,7 +353,16 @@ def _get_json(
                     timeout=timeout,
                     allowed_content_types=("application/json",),
                 )
-                return json.loads(content)
+                data = json.loads(content)
+                if not isinstance(data, dict):
+                    log.warning(
+                        "Unerwartetes Payload-Format von %s: %s erwartet, aber %s erhalten (Zero Trust)",
+                        sanitize_log_arg(url),
+                        "dict",
+                        type(data).__name__,
+                    )
+                    return {}
+                return data
             except (ValueError, json.JSONDecodeError) as exc:
                 log.warning(
                     "Antwort von %s ungültig oder kein JSON: %s",


### PR DESCRIPTION
This PR implements an architectural enhancement following Zero Trust principles.

**Vulnerability:**
Upstream provider integrations (`src/providers/vor.py` and `src/providers/wl_fetch.py`) parsed JSON directly via `json.loads` without validating the returned data type. A compromised or misconfigured API returning unexpected JSON structures (like a list instead of a dict) could cause runtime crashes or inject malformed data into downstream parsing logic that assumes dictionary methods (like `.get()`).

**Prevention:**
Added strict type validation (`if not isinstance(data, dict): return fallback`) immediately following deserialization. This drops malformed data at the network boundary, ensuring the application fails securely and gracefully. Tested and verified that no existing parsing functionality or circuit breakers were disrupted.

---
*PR created automatically by Jules for task [13608599256959262258](https://jules.google.com/task/13608599256959262258) started by @Origamihase*