### PR TITLE
Mitigate DoS/memory exhaustion vulnerability in truncate_html

### DIFF
--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -184,6 +184,11 @@ def truncate_html(text: str, limit: int, ellipsis: str = "...") -> str:
     if not text:
         return ""
 
+    # SECURITY: Mitigate DoS/memory exhaustion from massively oversized inputs
+    MAX_SAFE_LENGTH = 1_000_000
+    if len(text) > MAX_SAFE_LENGTH:
+        text = text[:MAX_SAFE_LENGTH]
+
     # Quick check if it's even needed
     # Note: This is a loose check because tags add length but don't count towards content limit.
     # But if raw length is <= limit, we certainly don't need to truncate content.


### PR DESCRIPTION
A missing hard length limit allows a large payload sent into `truncate_html` to trigger an out-of-memory or high-CPU state via `parser.feed(text)`.

This change strictly bounds the max length of the string passed to the inner logic, preventing the exhaustion.

---
*PR created automatically by Jules for task [6392464545537519295](https://jules.google.com/task/6392464545537519295) started by @Origamihase*