### PR TITLE
fix(ci+docs): concurrency, fork-friendly base, README inconsistencies, station data cleanup

### DIFF
--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -7,17 +7,25 @@ on:
   push:
     paths:
       - 'src/**'
+      - 'requirements.txt'
+      - 'pyproject.toml'
       - '.github/workflows/build-feed.yml'
 
 permissions:
   contents: read
+
+# Verhindert, dass sich Cron-, Push- und manuell ausgelöste Läufe gegenseitig
+# beim `git push` blockieren oder fehlschlagen lassen.
+concurrency:
+  group: build-feed-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    
+
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
@@ -25,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -36,7 +44,7 @@ jobs:
         run: |
           python -m pip install "pip<26"
           pip install -r requirements.txt
-          
+
       - name: Build feed
         run: python src/build_feed.py
         env:
@@ -46,20 +54,22 @@ jobs:
         run: |
           set -euo pipefail
           perl -0777 -i -pe '
-            my $base = $ENV{"BASE"} // "https://origamihase.github.io/wien-oepnv";
+            my $base = $ENV{"BASE"};
             my $s = $_;
 
             $s =~ s{<rss\b(?![^>]*\bxmlns:atom=)}{<rss xmlns:atom="http://www.w3.org/2005/Atom" }s;
             $s =~ s{(?:\r?\n)?[ \t]*<atom:link\b[^>]*?/>}{}gs;
             $s =~ s{(<channel>.*?<description>.*?</description>)(?:\s*<language>.*?</language>)?\s*}{
               my $prefix = $1;
-              "$prefix\n    <atom:link rel=\"alternate\" type=\"text/html\" href=\"$base/\"/>\n    <atom:link rel=\"self\" type=\"application/rss+xml\" href=\"$base/feed.xml\"/>\n    <language>de</language>\n"
+              "$prefix\n  <atom:link rel=\"alternate\" type=\"text/html\" href=\"$base/\"/>\n  <atom:link rel=\"self\" type=\"application/rss+xml\" href=\"$base/feed.xml\"/>\n  <language>de</language>\n"
             }es;
 
             $_ = $s;
           ' docs/feed.xml
         env:
-          BASE: https://origamihase.github.io/wien-oepnv
+          # Wird aus dem aktuellen Repo abgeleitet, damit Forks korrekte
+          # atom:link-URLs schreiben statt auf das Original-Repo zu zeigen.
+          BASE: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
 
       - name: Configure Git
         if: github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Wien ÖPNV Feed – Projektdokumentation
 
 ### Status Badges
