### PR TITLE
feat: Fix false positives on long-distance ÖBB disruptions

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -289,6 +289,20 @@ def _is_relevant(title: str, description: str) -> bool:
             if at_least_one_known:
                 return bool(vienna_endpoint)
 
+    # Check 1: Asymmetrischer Pendler-Check für unstrukturierte Meldungen (Veto-Logik)
+    found_stations = _find_stations_in_text(text)
+    if found_stations:
+        has_vienna_or_pendler = False
+        for s in found_stations:
+            info = station_info(s)
+            if info and (info.in_vienna or info.pendler):
+                has_vienna_or_pendler = True
+                break
+
+        # Veto: Wir haben Stationen gefunden, aber KEINE davon ist in Wien oder Pendler
+        if not has_vienna_or_pendler:
+            return False
+
     return text_has_vienna_connection(text)
 
 # ---------------- Region helpers ----------------
@@ -315,7 +329,7 @@ def _find_stations_in_text(blob: str) -> List[str]:
     Returns a list of unique canonical station names found.
     """
     # Use whitespace splitting to preserve punctuation like '.' in 'St. Pölten'
-    tokens = [t for t in blob.split() if t]
+    tokens = [t for t in re.split(r"[\s/]+", blob) if t]
     if not tokens:
         return []
 

--- a/tests/test_oebb_title_fallback.py
+++ b/tests/test_oebb_title_fallback.py
@@ -32,7 +32,9 @@ def mock_xml_response(items):
 @patch("src.providers.oebb._fetch_xml")
 @patch("src.providers.oebb.station_by_oebb_id")
 @patch("src.providers.oebb.canonical_name")
-def test_oebb_title_fallback_id(mock_canon, mock_station_lookup, mock_fetch):
+@patch("src.providers.oebb.station_info")
+def test_oebb_title_fallback_id(mock_station_info, mock_canon, mock_station_lookup, mock_fetch):
+    mock_station_info.return_value.in_vienna = True
     # Setup
     mock_station_lookup.return_value = "Wien ID-Station"
     mock_canon.side_effect = lambda x: x if x == "Wien ID-Station" else None
@@ -63,7 +65,9 @@ def test_oebb_title_fallback_id(mock_canon, mock_station_lookup, mock_fetch):
 @patch("src.providers.oebb._fetch_xml")
 @patch("src.providers.oebb.station_by_oebb_id")
 @patch("src.providers.oebb.canonical_name")
-def test_oebb_title_fallback_text(mock_canon, mock_station_lookup, mock_fetch):
+@patch("src.providers.oebb.station_info")
+def test_oebb_title_fallback_text(mock_station_info, mock_canon, mock_station_lookup, mock_fetch):
+    mock_station_info.return_value.in_vienna = True
     # Setup
     mock_station_lookup.return_value = None # No ID match
 
@@ -94,7 +98,9 @@ def test_oebb_title_fallback_text(mock_canon, mock_station_lookup, mock_fetch):
 @patch("src.providers.oebb._fetch_xml")
 @patch("src.providers.oebb.station_by_oebb_id")
 @patch("src.providers.oebb.canonical_name")
-def test_oebb_title_fallback_truncation(mock_canon, mock_station_lookup, mock_fetch):
+@patch("src.providers.oebb.station_info")
+def test_oebb_title_fallback_truncation(mock_station_info, mock_canon, mock_station_lookup, mock_fetch):
+    pass
     mock_station_lookup.return_value = None
     mock_canon.return_value = None # No stations found in text
 


### PR DESCRIPTION
The `_is_relevant` filter in `src/providers/oebb.py` failed to filter out unstructured international/long-distance disruptions (like `Bauarbeiten: Wien/München Roma Termini`). It would fall back to a generic regex check and pass just because "Wien" was present, even though none of the actual endpoints were inside the commuter zone. This PR:
- Fixes the string splitting logic to properly tokenize compound names like "Wien/München".
- Adds an asymmetric commuter check for unstructured text: if it extracts recognizable stations from the string but none of them match our `in_vienna` or `pendler` criteria, it will discard the message early.

---
*PR created automatically by Jules for task [7254280315119706975](https://jules.google.com/task/7254280315119706975) started by @Origamihase*