### PR TITLE
chore: comment pip<26 pin, relax description.minLength, drop dead VOR env

### DIFF
--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -42,13 +42,16 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Pin pip<26 vorsorglich gegen unerwartete Breaking Changes in pip 26.x.
+          # pip 26.0 ist seit 2026-01 released, 26.1 seit 2026-04 — Kompatibilität
+          # mit unseren Deps (defusedxml, openpyxl, dnspython) noch nicht durchgetestet.
+          # Re-evaluate als eigener Followup-PR. Letzte Prüfung: 2026-05-01.
           python -m pip install "pip<26"
           pip install -r requirements.txt
 
       - name: Build feed
         run: python src/build_feed.py
         env:
-          VOR_ACCESS_ID: ${{ secrets.VOR_API_KEY }}
           # Atom self/alternate-Links werden direkt im Python-Builder geschrieben.
           # Aus dem aktuellen Repo abgeleitet, damit Forks korrekte atom:link-URLs
           # schreiben statt auf das Original-Repo zu zeigen.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,10 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Pin pip<26 vorsorglich gegen unerwartete Breaking Changes in pip 26.x.
+          # pip 26.0 ist seit 2026-01 released, 26.1 seit 2026-04 — Kompatibilität
+          # mit unseren Deps (defusedxml, openpyxl, dnspython) noch nicht durchgetestet.
+          # Re-evaluate als eigener Followup-PR. Letzte Prüfung: 2026-05-01.
           python -m pip install "pip<26"
           pip install -r requirements-dev.txt
 

--- a/.github/workflows/update-google-places-stations.yml
+++ b/.github/workflows/update-google-places-stations.yml
@@ -40,6 +40,10 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Pin pip<26 vorsorglich gegen unerwartete Breaking Changes in pip 26.x.
+          # pip 26.0 ist seit 2026-01 released, 26.1 seit 2026-04 — Kompatibilität
+          # mit unseren Deps (defusedxml, openpyxl, dnspython) noch nicht durchgetestet.
+          # Re-evaluate als eigener Followup-PR. Letzte Prüfung: 2026-05-01.
           python -m pip install "pip<26"
           pip install -r requirements.txt
 

--- a/.github/workflows/update-oebb-cache.yml
+++ b/.github/workflows/update-oebb-cache.yml
@@ -37,6 +37,10 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Pin pip<26 vorsorglich gegen unerwartete Breaking Changes in pip 26.x.
+          # pip 26.0 ist seit 2026-01 released, 26.1 seit 2026-04 — Kompatibilität
+          # mit unseren Deps (defusedxml, openpyxl, dnspython) noch nicht durchgetestet.
+          # Re-evaluate als eigener Followup-PR. Letzte Prüfung: 2026-05-01.
           python -m pip install "pip<26"
           pip install -r requirements.txt
 

--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -30,6 +30,10 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Pin pip<26 vorsorglich gegen unerwartete Breaking Changes in pip 26.x.
+          # pip 26.0 ist seit 2026-01 released, 26.1 seit 2026-04 — Kompatibilität
+          # mit unseren Deps (defusedxml, openpyxl, dnspython) noch nicht durchgetestet.
+          # Re-evaluate als eigener Followup-PR. Letzte Prüfung: 2026-05-01.
           python -m pip install "pip<26"
           pip install -r requirements.txt
 

--- a/.github/workflows/update-vor-cache.yml
+++ b/.github/workflows/update-vor-cache.yml
@@ -51,6 +51,10 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Pin pip<26 vorsorglich gegen unerwartete Breaking Changes in pip 26.x.
+          # pip 26.0 ist seit 2026-01 released, 26.1 seit 2026-04 — Kompatibilität
+          # mit unseren Deps (defusedxml, openpyxl, dnspython) noch nicht durchgetestet.
+          # Re-evaluate als eigener Followup-PR. Letzte Prüfung: 2026-05-01.
           python -m pip install "pip<26"
           pip install -r requirements.txt
 

--- a/.github/workflows/update-wl-cache.yml
+++ b/.github/workflows/update-wl-cache.yml
@@ -43,6 +43,10 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Pin pip<26 vorsorglich gegen unerwartete Breaking Changes in pip 26.x.
+          # pip 26.0 ist seit 2026-01 released, 26.1 seit 2026-04 — Kompatibilität
+          # mit unseren Deps (defusedxml, openpyxl, dnspython) noch nicht durchgetestet.
+          # Re-evaluate als eigener Followup-PR. Letzte Prüfung: 2026-05-01.
           python -m pip install "pip<26"
           pip install -r requirements.txt
 

--- a/docs/feed.xml
+++ b/docs/feed.xml
@@ -4,8 +4,8 @@
     <title>ÖPNV Störungen Wien &amp; Pendler</title>
     <link>https://github.com/Origamihase/wien-oepnv</link>
     <description>Aktive Störungen/Baustellen/Einschränkungen aus offiziellen Quellen</description>
-    <atom:link rel="alternate" type="text/html" href="https://origamihase.github.io/wien-oepnv/" />
-    <atom:link rel="self" type="application/rss+xml" href="https://origamihase.github.io/wien-oepnv/feed.xml" />
+    <atom:link rel="alternate" type="text/html" href="https://origamihase.github.io/wien-oepnv/"/>
+    <atom:link rel="self" type="application/rss+xml" href="https://origamihase.github.io/wien-oepnv/feed.xml"/>
     <language>de</language>
     <lastBuildDate>Fri, 01 May 2026 22:47:57 +0200</lastBuildDate>
     <ttl>15</ttl>

