### PR TITLE
feat(seo): generate atom links + language inline, drop Perl normalize step

### DIFF
--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -49,27 +49,10 @@ jobs:
         run: python src/build_feed.py
         env:
           VOR_ACCESS_ID: ${{ secrets.VOR_API_KEY }}
-
-      - name: Normalize feed metadata (SEO)
-        run: |
-          set -euo pipefail
-          perl -0777 -i -pe '
-            my $base = $ENV{"BASE"};
-            my $s = $_;
-
-            $s =~ s{<rss\b(?![^>]*\bxmlns:atom=)}{<rss xmlns:atom="http://www.w3.org/2005/Atom" }s;
-            $s =~ s{(?:\r?\n)?[ \t]*<atom:link\b[^>]*?/>}{}gs;
-            $s =~ s{(<channel>.*?<description>.*?</description>)(?:\s*<language>.*?</language>)?\s*}{
-              my $prefix = $1;
-              "$prefix\n  <atom:link rel=\"alternate\" type=\"text/html\" href=\"$base/\"/>\n  <atom:link rel=\"self\" type=\"application/rss+xml\" href=\"$base/feed.xml\"/>\n  <language>de</language>\n"
-            }es;
-
-            $_ = $s;
-          ' docs/feed.xml
-        env:
-          # Wird aus dem aktuellen Repo abgeleitet, damit Forks korrekte
-          # atom:link-URLs schreiben statt auf das Original-Repo zu zeigen.
-          BASE: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+          # Atom self/alternate-Links werden direkt im Python-Builder geschrieben.
+          # Aus dem aktuellen Repo abgeleitet, damit Forks korrekte atom:link-URLs
+          # schreiben statt auf das Original-Repo zu zeigen.
+          PAGES_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
 
       - name: Configure Git
         if: github.ref == 'refs/heads/main'

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -61,6 +61,8 @@ from utils.text import html_to_text, truncate_html
 
 
 # Register namespaces globally for thread-safe XML generation
+ATOM_NS = "http://www.w3.org/2005/Atom"
+ET.register_namespace("atom", ATOM_NS)
 ET.register_namespace("ext", "https://wien-oepnv.example/schema")
 ET.register_namespace("content", "http://purl.org/rss/1.0/modules/content/")
 
