### PR TITLE
fix(cache+state): deterministic cache ordering, persistent state lock

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -567,40 +567,40 @@ def _load_state() -> Dict[str, Dict[str, Any]]:
 def _save_state(state: Dict[str, Dict[str, Any]], deletions: Optional[Set[str]] = None) -> None:
     path = validate_path(feed_config.STATE_FILE, "STATE_PATH")
     path.parent.mkdir(parents=True, exist_ok=True)
-    # Windows-fix: Use a separate lock file to avoid permission errors when atomic_write replaces the target
+    # Separate Lock-Datei vermeidet Permission-Fehler unter Windows, wenn
+    # atomic_write die Zieldatei austauscht. Die Lock-Datei wird bewusst NICHT
+    # nach Gebrauch entfernt: andernfalls entstünde eine Race, in der Prozess A
+    # die Datei nach dem Lock-Release unlinkt, während die parallel laufenden
+    # Prozesse B und C den Pfad bereits geöffnet haben und auf separaten Inodes
+    # locken — wodurch flock sich gegenseitig nicht mehr sieht. Eine persistente
+    # Lock-Datei (~0 Bytes) kostet nichts und ist zwischen Läufen wiederverwendbar.
     lock_path = path.with_suffix(".lock")
-    try:
-        with lock_path.open("a+", encoding="utf-8") as lock_file:
-            with file_lock(lock_file, exclusive=True):
-                # Safe merge: read existing state to avoid overwriting parallel updates
-                merged_state = {}
-                try:
-                    with path.open("r", encoding="utf-8") as f:
-                        existing = json.load(f)
-                        if isinstance(existing, dict):
-                            merged_state = existing
-                except FileNotFoundError:
-                    pass
-                except Exception as exc:
-                    log.warning(
-                        "State-Merge fehlgeschlagen (Lesefehler: %s) – überschreibe State.",
-                        exc,
-                    )
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        with file_lock(lock_file, exclusive=True):
+            # Safe merge: read existing state to avoid overwriting parallel updates
+            merged_state = {}
+            try:
+                with path.open("r", encoding="utf-8") as f:
+                    existing = json.load(f)
+                    if isinstance(existing, dict):
+                        merged_state = existing
+            except FileNotFoundError:
+                pass
+            except Exception as exc:
+                log.warning(
+                    "State-Merge fehlgeschlagen (Lesefehler: %s) – überschreibe State.",
+                    exc,
+                )
 
-                merged_state.update(state)
-                if deletions:
-                    for k in deletions:
-                        merged_state.pop(k, None)
+            merged_state.update(state)
+            if deletions:
+                for k in deletions:
+                    merged_state.pop(k, None)
 
-                with atomic_write(
-                    path, mode="w", encoding="utf-8", permissions=0o600
-                ) as f:
-                    json.dump(merged_state, f, ensure_ascii=False, indent=2, sort_keys=True)
-    finally:
-        try:
-            lock_path.unlink(missing_ok=True)
-        except OSError as e:
-            log.debug("Konnte Lock-Datei nicht löschen (Windows-Lock): %s", e)
+            with atomic_write(
+                path, mode="w", encoding="utf-8", permissions=0o600
+            ) as f:
+                json.dump(merged_state, f, ensure_ascii=False, indent=2, sort_keys=True)
 
 
 def _identity_for_item(item: FeedItem) -> str:

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -193,6 +193,24 @@ def _pretty_print_enabled(explicit: Optional[bool]) -> bool:
     return get_bool_env("WIEN_OEPNV_CACHE_PRETTY", True)
 
 
