### PR TITLE
chore(ci): replace hardcoded commit_message in update-stations.yml

### DIFF
--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -50,6 +50,6 @@ jobs:
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
-          commit_message: "chore(data): add VOR stations (900100, 900300) + CI harden"
+          commit_message: "chore(data): refresh station directory [skip ci]"
           add_options: "-A"
           push_options: "--force-with-lease"


### PR DESCRIPTION
## Was

`commit_message` im `git-auto-commit-action`-Step von
`update-stations.yml` von hardcoded auf generisch geändert.

Vorher: `"chore(data): add VOR stations (900100, 900300) + CI harden"`
Nachher: `"chore(data): refresh station directory [skip ci]"`

## Warum

Die alte Message war an einen konkreten alten PR gekoppelt. Bei jedem
Schedule-Lauf (monatlich) oder manuellen Trigger würde der Auto-Commit
genau diese irreführende Message tragen — "add VOR stations" suggeriert
eine Datenstruktur-Änderung, die in einem Routine-Refresh nicht
stattfindet.

Neue Message folgt dem Pattern der anderen update-Workflows (z. B.
`update-vor-cache.yml`: `'chore: update VOR cache [skip ci]'`),
inklusive `[skip ci]` für Routine-Datenrefreshes.

## Wie verifiziert

- `yaml.safe_load` ohne Exception.
- Alte Message-String 0 Vorkommen, neue Message-String genau 1.
- `commit_message:`-Key existiert weiterhin (nicht versehentlich
  entfernt).
- Step-Struktur unverändert.

## Berührte Dateien

- `.github/workflows/update-stations.yml` (eine Zeile geändert)

---
*PR created automatically by Jules for task [4416182028546708801](https://jules.google.com/task/4416182028546708801) started by @Origamihase*