### PR TITLE
chore(tests): type-annotate oebb-title tests (cluster 2)

### DIFF
--- a/tests/test_oebb_cleaning.py
+++ b/tests/test_oebb_cleaning.py
@@ -1,7 +1,7 @@
 from src.providers.oebb import _clean_description, _clean_title_keep_places
 from src.utils.text import html_to_text
 
-def test_clean_description_arrow_brackets():
+def test_clean_description_arrow_brackets() -> None:
     # Input simulating what comes from _get_text (unescaped)
     # Case 1: Brackets around arrow
     desc = "Wien < ↔ > Salzburg"
@@ -23,7 +23,7 @@ def test_clean_description_arrow_brackets():
     final = html_to_text(cleaned)
     assert final == "Wien ↔ Salzburg"
 
-def test_reproduce_issue_if_input_is_different():
+def test_reproduce_issue_if_input_is_different() -> None:
     # Maybe the input is actually like this?
     desc = "Wien &lt; ↔ &gt; Salzburg"
     # _clean_description should handle entities in the regex
@@ -39,24 +39,24 @@ def test_reproduce_issue_if_input_is_different():
     cleaned = _clean_description(desc)
     assert cleaned == "Wien ↔ Salzburg"
 
-def test_html_tag_arrow():
+def test_html_tag_arrow() -> None:
     # What if it's like a tag?
     desc = "Wien <-> Salzburg"
     cleaned = _clean_description(desc)
     assert cleaned == "Wien ↔ Salzburg"
 
-def test_double_escaped_entities():
+def test_double_escaped_entities() -> None:
     # This currently FAILS with the existing regex
     desc = "Wien &amp;lt; ↔ &amp;gt; Salzburg"
     cleaned = _clean_description(desc)
     assert cleaned == "Wien ↔ Salzburg"
 
-def test_clean_description_numeric_entities():
+def test_clean_description_numeric_entities() -> None:
     desc = "Wien &#60; ↔ &#62; Salzburg"
     cleaned = _clean_description(desc)
     assert cleaned == "Wien ↔ Salzburg"
 
-def test_clean_title_numeric_entities():
+def test_clean_title_numeric_entities() -> None:
     # "Wien" might be canonicalized to "Wien Hauptbahnhof"
     title = "Wien &#60; ↔ &#62; Salzburg"
     cleaned = _clean_title_keep_places(title)
@@ -67,7 +67,7 @@ def test_clean_title_numeric_entities():
     assert "<" not in cleaned
     assert ">" not in cleaned
 
-def test_clean_title_unknown_entities():
+def test_clean_title_unknown_entities() -> None:
     # If stations are unknown, it should still clean the arrow
     title = "FooBar &#60; ↔ &#62; BazQux"
     cleaned = _clean_title_keep_places(title)

--- a/tests/test_oebb_issue_linz_passau.py
+++ b/tests/test_oebb_issue_linz_passau.py
@@ -1,6 +1,6 @@
 from src.providers.oebb import _clean_title_keep_places, _is_relevant
 
-def test_clean_title_db_bauarbeiten():
+def test_clean_title_db_bauarbeiten() -> None:
     title = "DB-Bauarbeiten ↔ Umleitung/Haltausfall: Linz/Donau Passau"
     cleaned = _clean_title_keep_places(title)
     # With the new iterative prefix stripping, "DB-Bauarbeiten" is kept as a part,
@@ -8,7 +8,7 @@ def test_clean_title_db_bauarbeiten():
     # The output is joined as category: rest.
     assert cleaned == "DB-Bauarbeiten: Linz/Donau Passau"
 
