### PR TITLE
refactor(stations): extract VOR/OEBB validation into stations_validation library

### DIFF
--- a/scripts/validate_stations.py
+++ b/scripts/validate_stations.py
@@ -1,17 +1,26 @@
 #!/usr/bin/env python3
-"""Validate station directory entries for VOR metadata."""
+"""Validate station directory entries for VOR metadata.
+
+Thin CLI wrapper around :func:`src.utils.stations_validation.validate_stations`.
+Exit code semantics are preserved from the previous inline implementation:
+only ``provider_issues`` and ``cross_station_id_issues`` trigger a non-zero
+exit. Other issue categories (alias, coordinate, GTFS, security, duplicate)
+are tolerated to match historical CLI behaviour and to keep the
+``scripts/update_all_stations.py`` wrapper's strictness contract unchanged.
+"""
 
 from __future__ import annotations
 
 import argparse
-import json
-import re
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
-from src.utils.stations_validation import validate_stations
+from src.utils.stations_validation import (  # noqa: E402
+    StationValidationError,
+    validate_stations,
+)
 
 
 def main() -> int:
@@ -25,87 +34,31 @@ def main() -> int:
         help="Path to stations.json to validate (default: data/stations.json)",
     )
     args = parser.parse_args()
-    stations_path = args.stations
 
     try:
-        data = json.loads(stations_path.read_text(encoding="utf-8"))
-        if isinstance(data, dict):
-            stations = data.get("stations", [])
-        elif isinstance(data, list):
-            stations = data
-        else:
-            stations = []
-    except FileNotFoundError:
-        print("data/stations.json not found", file=sys.stderr)
-        return 1
-    except json.JSONDecodeError as exc:
-        print(f"Invalid JSON in data/stations.json: {exc}", file=sys.stderr)
+        report = validate_stations(args.stations)
+    except StationValidationError as exc:
+        print(str(exc), file=sys.stderr)
         return 1
 
-    vor_entries = []
-    for station in stations:
-        source = station.get("source")
-        is_vor = False
-        if isinstance(source, str):
-            parts = [s.strip() for s in source.split(",")]
-            if "vor" in parts:
-                is_vor = True
-        elif isinstance(source, list):
-            if "vor" in source:
-                is_vor = True
+    has_error = False
 
-        if is_vor:
-            vor_entries.append(station)
+    if report.provider_issues:
+        for p_issue in report.provider_issues:
+            print(p_issue.reason, file=sys.stderr)
+        has_error = True
 
-    if len(vor_entries) < 2:
-        print("Need at least two VOR entries", file=sys.stderr)
-        return 1
-
-    # Historically, we expected all VOR identifiers to start with "900" and be six
-    # digits long. In practice there are legitimate five digit identifiers such as
-    # "93010" which caused the validation to reject otherwise valid data. Allow
-    # either five or six digit numeric identifiers starting with "9".
-    pattern = re.compile(r"9\d{4,5}")
-    for station in vor_entries:
-        for key in ("bst_id", "bst_code"):
-            value = station.get(key)
-            if not isinstance(value, str) or not pattern.fullmatch(value):
-                print(f"Invalid {key} for VOR: {value}", file=sys.stderr)
-                return 1
-
-    oebb_codes = set()
-    for station in stations:
-        source = station.get("source")
-        is_oebb = False
-        if isinstance(source, str):
-            parts = [s.strip() for s in source.split(",")]
-            if "oebb" in parts:
-                is_oebb = True
-        elif isinstance(source, list):
-            if "oebb" in source:
-                is_oebb = True
-
-        if is_oebb:
-            bst_code = station.get("bst_code")
-            if bst_code:
-                oebb_codes.add(bst_code)
-    conflicts = [station for station in vor_entries if station.get("bst_code") in oebb_codes]
-    if conflicts:
-        print("VOR bst_code collides with OEBB", file=sys.stderr)
-        return 1
-
-    report = validate_stations(stations_path)
     if report.cross_station_id_issues:
