### PR TITLE
fix(stations): include cross_station_id_issues in to_markdown report

### DIFF
--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -121,6 +121,7 @@ class ValidationReport:
         lines.append(f"*GTFS mismatches*: {len(self.gtfs_issues)}")
         lines.append(f"*Security warnings*: {len(self.security_issues)}")
         lines.append(f"*Provider issues*: {len(self.provider_issues)}")
+        lines.append(f"*Cross station ID issues*: {len(self.cross_station_id_issues)}")
         lines.append("")
 
         if self.security_issues:
@@ -136,6 +137,14 @@ class ValidationReport:
             for provider_issue in self.provider_issues:
                 lines.append(
                     f"- {provider_issue.identifier} ({provider_issue.name}): {provider_issue.reason}"
+                )
+            lines.append("")
+
+        if self.cross_station_id_issues:
+            lines.append("## Cross station ID issues")
+            for cross_issue in self.cross_station_id_issues:
+                lines.append(
+                    f"- {cross_issue.identifier} ({cross_issue.name}): alias {cross_issue.alias!r} collides with {cross_issue.colliding_field} of {cross_issue.colliding_identifier} ({cross_issue.colliding_name})"
                 )
             lines.append("")
 

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -144,7 +144,8 @@ class ValidationReport:
             lines.append("## Cross station ID issues")
             for cross_issue in self.cross_station_id_issues:
                 lines.append(
-                    f"- {cross_issue.identifier} ({cross_issue.name}): alias {cross_issue.alias!r} collides with {cross_issue.colliding_field} of {cross_issue.colliding_identifier} ({cross_issue.colliding_name})"
+                    f"- {cross_issue.identifier} ({cross_issue.name}): alias {cross_issue.alias!r} collides with "
+                    f"{cross_issue.colliding_field} of {cross_issue.colliding_identifier} ({cross_issue.colliding_name})"
                 )
             lines.append("")
 

--- a/tests/test_station_validation.py
+++ b/tests/test_station_validation.py
@@ -8,7 +8,9 @@ import pytest
 from src.utils.stations_validation import (
     AliasIssue,
     CoordinateIssue,
+    CrossStationIDIssue,
     DuplicateGroup,
+    ValidationReport,
     validate_stations,
 )
 
@@ -159,3 +161,36 @@ def test_coordinate_validation_detects_missing_and_out_of_bounds(tmp_path: Path)
             reason="coordinates look swapped (lat=16.6, lon=48.2)",
         ),
     )
+
+
+def test_markdown_rendering_contains_cross_station_id_section() -> None:
+    """to_markdown() must render cross_station_id_issues in counts and detail."""
+    issue = CrossStationIDIssue(
+        identifier="bst:1234",
+        name="Wien Mitte",
+        alias="Mitte",
+        colliding_identifier="bst:5678",
+        colliding_name="Praterstern",
+        colliding_field="bst_code",
+    )
+    report = ValidationReport(
+        total_stations=2,
+        duplicates=(),
+        alias_issues=(),
+        coordinate_issues=(),
+        gtfs_issues=(),
+        security_issues=(),
+        cross_station_id_issues=(issue,),
+        provider_issues=(),
+        gtfs_stop_count=0,
+    )
+
+    markdown = report.to_markdown()
+
+    assert "*Cross station ID issues*: 1" in markdown
+    assert "## Cross station ID issues" in markdown
+    assert "bst:1234" in markdown
+    assert "'Mitte'" in markdown
+    assert "bst_code" in markdown
+    assert "bst:5678" in markdown
+    assert "No issues detected." not in markdown


### PR DESCRIPTION
## Summary

`ValidationReport.to_markdown()` rendered seven of the eight issue
categories tracked by the dataclass. The `cross_station_id_issues`
field — which triggers exit 1 in the strictness contract from #1105 —
appeared in neither the header counts block nor the detail sections.
Operators reading the rendered report could not see why validation
had failed.

This PR adds the missing `*Cross station ID issues*: N` header line
and the missing `## Cross station ID issues` detail section, both
positioned next to the existing `provider_issues` block (the other
exit-1 trigger). A new regression test in
`tests/test_station_validation.py` pins the contract.

## Changes

- `src/utils/stations_validation.py`: add header count line and detail
  section for `cross_station_id_issues` in `ValidationReport.to_markdown()`.
- `tests/test_station_validation.py`: extend the import block with
  `CrossStationIDIssue` and `ValidationReport`; add
  `test_markdown_rendering_contains_cross_station_id_section`
  regression test.

## Verification

**Anchor counts** (`src/utils/stations_validation.py`):

- `cross_station_id_issues`: pre = 4, post = 7
- `Cross station ID`: pre = 0, post = 2

**Anchor counts** (`tests/test_station_validation.py`):

- `CrossStationIDIssue`: pre = 0, post = 2
- `ValidationReport`: pre = 0, post = 2
- `def test_markdown_rendering`: pre = 1, post = 2

**Pytest** (file-scoped activity proof):

```
$ python -m pytest tests/test_station_validation.py 2>&1 | tail -1
============================== 5 passed in 0.71s ===============================
$ python -m pytest tests/test_station_validation.py 2>&1 | tail -1
============================== 6 passed in 0.75s ===============================
```

**Pytest** (full suite):

```
$ python -m pytest 2>&1 | tail -3
tests/test_xml_ends_at.py ..                                             [100%]

======================= 986 passed, 1 skipped in 43.61s ========================
```

**Mypy** (per file, separate invocations, output identical to baseline):

```
$ python -m mypy src/utils/stations_validation.py
Success: no issues found in 1 source file
$ python -m mypy tests/test_station_validation.py
Success: no issues found in 1 source file
```

## Out of scope

- The `has_issues` property already accounts for `cross_station_id_issues`
  (line 95 of `src/utils/stations_validation.py`) and is unchanged.
- No changes to `_find_cross_station_id_conflicts`, `CrossStationIDIssue`,
  or the strictness contract in `validate_stations`.
- No changes to other header lines, detail sections, or test files.

## Related

- #1105 — origin of `cross_station_id_issues` field and the strictness
  contract that makes this category an exit-1 trigger.

---
*PR created automatically by Jules for task [11802516670157787182](https://jules.google.com/task/11802516670157787182) started by @Origamihase*