### PR TITLE
chore(ci): SHA-pin GitHub Actions and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# Configuration for Dependabot version updates.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates
+
+version: 2
+updates:
+  # GitHub Actions: SHA-gepinnte Actions werden mit jedem neuen Tag-Release
+  # automatisch als PR aktualisiert. Tag-Kommentar (z.B. "# v4") bleibt durch
+  # Dependabot erhalten.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Vienna"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    open-pull-requests-limit: 5

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -34,10 +34,10 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -30,12 +30,12 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/seo-guard.yml
+++ b/.github/workflows/seo-guard.yml
@@ -24,7 +24,7 @@ jobs:
       DESC: Konsolidierter RSS-Feed für Störungen und Baustellenmeldungen im Wiener ÖPNV (WL/ÖBB/VOR), inkl. Doku & Open-Data-Workflows.
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test-vor-api.yml
+++ b/.github/workflows/test-vor-api.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Validate required secrets
         shell: bash
@@ -36,7 +36,7 @@ jobs:
 
       - name: Set up Python
         if: ${{ success() }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
       PYTHONPATH: src
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
           cache: pip

--- a/.github/workflows/update-google-places-stations.yml
+++ b/.github/workflows/update-google-places-stations.yml
@@ -29,12 +29,12 @@ jobs:
       PLACES_QUOTA_STATE: data/places_quota.json
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/update-oebb-cache.yml
+++ b/.github/workflows/update-oebb-cache.yml
@@ -24,13 +24,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Ensure pip cache directory exists
         run: mkdir -p "$PIP_CACHE_DIR"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -47,7 +47,7 @@ jobs:
         run: git pull --rebase --autostash
 
       - name: Commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: 'chore: update ÖBB cache'
           file_pattern: 'cache/oebb*/events.json'

--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -19,12 +19,12 @@ jobs:
       PYTHONPATH: src
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
 
@@ -50,7 +50,7 @@ jobs:
         run: git pull --rebase --autostash
 
       - name: Commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: "chore(data): add VOR stations (900100, 900300) + CI harden"
           add_options: "-A"

--- a/.github/workflows/update-vor-cache.yml
+++ b/.github/workflows/update-vor-cache.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Ensure pip cache directory exists
         run: mkdir -p "$PIP_CACHE_DIR"
@@ -44,7 +44,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -85,7 +85,7 @@ jobs:
 
       - name: Commit and push changes
         if: ${{ github.ref_type == 'branch' }}
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: 'chore: update VOR cache [skip ci]'
           file_pattern: 'cache/vor*/events.json data/vor_request_count.json'

--- a/.github/workflows/update-wl-cache.yml
+++ b/.github/workflows/update-wl-cache.yml
@@ -22,7 +22,7 @@ jobs:
       PYTHONPATH: src
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Ensure pip cache directory exists
         shell: bash
@@ -36,7 +36,7 @@ jobs:
           echo "$EOF" >> "$GITHUB_ENV"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -53,7 +53,7 @@ jobs:
         run: git pull --rebase --autostash
 
       - name: Commit and push changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: 'chore: update Wiener Linien cache'
           file_pattern: 'cache/wl*/events.json'

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -4,8 +4,8 @@
     <title>ÖPNV Störungen Wien &amp; Pendler</title>
     <link>https://github.com/Origamihase/wien-oepnv</link>
     <description>Aktive Störungen/Baustellen/Einschränkungen aus offiziellen Quellen</description>
-    <atom:link rel="alternate" type="text/html" href="https://origamihase.github.io/wien-oepnv/" />
-    <atom:link rel="self" type="application/rss+xml" href="https://origamihase.github.io/wien-oepnv/feed.xml" />
+    <atom:link rel="alternate" type="text/html" href="https://origamihase.github.io/wien-oepnv/"/>
+    <atom:link rel="self" type="application/rss+xml" href="https://origamihase.github.io/wien-oepnv/feed.xml"/>
     <language>de</language>
     <lastBuildDate>Fri, 01 May 2026 22:28:40 +0200</lastBuildDate>
     <ttl>15</ttl>


### PR DESCRIPTION
## Kontext 
 
Drei GitHub Actions waren bisher per Tag (`@v4`, `@v5`, `@v7`) referenziert. Tags sind in Git mutable — ein Maintainer kann jederzeit `v4` auf einen anderen Commit umzeigen. Bei einem Supply-Chain-Angriff (z.B. dem `tj-actions/changed-files`-Vorfall im Frühjahr 2025) lief auf zehntausenden Repos plötzlich anderer Code, ohne dass irgendjemand etwas committet hatte. SHA-Pinning macht das unmöglich: ein bestimmter Commit ist unveränderlich, eine Aktualisierung benötigt einen expliziten Diff im Repo. 
 
Plus Dependabot-Konfiguration: ab sofort kommen Action-Updates monatlich als PR, mit Release-Notes im PR-Body und sichtbarem SHA-Diff. 
 
## Änderungen 
 
### `.github/workflows/*.yml` — SHA-Pinning 
 
Drei Actions wurden gepinnt: 
 
- `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4` (11 Vorkommen, alle 11 Workflow-Files) 
- `actions/setup-python@v5` → `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5` (9 Vorkommen) 
- `stefanzweifel/git-auto-commit-action@v7` → `stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7` (4 Vorkommen) 
 
Tag-Name als Kommentar (`# v4` etc.) bleibt erhalten — das ist die übliche Konvention und Dependabot pflegt den Kommentar bei Updates automatisch nach. 
 
### `.github/dependabot.yml` (neu) 
 
Konfiguriert Dependabot für GitHub Actions: 
 
- Package-Ecosystem: `github-actions` 
- Schedule: monthly (Mo, 06:00 Europe/Vienna) 
- Commit-Prefix: `chore(ci)` mit Scope 
- PR-Limit: 5 
 
Pip ist bewusst nicht in der Konfig — Python-Dependency-Updates wären eigener Scope und können in einem separaten PR ergänzt werden. 
 
## Bewusst unverändert 
 
Bereits SHA-gepinnte Actions wurden nicht angefasst: 
 
- `github/codeql-action/init@c10b8064…` (in `codeql.yml`) 
- `github/codeql-action/analyze@c10b8064…` (in `codeql.yml`) 
- `github/codeql-action/upload-sarif@c10b8064…` (in `bandit.yml`) 
- `actions/upload-artifact@b4b15b8c…` (in `test-vor-api.yml`, `update-google-places-stations.yml`) 
 
Diese SHA-Pins haben keine Tag-Kommentare (wie `# v4`) — kosmetische Inkonsistenz, aber out of scope für diesen PR. Falls gewünscht: separater Mini-PR. 
 
## Sicherheits-Coverage 
 
| Vektor | Vorher | Nachher | 
|--------|--------|---------| 
| Maintainer-Tag-Re-Targeting | 3 Actions ungeschützt | 0 — alle SHA-gepinnt | 
| Erkennbarkeit von Action-Updates | manuell, niemand schaut | monatlich automatischer PR mit Release-Notes | 
| Audit-Trail von Action-Versionen | im Log nur `@v4` | im Repo: SHA + Tag-Kommentar | 
 
## Test-Plan 
 
- [x] Substitutions-Counts gleich Pre-Verify-Counts (11/9/4) 
- [x] YAML-Syntax aller Workflow-Files + Dependabot-Konfig valid 
- [x] `python scripts/run_static_checks.py` grün 
- [x] `python scripts/validate_stations.py` grün 
- [x] Vollständige pytest-Suite grün 
 
## Erwartetes Verhalten nach Merge 
 
- Beim nächsten Workflow-Lauf werden die neuen SHAs verwendet — funktional identisch zu den vorherigen Tag-Versionen, weil sie auf denselben Commit zeigen. 
- Dependabot startet seine Scans und öffnet beim nächsten Schedule (Mo 06:00 Wien) seinen ersten PR-Schub, falls neue Versionen verfügbar sind. Das ist erwartetes Verhalten. 
 
## Verbleibende Followups 
 
Aus #1081/#1082/#1083 unverändert: 
 
- README-Cache-Pfade konsolidieren, Badge-Casing zweite Gruppe, `.gitignore`-Pattern 
- mypy-Konfig schärfen 
- Eventschema `description minLength: 1` lockern 
- `pip<26`-Pin zeitlich begrenzen 
- `seo-guard.yml` Perl-Block migrieren 
- Build-Feed-Step `VOR_ACCESS_ID`-Cargo-Cult-Zeile entfernen 
- Optional: existierende SHA-Pins um Tag-Kommentare ergänzen (kosmetisch) 
- Optional: pip-Ecosystem in Dependabot-Konfig ergänzen 

---
*PR created automatically by Jules for task [3479983717076885520](https://jules.google.com/task/3479983717076885520) started by @Origamihase*