### PR TITLE
chore(wrapper): three small cleanups (mypy fix, dead code, constant lift)

### DIFF
--- a/scripts/update_all_stations.py
+++ b/scripts/update_all_stations.py
@@ -23,6 +23,13 @@ _SCRIPT_ORDER = (
     "enrich_station_aliases.py",
 )
 
+_SCRIPT_OUTPUT_FLAG = {
+    "update_station_directory.py": "--output",
+    "update_vor_stations.py": "--stations",
+    "update_wl_stations.py": "--stations",
+    "enrich_station_aliases.py": "--stations",
+}
+
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -62,13 +69,6 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     script_dir = Path(__file__).resolve().parent
     target_stations_json = Path("data/stations.json").resolve()
-
-    _SCRIPT_OUTPUT_FLAG = {
-        "update_station_directory.py": "--output",
-        "update_vor_stations.py": "--stations",
-        "update_wl_stations.py": "--stations",
-        "enrich_station_aliases.py": "--stations",
-    }
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_stations_path = Path(tmp_dir) / "stations.json"

--- a/tests/test_update_all_stations_wrapper.py
+++ b/tests/test_update_all_stations_wrapper.py
@@ -43,8 +43,13 @@ def test_wrapper_preserves_stations_json_on_validation_failure(
     real_stations = REPO_ROOT / "data" / "stations.json"
     original_bytes = real_stations.read_bytes()
 
-    # Replace sub-script subprocess invocations with no-ops.
-    monkeypatch.setattr(wrapper.subprocess, "run", lambda *a, **kw: None)
+    # Replace sub-script subprocess invocations with no-ops. String target form
+    # keeps mypy --no-implicit-reexport happy without broadening the mock — the
+    # patch still applies only to subprocess.run as accessed through
+    # scripts.update_all_stations, not globally.
+    monkeypatch.setattr(
+        "scripts.update_all_stations.subprocess.run", lambda *a, **kw: None
+    )
 
     # Force validation to fail with a provider_issue.
     failing_report = ValidationReport(
@@ -77,9 +82,6 @@ def test_wrapper_preserves_stations_json_on_validation_failure(
 
 def test_wrapper_atomic_on_success(tmp_path: Path) -> None:
     """Bei Erfolg ist data/stations.json nach dem Lauf valide."""
-    # Setup: aktueller Stand
-    stations_before = (REPO_ROOT / "data" / "stations.json").read_text(encoding="utf-8")
-
     # Run the wrapper without modifications — should succeed if main is clean.
     result = subprocess.run(
         [sys.executable, str(REPO_ROOT / "scripts" / "update_all_stations.py")],  # noqa: S603


### PR DESCRIPTION
## Summary

Three small cleanups from the warm-up backlog, all in the wrapper area touched by #1106. None of them changes behaviour.

1. **mypy fix (test file)**: `monkeypatch.setattr(wrapper.subprocess, "run", ...)` → `monkeypatch.setattr("scripts.update_all_stations.subprocess.run", ...)`. Resolves the attr-defined error that #1106's verification reported but did not fix. The mock is still narrowly scoped to `update_all_stations`'s `subprocess.run`, not global.

2. **Dead code removal (test file)**: `stations_before` in `test_wrapper_atomic_on_success` was assigned but never compared. Leftover from the test's skeleton phase, no longer needed now that the proper byte-equality contract is asserted in the sibling test (`test_wrapper_preserves_stations_json_on_validation_failure`, reactivated in #1106).

3. **Constant scope lift**: `_SCRIPT_OUTPUT_FLAG` moved from inside `main()` to module scope, parallel to `_SCRIPT_ORDER`. Both are static configuration; placing them next to each other matches conventions and makes the constant importable for tests or other tooling.

## Behaviour

No behaviour changes. The lift in Item 3 is scope-only — the call site `output_flag = _SCRIPT_OUTPUT_FLAG.get(script_name)` resolves through lexical scope to the module-level constant exactly as it did to the function-local one.

## Activity proofs

- mypy: was 1 error in the pre-verify baseline, 0 errors after the edit.
- Importability: `from scripts.update_all_stations import _SCRIPT_OUTPUT_FLAG` was `ImportError` before the edit, succeeds after.

Both were captured as exit-code-differentiated checks in the verify section below.

## Out of scope (followups)

- The duplicated `sys.path.insert` lines at the top of `scripts/validate_stations.py`.
- The missing `cross_station_id_issues` section in `ValidationReport.to_markdown()`.

## Verification

### Pre-verify

```bash
$ grep -n "from src.utils.stations_validation" scripts/update_all_stations.py
14:from src.utils.stations_validation import (

$ grep -n "wrapper.subprocess" tests/test_update_all_stations_wrapper.py
47:    monkeypatch.setattr(wrapper.subprocess, "run", lambda *a, **kw: None)

$ grep -n "stations_before" tests/test_update_all_stations_wrapper.py
81:    stations_before = (REPO_ROOT / "data" / "stations.json").read_text(encoding="utf-8")

$ grep -nE "^_SCRIPT_OUTPUT_FLAG" scripts/update_all_stations.py
```

```bash
$ PYTHONPATH=src pytest tests/ -v 2>&1 | tail -10
tests/test_wl_stations_directory.py::test_wl_alias_matching_by_name PASSED [ 99%]
tests/test_wl_stations_directory.py::test_wl_canonical_name_for_diva PASSED [ 99%]
tests/test_wl_title.py::test_bucket_merge_prefers_informative_title_and_description PASSED [ 99%]
tests/test_wl_title.py::test_line_prefix_and_house_number_false_positive PASSED [ 99%]
tests/test_wl_title.py::test_line_prefix_empty_title PASSED              [ 99%]
tests/test_wl_title.py::test_tidy_title_wl_strips_label PASSED           [ 99%]
tests/test_xml_ends_at.py::TestXmlEndsAt::test_ends_at_missing_in_xml_when_none PASSED [ 99%]
tests/test_xml_ends_at.py::TestXmlEndsAt::test_ends_at_xml_generation PASSED [100%]

======================= 984 passed, 1 skipped in 50.42s ========================
```

```bash
$ python -m mypy scripts/update_all_stations.py tests/test_update_all_stations_wrapper.py
scripts/update_all_stations.py: error: Source file found twice under different
module names: "update_all_stations" and "scripts.update_all_stations"
scripts/update_all_stations.py: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#mapping-file-paths-to-modules for more info
scripts/update_all_stations.py: note: Common resolutions include: a) adding `__init__.py` somewhere, b) using `--explicit-package-bases` or adjusting MYPYPATH
Found 1 error in 1 file (errors prevented further checking)

$ python -m mypy tests/test_update_all_stations_wrapper.py
tests/test_update_all_stations_wrapper.py:47: error: Module
"scripts.update_all_stations" does not explicitly export attribute "subprocess" 
[attr-defined]
        monkeypatch.setattr(wrapper.subprocess, "run", lambda *a, **kw: No...
                            ^~~~~~~~~~~~~~~~~~
Found 1 error in 1 file (checked 1 source file)
```

```bash
$ PYTHONPATH=src python -c "from scripts.update_all_stations import _SCRIPT_OUTPUT_FLAG" 2>&1
$ echo "Exit: $?"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: cannot import name '_SCRIPT_OUTPUT_FLAG' from 'scripts.update_all_stations' (/app/scripts/update_all_stations.py)
Exit: 1
```

```bash
$ PYTHONPATH=.:src python scripts/update_all_stations.py --help
usage: update_all_stations.py [-h] [--python PYTHON] [-v]

Run all station update scripts in sequence.

options:
  -h, --help       show this help message and exit
  --python PYTHON  Python interpreter used to invoke the update scripts
                   (default: current interpreter).
  -v, --verbose    Enable verbose logging output for the wrapper and update
                   scripts.
```

### Post-edit verify

```bash
$ python -m mypy tests/test_update_all_stations_wrapper.py
Success: no issues found in 1 source file
$ python -m mypy scripts/update_all_stations.py
Success: no issues found in 1 source file
```

```bash
$ PYTHONPATH=.:src python -c "from scripts.update_all_stations import _SCRIPT_OUTPUT_FLAG; print(sorted(_SCRIPT_OUTPUT_FLAG.keys()))"
['enrich_station_aliases.py', 'update_station_directory.py', 'update_vor_stations.py', 'update_wl_stations.py']
```

```bash
$ PYTHONPATH=src pytest tests/test_update_all_stations_wrapper.py::test_wrapper_preserves_stations_json_on_validation_failure -v
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /home/jules/.pyenv/versions/3.12.13/bin/python3.12
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /app
configfile: pyproject.toml
plugins: hypothesis-6.152.4, timeout-2.4.0
timeout: 60.0s
timeout method: signal
timeout func_only: False
collecting ... collected 1 item

tests/test_update_all_stations_wrapper.py::test_wrapper_preserves_stations_json_on_validation_failure PASSED [100%]

============================== 1 passed in 0.62s ===============================
```

```bash
$ PYTHONPATH=src pytest tests/test_update_all_stations_wrapper.py -v
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0 -- /home/jules/.pyenv/versions/3.12.13/bin/python3.12
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /app
configfile: pyproject.toml
plugins: hypothesis-6.152.4, timeout-2.4.0
timeout: 60.0s
timeout method: signal
timeout func_only: False
collecting ... collected 2 items

tests/test_update_all_stations_wrapper.py::test_wrapper_preserves_stations_json_on_validation_failure PASSED [ 50%]
tests/test_update_all_stations_wrapper.py::test_wrapper_atomic_on_success SKIPPED [100%]

========================= 1 passed, 1 skipped in 0.80s =========================
```

```bash
$ PYTHONPATH=src pytest tests/ -v 2>&1 | tail -10
tests/test_wl_stations_directory.py::test_wl_alias_matching_by_name PASSED [ 99%]
tests/test_wl_stations_directory.py::test_wl_canonical_name_for_diva PASSED [ 99%]
tests/test_wl_title.py::test_bucket_merge_prefers_informative_title_and_description PASSED [ 99%]
tests/test_wl_title.py::test_line_prefix_and_house_number_false_positive PASSED [ 99%]
tests/test_wl_title.py::test_line_prefix_empty_title PASSED              [ 99%]
tests/test_wl_title.py::test_tidy_title_wl_strips_label PASSED           [ 99%]
tests/test_xml_ends_at.py::TestXmlEndsAt::test_ends_at_missing_in_xml_when_none PASSED [ 99%]
tests/test_xml_ends_at.py::TestXmlEndsAt::test_ends_at_xml_generation PASSED [100%]

======================= 984 passed, 1 skipped in 42.37s ========================
```

```bash
$ PYTHONPATH=.:src python scripts/update_all_stations.py --help
usage: update_all_stations.py [-h] [--python PYTHON] [-v]

Run all station update scripts in sequence.

options:
  -h, --help       show this help message and exit
  --python PYTHON  Python interpreter used to invoke the update scripts
                   (default: current interpreter).
  -v, --verbose    Enable verbose logging output for the wrapper and update
                   scripts.
```

```bash
$ git status data/stations.json
On branch chore/wrapper-cleanups
nothing to commit, working tree clean
```

---
*PR created automatically by Jules for task [16006006564746530736](https://jules.google.com/task/16006006564746530736) started by @Origamihase*