-![Update VOR Cache](https://github.com/origamihase/wien-oepnv/actions/workflows/update-vor-cache.yml/badge.svg)
-![Update ÖBB Cache](https://github.com/origamihase/wien-oepnv/actions/workflows/update-oebb-cache.yml/badge.svg)
-![Test VOR API](https://github.com/origamihase/wien-oepnv/actions/workflows/test-vor-api.yml/badge.svg)
-![Run Tests](https://github.com/origamihase/wien-oepnv/actions/workflows/test.yml/badge.svg)
+[![Update VOR Cache](https://github.com/Origamihase/wien-oepnv/actions/workflows/update-vor-cache.yml/badge.svg)](https://github.com/Origamihase/wien-oepnv/actions/workflows/update-vor-cache.yml)
+[![Update ÖBB Cache](https://github.com/Origamihase/wien-oepnv/actions/workflows/update-oebb-cache.yml/badge.svg)](https://github.com/Origamihase/wien-oepnv/actions/workflows/update-oebb-cache.yml)
+[![Test VOR API](https://github.com/Origamihase/wien-oepnv/actions/workflows/test-vor-api.yml/badge.svg)](https://github.com/Origamihase/wien-oepnv/actions/workflows/test-vor-api.yml)
 
 [![Feed Build](https://github.com/origamihase/wien-oepnv/actions/workflows/build-feed.yml/badge.svg?branch=main)](https://github.com/origamihase/wien-oepnv/actions/workflows/build-feed.yml)
 [![Tests](https://github.com/origamihase/wien-oepnv/actions/workflows/test.yml/badge.svg)](https://github.com/origamihase/wien-oepnv/actions/workflows/test.yml)
@@ -335,7 +334,7 @@ Die wichtigsten GitHub Actions:
 - `build-feed.yml` – erzeugt `docs/feed.xml` auf Basis der aktuellen Caches.
 - `test.yml` & `test-vor-api.yml` – führen die vollständige Test-Suite bzw. VOR-spezifische Integrationstests aus; `test.yml` läuft bei jedem Push sowie Pull Request und stellt die kontinuierliche Testabdeckung sicher.
 
-Alle Feed-Builds warten auf die Cache-Jobs (`needs`-Abhängigkeit), damit stets konsistente Daten verwendet werden.
+Cache-Update-Workflows committen ihre Ergebnisse in den Branch; der Feed-Build liest beim nächsten Lauf den jeweils aktuellen Stand. Eine direkte `needs:`-Abhängigkeit zwischen Workflows ist in GitHub Actions nicht vorgesehen — bei zeitkritischer Konsistenz lässt sich stattdessen ein `workflow_run`-Trigger ergänzen.
 
 ## Entwicklung & Qualitätssicherung
 
@@ -363,7 +362,7 @@ Die neue Kommandozeile (`python -m src.cli`) bündelt bisher verstreute Skripte.
 
 ### Logging & Beobachtbarkeit
 
-Die CLI respektiert die vorhandene Logging-Konfiguration (`log/errors.log`, `log/diagnostics.log`). Für Ad-hoc-Audits lassen sich Berichte und Skriptausgaben über `--output`-Parameter in nachvollziehbaren Pfaden versionieren. Jeder Feed-Build erzeugt zusätzlich einen aktuellen Gesundheitsbericht unter [`docs/feed-health.md`](docs/feed-health.md).
+Die CLI respektiert die vorhandene Logging-Konfiguration (`log/errors.log`, `log/diagnostics.log`). Für Ad-hoc-Audits lassen sich Berichte und Skriptausgaben über `--output`-Parameter in nachvollziehbaren Pfaden versionieren. Jeder Feed-Build erzeugt zusätzlich einen aktuellen Gesundheitsbericht unter `docs/feed-health.md` (lokal nach jedem Build, nicht im Repository versioniert).
 
 ## Authentifizierung & Sicherheit
 

--- a/data/stations.json
+++ b/data/stations.json
@@ -202,16 +202,12 @@
       ],
       "bst_code": "Fws",
       "bst_id": "528",
-      "id": "A=1@O=Flughafen Wien Bahnhof@X=16563659@Y=48120560@U=81@L=430470800@p=1769895381@i=A×at:43:4708@",
       "in_vienna": false,
-      "lat": 48.119,
       "latitude": 48.12056,
-      "lon": 16.564,
       "longitude": 16.563659,
       "name": "Flughafen Wien",
       "pendler": true,
       "source": "oebb",
-      "type": "stop",
       "vor_id": "430470800"
     },
     {


### PR DESCRIPTION
## Kontext

Externes Code-Review hat mehrere CI-, Doku- und Datenkonsistenz-Probleme aufgedeckt. Dieser PR adressiert nur die Punkte, die ohne Eingriff in die tiefere Python-Logik gelöst werden können. Komplexere Folgepunkte (Cache-Sortierung, Perl-zu-Python-Migration, Schema-Lockerung, mypy-Strictness) sind bewusst aufgespart und unten als Follow-ups vermerkt.

## Änderungen

### `.github/workflows/build-feed.yml`

- **`concurrency`-Block ergänzt.** Verhindert, dass sich überlappende Cron- und Push-Läufe beim `git push origin main` gegenseitig blockieren. `cancel-in-progress: false` schützt einen aktiv laufenden Build vor einem Abbruch durch einen nachrückenden Lauf.
- **Push-Trigger erweitert** um `requirements.txt` und `pyproject.toml`. Vorher lösten Dependency-Bumps keinen Build aus, obwohl sie das Verhalten ändern können.
- **`BASE`-URL aus dem Workflow-Kontext abgeleitet.** Statt der hardcoded Origin-URL nutzt der SEO-Normalize-Step jetzt `${{ github.repository_owner }}` und `${{ github.event.repository.name }}`. Forks bekommen damit korrekte `<atom:link rel="self">`-URLs; das bestehende Pages-Setup von `Origamihase` bleibt unverändert (case-insensitive).

### `data/stations.json`

Der Eintrag „Flughafen Wien" enthielt vier Restfelder aus einer früheren VAO/HAFAS-Antwort, die vom OEBB-Schema der übrigen Einträge abweichen: `id` (HAFAS-Location-String), `lat`/`lon` (gerundete Duplikate von `latitude`/`longitude` mit niedrigerer Genauigkeit), `type`. Diese Felder wurden entfernt. Die genauen Koordinaten (`latitude` 48.12056, `longitude` 16.563659), `vor_id`, `bst_id`, `bst_code` und Aliase bleiben unverändert.

### `README.md`

- Erster Status-Badge-Block: Bild-Embeds zu klickbaren Links auf die Workflow-Run-Übersicht umgewandelt, Owner-Casing auf `Origamihase` vereinheitlicht, doppeltes Tests-Badge entfernt.
- Fehleinschätzung zur `needs:`-Abhängigkeit zwischen Workflows korrigiert (gibt es so in GitHub Actions nicht).
- Toten Link auf das nie committete `docs/feed-health.md` (steht in `.gitignore`) durch eine korrekte textuelle Beschreibung des lokalen Verhaltens ersetzt.

## Test-Plan

- [x] `python scripts/run_static_checks.py` grün
- [x] `python scripts/validate_stations.py` grün
- [x] `python -m pytest` grün
- [x] YAML-Parse von `.github/workflows/build-feed.yml` erfolgreich
- [ ] Nach Merge: Build-Feed-Workflow läuft erfolgreich durch und schreibt korrektes `<atom:link rel="self">` (manuell auf Pages prüfen)

## Bewusste Follow-ups (nicht in diesem PR)

1. Cache-Items vor `json.dump` deterministisch sortieren (z. B. nach `(_identity, guid)`) — beendet das Reshuffling bei jedem Cache-Update und reduziert History-Bloat.
2. Klärung `.gitignore` vs. tatsächlich getrackte `cache/<bucket>/events.json` (Pattern ist wirkungslos, weil Dateien bereits getrackt sind).
3. SEO-Normalize-Step von Perl-Regex auf Python-XML-Logik im Feed-Builder umziehen.
4. README-Cache-Pfade (`cache/wl/events.json` vs. real `cache/wl_9d709a/events.json`) konsolidieren.
5. Eventschema: `description` mit `minLength: 1` ist gegenüber realen Provider-Daten zu streng.
6. mypy-Konfig schärfen (`warn_unused_ignores`, `warn_return_any`).
7. `pip<26`-Pin zeitlich begrenzen.

---
*PR created automatically by Jules for task [11724995519255828815](https://jules.google.com/task/11724995519255828815) started by @Origamihase*