### PR TITLE
refactor(wrapper): atomic copy-back of stations.json via atomic_write

### DIFF
--- a/scripts/update_all_stations.py
+++ b/scripts/update_all_stations.py
@@ -11,6 +11,7 @@ import tempfile
 from pathlib import Path
 from typing import Sequence
 
+from src.utils.files import atomic_write
 from src.utils.stations_validation import (
     StationValidationError,
     validate_stations,
@@ -125,8 +126,15 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 1
 
-        # Copy back to target on success
-        shutil.copy(tmp_stations_path, target_stations_json)
+        # Atomic copy-back: atomic_write writes a temp file inside
+        # target_stations_json.parent (same filesystem as the target —
+        # sidesteps the cross-FS issue with tempfile.TemporaryDirectory
+        # which lives on /tmp), fsyncs, then os.replace's into position.
+        # No partial-file window on data/stations.json.
+        with open(tmp_stations_path, "rb") as src, atomic_write(
+            target_stations_json, mode="wb"
+        ) as dst:
+            shutil.copyfileobj(src, dst)
         logging.info("stations.json successfully updated and validated.")
 
     logging.info("All station update scripts completed successfully.")

--- a/tests/test_update_all_stations_wrapper.py
+++ b/tests/test_update_all_stations_wrapper.py
@@ -80,6 +80,65 @@ def test_wrapper_preserves_stations_json_on_validation_failure(
     )
 
 
+def test_wrapper_preserves_stations_json_on_atomic_write_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Bei Fehler im finalen atomic_write bleibt data/stations.json bytewise unverändert.
+
+    Verfahren: sub-scripts werden zu no-ops gemockt, validate_stations liefert
+    einen sauberen (issue-freien) Report — der Wrapper erreicht also den
+    finalen copy-back-Block. atomic_write wird zum Fehlschlagen gebracht
+    (OSError beim Aufruf). Erwartung: die Exception propagiert hoch und das
+    Original ist bytewise unverändert. Pinst die Atomicity-Garantie der
+    Migration von shutil.copy zu atomic_write.
+    """
+    from src.utils.stations_validation import ValidationReport
+    from scripts import update_all_stations as wrapper
+
+    real_stations = REPO_ROOT / "data" / "stations.json"
+    original_bytes = real_stations.read_bytes()
+
+    # Sub-scripts as no-ops.
+    monkeypatch.setattr(
+        "scripts.update_all_stations.subprocess.run", lambda *a, **kw: None
+    )
+
+    # Validation passes with a clean report — the wrapper proceeds to the
+    # final copy-back block.
+    clean_report = ValidationReport(
+        total_stations=0,
+        duplicates=(),
+        alias_issues=(),
+        coordinate_issues=(),
+        gtfs_issues=(),
+        security_issues=(),
+        cross_station_id_issues=(),
+        provider_issues=(),
+        gtfs_stop_count=0,
+    )
+    monkeypatch.setattr(wrapper, "validate_stations", lambda *a, **kw: clean_report)
+
+    # Force atomic_write to raise immediately on call.
+    def failing_atomic_write(*args: object, **kwargs: object) -> None:
+        raise OSError("Simulated atomic_write failure for regression test")
+
+    monkeypatch.setattr(
+        "scripts.update_all_stations.atomic_write", failing_atomic_write
+    )
+
+    # The wrapper has no try/except around the final copy-back block, so the
+    # OSError propagates. That's intentional and consistent with shutil.copy's
+    # historical behaviour — atomic_write failure is exceptional (disk full,
+    # permission, etc.), not a "validation failed" condition.
+    with pytest.raises(OSError, match="Simulated atomic_write failure"):
+        wrapper.main([])
+
+    assert real_stations.read_bytes() == original_bytes, (
+        "Wrapper modified data/stations.json on atomic_write failure — "
+        "atomicity contract violated"
+    )
+
+
 def test_wrapper_atomic_on_success(tmp_path: Path) -> None:
     """Bei Erfolg ist data/stations.json nach dem Lauf valide."""
     # Run the wrapper without modifications — should succeed if main is clean.


### PR DESCRIPTION
Replaces the non-atomic `shutil.copy(tmp_stations_path, target_stations_json)` final step in `scripts/update_all_stations.py` with `src.utils.files.atomic_write`. The helper writes a temp file in `data/` (same filesystem as the target), `fsync`s, then `os.replace`s into place — atomic on the same filesystem, with cleanup on exception. Closes the last partial-write window on `data/stations.json` and completes the pre-write copy-on-write pipeline from #1104 / #1105 / #1106.

## Why now

The diagnose phase confirmed:
- `src.utils.files.atomic_write` already exists, is battle-tested, and is used widely in the repo (`src/places/merge.py`, `src/providers/vor.py`, `scripts/update_vor_stations.py`, `scripts/update_station_directory.py`, `src/build_feed.py`).
- The temp file lives in `target.with_name(...)`, so `os.replace` runs within the same directory — sidesteps the cross-FS issue with `tempfile.TemporaryDirectory()` which defaults to `/tmp` (a different filesystem on typical CI runners).
- Comprehensive tests already exist for the helper (`tests/test_atomic_write_security.py`, `tests/test_utils_files.py` including `test_atomic_write_cleanup_on_error` which simulates mid-write failure). We do not re-test the helper here; we test that the wrapper uses it correctly.

## Changes

- New import `from src.utils.files import atomic_write` in `scripts/update_all_stations.py`, alphabetically before `from src.utils.stations_validation import (...)`.
- The final `shutil.copy(tmp_stations_path, target_stations_json)` is replaced with a streaming `with atomic_write(target_stations_json, mode="wb") as dst: shutil.copyfileobj(src, dst)` block. Binary mode preserves byte-identical content.
- The initial `shutil.copy2(target_stations_json, tmp_stations_path)` at the start of the wrapper is **unchanged** — it copies INTO the throwaway temp dir, atomicity is irrelevant there.
- New regression test `test_wrapper_preserves_stations_json_on_atomic_write_failure` in `tests/test_update_all_stations_wrapper.py`, mirroring the structure of `test_wrapper_preserves_stations_json_on_validation_failure` from #1106.

## Activity proofs

- `grep -c "shutil.copy" scripts/update_all_stations.py` was `2` in pre-verify, is `1` post-edit (only the initial `shutil.copy2` into the temp dir remains).
- `grep -c "atomic_write" scripts/update_all_stations.py` was `0` in pre-verify, is `2` post-edit (one import, one usage).
- `pytest tests/test_update_all_stations_wrapper.py` was `1 passed, 1 skipped` in pre-verify, is `2 passed, 1 skipped` post-edit.

## Known limitations (out of scope, tracked as followups)

- **SIGKILL race**: if the wrapper process is `SIGKILL`-ed *during* `atomic_write` (between `os.fsync` and `os.replace`), the helper's `except` cleanup doesn't run, and a leftover `data/stations.json.<hex>.tmp` remains. The `git-auto-commit-action` in `update-stations.yml` then `add -A`s and could commit it. Mitigation options for a separate followup PR: a `data/*.tmp` entry in `.gitignore`, or a glob-cleanup at the start of `main()`. This PR does not change `.gitignore` or the workflow.
- The §6 grep from the diagnose phase (other `shutil.copy*` / `os.rename` sites in the repo) was deferred. Tracked as a followup; sweeping them blindly would expand scope.

## Out of scope (existing followups, not addressed here)

- The duplicated `sys.path.insert` lines at the top of `scripts/validate_stations.py`.
- The missing `cross_station_id_issues` section in `ValidationReport.to_markdown()`.

---
*PR created automatically by Jules for task [2539510278047897658](https://jules.google.com/task/2539510278047897658) started by @Origamihase*