### PR TITLE
feat(stations): match-strength tie-breaking in _station_lookup

### DIFF
--- a/src/utils/stations.py
+++ b/src/utils/stations.py
@@ -7,6 +7,7 @@ import logging
 import math
 import re
 import unicodedata
+from enum import IntEnum
 from functools import lru_cache
 from pathlib import Path
 from typing import Iterable, NamedTuple
@@ -246,45 +247,101 @@ def _vienna_polygons() -> tuple[Polygon, ...]:
     return tuple(polygons)
 
 
-def _iter_aliases(
-    name: str, code: str | None, extras: Iterable[str] | None = None
-) -> Iterable[str]:
-    """Yield alias strings for a station entry (canonical name first)."""
+class _MatchStrength(IntEnum):
+    """Strength of a match between an alias token and a station record.
 
-    variants: list[str] = []
+    Higher values win in tie-breaking. ``IDENTITY``-class tokens come from
+    fields that uniquely identify a station (``bst_code``, ``bst_id``,
+    ``vor_id``, ``wl_diva``, ``stop_id``). ``TEXT``-class tokens come from
+    the canonical name, its textual variations, and the freeform
+    ``aliases`` list. An IDENTITY match by one station outranks a TEXT
+    match by another station for the same token, which is what prevents a
+    foreign station's ``aliases`` entry from shadowing the rightful
+    ID-bearing station (the root cause of the '900100' bug, see #1082).
+    """
+
+    TEXT = 1
+    IDENTITY = 2
+
+
+def _iter_aliases_with_strength(
+    name: str,
+    code: str | None,
+    identity_extras: Iterable[str] | None = None,
+    text_extras: Iterable[str] | None = None,
+) -> list[tuple[str, _MatchStrength]]:
+    """Yield ``(alias, strength)`` pairs for a station entry.
+
+    The canonical *name* and its variations (bracket-stripped, hyphen and
+    slash flattened, St./Sankt forms) are emitted as
+    :attr:`_MatchStrength.TEXT`. The *code* (a station's ``bst_code``) and
+    any *identity_extras* (``vor_id``, ``wl_diva``, stop IDs) are emitted
+    as :attr:`_MatchStrength.IDENTITY`. Entries in *text_extras*
+    (``aliases`` array, stop names) are emitted as TEXT.
+
+    Order is preserved from the legacy :func:`_iter_aliases`: first the
+    name and its variations, then identity_extras, then text_extras. The
+    first occurrence of a candidate string wins, so identity-class wins
+    over text-class on duplicates within a single station entry.
+    """
+
     seen: set[str] = set()
+    variants: list[tuple[str, _MatchStrength]] = []
 
-    def add(raw: str) -> None:
+    def add(raw: str, strength: _MatchStrength) -> None:
         candidate = re.sub(r"\s{2,}", " ", raw.strip())
         if candidate and candidate not in seen:
             seen.add(candidate)
-            variants.append(candidate)
+            variants.append((candidate, strength))
 
-    add(name)
+    add(name, _MatchStrength.TEXT)
     if code:
-        add(code)
+        add(code, _MatchStrength.IDENTITY)
 
     no_paren = re.sub(r"\s*\([^)]*\)\s*", " ", name)
-    add(no_paren)
-    add(no_paren.replace("-", " "))
-    add(no_paren.replace("/", " "))
-    add(name.replace("-", " "))
-    add(name.replace("/", " "))
+    add(no_paren, _MatchStrength.TEXT)
+    add(no_paren.replace("-", " "), _MatchStrength.TEXT)
+    add(no_paren.replace("/", " "), _MatchStrength.TEXT)
+    add(name.replace("-", " "), _MatchStrength.TEXT)
+    add(name.replace("/", " "), _MatchStrength.TEXT)
 
     if re.search(r"\bSt\.?\b", name):
