### PR TITLE
chore(docs): document cache hash suffix, fix badge URL casing, drop dead .gitignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,3 @@ docs/sitemap.xml
 data/vor_request_count.json
 .hypothesis/
 patch_lines.patch
-cache/*/events.json

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Update ÖBB Cache](https://github.com/Origamihase/wien-oepnv/actions/workflows/update-oebb-cache.yml/badge.svg)](https://github.com/Origamihase/wien-oepnv/actions/workflows/update-oebb-cache.yml)
 [![Test VOR API](https://github.com/Origamihase/wien-oepnv/actions/workflows/test-vor-api.yml/badge.svg)](https://github.com/Origamihase/wien-oepnv/actions/workflows/test-vor-api.yml)
 
-[![Feed Build](https://github.com/origamihase/wien-oepnv/actions/workflows/build-feed.yml/badge.svg?branch=main)](https://github.com/origamihase/wien-oepnv/actions/workflows/build-feed.yml)
-[![Tests](https://github.com/origamihase/wien-oepnv/actions/workflows/test.yml/badge.svg)](https://github.com/origamihase/wien-oepnv/actions/workflows/test.yml)
-[![SEO-Checks](https://github.com/origamihase/wien-oepnv/actions/workflows/seo-guard.yml/badge.svg)](https://github.com/origamihase/wien-oepnv/actions/workflows/seo-guard.yml)
+[![Feed Build](https://github.com/Origamihase/wien-oepnv/actions/workflows/build-feed.yml/badge.svg?branch=main)](https://github.com/Origamihase/wien-oepnv/actions/workflows/build-feed.yml)
+[![Tests](https://github.com/Origamihase/wien-oepnv/actions/workflows/test.yml/badge.svg)](https://github.com/Origamihase/wien-oepnv/actions/workflows/test.yml)
+[![SEO-Checks](https://github.com/Origamihase/wien-oepnv/actions/workflows/seo-guard.yml/badge.svg)](https://github.com/Origamihase/wien-oepnv/actions/workflows/seo-guard.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Subscribe to Feed](https://img.shields.io/badge/RSS-Subscribe_to_Feed-orange?style=flat&logo=rss)](https://origamihase.github.io/wien-oepnv/feed.xml)
 
@@ -52,6 +52,9 @@ Der Feed-Bau folgt einem klaren Ablauf:
 | `docs/`               | Audit-Berichte, Referenzen, Beispiel-Feeds und das offizielle VAO/VOR-API-Handbuch.              |
 | `.github/workflows/`  | Automatisierte Jobs für Cache-Updates, Stationspflege, Feed-Erzeugung und Tests.                |
 | `tests/`              | Umfangreiche Pytest-Suite (>250 Tests) für Feed-Logik, Provider-Adapter und Utility-Funktionen.  |
+
+
+> **Hinweis zu Cache-Pfaden:** Die tatsächlichen Verzeichnisse unter `cache/` tragen einen Hash-Suffix zur Cache-Versionierung (Stand Mai 2026: `cache/wl_9d709a/`, `cache/oebb_c40d21/`, `cache/vor_929f1c/`). In dieser Dokumentation werden aus Lesbarkeitsgründen verkürzte Schreibweisen wie `cache/wl/events.json` verwendet — sie verweisen jeweils auf das aktuelle Provider-Verzeichnis.
 
 ## Repository-SEO & Promotion
 


### PR DESCRIPTION
## Kontext

Drei kleine Doku-Cleanups, die als Endspurt der laufenden Code-Hygiene-Welle gehören. Jeder einzelne unter 5 Zeilen Diff, alle drei zusammen schließen die letzten dokumentierbaren Loose Ends ab.

## Änderungen

### 1. Cache-Hash-Suffix dokumentiert

Die tatsächlichen Cache-Verzeichnisse heißen `cache/wl_9d709a/`, `cache/oebb_c40d21/`, `cache/vor_929f1c/` — also mit Hash-Suffix zur Cache-Versionierung. Die README verwendet aber an mehreren Stellen die abgekürzte Schreibweise `cache/wl/events.json` ohne Erklärung, was zu Verwirrung führen kann (besonders für externe Datenkonsumenten, die im Repo schauen und ihre Pfade nicht finden).

Eine kurze Hinweis-Box am Ende der Repository-Gliederung erklärt das Hash-System mit den aktuellen Hashes als Beispielen und legitimiert die abgekürzten Schreibweisen als bewusste Lesbarkeits-Konvention. Die Hashes sind mit „Stand Mai 2026" datiert, weil sie sich bei Konfigurations-Änderungen ändern können.

### 2. Badge-URL-Casing in der zweiten Gruppe konsistent gemacht

Im Status-Badge-Bereich am Anfang der README hatten die drei Badges der zweiten Gruppe (Feed Build, Tests, SEO-Checks) GitHub-API-URLs mit `origamihase` (klein), während die drei Badges der ersten Gruppe (Update VOR Cache, Update ÖBB Cache, Test VOR API) bereits `Origamihase` (groß, korrekt) verwendeten. Beide Schreibweisen funktionieren, weil GitHub case-insensitive auf Usernames reagiert, aber konsistent ist nur die korrekte Schreibweise.

Sechs Substitutionen (drei Badges × image-URL + link-URL): `github.com/origamihase/wien-oepnv` → `github.com/Origamihase/wien-oepnv`.

Die Subscribe-Badge mit `origamihase.github.io/wien-oepnv/feed.xml` bleibt unverändert — GitHub Pages folgt einer anderen Convention und erwartet Lowercase.

### 3. Toter `.gitignore`-Eintrag entfernt

`.gitignore` enthielt `cache/*/events.json`, was wirkungslos war: die `events.json`-Files in `cache/wl_*/`, `cache/oebb_*/`, `cache/vor_*/` werden bewusst committed und sind als „versionierte Provider-Zwischenspeicher" Teil des Repos. Das Pattern hatte keinen aktiven Effekt mehr und kein vorausschauender Zweck war erkennbar.

## Test-Plan

- [x] Pytest-Suite grün (keine Verhaltensänderung, aber als Sicherheitsnetz gefahren)
- [x] `python scripts/run_static_checks.py` grün
- [x] `python scripts/validate_stations.py` grün
- [x] README rendert auf GitHub korrekt (Badge-Section, neue Hinweis-Box)

## Bewusst unverändert

- **Konkrete Cache-Pfad-Erwähnungen** (`cache/wl/events.json` an Zeile 228, `cache/oebb/events.json` an Zeile 241, etc.) bleiben in ihrer abgekürzten Form. Mit der neuen Hinweis-Box sind sie jetzt offiziell legitimiert.
- **Subscribe-Badge** mit `origamihase.github.io` bleibt klein — GitHub Pages convention.
- **Erste Badge-Gruppe** war schon korrekt mit `Origamihase` (groß).

## Verbleibende Followups

Nach diesem PR offen:

- `seo-guard.yml` Perl-Block migrieren (umfangreich: robots.txt, sitemap, canonical URLs, global dedupe)
- pip-Pin lockern oder entfernen (separater PR mit Test-Plan)
- `python -m src.cli checks`-Wrapper-Bug untersuchen falls reproducibel kaputt
- Optional: existierende SHA-Pins (codeql-action, upload-artifact) um Tag-Kommentare ergänzen
- Optional: pip-Ecosystem in Dependabot-Konfig ergänzen
- Optional: `tests/` strikt typisieren (großer eigener Refactor)
- Optional: `disallow_any_explicit` aktivieren (220 Findings)

---
*PR created automatically by Jules for task [2391376632747809268](https://jules.google.com/task/2391376632747809268) started by @Origamihase*