### PR TITLE
chore(deps): remove duplicate pytest-timeout entry in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,3 @@ hypothesis>=6.0
 pytest>=9.0.3
 responses>=0.25,<1
 pytest-timeout
-pytest-timeout


### PR DESCRIPTION
## Was 
 
Doppelten `pytest-timeout`-Eintrag in `requirements-dev.txt` entfernt 
(stand zweimal am Ende, beide unversioned). 
 
## Warum 
 
Kosmetisch. pip dedupliziert bereits, der zweite Eintrag war ein no-op 
— aber im Repo unsauber sichtbar. 
 
## Wie verifiziert 
 
- `grep -c '^pytest-timeout$' requirements-dev.txt` zeigt jetzt 1 (vorher 2). 
- `pip install --dry-run -r requirements*.txt` löst auf. 
- `python -c "import pytest_timeout"` importable. 
- `pytest --collect-only` läuft, das Plugin lädt korrekt. 
 
## Berührte Dateien 
 
- `requirements-dev.txt` (eine Zeile entfernt)

---
*PR created automatically by Jules for task [15625418756256713957](https://jules.google.com/task/15625418756256713957) started by @Origamihase*