### PR TITLE
Fix bst_id lookup mismatch in station metadata merge

### DIFF
--- a/scripts/enrich_station_aliases.py
+++ b/scripts/enrich_station_aliases.py
@@ -274,7 +274,10 @@ def _load_vor_mapping(path: Path) -> dict[int, str]:
         if not isinstance(item, dict):
             continue
         try:
-            bst_id = int(item.get("bst_id"))
+            bst_id_raw = item.get("bst_id")
+            if bst_id_raw is None:
+                continue
+            bst_id = int(bst_id_raw)  # type: ignore
         except (TypeError, ValueError):
             continue
         resolved_name = (item.get("resolved_name") or "").strip()
@@ -340,7 +343,8 @@ def _alias_candidates(
         push(vor_names.get(vor_id))
 
     try:
-        bst_id = int(station.get("bst_id"))
+        bst_id_raw = station.get("bst_id")
+        bst_id = int(bst_id_raw) if bst_id_raw is not None else None  # type: ignore
     except (TypeError, ValueError):
         bst_id = None
     if bst_id is not None:

--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -430,8 +430,13 @@ def _load_existing_station_entries(path: Path) -> dict[str, dict[str, object]]:
             if not isinstance(entry, dict):
                 continue
             bst_id = entry.get("bst_id")
-            if isinstance(bst_id, str) and bst_id:
-                mapping[bst_id] = entry
+            if bst_id is not None:
+                try:
+                    lookup_id = str(int(float(bst_id)))  # type: ignore
+                except (ValueError, TypeError):
+                    lookup_id = str(bst_id)
+                if lookup_id:
+                    mapping[lookup_id] = entry
     return mapping
 
 
@@ -439,7 +444,11 @@ def _restore_existing_metadata(
     stations: Iterable[Station], existing_entries: dict[str, dict[str, object]]
 ) -> None:
     for station in stations:
-        existing = existing_entries.get(station.bst_id)
+        try:
+            lookup_id = str(int(float(station.bst_id)))  # type: ignore
+        except (ValueError, TypeError):
+            lookup_id = str(station.bst_id)
+        existing = existing_entries.get(lookup_id)
         if not existing:
             continue
         vor_id_raw = existing.get("vor_id")
@@ -836,7 +845,11 @@ def _harmonize_station_names(
         return
 
     for station in stations:
-        existing = existing_entries.get(station.bst_id)
+        try:
+            lookup_id = str(int(float(station.bst_id)))  # type: ignore
+        except (ValueError, TypeError):
+            lookup_id = str(station.bst_id)
+        existing = existing_entries.get(lookup_id)
         if existing:
             name_raw = existing.get("name")
             if isinstance(name_raw, str) and name_raw.strip():


### PR DESCRIPTION
Ensures that stations parsed from upstream providers or JSON are stringified correctly before lookup mapping so integer-typed `bst_id` keys successfully match.

---
*PR created automatically by Jules for task [5867503628760167756](https://jules.google.com/task/5867503628760167756) started by @Origamihase*