--- a/docs/schema/events.schema.json
+++ b/docs/schema/events.schema.json
@@ -32,7 +32,6 @@
     },
     "description": {
       "type": "string",
-      "minLength": 1,
       "description": "Ausführliche Beschreibung, inklusive Umleitungen und Zusatzinformationen."
     },
     "link": {


### PR DESCRIPTION
---

## Kontext

Drei voneinander unabhängige Mini-Cleanups, die für sich allein einen eigenen PR nicht rechtfertigen würden. Jeder unter 5 Zeilen Diff. Bewusster Bruch unseres Single-Issue-Patterns aus Effizienzgründen.

## Änderungen

### 1. `pip<26`-Pin mit Kontext kommentieren (7 Workflow-Files)

Der Pin `python -m pip install "pip<26"` existiert in sieben Workflow-Files ohne Kommentar oder Begründung. Pip 26.0 ist seit 2026-01-30 released und stabil, pip 26.1 seit 2026-04-26 — der Pin blockt also bewusst eine produktiv genutzte Major-Linie. Damit zukünftige Maintainer den Pin nicht für Cargo-Cult halten und pauschal entfernen, bekommt er einen Kommentar mit Re-Evaluations-Anker:

```yaml
          # Pin pip<26 vorsorglich gegen unerwartete Breaking Changes in pip 26.x.
          # pip 26.0 ist seit 2026-01 released, 26.1 seit 2026-04 — Kompatibilität
          # mit unseren Deps (defusedxml, openpyxl, dnspython) noch nicht durchgetestet.
          # Re-evaluate als eigener Followup-PR. Letzte Prüfung: 2026-05-01.
          python -m pip install "pip<26"
```

Betroffene Files: `update-vor-cache.yml`, `update-oebb-cache.yml`, `update-google-places-stations.yml`, `update-stations.yml`, `update-wl-cache.yml`, `build-feed.yml`, `test.yml`. Identischer Kommentarblock in allen sieben.

Eine inhaltliche Lockerung des Pins (z.B. auf `pip<27`) ist bewusst out of scope — das ist ein eigener PR mit eigenem Test-Plan.

### 2. `description.minLength: 1` aus dem Eventschema entfernen

Datei: `docs/schema/events.schema.json`. Die `description`-Property hatte `minLength: 1`, was leere Beschreibungen invalidiert hätte. In der Praxis gibt es Meldungen, deren Title bereits alle relevanten Informationen enthält (z.B. „U4 Karlsplatz: Aufzug außer Betrieb") — eine zusätzliche Description wäre redundant. Die anderen Required-Felder (`source`, `category`, `title`, `guid`) behalten ihren `minLength: 1`-Pin, weil leere Werte dort tatsächlich auf einen Datenfehler hindeuten würden.

Hinweis: Das Schema wird derzeit in keiner automatisierten Validierung im Code verwendet (keine `.py`-Datei lädt es via JSON-Schema-Validator). Es dient als Dokumentation für externe Konsumenten gemäß README-Sektion „Datenformat der Ereignisse". Die Änderung hat damit keinen Test-Effekt, ist aber inhaltlich korrekter.

### 3. `VOR_ACCESS_ID: ${{ secrets.VOR_API_KEY }}`-Zeile aus `build-feed.yml` entfernen

Das Secret `VOR_API_KEY` existiert nicht (mehr) in den Repo-Settings — es wurde durch `VOR_ACCESS_ID` ersetzt. Die Zeile setzte die Env-Var also auf `""`. Da `build_feed.py` ohnehin nur Caches aus `cache/vor/events.json` liest und keine Live-VOR-API-Calls macht, war die Zeile schon vorher inert. Wir entfernen sie zur Aufräumen — der Build-Feed-Step braucht keinen VOR-Token-Pfad.

Die Atom-Link-Kommentare und `PAGES_BASE_URL` im selben env-Block bleiben unverändert.

## Test-Plan

- [x] 7 Workflow-Files mit identischem `# Pin pip<26 vorsorglich`-Kommentar
- [x] `docs/schema/events.schema.json` ist valides JSON, `description.minLength` weg, andere `minLength`-Pins bleiben
- [x] `build-feed.yml` enthält kein `VOR_ACCESS_ID` mehr, env-Block syntaktisch sauber
- [x] YAML-Syntax aller `.github/**/*.yml` valid
- [x] `python scripts/run_static_checks.py` grün
- [x] `python scripts/validate_stations.py` grün
- [x] Vollständige pytest-Suite grün

## Erwartetes Verhalten nach Merge

Funktional unverändert. Kein Workflow-Lauf-Verhalten ändert sich. Nur Code-Hygiene und Dokumentation.

## Verbleibende Followups

Aus früheren PRs:

- README-Cache-Pfade konsolidieren, Badge-Casing zweite Gruppe, `.gitignore`-Pattern
- mypy-Konfig schärfen
- `seo-guard.yml` Perl-Block migrieren (umfangreicher als #1087, weil zusätzlich robots.txt, sitemap, canonical URLs, global dedupe)
- pip-Pin lockern oder entfernen (separater PR mit Test-Plan)
- `VOR_API_KEY` → `VOR_ACCESS_ID`-Rename (mit dieser PR faktisch komplett — Suche nach `VOR_API_KEY` liefert nach Merge null Treffer)
- Optional: existierende SHA-Pins (codeql-action, upload-artifact) um Tag-Kommentare ergänzen
- Optional: pip-Ecosystem in Dependabot-Konfig ergänzen

---

---
*PR created automatically by Jules for task [10298858231784369952](https://jules.google.com/task/10298858231784369952) started by @Origamihase*