### PR TITLE
chore(tests): type-annotate log_sanitization plain tests (cluster 5a)

### DIFF
--- a/tests/test_log_sanitization_multiline.py
+++ b/tests/test_log_sanitization_multiline.py
@@ -3,7 +3,7 @@ import sys
 from unittest.mock import patch
 from src.utils.logging import sanitize_log_message
 
-def test_multiline_leak():
+def test_multiline_leak() -> None:
     msg = "Token: \n harmless \n SUPER_SECRET_VALUE"
     sanitized = sanitize_log_message(msg)
     print(f"Original: {repr(msg)}")
@@ -11,7 +11,7 @@ def test_multiline_leak():
     assert "SUPER_SECRET_VALUE" not in sanitized
     assert "Token: ***" in sanitized or "Token: \\n ***" in sanitized or "Token: \\n harmless \\n ***" in sanitized
 
-def test_multiline_header_leak():
+def test_multiline_header_leak() -> None:
     # Multiline headers must be indented (folding) to be treated as part of the value
     msg = "Authorization: Bearer\n  token"
     sanitized = sanitize_log_message(msg)
@@ -19,7 +19,7 @@ def test_multiline_header_leak():
     assert "token" not in sanitized
     assert "Authorization: ***" in sanitized
 
-def test_env_fallback_multiline():
+def test_env_fallback_multiline() -> None:
     # Save original modules
     original_env = sys.modules.get('src.utils.env')
     original_logging = sys.modules.get('src.utils.logging')

--- a/tests/test_log_sanitization_multiline_leak.py
+++ b/tests/test_log_sanitization_multiline_leak.py
@@ -1,6 +1,6 @@
 from src.utils.logging import sanitize_log_message
 
-def test_space_leakage_unquoted():
+def test_space_leakage_unquoted() -> None:
     """Test handling of unquoted secrets with spaces."""
     # "password=my secret user=1"
     # New behavior consumes spaces until the next key assignment.
@@ -16,7 +16,7 @@ def test_space_leakage_unquoted():
 
     assert sanitized == "password=*** user=1"
 
-def test_pem_block_redaction():
+def test_pem_block_redaction() -> None:
     """Test that PEM blocks (keys/certs) are fully redacted."""
     pem = """-----BEGIN PRIVATE KEY-----
 MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQD
@@ -31,7 +31,7 @@ MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQD
     assert "-----END PRIVATE KEY-----" in sanitized
     assert "***" in sanitized
 
-def test_multiline_header_leak():
+def test_multiline_header_leak() -> None:
     """Test that multiline headers (not indented) don't leak subsequent lines."""
     # Using 'Private-Key' which matches 'key' or 'private' in _header_keys
     pem = """-----BEGIN PRIVATE KEY-----
@@ -42,19 +42,19 @@ MIIEvg...
 
     assert "MIIEvg" not in sanitized, "PEM content in header leaked!"
 
-def test_ampersand_separation():
+def test_ampersand_separation() -> None:
     """Test that & acts as separator."""
     msg = "password=val&user=1"
     sanitized = sanitize_log_message(msg)
     assert sanitized == "password=***&user=1"
 
-def test_comma_separation():
+def test_comma_separation() -> None:
     """Test that comma acts as separator (common in repr)."""
     msg = "password=val,user=1"
     sanitized = sanitize_log_message(msg)
     assert sanitized == "password=***,user=1"
 
-def test_space_separated_keys():
+def test_space_separated_keys() -> None:
     """Test multiple space separated keys."""
     # usage of api_key (matches [a-z0-9_.\-]*api[-_.\s]*key)
     # usage of client_secret (matches client[-_.\s]*secret)
@@ -65,7 +65,7 @@ def test_space_separated_keys():
     assert "secret2" not in sanitized
     assert "user_id=123" in sanitized # user_id is not sensitive, should be preserved.
 
-def test_over_redaction_space_followed_by_text():
+def test_over_redaction_space_followed_by_text() -> None:
     """Test that text following a key-value pair IS redacted if it doesn't look like a key."""
     msg = "password=secret123 and some other text"
     sanitized = sanitize_log_message(msg)
@@ -74,14 +74,14 @@ def test_over_redaction_space_followed_by_text():
     expected = "password=***"
     assert sanitized == expected
 
-def test_over_redaction_space_followed_by_key_lookalike():
+def test_over_redaction_space_followed_by_key_lookalike() -> None:
     """Test that text that looks like a key but is not (no '=') IS consumed."""
     msg = "api_key=secret foo bar"
     sanitized = sanitize_log_message(msg)
     expected = "api_key=***"
     assert sanitized == expected
 