+def _stable_sort_key(item: Any) -> tuple[str, str, str, str]:
+    """Stabiler Sortierschlüssel für Cache-Items.
+
+    Verwendet ``_identity`` als primäres Kriterium (vom Provider explizit gesetzt
+    und bewusst gegen Titel-Kosmetik invariant), dann ``guid``, danach ``title``
+    und ``source`` als Tie-Breaker für Items, denen die Hauptfelder fehlen. Items,
+    die keine Dicts sind, sortieren konsistent auf den leeren Tupel.
+    """
+    if not isinstance(item, dict):
+        return ("", "", "", "")
+    return (
+        str(item.get("_identity") or ""),
+        str(item.get("guid") or ""),
+        str(item.get("title") or ""),
+        str(item.get("source") or ""),
+    )
+
+
 def write_cache(provider: str, items: List[Any], *, pretty: Optional[bool] = None) -> None:
     """Write *items* to the cache for *provider* atomically.
 
@@ -239,8 +257,13 @@ def write_cache(provider: str, items: List[Any], *, pretty: Optional[bool] = Non
                 indent = None
                 separators = (",", ":")
 
+            # Deterministische Sortierung gegen Diff-Reshuffle bei jedem Cache-Update.
+            # Reduziert die History-Bloat erheblich, ohne dass sich Inhalt oder
+            # Reihenfolge im Feed ändern (Items werden im Builder ohnehin neu sortiert).
+            sorted_items = sorted(items, key=_stable_sort_key)
+
             json.dump(
-                items,
+                sorted_items,
                 fh,
                 ensure_ascii=False,
                 indent=indent,


### PR DESCRIPTION
## Kontext

Zwei Follow-ups aus der Liste in #1081, die ich bewusst aus dem ersten Doku-/CI-PR rausgehalten hatte, weil sie Code-Logik verändern und eigene Review-Aufmerksamkeit verdienen.

## Änderungen

### `src/utils/cache.py` — deterministische Sortierung

Bei jedem `write_cache` werden die Items vor dem `json.dump` nach einem stabilen Schlüssel sortiert: zuerst nach `_identity` (vom Provider gesetzt, bewusst gegen Titel-Kosmetik invariant), dann nach `guid`, danach `title`/`source` als Tie-Breaker. Items, die keine Dicts sind, sortieren konsistent auf einen leeren Tupel.

Begründung: Vorher haben sich die Cache-Dateien (`cache/<provider>/events.json`) bei *jedem* Update reshuffled, weil die Provider-internen Dedupe-/Merge-Logik die Reihenfolge nicht stabilisiert. Resultat war ein typisches 78+/54− Diff-Profil für drei tatsächlich neue Items pro Lauf. Mit dem Fix produzieren Folgeläufe nur noch die wirklich geänderten Zeilen.

**Erwarteter Nebeneffekt nach dem Merge:** Der erste Lauf jedes Cache-Update-Workflows nach dem Merge wird einen großen "chore: update X cache"-Commit erzeugen, weil die existierenden Cache-Dateien einmalig sortiert umgeschrieben werden. Danach normalisieren sich die Diffs. Das ist erwartet und unkritisch.

### `src/build_feed.py` — `_save_state` Lock-Cleanup

Die Lock-Datei (`first_seen.lock`) wird nicht mehr nach Gebrauch entfernt. Vorher gab es ein `finally`-Block, der `lock_path.unlink(missing_ok=True)` aufrief — das öffnet eine subtile Race:

1. Prozess A: hält Lock, schreibt State, gibt Lock frei
2. Prozess B: öffnet `lock_path`, bekommt Lock auf B's eigenem Inode
3. Prozess A: läuft in `finally` → `unlink(lock_path)` — entfernt B's Lock-Datei aus dem Verzeichnis
4. Prozess C: öffnet `lock_path` → erstellt frischen Inode → bekommt Lock — gleichzeitig mit B

`flock` arbeitet auf Inode-Ebene; B und C sehen sich also gegenseitig nicht mehr und schreiben parallel. Bei der hohen Cron-Dichte des Repos (vier Workflows × ~30 Minuten) ist das kein Nullrisiko.

Fix: Lock-Datei stehen lassen. Sie ist effektiv 0 Bytes groß, persistiert wartungsfrei und ist zwischen Läufen wiederverwendbar.

## Test-Plan

- [x] `python scripts/run_static_checks.py` grün
- [x] `python -m pytest` grün

## Bewusste Follow-ups (nicht in diesem PR)

Aus der Liste in #1081 verbleiben (unverändert):

1. `.gitignore`-Pattern `cache/*/events.json` klären (wirkungslos, weil Dateien getrackt sind).
2. SEO-Normalize-Step von Perl-Regex auf Python-XML-Logik im Feed-Builder umziehen.
3. README-Cache-Pfade (`cache/wl/events.json` vs. real `cache/wl_9d709a/events.json`) konsolidieren.
4. Eventschema: `description` mit `minLength: 1` ist gegenüber realen Provider-Daten zu streng.
5. mypy-Konfig schärfen.
6. `pip<26`-Pin zeitlich begrenzen.

---
*PR created automatically by Jules for task [13392532026956136874](https://jules.google.com/task/13392532026956136874) started by @Origamihase*