-        for issue in report.cross_station_id_issues:
+        for c_issue in report.cross_station_id_issues:
             print(
-                f"Cross-station alias conflict: Alias '{issue.alias}' in '{issue.name}' "
-                f"({issue.identifier}) collides with {issue.colliding_field} of "
-                f"'{issue.colliding_name}' ({issue.colliding_identifier})",
+                f"Cross-station alias conflict: Alias '{c_issue.alias}' in '{c_issue.name}' "
+                f"({c_issue.identifier}) collides with {c_issue.colliding_field} of "
+                f"'{c_issue.colliding_name}' ({c_issue.colliding_identifier})",
                 file=sys.stderr,
             )
-        return 1
+        has_error = True
 
-    return 0
+    return 1 if has_error else 0
 
 
 if __name__ == "__main__":

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -77,6 +77,15 @@ class CrossStationIDIssue:
 
 
 @dataclass(frozen=True)
+class ProviderIssue:
+    """VOR/OEBB consistency issue (e.g. invalid VOR identifier, OEBB collision)."""
+
+    identifier: str
+    name: str
+    reason: str
+
+
+@dataclass(frozen=True)
 class ValidationReport:
     """Summary returned by :func:`validate_stations`."""
 
@@ -87,6 +96,7 @@ class ValidationReport:
     gtfs_issues: tuple[GTFSIssue, ...]
     security_issues: tuple[SecurityIssue, ...]
     cross_station_id_issues: tuple[CrossStationIDIssue, ...]
+    provider_issues: tuple[ProviderIssue, ...]
     gtfs_stop_count: int
 
     @property
@@ -98,6 +108,7 @@ class ValidationReport:
             or self.gtfs_issues
             or self.security_issues
             or self.cross_station_id_issues
+            or self.provider_issues
         )
 
     def to_markdown(self) -> str:
@@ -109,6 +120,7 @@ class ValidationReport:
         lines.append(f"*Coordinate anomalies*: {len(self.coordinate_issues)}")
         lines.append(f"*GTFS mismatches*: {len(self.gtfs_issues)}")
         lines.append(f"*Security warnings*: {len(self.security_issues)}")
+        lines.append(f"*Provider issues*: {len(self.provider_issues)}")
         lines.append("")
 
         if self.security_issues:
@@ -116,6 +128,14 @@ class ValidationReport:
             for sec_issue in self.security_issues:
                 lines.append(
                     f"- {sec_issue.identifier} ({sec_issue.name}): {sec_issue.reason}"
+                )
+            lines.append("")
+
+        if self.provider_issues:
+            lines.append("## Provider issues (VOR/OEBB)")
+            for provider_issue in self.provider_issues:
+                lines.append(
+                    f"- {provider_issue.identifier} ({provider_issue.name}): {provider_issue.reason}"
                 )
             lines.append("")
 