-def test_crlf_log_injection_formatters():
+def test_crlf_log_injection_formatters() -> None:
     import logging
     from src.feed.logging_safe import SafeFormatter, SafeJSONFormatter
 

--- a/tests/test_log_sanitization_multiword.py
+++ b/tests/test_log_sanitization_multiword.py
@@ -1,7 +1,7 @@
 
 from src.utils.logging import sanitize_log_message
 
-def test_sanitization_multiword_unquoted_secret():
+def test_sanitization_multiword_unquoted_secret() -> None:
     """
     Test that multi-word unquoted secrets (e.g. passphrase) are fully redacted.
     This was previously leaking words after the first space.
@@ -16,7 +16,7 @@ def test_sanitization_multiword_unquoted_secret():
     assert "staple" not in sanitized
     assert sanitized == "passphrase=***"
 
-def test_sanitization_multiword_followed_by_key():
+def test_sanitization_multiword_followed_by_key() -> None:
     """
     Test that unquoted value followed by a new key assignment stops correctly.
     """
@@ -35,7 +35,7 @@ def test_sanitization_multiword_followed_by_key():
     assert "foo" not in sanitized2
     assert sanitized2 == "password=*** token=***"
 
-def test_sanitization_multiword_followed_by_non_key_text():
+def test_sanitization_multiword_followed_by_non_key_text() -> None:
     """
     Test behavior when unquoted value is followed by text that is NOT a key assignment.
     With the new stricter regex, this text is considered part of the value and redacted.
@@ -50,7 +50,7 @@ def test_sanitization_multiword_followed_by_non_key_text():
     assert "(expired)" not in sanitized
     assert sanitized == "token=***"
 
-def test_sanitization_separators():
+def test_sanitization_separators() -> None:
     """Test that standard separators still work correctly."""
     msg = "password=secret, user=me"
     sanitized = sanitize_log_message(msg)
@@ -64,7 +64,7 @@ def test_sanitization_separators():
     assert "user=me" in sanitized2
     assert sanitized2 == "password=***&user=me"
 
-def test_sanitization_newline():
+def test_sanitization_newline() -> None:
     """Test that newline stops unquoted value matching."""
     msg = "password=secret\nuser=me"
     sanitized = sanitize_log_message(msg)

--- a/tests/test_log_sanitization_spaces.py
+++ b/tests/test_log_sanitization_spaces.py
@@ -1,27 +1,27 @@
 
 from src.utils.logging import sanitize_log_message
 
-def test_sanitization_spaces_assignment():
+def test_sanitization_spaces_assignment() -> None:
     """Test that assignments with spaces around '=' are redacted."""
     msg = 'password = "secret123"'
     sanitized = sanitize_log_message(msg)
     assert "***" in sanitized
     assert "secret123" not in sanitized
 
-def test_sanitization_spaces_assignment_unquoted():
+def test_sanitization_spaces_assignment_unquoted() -> None:
     """Test that unquoted assignments with spaces are redacted."""
     msg = "password = secret123"
     sanitized = sanitize_log_message(msg)
     assert "***" in sanitized
     assert "secret123" not in sanitized
 
-def test_sanitization_spaces_assignment_multiline():
+def test_sanitization_spaces_assignment_multiline() -> None:
     """Test multiline assignment with spaces."""
     msg = "password \n = \n secret123"
     sanitized = sanitize_log_message(msg)
     assert "secret123" not in sanitized
 
-def test_sanitization_spaces_assignment_key_value_pairs():
+def test_sanitization_spaces_assignment_key_value_pairs() -> None:
     """Test space separated key-value pairs with spaces in assignment."""
     # Use 'token' which is in _keys
     msg = "password = secret123 token = foo"


### PR DESCRIPTION
Cluster 5a — log_sanitization plain tests. Annotates 21 plain 
parameterless test functions across 4 files. 

Whole-repo `no-untyped-def` count: 786 → 766 (− 20). 

Files: 
- tests/test_log_sanitization_multiline.py (3 functions) 
- tests/test_log_sanitization_multiline_leak.py (9 functions) 
- tests/test_log_sanitization_multiword.py (5 functions) 
- tests/test_log_sanitization_spaces.py (4 functions)

---
*PR created automatically by Jules for task [471090792041926355](https://jules.google.com/task/471090792041926355) started by @Origamihase*