### PR TITLE
chore(ci): pip in dependabot, concurrency in update-stations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,18 @@ updates:
       prefix: "chore(ci)"
       include: "scope"
     open-pull-requests-limit: 5
+
+  # pip: aktualisiert Python-Dependencies (requirements.txt, requirements-dev.txt,
+  # pyproject.toml) im selben monatlichen Schedule wie github-actions.
+  # Sicherheitsupdates fließen separat über Dependabot Security Advisories.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Vienna"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    open-pull-requests-limit: 5

--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+# Verhindert, dass sich Cron- und manuell ausgelöste Läufe gegenseitig
+# beim `git push` blockieren oder fehlschlagen lassen.
+concurrency:
+  group: update-stations-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Two small CI config items from the warm-up backlog. Both YAML-only.

1. **pip ecosystem in Dependabot**: `.github/dependabot.yml` gains a `pip` watcher that mirrors the existing `github-actions` entry's style — monthly cadence on Monday 06:00 Europe/Vienna, `commit-message.prefix: "chore(deps)"` with `include: "scope"`, max 5 open PRs. Closes the gap where Python deps weren't tracked despite the wrapper and CI relying on pinned pip installs (`pip<27` in `.github/actions/install-deps/action.yml`).

2. **Concurrency in `update-stations.yml`**: top-level `concurrency: { group: update-stations-${{ github.ref }}, cancel-in-progress: false }`. Pattern matches `build-feed.yml`'s workflow-specific + ref-aware form. We deliberately do **not** use the `external-api-fetch` shared group from the cache workflows — that would block hourly cache updates for the 30-minute duration of a stations refresh. The wrapper is already atomic (#1104+#1106), so this prevents two parallel runs from both fetching/validating/committing, not a correctness fix.

## Behaviour

No code or test changes. Dependabot will start raising PRs on its next monthly run; the workflow will queue concurrent invocations on its next overlap.

## Activity proofs

- `grep "package-ecosystem.*\"pip\"" .github/dependabot.yml` was `NO PIP ECOSYSTEM` in the pre-verify baseline, matches exactly one line after the edit.
- `grep "^concurrency:" .github/workflows/update-stations.yml` was `NO TOP-LEVEL CONCURRENCY` in the pre-verify baseline, matches exactly one line after the edit.

## Out of scope (followups)

- The duplicated `sys.path.insert` lines at the top of `scripts/validate_stations.py`.
- The missing `cross_station_id_issues` section in `ValidationReport.to_markdown()`.

## Verification

### Pre-verify

```
60a6a01c3 Merge pull request #1107 from Origamihase/chore/wrapper-cleanups-16006006564746530736
b77d41b67 chore(wrapper): three small cleanups (mypy fix, dead code, constant lift)
31a074a05 Update feed
```

```
# Configuration for Dependabot version updates.
# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates

version: 2
updates:
  # GitHub Actions: SHA-gepinnte Actions werden mit jedem neuen Tag-Release
  # automatisch als PR aktualisiert. Tag-Kommentar (z.B. "# v4") bleibt durch
  # Dependabot erhalten.
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "monthly"
      day: "monday"
      time: "06:00"
      timezone: "Europe/Vienna"
    commit-message:
      prefix: "chore(ci)"
      include: "scope"
    open-pull-requests-limit: 5
```

```
NO PIP ECOSYSTEM
```

```
name: Update station directory

on:
  schedule:
    - cron: '0 1 1 * *'
  workflow_dispatch:

permissions:
  contents: read

jobs:
  update:
    runs-on: ubuntu-latest
    permissions:
      contents: write

    env:
      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
      PYTHONPATH: src
    steps:
      - name: Check out repository
        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
        with:
          fetch-depth: 0

      - name: Set up Python
        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
        with:
          python-version: '3.11'

      - name: Install dependencies
        uses: ./.github/actions/install-deps

      - name: Refresh station directory
        run: python scripts/update_all_stations.py --verbose

      - name: Prepare repository (rebase main)
        run: |
          git config user.name "github-actions[bot]"
          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
          git fetch origin main
          git pull --rebase --autostash origin main

      - name: Pull concurrent remote changes
        run: git pull --rebase --autostash

      - name: Commit and push changes
        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
        with:
          commit_message: "chore(data): refresh station directory [skip ci]"
          add_options: "-A"
          push_options: "--force-with-lease"
```

```
NO TOP-LEVEL CONCURRENCY
```

```
NO JOB-LEVEL CONCURRENCY
```

```
dependabot.yml: parse OK
update-stations.yml: parse OK
```

### Post-edit verify

```
19:  - package-ecosystem: "pip"
```

```
13:concurrency:
```

```
dependabot.yml: parse OK
update-stations.yml: parse OK
```

```
actionlint not installed, skipping
```

```
tests/test_wl_title.py::test_tidy_title_wl_strips_label PASSED           [ 99%]
tests/test_xml_ends_at.py::TestXmlEndsAt::test_ends_at_missing_in_xml_when_none PASSED [ 99%]
tests/test_xml_ends_at.py::TestXmlEndsAt::test_ends_at_xml_generation PASSED [100%]

======================= 984 passed, 1 skipped in 51.05s ========================
```

```
On branch chore/ci-hardening
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   .github/dependabot.yml
	modified:   .github/workflows/update-stations.yml

no changes added to commit (use "git add" and/or "git commit -a")
```

```
 .github/dependabot.yml                | 15 +++++++++++++++
 .github/workflows/update-stations.yml |  6 ++++++
 2 files changed, 21 insertions(+)
diff --git a/.github/dependabot.yml b/.github/dependabot.yml
index acd918dd0..f2163feeb 100644
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,18 @@ updates:
       prefix: "chore(ci)"
       include: "scope"
     open-pull-requests-limit: 5
+
+  # pip: aktualisiert Python-Dependencies (requirements.txt, requirements-dev.txt,
+  # pyproject.toml) im selben monatlichen Schedule wie github-actions.
+  # Sicherheitsupdates fließen separat über Dependabot Security Advisories.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Vienna"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    open-pull-requests-limit: 5
diff --git a/.github/workflows/update-stations.yml b/.github/workflows/update-stations.yml
index c36d792d2..a2a5bf16c 100644
--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+# Verhindert, dass sich Cron- und manuell ausgelöste Läufe gegenseitig
+# beim `git push` blockieren oder fehlschlagen lassen.
+concurrency:
+  group: update-stations-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   update:
     runs-on: ubuntu-latest
```

---
*PR created automatically by Jules for task [18251718283087941963](https://jules.google.com/task/18251718283087941963) started by @Origamihase*