@@ -184,6 +204,7 @@ def validate_stations(
     gtfs_issues = tuple(_find_gtfs_issues(stations, gtfs_stop_ids))
     security_issues = tuple(_find_security_issues(stations))
     cross_station_id_issues = tuple(_find_cross_station_id_conflicts(stations))
+    provider_issues = tuple(_find_provider_issues(stations))
 
     return ValidationReport(
         total_stations=len(stations),
@@ -193,6 +214,7 @@ def validate_stations(
         gtfs_issues=gtfs_issues,
         security_issues=security_issues,
         cross_station_id_issues=cross_station_id_issues,
+        provider_issues=provider_issues,
         gtfs_stop_count=gtfs_count,
     )
 
@@ -422,6 +444,10 @@ def _find_gtfs_issues(
 
 _UNSAFE_CHARS_RE = re.compile(r"[<>\x00-\x08\x0b\x0c\x0e-\x1f\u2028-\u202e\u2066-\u2069]")
 
+# Historically VOR identifiers were six digits starting with "9". In practice some
+# legitimate identifiers are five digits (e.g. "93010"), so we accept either.
+_VOR_ID_PATTERN = re.compile(r"9\d{4,5}")
+
 
 def _find_cross_station_id_conflicts(
     stations: Sequence[Mapping[str, object]]
@@ -460,6 +486,75 @@ def _find_cross_station_id_conflicts(
                             colliding_name=str(colliding_entry.get("name", "")).strip() or "<unknown>",
                             colliding_field=field,
                         )
+
+
+def _extract_source_tokens(value: object) -> set[str]:
+    """Return the set of provider source tokens for a stations entry.
+
+    Mirrors the behaviour of the inline logic that previously lived in
+    ``scripts/validate_stations.py``: comma-separated strings are split and
+    stripped, lists are taken as-is (filtered to strings).
+    """
+    if isinstance(value, str):
+        return {token.strip() for token in value.split(",") if token.strip()}
+    if isinstance(value, list):
+        return {item for item in value if isinstance(item, str)}
+    return set()
+
+
+def _find_provider_issues(
+    stations: Sequence[Mapping[str, object]]
+) -> Iterator[ProviderIssue]:
+    """Find VOR/OEBB consistency issues.
+
+    Replicates the checks from the previous inline implementation in
+    ``scripts/validate_stations.py``:
+
+    1. At least two stations must declare VOR as a source.
+    2. Each VOR station's ``bst_id`` and ``bst_code`` must match the VOR id
+       pattern (``_VOR_ID_PATTERN``).
+    3. No VOR station's ``bst_code`` may collide with the ``bst_code`` of any
+       OEBB-sourced station.
+    """
+    vor_entries: list[Mapping[str, object]] = []
+    oebb_codes: set[object] = set()
+
+    for entry in stations:
+        sources = _extract_source_tokens(entry.get("source"))
+        if "vor" in sources:
+            vor_entries.append(entry)
+        if "oebb" in sources:
+            bst_code = entry.get("bst_code")
+            if bst_code:
+                oebb_codes.add(bst_code)
+
+    if len(vor_entries) < 2:
+        yield ProviderIssue(
+            identifier="<global>",
+            name="<global>",
+            reason="Need at least two VOR entries",
+        )
+        return
+
+    for entry in vor_entries:
+        identifier = _format_identifier(entry)
+        name = str(entry.get("name", "")).strip() or "<unknown>"
+        for key in ("bst_id", "bst_code"):
+            value = entry.get(key)
+            if not isinstance(value, str) or not _VOR_ID_PATTERN.fullmatch(value):
+                yield ProviderIssue(
+                    identifier=identifier,
+                    name=name,
+                    reason=f"Invalid {key} for VOR: {value}",
+                )
+
+    for entry in vor_entries:
+        if entry.get("bst_code") in oebb_codes:
+            yield ProviderIssue(
+                identifier=_format_identifier(entry),
+                name=str(entry.get("name", "")).strip() or "<unknown>",
+                reason="VOR bst_code collides with OEBB",
+            )
 
 
 def _find_security_issues(

--- a/tests/test_stations_validation_provider.py
+++ b/tests/test_stations_validation_provider.py
@@ -1,0 +1,169 @@
+"""Tests for VOR/OEBB provider validation in stations_validation.
+
+These tests cover the logic that was previously inline in
+``scripts/validate_stations.py:main()`` and is now in
+``src.utils.stations_validation._find_provider_issues``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.utils.stations_validation import validate_stations
+
+
+def _write(path: Path, entries: list[dict[str, object]]) -> None:
+    path.write_text(json.dumps({"stations": entries}), encoding="utf-8")
+
+
+def _vor_entry(bst: str, name: str, lat: float = 48.2, lon: float = 16.4) -> dict[str, object]:
+    return {
+        "name": name,
+        "bst_id": bst,
+        "bst_code": bst,
+        "vor_id": bst,
+        "aliases": [name, bst],
+        "latitude": lat,
+        "longitude": lon,
+        "source": "vor",
+    }
+
+
+def _oebb_entry(bst_code: str, name: str, lat: float = 48.2, lon: float = 16.4) -> dict[str, object]:
+    return {
+        "name": name,
+        "bst_id": "100",
+        "bst_code": bst_code,
+        "vor_id": "490000000",
+        "aliases": [name, bst_code, "490000000"],
+        "latitude": lat,
+        "longitude": lon,
+        "source": "oebb",
+    }
+
+
+def test_provider_issues_field_exists(tmp_path: Path) -> None:
+    """Regression: ValidationReport must expose provider_issues."""
+    path = tmp_path / "stations.json"
+    _write(path, [_vor_entry("900100", "A"), _vor_entry("900200", "B", lat=48.3)])
+    report = validate_stations(path)
+    assert hasattr(report, "provider_issues")
+    assert isinstance(report.provider_issues, tuple)
+
+
+def test_clean_data_has_no_provider_issues(tmp_path: Path) -> None:
+    path = tmp_path / "stations.json"
+    _write(path, [_vor_entry("900100", "A"), _vor_entry("900200", "B", lat=48.3)])
+    report = validate_stations(path)
+    assert report.provider_issues == ()
+
+
+def test_less_than_two_vor_entries_reports_global_issue(tmp_path: Path) -> None:
+    path = tmp_path / "stations.json"
+    _write(path, [_vor_entry("900100", "A")])
+    report = validate_stations(path)
+    reasons = [issue.reason for issue in report.provider_issues]
+    assert "Need at least two VOR entries" in reasons
+    # When the global check fails, the per-entry checks must be skipped to match
+    # the early-return behaviour of the previous implementation.
+    assert len(report.provider_issues) == 1
+
+
+def test_zero_vor_entries_reports_global_issue(tmp_path: Path) -> None:
+    path = tmp_path / "stations.json"
+    _write(path, [_oebb_entry("Abc", "A"), _oebb_entry("Def", "B", lat=48.3)])
+    report = validate_stations(path)
+    reasons = [issue.reason for issue in report.provider_issues]
+    assert reasons == ["Need at least two VOR entries"]
+
+
+def test_invalid_vor_bst_id_is_reported(tmp_path: Path) -> None:
+    path = tmp_path / "stations.json"
+    bad = _vor_entry("900100", "A")
+    bad["bst_id"] = "not-a-vor-id"
+    _write(path, [bad, _vor_entry("900200", "B", lat=48.3)])
+    report = validate_stations(path)
+    reasons = [issue.reason for issue in report.provider_issues]
+    assert "Invalid bst_id for VOR: not-a-vor-id" in reasons
+
+
+def test_invalid_vor_bst_code_is_reported(tmp_path: Path) -> None:
+    path = tmp_path / "stations.json"
+    bad = _vor_entry("900100", "A")
+    bad["bst_code"] = "not-a-vor-code"
+    _write(path, [bad, _vor_entry("900200", "B", lat=48.3)])
+    report = validate_stations(path)
+    reasons = [issue.reason for issue in report.provider_issues]
+    assert "Invalid bst_code for VOR: not-a-vor-code" in reasons
+
+
+def test_missing_vor_bst_id_is_reported(tmp_path: Path) -> None:
+    path = tmp_path / "stations.json"
+    bad = _vor_entry("900100", "A")
+    del bad["bst_id"]
+    _write(path, [bad, _vor_entry("900200", "B", lat=48.3)])
+    report = validate_stations(path)
+    reasons = [issue.reason for issue in report.provider_issues]
+    assert "Invalid bst_id for VOR: None" in reasons
+
+
+def test_five_digit_vor_id_is_accepted(tmp_path: Path) -> None:
+    """Five-digit VOR ids like '93010' must validate (regression: see comment in module)."""
+    path = tmp_path / "stations.json"
+    _write(
+        path,
+        [
+            _vor_entry("93010", "A"),
+            _vor_entry("93011", "B", lat=48.3),
+        ],
+    )
+    report = validate_stations(path)
+    assert report.provider_issues == ()
+
+
+def test_vor_bst_code_collides_with_oebb(tmp_path: Path) -> None:
+    path = tmp_path / "stations.json"
+    _write(
+        path,
+        [
+            _vor_entry("900100", "VOR-A"),
+            _vor_entry("900200", "VOR-B", lat=48.3),
+            _oebb_entry("900100", "OEBB-conflict", lat=48.4),
+        ],
+    )
+    report = validate_stations(path)
+    reasons = [issue.reason for issue in report.provider_issues]
+    assert "VOR bst_code collides with OEBB" in reasons
+
+
+def test_source_string_with_spaces_is_parsed(tmp_path: Path) -> None:
+    """`source: 'google_places, vor, wl'` (with whitespace after commas) must be recognised as VOR.
+
+    This format appears in real production data (data/stations.json).
+    """
+    path = tmp_path / "stations.json"
+    entry_a = _vor_entry("900100", "A")
+    entry_a["source"] = "google_places, vor, wl"
+    entry_b = _vor_entry("900200", "B", lat=48.3)
+    entry_b["source"] = "google_places,vor"  # no whitespace variant
+    _write(path, [entry_a, entry_b])
+    report = validate_stations(path)
+    assert report.provider_issues == ()
+
+
+def test_real_data_has_no_provider_issues() -> None:
+    """Regression test against the actual repo data."""
+    path = Path("data/stations.json")
+    report = validate_stations(path)
+    assert report.provider_issues == (), (
+        f"Unexpected provider issues in data/stations.json: {report.provider_issues}"
+    )
+
+
+def test_has_issues_flips_on_provider_issue(tmp_path: Path) -> None:
+    """ValidationReport.has_issues must include provider_issues."""
+    path = tmp_path / "stations.json"
+    _write(path, [_vor_entry("900100", "A")])  # only 1 VOR entry → provider issue
+    report = validate_stations(path)
+    assert report.provider_issues
+    assert report.has_issues is True

--- a/tests/test_stations_validation_unsafe.py
+++ b/tests/test_stations_validation_unsafe.py
@@ -53,9 +53,23 @@ def test_validation_passes_safe_chars(tmp_path):
         "stations": [
             {
                 "name": "Safe Station (Hbf)",
+                "bst_id": "900100",
+                "bst_code": "900100",
+                "vor_id": "900100",
+                "aliases": ["Safe Station (Hbf)", "Safe / Alias", "St. Pölten", "900100"],
                 "latitude": 48.0,
                 "longitude": 16.0,
-                "aliases": ["Safe Station (Hbf)", "Safe / Alias", "St. Pölten"]
+                "source": "vor"
+            },
+            {
+                "name": "Safe Station 2",
+                "bst_id": "900200",
+                "bst_code": "900200",
+                "vor_id": "900200",
+                "aliases": ["Safe Station 2", "900200"],
+                "latitude": 48.1,
+                "longitude": 16.1,
+                "source": "vor"
             }
         ]
     }


### PR DESCRIPTION
## Summary

Extracts the VOR/OEBB validation logic from `scripts/validate_stations.py:main()` into `src.utils.stations_validation` so it can be reused as a library. The CLI is rewritten as a thin wrapper around `validate_stations()`. The wrapper in `scripts/update_all_stations.py` is **not** touched in this PR.

## Why

`scripts/update_all_stations.py` currently invokes `scripts/validate_stations.py` via `subprocess.run`. The reason is purely historical: the VOR/OEBB checks lived only in the script. With those checks now in the library, a follow-up PR-B can replace the subprocess call with a direct `validate_stations()` import, completing the pre-write copy-on-write pattern from #1104.

## Changes

- New `ProviderIssue` dataclass in `src.utils.stations_validation`.
- New `_find_provider_issues` finder, replicating the three checks from the old CLI:
  1. At least two VOR entries must exist.
  2. Each VOR entry's `bst_id` and `bst_code` must match `r"9\d{4,5}"` (preserving the five-digit-allowance regression fix).
  3. No VOR entry's `bst_code` may collide with an OEBB entry's `bst_code`.
- New `_extract_source_tokens` helper that mirrors the inline source-parsing semantics (comma-split with strip for strings, identity for lists).
- New `_VOR_ID_PATTERN` module-level constant to avoid recompiling the regex per call.
- `ValidationReport` gains a `provider_issues: tuple[ProviderIssue, ...]` field, included in `has_issues` and in `to_markdown()`.
- `scripts/validate_stations.py` rewritten as a thin CLI wrapper.

## Behaviour preservation

The CLI's exit-code contract is preserved: only `provider_issues` and `cross_station_id_issues` cause a non-zero exit. Alias, coordinate, GTFS, security, and duplicate issues remain tolerated, as they were before. This matches the historical CLI strictness and keeps `scripts/update_all_stations.py` unaffected.

## Behaviour change (intentional, minor)

The old CLI returned at the first failure within each check block. The new CLI prints **all** `provider_issues` before exiting. Exit codes are identical. This is a small UX improvement and does not affect any caller that only inspects the exit code (the wrapper).

## Test fixture adjustment

`tests/test_stations_validation_unsafe.py:test_validation_passes_safe_chars` previously used a single-station fixture without VOR data. With `provider_issues` now included in `ValidationReport.has_issues`, that fixture would trip the new "Need at least two VOR entries" check and fail the test's `assert not report.has_issues`.

The fixture is updated to contain two valid VOR entries while preserving the original safe-character test data. The test's intent — that safe characters in `name` / `bst_code` / `vor_id` / `aliases` do not produce `security_issues` — is unchanged, and the assertions that exercise that behaviour remain in place.

This adjustment is the only change to an existing test file in this PR.

## Out of scope (follow-ups)

- **PR-B**: replace the `subprocess.run(["python", "scripts/validate_stations.py", ...])` call in `scripts/update_all_stations.py` with `from src.utils.stations_validation import validate_stations` and check `report.provider_issues or report.cross_station_id_issues` (preserving today's strictness).
- The `cross_station_id_issues` block is missing from `to_markdown()` — pre-existing bug, tracked separately.
- The duplicated `sys.path.insert` lines at the top of the CLI — pre-existing, separate cleanup.

## Verification

Existing tests pass:
```
tests/test_stations_validation_cross_id.py::test_cross_station_id_conflict_bst_code PASSED [ 20%]
tests/test_stations_validation_cross_id.py::test_cross_station_id_conflict_vor_id PASSED [ 40%]
tests/test_stations_validation_cross_id.py::test_cross_station_id_no_conflict_self_reference PASSED [ 60%]
tests/test_stations_validation_cross_id.py::test_cross_station_id_no_conflict_clean_data PASSED [ 80%]
tests/test_stations_validation_cross_id.py::test_cross_station_id_real_data PASSED [100%]

============================== 5 passed in 0.70s ===============================

tests/test_station_validation.py::test_validation_detects_duplicates_and_alias_issues PASSED [  7%]
tests/test_station_validation.py::test_validation_without_gtfs_file_reports_zero_stops PASSED [ 15%]
tests/test_station_validation.py::test_markdown_rendering_contains_sections PASSED [ 23%]
tests/test_station_validation.py::test_report_flags_missing_alias_list PASSED [ 30%]
tests/test_station_validation.py::test_coordinate_validation_detects_missing_and_out_of_bounds PASSED [ 38%]
tests/test_station_validation_security.py::test_validation_rejects_nan_and_infinity PASSED [ 46%]
tests/test_stations_validation_cross_id.py::test_cross_station_id_conflict_bst_code PASSED [ 53%]
tests/test_stations_validation_cross_id.py::test_cross_station_id_conflict_vor_id PASSED [ 61%]
tests/test_stations_validation_cross_id.py::test_cross_station_id_no_conflict_self_reference PASSED [ 69%]
tests/test_stations_validation_cross_id.py::test_cross_station_id_no_conflict_clean_data PASSED [ 76%]
tests/test_stations_validation_cross_id.py::test_cross_station_id_real_data PASSED [ 84%]
tests/test_stations_validation_unsafe.py::test_validation_flags_unsafe_chars PASSED [ 92%]
tests/test_stations_validation_unsafe.py::test_validation_passes_safe_chars PASSED [100%]

====================== 13 passed, 960 deselected in 2.27s ======================
```

New tests pass:
```
tests/test_stations_validation_provider.py::test_provider_issues_field_exists PASSED [  8%]
tests/test_stations_validation_provider.py::test_clean_data_has_no_provider_issues PASSED [ 16%]
tests/test_stations_validation_provider.py::test_less_than_two_vor_entries_reports_global_issue PASSED [ 25%]
tests/test_stations_validation_provider.py::test_zero_vor_entries_reports_global_issue PASSED [ 33%]
tests/test_stations_validation_provider.py::test_invalid_vor_bst_id_is_reported PASSED [ 41%]
tests/test_stations_validation_provider.py::test_invalid_vor_bst_code_is_reported PASSED [ 50%]
tests/test_stations_validation_provider.py::test_missing_vor_bst_id_is_reported PASSED [ 58%]
tests/test_stations_validation_provider.py::test_five_digit_vor_id_is_accepted PASSED [ 66%]
tests/test_stations_validation_provider.py::test_vor_bst_code_collides_with_oebb PASSED [ 75%]
tests/test_stations_validation_provider.py::test_source_string_with_spaces_is_parsed PASSED [ 83%]
tests/test_stations_validation_provider.py::test_real_data_has_no_provider_issues PASSED [ 91%]
tests/test_stations_validation_provider.py::test_has_issues_flips_on_provider_issue PASSED [100%]

============================== 12 passed in 0.76s ==============================
```

CLI exit code behavior:
```
$ python scripts/validate_stations.py
$ echo "Exit: $?"
Exit: 0

$ python scripts/validate_stations.py --stations /tmp/broken_one_vor.json
Need at least two VOR entries
$ echo "Exit: $?"
Exit: 1

$ python scripts/validate_stations.py --stations /tmp/broken_collision.json
VOR bst_code collides with OEBB
Cross-station alias conflict: Alias '900100' in 'VOR-A' (code:900100 / source:vor) collides with bst_code of 'OEBB-collision' (code:900100 / source:oebb)
Cross-station alias conflict: Alias '900100' in 'OEBB-collision' (code:900100 / source:oebb) collides with bst_id of 'VOR-A' (code:900100 / source:vor)
Cross-station alias conflict: Alias '900100' in 'OEBB-collision' (code:900100 / source:oebb) collides with bst_code of 'VOR-A' (code:900100 / source:vor)
Cross-station alias conflict: Alias '900100' in 'OEBB-collision' (code:900100 / source:oebb) collides with vor_id of 'VOR-A' (code:900100 / source:vor)
$ echo "Exit: $?"
Exit: 1
```

Mypy checks out cleanly:
```
$ mypy src/utils/stations_validation.py scripts/validate_stations.py tests/test_stations_validation_provider.py
Success: no issues found in 3 source files
```

---
*PR created automatically by Jules for task [4635924657235045320](https://jules.google.com/task/4635924657235045320) started by @Origamihase*