-        add(re.sub(r"\bSt\.?\b", "St", name))
-        add(re.sub(r"\bSt\.?\b", "St ", name))
-        add(re.sub(r"\bSt\.?\b", "Sankt ", name))
+        add(re.sub(r"\bSt\.?\b", "St", name), _MatchStrength.TEXT)
+        add(re.sub(r"\bSt\.?\b", "St ", name), _MatchStrength.TEXT)
+        add(re.sub(r"\bSt\.?\b", "Sankt ", name), _MatchStrength.TEXT)
     if re.search(r"\bSankt\b", name):
-        add(re.sub(r"\bSankt\b", "St.", name))
-        add(re.sub(r"\bSankt\b", "St ", name))
-        add(re.sub(r"\bSankt\b", "St", name))
+        add(re.sub(r"\bSankt\b", "St.", name), _MatchStrength.TEXT)
+        add(re.sub(r"\bSankt\b", "St ", name), _MatchStrength.TEXT)
+        add(re.sub(r"\bSankt\b", "St", name), _MatchStrength.TEXT)
 
-    if extras:
-        for extra in extras:
-            add(str(extra))
+    if identity_extras:
+        for extra in identity_extras:
+            add(str(extra), _MatchStrength.IDENTITY)
+
+    if text_extras:
+        for extra in text_extras:
+            add(str(extra), _MatchStrength.TEXT)
 
     return variants
+
+
+def _iter_aliases(
+    name: str, code: str | None, extras: Iterable[str] | None = None
+) -> Iterable[str]:
+    """Yield alias strings for a station entry (canonical name first).
+
+    Backward-compatible wrapper around :func:`_iter_aliases_with_strength`
+    that drops the strength annotation. Treats *extras* as TEXT-class.
+    Existing external callers (diagnostic scripts, validators) keep
+    working unchanged.
+    """
+
+    return [
+        alias
+        for alias, _ in _iter_aliases_with_strength(
+            name, code, identity_extras=None, text_extras=extras
+        )
+    ]
 
 
 @lru_cache(maxsize=1)
@@ -312,9 +369,16 @@ def _station_entries() -> tuple[dict, ...]:
 
 @lru_cache(maxsize=1)
 def _station_lookup() -> dict[str, StationInfo]:
-    """Return a mapping from normalized aliases to :class:`StationInfo` records."""
+    """Return a mapping from normalized aliases to :class:`StationInfo` records.
 
-    mapping: dict[str, StationInfo] = {}
+    The internal mapping carries match-strength alongside each record so
+    that a later entry whose alias matches via a stronger class
+    (:attr:`_MatchStrength.IDENTITY`) can evict an earlier weaker match
+    (:attr:`_MatchStrength.TEXT`). The strength annotation is dropped from
+    the returned mapping; only :class:`StationInfo` is exposed.
+    """
+
+    mapping: dict[str, tuple[StationInfo, _MatchStrength]] = {}
 
     for entry in _station_entries():
         name = str(entry.get("name", "")).strip()
@@ -326,11 +390,19 @@ def _station_lookup() -> dict[str, StationInfo]:
         wl_diva = str(wl_diva_raw).strip() if wl_diva_raw is not None else ""
         vor_id_raw = entry.get("vor_id") or entry.get("id")
         vor_id = str(vor_id_raw).strip() if vor_id_raw is not None else ""
-        extra_aliases: set[str] = set()
+
+        # Identity-class aliases: authoritative IDs that uniquely identify
+        # this station. A match against any of these outranks any text alias.
+        identity_aliases: set[str] = set()
         if wl_diva:
-            extra_aliases.add(wl_diva)
+            identity_aliases.add(wl_diva)
         if vor_id:
-            extra_aliases.add(vor_id)
+            identity_aliases.add(vor_id)
+
+        # Text-class aliases: the explicit ``aliases`` list and stop names.
+        # Conflicts between two text matches fall through to the historical
+        # source-based tie-break below.
+        text_aliases: set[str] = set()
         aliases_field = entry.get("aliases")
         if isinstance(aliases_field, list):
             for alias in aliases_field:
@@ -338,7 +410,8 @@ def _station_lookup() -> dict[str, StationInfo]:
                     continue
                 alias_text = str(alias).strip()
                 if alias_text:
-                    extra_aliases.add(alias_text)
+                    text_aliases.add(alias_text)
+
         stop_records: list[WLStop] = []
         stops_field = entry.get("wl_stops")
         if isinstance(stops_field, list):
@@ -352,9 +425,10 @@ def _station_lookup() -> dict[str, StationInfo]:
                 latitude = _coerce_lat(stop.get("latitude"))
                 longitude = _coerce_lon(stop.get("longitude"))
                 if stop_id:
-                    extra_aliases.add(stop_id)
+                    # Stop IDs are authoritative and rank as IDENTITY.
+                    identity_aliases.add(stop_id)
                 if stop_name:
-                    extra_aliases.add(stop_name)
+                    text_aliases.add(stop_name)
                 stop_records.append(
                     WLStop(
                         stop_id=stop_id,
@@ -379,8 +453,12 @@ def _station_lookup() -> dict[str, StationInfo]:
         )
         vor_name_raw = entry.get("vor_name")
         vor_name = str(vor_name_raw).strip() if isinstance(vor_name_raw, str) else ""
-        for alias in _iter_aliases(name, code or None, extra_aliases):
-            alias_text = str(alias)
+        for alias_text, strength in _iter_aliases_with_strength(
+            name,
+            code or None,
+            identity_extras=identity_aliases,
+            text_extras=text_aliases,
+        ):
             alias_lower = alias_text.casefold()
             alias_is_numeric = alias_text.isdigit()
             alias_mentions_vor = "vor" in alias_lower
@@ -406,12 +484,29 @@ def _station_lookup() -> dict[str, StationInfo]:
                 continue
             existing = mapping.get(key)
             if existing is None:
-                mapping[key] = alias_record
+                mapping[key] = (alias_record, strength)
                 continue
-            if existing == alias_record or existing.name == alias_record.name:
+            existing_record, existing_strength = existing
+
+            if existing_record == alias_record or existing_record.name == alias_record.name:
                 continue
 
-            existing_source = existing.source or ""
+            # Match-strength precedence: an IDENTITY-class match by one
+            # station outranks a TEXT-class match by another station for
+            # the same token. This prevents a foreign station's aliases
+            # entry from shadowing the rightful ID-bearing station (the
+            # root cause of the '900100' bug, see #1082).
+            if strength > existing_strength:
+                mapping[key] = (alias_record, strength)
+                continue
+            if strength < existing_strength:
+                continue
+
+            # Equal strength: fall back to the historical source-based and
+            # name-token-based tie-break. The branches below are wordwise
+            # identical to the pre-refactor logic; only the mapping value
+            # type carries the strength annotation now.
+            existing_source = existing_record.source or ""
             record_source = alias_record.source or ""
             if existing_source == "combined":
                 existing_source = "wl"
@@ -420,36 +515,38 @@ def _station_lookup() -> dict[str, StationInfo]:
 
             alias_token = _normalize_token(alias_text)
             record_token = _normalize_token(alias_record.name)
-            existing_token = _normalize_token(existing.name)
+            existing_token = _normalize_token(existing_record.name)
 
             if alias_token and alias_token == record_token and alias_token != existing_token:
-                mapping[key] = alias_record
+                mapping[key] = (alias_record, strength)
                 continue
             if alias_token and alias_token == existing_token and alias_token != record_token:
                 continue
 
-            if existing.vor_id and alias_record.vor_id and existing.vor_id == alias_record.vor_id:
+            if existing_record.vor_id and alias_record.vor_id and existing_record.vor_id == alias_record.vor_id:
                 if alias_is_numeric or alias_mentions_vor:
                     if record_source == "vor" and existing_source != "vor":
-                        mapping[key] = alias_record
+                        mapping[key] = (alias_record, strength)
                 else:
                     if record_source == "wl" and existing_source != "wl":
-                        mapping[key] = alias_record
+                        mapping[key] = (alias_record, strength)
                 continue
 
             if existing_source == "vor" and record_source != "vor":
-                mapping[key] = alias_record
+                mapping[key] = (alias_record, strength)
                 continue
             if record_source == "vor" and existing_source != "vor":
                 continue
             logger.warning(
                 "Duplicate station alias %r normalized to %r for %s conflicts with %s",
-                alias,
+                alias_text,
                 key,
                 alias_record.name,
-                existing.name,
+                existing_record.name,
             )
-    return mapping
+
+    # Drop the strength annotation from the public mapping.
+    return {key: record for key, (record, _) in mapping.items()}
 
 
 def _candidate_values(value: str) -> list[str]:

--- a/tests/test_vor_stations_directory.py
+++ b/tests/test_vor_stations_directory.py
@@ -69,6 +69,72 @@ def test_vor_bst_code_prefers_directory_entry(monkeypatch):
         stations.station_info.cache_clear()
 
 
+def test_bst_code_identity_outranks_foreign_alias(monkeypatch):
+    """Regression for the '900100' bug class.
+
+    Reconstructs the exact configuration that triggered #1082: Wien
+    Aspern Nord listed '900100' in its ``aliases`` array (TEXT match),
+    while '900100' is in fact Wien Hauptbahnhof's ``bst_code`` (IDENTITY
+    match). Aspern Nord is intentionally placed FIRST in the entries
+    list — under the pre-refactor logic it would claim the mapping key
+    before Hauptbahnhof's ``bst_code`` is ever processed, and the
+    source-based tie-break would let it keep the slot. With
+    match-strength precedence in place, IDENTITY > TEXT must let Wien
+    Hauptbahnhof win regardless of iteration order.
+    """
+
+    import src.utils.stations as stations
+
+    stations._station_lookup.cache_clear()
+    stations.station_info.cache_clear()
+
+    def fake_entries():
+        return (
+            {
+                "bst_id": "4773541",
+                "bst_code": "Sty",
+                "name": "Wien Aspern Nord",
+                "in_vienna": True,
+                "pendler": False,
+                "vor_id": "490091000",
+                "aliases": [
+                    "Wien Aspern Nord",
+                    "490091000",
+                    "Sty",
+                    "900100",
+                    "Aspern Nord",
+                ],
+                "latitude": 48.234567,
+                "longitude": 16.520123,
+                "source": "oebb",
+            },
+            {
+                "name": "Wien Hauptbahnhof",
+                "in_vienna": True,
+                "pendler": False,
+                "vor_id": "490134900",
+                "aliases": ["490134900", "Wien Hauptbahnhof"],
+                "latitude": 48.185184,
+                "longitude": 16.376413,
+                "source": "vor",
+                "bst_id": "900100",
+                "bst_code": "900100",
+            },
+        )
+
+    monkeypatch.setattr(stations, "_station_entries", fake_entries)
+    try:
+        info = stations.station_info("900100")
+        assert info is not None
+        assert info.name == "Wien Hauptbahnhof", (
+            "bst_code IDENTITY match must outrank a foreign aliases TEXT "
+            "match, regardless of iteration order"
+        )
+    finally:
+        stations._station_lookup.cache_clear()
+        stations.station_info.cache_clear()
+
+
 def test_vor_lookup_by_alias():
     info = station_info("Vienna Airport")
     assert info is not None


### PR DESCRIPTION
## Kontext

Letztes Follow-up aus dem „900100"-Themen-Cluster (#1082, #1083, #1084). Der Datenfehler in `data/stations.json` ist gefixt (#1082) und der Validator (#1084) verhindert, dass dieselbe Klasse von Daten-Bugs unbemerkt zurückkehrt. Was bisher fehlte: die Lookup-Logik selbst akzeptierte still, dass ein `aliases`-Eintrag einer fremden Station einen direkten ID-Treffer der „eigentlichen" Station verdrängt — abhängig von der Reihenfolge in der JSON-Datei und der `source`-Markierung. Dieser PR macht diese Verdrängung unmöglich.

## Änderungen

### `src/utils/stations.py` — neue Match-Strength-Stufe

Eingeführt:

- `_MatchStrength` (`IntEnum` mit `TEXT=1`, `IDENTITY=2`).
- `_iter_aliases_with_strength(...)` — Variante von `_iter_aliases`, die für jeden Alias-Token zusätzlich die Match-Klasse mitliefert: IDENTITY für `bst_code`, `vor_id`, `wl_diva`, Stop-IDs; TEXT für Name, Name-Variationen, `aliases`-Array und Stop-Namen.
- `_iter_aliases(...)` bleibt als Backward-Compatible-Wrapper (Strength-Annotation wird verworfen, externe Aufrufe ändern sich nicht).

`_station_lookup()` führt die Strength jetzt im internen Mapping-Wert (`tuple[StationInfo, _MatchStrength]`) mit. Beim Konflikt:

1. Stärkeres Match überschreibt schwächeres (IDENTITY > TEXT).
2. Bei Gleichstand fällt der Code unverändert auf die historische source-basierte und name-token-basierte Tie-Break-Logik zurück. Die Branches dort sind Wort-für-Wort identisch zur Pre-Refactor-Version.

Die Public-API von `_station_lookup()` (`dict[str, StationInfo]`) bleibt unverändert — die Strength-Annotation wird beim Return abgestreift.

### `tests/test_vor_stations_directory.py` — Regression-Test

Neuer Test `test_bst_code_identity_outranks_foreign_alias` rekonstruiert die exakte Konfiguration des #1082-Bugs im Stub: Wien Aspern Nord steht zuerst und führt `"900100"` in seinem `aliases`-Array, Wien Hauptbahnhof steht danach und führt `"900100"` als `bst_code`/`bst_id`. Pre-Refactor wäre Aspern Nord der Gewinner; mit Match-Strength gewinnt Hauptbahnhof zwingend, weil IDENTITY > TEXT — unabhängig von Iterationsreihenfolge und `source`.

## Verhaltens-Garantien

Bewusst unverändertes Verhalten (alle bestehenden Tests grün):

- TEXT-vs-TEXT-Konflikte loggen weiterhin die `Duplicate station alias`-Warnung (`test_station_alias_collision_logs_warning`).
- WL-Stationen gewinnen weiterhin gegen VOR-Text-Aliase, wenn beide TEXT-Klasse sind (`test_wl_aliases_take_precedence_over_vor_text_aliases`).
- Der `vor_name`-Re-Labeling-Pfad bleibt unangetastet.

## Test-Plan

- [x] `python scripts/run_static_checks.py` grün
- [x] `python scripts/validate_stations.py` grün
- [x] Vollständige pytest-Suite grün
- [x] Neuer Regression-Test `test_bst_code_identity_outranks_foreign_alias` grün

## Verbleibende Follow-ups (separate PRs)

Aus #1081/#1082/#1083 unverändert:

- README-Cache-Pfade konsolidieren, Badge-Casing in zweiter Gruppe, `.gitignore`-Pattern klären
- SEO-Normalize-Step Perl → Python migrieren
- Action-Versionen SHA-pinnen + Dependabot
- mypy-Konfig schärfen
- Eventschema `description minLength: 1` lockern
- `pip<26`-Pin zeitlich begrenzen
- `VOR_API_KEY` → `VOR_ACCESS_ID` umbenennen (breaking)

---
*PR created automatically by Jules for task [481436032761846409](https://jules.google.com/task/481436032761846409) started by @Origamihase*