@@ -1438,6 +1440,23 @@ def _make_rss(
     ET.SubElement(channel, "title").text = feed_config.FEED_TITLE
     ET.SubElement(channel, "link").text = feed_config.FEED_LINK
     ET.SubElement(channel, "description").text = feed_config.FEED_DESC
+
+    # Atom self/alternate-Links + Sprache. Diese drei Tags wurden früher
+    # vom Perl-basierten "Normalize feed metadata (SEO)"-Step in
+    # .github/workflows/build-feed.yml nachträglich injiziert. Generierung
+    # direkt im Python-Builder hält das XML strukturell wohlgeformt und
+    # entfernt den Sprachen-Mix in CI.
+    pages_base = feed_config.PAGES_BASE_URL.rstrip("/")
+    atom_alternate = ET.SubElement(channel, f"{{{ATOM_NS}}}link")
+    atom_alternate.set("rel", "alternate")
+    atom_alternate.set("type", "text/html")
+    atom_alternate.set("href", f"{pages_base}/")
+    atom_self = ET.SubElement(channel, f"{{{ATOM_NS}}}link")
+    atom_self.set("rel", "self")
+    atom_self.set("type", "application/rss+xml")
+    atom_self.set("href", f"{pages_base}/feed.xml")
+    ET.SubElement(channel, "language").text = "de"
+
     ET.SubElement(channel, "lastBuildDate").text = _fmt_rfc2822(now)
     ET.SubElement(channel, "ttl").text = str(feed_config.FEED_TTL)
 

--- a/src/config/defaults.py
+++ b/src/config/defaults.py
@@ -11,6 +11,7 @@ __all__ = [
     "DEFAULT_FEED_TITLE",
     "DEFAULT_FEED_DESCRIPTION",
     "DEFAULT_FEED_LINK",
+    "DEFAULT_PAGES_BASE_URL",
     "DEFAULT_FEED_TTL_MINUTES",
     "DEFAULT_TITLE_CHAR_LIMIT",
     "DEFAULT_DESCRIPTION_CHAR_LIMIT",
@@ -33,6 +34,7 @@ DEFAULT_FEED_HEALTH_JSON_PATH = Path("docs/feed-health.json")
 DEFAULT_FEED_TITLE = "ÖPNV Störungen Wien & Pendler"
 DEFAULT_FEED_DESCRIPTION = "Aktive Störungen/Baustellen/Einschränkungen aus offiziellen Quellen"
 DEFAULT_FEED_LINK = "https://github.com/Origamihase/wien-oepnv"
+DEFAULT_PAGES_BASE_URL = "https://origamihase.github.io/wien-oepnv"
 DEFAULT_FEED_TTL_MINUTES = 15
 DEFAULT_TITLE_CHAR_LIMIT = 256
 DEFAULT_DESCRIPTION_CHAR_LIMIT = 4000

--- a/src/feed/config.py
+++ b/src/feed/config.py
@@ -23,6 +23,7 @@ try:  # pragma: no cover - support package and script execution
         DEFAULT_MAX_ITEMS,
         DEFAULT_MAX_ITEM_AGE_DAYS,
         DEFAULT_OUT_PATH,
+        DEFAULT_PAGES_BASE_URL,
         DEFAULT_CACHE_MAX_AGE_HOURS,
         DEFAULT_PROVIDER_MAX_WORKERS,
         DEFAULT_PROVIDER_TIMEOUT,
@@ -47,6 +48,7 @@ except ModuleNotFoundError:  # pragma: no cover
         DEFAULT_MAX_ITEMS,
         DEFAULT_MAX_ITEM_AGE_DAYS,
         DEFAULT_OUT_PATH,
+        DEFAULT_PAGES_BASE_URL,
         DEFAULT_CACHE_MAX_AGE_HOURS,
         DEFAULT_PROVIDER_MAX_WORKERS,
         DEFAULT_PROVIDER_TIMEOUT,
@@ -157,6 +159,7 @@ FEED_HEALTH_PATH: Path = DEFAULT_FEED_HEALTH_PATH
 FEED_HEALTH_JSON_PATH: Path = DEFAULT_FEED_HEALTH_JSON_PATH
 FEED_TITLE: str = DEFAULT_FEED_TITLE
 FEED_LINK: str = DEFAULT_FEED_LINK
+PAGES_BASE_URL: str = DEFAULT_PAGES_BASE_URL
 FEED_DESC: str = DEFAULT_FEED_DESCRIPTION
 FEED_TTL: int = DEFAULT_FEED_TTL_MINUTES
 TITLE_CHAR_LIMIT: int = DEFAULT_TITLE_CHAR_LIMIT
@@ -175,7 +178,7 @@ STATE_RETENTION_DAYS: int = DEFAULT_STATE_RETENTION_DAYS
 
 def _load_from_env() -> None:
     global LOG_LEVEL, LOG_FORMAT, LOG_DIR_PATH, LOG_MAX_BYTES, LOG_BACKUP_COUNT
-    global OUT_PATH, FEED_HEALTH_PATH, FEED_HEALTH_JSON_PATH, FEED_TITLE, FEED_LINK, FEED_DESC, FEED_TTL
+    global OUT_PATH, FEED_HEALTH_PATH, FEED_HEALTH_JSON_PATH, FEED_TITLE, FEED_LINK, PAGES_BASE_URL, FEED_DESC, FEED_TTL
     global TITLE_CHAR_LIMIT, DESCRIPTION_CHAR_LIMIT, FRESH_PUBDATE_WINDOW_MIN, MAX_ITEMS
     global MAX_ITEM_AGE_DAYS, ABSOLUTE_MAX_AGE_DAYS, ENDS_AT_GRACE_MINUTES
     global PROVIDER_TIMEOUT, PROVIDER_MAX_WORKERS, STATE_FILE, STATE_RETENTION_DAYS
@@ -203,6 +206,13 @@ def _load_from_env() -> None:
         if raw_feed_link.strip() and raw_feed_link.strip() != DEFAULT_FEED_LINK:
             log.warning("Invalid FEED_LINK provided; falling back to default.")
     FEED_LINK = validated_feed_link
+    raw_pages_base = os.getenv("PAGES_BASE_URL", DEFAULT_PAGES_BASE_URL)
+    validated_pages_base = validate_http_url(raw_pages_base)
+    if not validated_pages_base:
+        validated_pages_base = validate_http_url(DEFAULT_PAGES_BASE_URL) or DEFAULT_PAGES_BASE_URL
+        if raw_pages_base.strip() and raw_pages_base.strip() != DEFAULT_PAGES_BASE_URL:
+            log.warning("Invalid PAGES_BASE_URL provided; falling back to default.")
+    PAGES_BASE_URL = validated_pages_base.rstrip("/")
     FEED_DESC = os.getenv("FEED_DESC", DEFAULT_FEED_DESCRIPTION)
     FEED_TTL = max(get_int_env("FEED_TTL", DEFAULT_FEED_TTL_MINUTES), 0)
     TITLE_CHAR_LIMIT = max(
@@ -302,6 +312,7 @@ __all__ = [
     "MAX_ITEM_AGE_DAYS",
     "MAX_ITEMS",
     "OUT_PATH",
+    "PAGES_BASE_URL",
     "PROVIDER_MAX_WORKERS",
     "PROVIDER_TIMEOUT",
     "RFC",

--- a/tests/test_build_feed_atom.py
+++ b/tests/test_build_feed_atom.py
@@ -1,0 +1,94 @@
+"""Tests for atom:link / language SEO metadata in the generated RSS.
+
+These tests cover the migration of SEO normalization from the Perl-based
+"Normalize feed metadata (SEO)" step in .github/workflows/build-feed.yml
+into the Python feed builder (_make_rss in src/build_feed.py). They guard
+against regressions in atom namespace declaration, atom:link self/alternate
+emission, and the <language>de</language> tag.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from defusedxml import ElementTree as ET
+import pytest
+
+from src.build_feed import _make_rss
+
+
+_NOW = datetime(2026, 5, 1, 18, 0, 0, tzinfo=timezone.utc)
+_ATOM_NS = "http://www.w3.org/2005/Atom"
+
+
+@pytest.fixture
+def pages_base_url(monkeypatch):
+    """Set PAGES_BASE_URL via env and refresh feed config; restore on teardown."""
+
+    import src.build_feed
+
+    def _set(url: str) -> None:
+        monkeypatch.setenv("PAGES_BASE_URL", url)
+        src.build_feed.feed_config.refresh_from_env()
+
+    yield _set
+    monkeypatch.delenv("PAGES_BASE_URL", raising=False)
+    src.build_feed.feed_config.refresh_from_env()
+
+
+def test_make_rss_declares_atom_namespace(pages_base_url):
+    pages_base_url("https://example.github.io/test-repo")
+    rss_str = _make_rss([], _NOW, {})
+    assert 'xmlns:atom="http://www.w3.org/2005/Atom"' in rss_str
+
+
+def test_make_rss_emits_self_and_alternate_atom_links(pages_base_url):
+    pages_base_url("https://example.github.io/test-repo")
+    rss_str = _make_rss([], _NOW, {})
+
+    root = ET.fromstring(rss_str)
+    channel = root.find("channel")
+    assert channel is not None
+
+    atom_links = channel.findall(f"{{{_ATOM_NS}}}link")
+    assert len(atom_links) == 2, "expected one self plus one alternate atom:link"
+
+    by_rel = {link.get("rel"): link for link in atom_links}
+    assert set(by_rel.keys()) == {"self", "alternate"}
+
+    alt = by_rel["alternate"]
+    assert alt.get("type") == "text/html"
+    assert alt.get("href") == "https://example.github.io/test-repo/"
+
+    self_link = by_rel["self"]
+    assert self_link.get("type") == "application/rss+xml"
+    assert self_link.get("href") == "https://example.github.io/test-repo/feed.xml"
+
+
+def test_make_rss_emits_language_de(pages_base_url):
+    pages_base_url("https://example.github.io/test-repo")
+    rss_str = _make_rss([], _NOW, {})
+
+    root = ET.fromstring(rss_str)
+    channel = root.find("channel")
+    assert channel is not None
+
+    language = channel.find("language")
+    assert language is not None
+    assert language.text == "de"
+
+
+def test_make_rss_strips_trailing_slash_from_pages_base_url(pages_base_url):
+    """A trailing slash in PAGES_BASE_URL must not produce a double slash in href."""
+
+    pages_base_url("https://example.github.io/test-repo/")
+    rss_str = _make_rss([], _NOW, {})
+
+    root = ET.fromstring(rss_str)
+    channel = root.find("channel")
+    assert channel is not None
+    atom_links = channel.findall(f"{{{_ATOM_NS}}}link")
+
+    for link in atom_links:
+        href = link.get("href") or ""
+        assert "//feed.xml" not in href
+        assert not href.endswith("//"), f"unexpected double slash in {href!r}"


### PR DESCRIPTION
## Kontext

Bislang wurden drei SEO-relevante Tags nachträglich per Perl in `docs/feed.xml` injiziert: der `xmlns:atom`-Namespace im `<rss>`-Tag, ein `<atom:link rel="alternate">`, ein `<atom:link rel="self">` und ein `<language>de</language>`. Der Perl-Block stand in `.github/workflows/build-feed.yml` direkt nach dem `python src/build_feed.py`-Aufruf und ergänzte das XML byte-weise per Regex.

Diese PR verlagert die Generierung in den Python-Feed-Builder. Das hat mehrere Vorteile:

- **Eine Sprache weniger im CI-Stack** — Perl fällt aus `build-feed.yml` weg.
- **Strukturell wohlgeformtes XML** — der Perl-Block produzierte ein doppeltes Leerzeichen im `<rss>`-Tag und uneinheitlich eingerückte Tags (atom:links mit 2 Spaces, Rest mit 4 Spaces, `<lastBuildDate>` ohne Indent). Die ElementTree-basierte Generierung erzeugt konsistent eingerückten Output.
- **Lokale Reproduzierbarkeit** — `python src/build_feed.py` produziert lokal denselben Feed wie in CI, ohne dass der Perl-Step nachgeschaltet werden muss.
- **Forks erben das Verhalten automatisch** — der neue Config-Wert `PAGES_BASE_URL` hat einen Default für das Original-Repo und wird im Workflow aus `${{ github.repository_owner }}` / `${{ github.event.repository.name }}` befüllt, gleich wie zuvor die `BASE`-Variable.

## Änderungen

### `src/config/defaults.py`

Neuer Default `DEFAULT_PAGES_BASE_URL = "https://origamihase.github.io/wien-oepnv"`. Wird in `__all__` exportiert.

### `src/feed/config.py`

Neue Module-Level-Konstante `PAGES_BASE_URL`, geladen aus der gleichnamigen Env-Var via `_load_from_env()`. Validierung über `validate_http_url` analog zu `FEED_LINK`. Trailing-Slash wird beim Laden entfernt, sodass nachgelagerte URL-Konkatenationen keine Doppel-Slashes erzeugen können.

### `src/build_feed.py`

`_make_rss()` schreibt zwischen `<description>` und `<lastBuildDate>` jetzt direkt:

- `<atom:link rel="alternate" type="text/html" href="{PAGES_BASE_URL}/"/>`
- `<atom:link rel="self" type="application/rss+xml" href="{PAGES_BASE_URL}/feed.xml"/>`
- `<language>de</language>`

Plus neue Module-Level-Konstante `ATOM_NS` und `ET.register_namespace("atom", ATOM_NS)` für die Namespace-Deklaration im `<rss>`-Tag.

### `tests/test_build_feed_atom.py` (neu)

Vier strukturelle Tests:

- Atom-Namespace ist im `<rss>`-Tag deklariert.
- Genau ein `<atom:link rel="self">` und ein `<atom:link rel="alternate">` mit korrekten `type`/`href`-Attributen.
- `<language>de</language>` ist vorhanden.
- Trailing-Slash in `PAGES_BASE_URL` produziert keinen Doppel-Slash in den `href`-Werten.

Die Tests parsen den `_make_rss`-Output mit `defusedxml` (gleicher Parser wie in den bestehenden ÖBB/VOR-Tests).

### `.github/workflows/build-feed.yml`

- Perl-basierter Step `Normalize feed metadata (SEO)` entfernt.
- `BASE`-Env-Var entfernt — sie hatte nur den Perl-Step gespeist.
- Neue `PAGES_BASE_URL`-Env-Var im `Build feed`-Step, gespeist aus den gleichen GitHub-Variablen wie zuvor `BASE`.

## Erwarteter Nebeneffekt nach Merge

Der erste Build-Feed-Workflow-Lauf nach diesem PR erzeugt einen einmaligen größeren `Update feed`-Diff in `docs/feed.xml`, weil die Datei jetzt strukturell konsistent eingerückt geschrieben wird (kein doppeltes Leerzeichen im `<rss>`-Tag mehr, einheitliches 4-Space-Indenting im Channel). Folgeläufe normalisieren sich auf die üblichen kleinen Item-Änderungen.

## Bewusst unverändert (separate Followups)

- **`seo-guard.yml` Perl-Block bleibt:** dient als idempotentes Sicherheitsnetz gegen den unwahrscheinlichen Fall, dass `docs/feed.xml` aus anderen Quellen den `xmlns:atom`-Namespace oder die Atom-Links verliert. Wenn `_make_rss` korrekten Output produziert, erkennt der Block keinen Diff und committet nichts. Sein Removal ist eigener PR.
- **`VOR_ACCESS_ID: ${{ secrets.VOR_API_KEY }}` im Build-Feed-Step bleibt:** das Secret `VOR_API_KEY` existiert nicht (mehr) in den Repo-Settings (verifiziert per Secrets-Übersicht), die Env-Var wird also auf `""` gesetzt. Da Build-Feed nur Caches liest und keine Live-VOR-API-Calls macht, ist die Zeile inert. Aufräumen separat im VOR-Cleanup-PR (zusammen mit dem geplanten `VOR_API_KEY → VOR_ACCESS_ID`-Rename, der hier ohnehin schon faktisch passiert ist).

## Verbleibende Followups (Liste unverändert)

Aus #1081/#1082/#1083:

- README-Cache-Pfade konsolidieren, Badge-Casing zweite Gruppe, `.gitignore`-Pattern
- Action-Versionen SHA-pinnen + Dependabot
- mypy-Konfig schärfen
- Eventschema `description minLength: 1` lockern
- `pip<26`-Pin zeitlich begrenzen
- `seo-guard.yml` Perl-Block migrieren
- Build-Feed-Step `VOR_ACCESS_ID`-Cargo-Cult-Zeile entfernen

---
*PR created automatically by Jules for task [6501188697633736664](https://jules.google.com/task/6501188697633736664) started by @Origamihase*