-def test_is_relevant_db_bauarbeiten():
+def test_is_relevant_db_bauarbeiten() -> None:
     title = "DB-Bauarbeiten ↔ Umleitung/Haltausfall: Linz/Donau Passau"
     desc = (
         "Wegen Bauarbeiten der Deutschen Bahn (DB) wird von 22.04. auf 23.04.2026 der Zug NJ 498 "
@@ -20,7 +20,7 @@ def test_is_relevant_db_bauarbeiten():
     # Linz/Donau and Passau do not have vienna connections and aren't in pendler range
     assert _is_relevant(cleaned, desc) is False
 
-def test_clean_title_compound_category():
+def test_clean_title_compound_category() -> None:
     title = "ÖBB-Verspätung ↔ Zugausfall: Wien Hbf ↔ St. Pölten"
     cleaned = _clean_title_keep_places(title)
     # "ÖBB-Verspätung" is kept as the first part (category).

--- a/tests/test_oebb_title.py
+++ b/tests/test_oebb_title.py
@@ -1,22 +1,22 @@
 from src.providers.oebb import _clean_title_keep_places
 
 
-def test_wien_und_arrow_and_clean():
+def test_wien_und_arrow_and_clean() -> None:
     t = "Verkehrsmeldung: Wien Floridsdorf Bahnhof und Wien Meidling Hbf"
     assert _clean_title_keep_places(t) == "Wien Floridsdorf ↔ Wien Meidling"
 
 
-def test_clean_title_canonicalizes_endpoints():
+def test_clean_title_canonicalizes_endpoints() -> None:
     t = "Verkehrsmeldung: Wien Franz Josefs Bahnhof - St Poelten Hbf"
     assert _clean_title_keep_places(t) == "Wien Franz-Josefs-Bf ↔ St.Pölten Hbf"
 
 
-def test_clean_title_expands_wien_hbf_abbreviation():
+def test_clean_title_expands_wien_hbf_abbreviation() -> None:
     t = "Störung: Wien Hbf (U) <-> Wien Meidling Bahnhof"
     assert _clean_title_keep_places(t) == "Wien Hauptbahnhof ↔ Wien Meidling"
 
 
-def test_clean_title_removes_redundant_suffix():
+def test_clean_title_removes_redundant_suffix() -> None:
     # Issue: Station name is duplicated in the feed title if it's already part of the message text.
     t = "Bahnsteig 2/3 in Sigmundsherberg nicht barrierefrei: Sigmundsherberg"
     assert _clean_title_keep_places(t) == "Bahnsteig 2/3 in Sigmundsherberg nicht barrierefrei"

--- a/tests/test_oebb_title_ordering.py
+++ b/tests/test_oebb_title_ordering.py
@@ -1,6 +1,6 @@
 from src.providers.oebb import _clean_title_keep_places
 
-def test_title_reordering_vienna_first():
+def test_title_reordering_vienna_first() -> None:
     # Case 1: Vienna station second -> should swap
     # "Linz/Donau" (unknown/outer) <-> "Wien Hauptbahnhof" (known/vienna)
     # Note: "Linz/Donau" is not in stations.json, so it's treated as raw string (non-Vienna)
@@ -9,24 +9,24 @@ def test_title_reordering_vienna_first():
     # Desired behavior: "Wien Hauptbahnhof ↔ Linz/Donau"
     assert _clean_title_keep_places(t) == "Wien Hauptbahnhof ↔ Linz/Donau"
 
-def test_title_reordering_vienna_first_salzburg():
+def test_title_reordering_vienna_first_salzburg() -> None:
     # Case 2: Vienna station second
     t = "Salzburg ↔ Wien Hauptbahnhof"
     assert _clean_title_keep_places(t) == "Wien Hauptbahnhof ↔ Salzburg"
 
-def test_title_ordering_preserved_if_vienna_first():
+def test_title_ordering_preserved_if_vienna_first() -> None:
     # Case 3: Vienna station first -> keep
     t = "Wien Hauptbahnhof ↔ Bruck/Mur"
     # Bruck/Mur might be "Bruck an der Mur" or just unknown.
     # Assuming "Wien Hauptbahnhof" is Vienna.
     assert _clean_title_keep_places(t) == "Wien Hauptbahnhof ↔ Bruck/Mur"
 
-def test_title_ordering_preserved_if_both_vienna():
+def test_title_ordering_preserved_if_both_vienna() -> None:
     # Case 4: Both Vienna -> keep order
     t = "Wien Floridsdorf ↔ Wien Meidling"
     assert _clean_title_keep_places(t) == "Wien Floridsdorf ↔ Wien Meidling"
 
-def test_title_ordering_preserved_if_neither_vienna():
+def test_title_ordering_preserved_if_neither_vienna() -> None:
     # Case 5: Neither Vienna -> keep order
     t = "Linz/Donau ↔ Salzburg"
     assert _clean_title_keep_places(t) == "Linz/Donau ↔ Salzburg"

--- a/tests/test_oebb_title_prefix.py
+++ b/tests/test_oebb_title_prefix.py
@@ -1,6 +1,6 @@
 from src.providers.oebb import _is_relevant
 
-def test_rex_51_multiple_colons():
+def test_rex_51_multiple_colons() -> None:
     # REX 51: Störung: Wien Meidling ↔ Mödling
     title = "REX 51: Störung: Wien Meidling ↔ Mödling"
     description = "Wegen einer Störung..."


### PR DESCRIPTION
## Summary 
 
Second cluster of the `tests/` strict typing migration. Type-annotates 
20 test functions across 5 oebb-title test files. No code changes 
outside test function signatures, no new imports, no behavior changes. 
 
Whole-repo `no-untyped-def` count: **865 → 845** (− 20). 
 
## Files changed 
 
- `tests/test_oebb_cleaning.py` (7 functions) 
- `tests/test_oebb_issue_linz_passau.py` (3 functions) 
- `tests/test_oebb_title.py` (4 functions) 
- `tests/test_oebb_title_ordering.py` (5 functions) 
- `tests/test_oebb_title_prefix.py` (1 function) 
 
## Verification 
 
### Tooling 
 
``` 
mypy 1.10.1 (compiled: yes)
pytest 9.0.3
``` 
 
### Pre-state — per-file mypy 
 
``` 
== tests/test_oebb_cleaning.py ==
    ^
tests/test_oebb_cleaning.py:70: note: Use "-> None" if function does not return a value
Found 7 errors in 1 file (checked 1 source file)
== tests/test_oebb_issue_linz_passau.py ==
    ^
tests/test_oebb_issue_linz_passau.py:23: note: Use "-> None" if function does not return a value
Found 3 errors in 1 file (checked 1 source file)
== tests/test_oebb_title.py ==
    ^
tests/test_oebb_title.py:19: note: Use "-> None" if function does not return a value
Found 4 errors in 1 file (checked 1 source file)
== tests/test_oebb_title_ordering.py ==
    ^
tests/test_oebb_title_ordering.py:29: note: Use "-> None" if function does not return a value
Found 5 errors in 1 file (checked 1 source file)
== tests/test_oebb_title_prefix.py ==
    ^
tests/test_oebb_title_prefix.py:3: note: Use "-> None" if function does not return a value
Found 1 error in 1 file (checked 1 source file)
``` 
 
Expected `Found N errors`: 7 / 3 / 4 / 5 / 1. 
 
### Pre-state — pytest 
 
``` 
tests/test_oebb_title_prefix.py .                                        [100%]

============================== 20 passed in 2.66s ==============================
``` 
 
### Post-state — per-file mypy 
 
``` 
== tests/test_oebb_cleaning.py ==
Success: no issues found in 1 source file
== tests/test_oebb_issue_linz_passau.py ==
Success: no issues found in 1 source file
== tests/test_oebb_title.py ==
Success: no issues found in 1 source file
== tests/test_oebb_title_ordering.py ==
Success: no issues found in 1 source file
== tests/test_oebb_title_prefix.py ==
Success: no issues found in 1 source file
``` 
 
### Post-state — pytest 
 
``` 
tests/test_oebb_title_prefix.py .                                        [100%]

============================== 20 passed in 1.15s ==============================
``` 
 
### Activity proof — annotated signature counts 
 
``` 
tests/test_oebb_cleaning.py annotated=7 unannotated=0
tests/test_oebb_issue_linz_passau.py annotated=3 unannotated=0
tests/test_oebb_title.py annotated=4 unannotated=0
tests/test_oebb_title_ordering.py annotated=5 unannotated=0
tests/test_oebb_title_prefix.py annotated=1 unannotated=0
``` 
 
Expected: every file `annotated=N unannotated=0`. 
 
### Activity proof — whole-repo no-untyped-def count 
 
``` 
845
``` 
 
Expected: `845`. 
 
### Diff stats and staging 
 
``` 
 tests/test_oebb_cleaning.py          | 14 +++++++-------
 tests/test_oebb_issue_linz_passau.py |  6 +++---
 tests/test_oebb_title.py             |  8 ++++----
 tests/test_oebb_title_ordering.py    | 10 +++++-----
 tests/test_oebb_title_prefix.py      |  2 +-
 5 files changed, 20 insertions(+), 20 deletions(-)
M  tests/test_oebb_cleaning.py
M  tests/test_oebb_issue_linz_passau.py
M  tests/test_oebb_title.py
M  tests/test_oebb_title_ordering.py
M  tests/test_oebb_title_prefix.py
``` 
 
Expected `git status --porcelain`: exactly 5 lines, each starting 
with `M  ` (capital M, two spaces), no other entries.

---
*PR created automatically by Jules for task [1100138798209080935](https://jules.google.com/task/1100138798209080935) started by @Origamihase*