### PR TITLE
chore(tests): type-annotate log_sanitization parametrize and testcase tests (cluster 5b)

### DIFF
--- a/tests/test_log_sanitization_broad.py
+++ b/tests/test_log_sanitization_broad.py
@@ -25,6 +25,6 @@ from src.utils.logging import sanitize_log_message
         ('{"api_key": "abc"}', '{"api_key": "***"}'),
     ]
 )
-def test_log_sanitization_broad(input_text, expected_redacted):
+def test_log_sanitization_broad(input_text: str, expected_redacted: str) -> None:
     sanitized = sanitize_log_message(input_text)
     assert sanitized == expected_redacted

--- a/tests/test_log_sanitization_email_variants.py
+++ b/tests/test_log_sanitization_email_variants.py
@@ -10,7 +10,7 @@ from src.utils.logging import sanitize_log_message
     "customer.e-mail",
     "contact_e_mail"
 ])
-def test_email_variants_redaction(key):
+def test_email_variants_redaction(key: str) -> None:
     secret = "user@example.com"
     # Test query param style
     msg = f"User logged in with {key}={secret}"

--- a/tests/test_log_sanitization_enhancements.py
+++ b/tests/test_log_sanitization_enhancements.py
@@ -10,7 +10,7 @@ from src.utils.logging import sanitize_log_message
     "authorization_code",
     "auth_code",
 ])
-def test_sensitive_keys_redaction(key):
+def test_sensitive_keys_redaction(key: str) -> None:
     secret = "supersecretvalue"
     # Test query param style
     msg = f"Request failed with {key}={secret}"
@@ -30,7 +30,7 @@ def test_sensitive_keys_redaction(key):
     assert secret not in sanitized_header
     assert "***" in sanitized_header
 
-def test_passphrase_redaction_header():
+def test_passphrase_redaction_header() -> None:
     key = "Passphrase"
     secret = "secret123"
     msg = f"{key}: {secret}"
@@ -46,7 +46,7 @@ def test_passphrase_redaction_header():
     "email_address",
     "customer.email"
 ])
-def test_email_redaction(key):
+def test_email_redaction(key: str) -> None:
     secret = "user@example.com"
     # Test query param style
     msg = f"User logged in with {key}={secret}"

--- a/tests/test_log_sanitization_new_keys.py
+++ b/tests/test_log_sanitization_new_keys.py
@@ -3,7 +3,7 @@ import unittest
 from src.utils.logging import sanitize_log_message
 
 class TestLogSanitizationNewKeys(unittest.TestCase):
-    def test_new_keys_redaction(self):
+    def test_new_keys_redaction(self) -> None:
         # otp
         msg = "my_otp_code=123456"
         self.assertEqual(sanitize_log_message(msg), "my_otp_code=***")
@@ -20,7 +20,7 @@ class TestLogSanitizationNewKeys(unittest.TestCase):
         msg = "github_ghp_token=ghp_123"
         self.assertEqual(sanitize_log_message(msg), "github_ghp_token=***")
 
-    def test_false_positives(self):
+    def test_false_positives(self) -> None:
         # hotpot (contains otp but not at boundary)
         # Should NOT be redacted
         msg = "hotpot=delicious"

--- a/tests/test_log_sanitization_oauth_saml.py
+++ b/tests/test_log_sanitization_oauth_saml.py
@@ -11,7 +11,7 @@ from src.utils.logging import sanitize_log_message
     "nonce",
     "state",
 ])
-def test_sensitive_oauth_saml_keys_redaction(key):
+def test_sensitive_oauth_saml_keys_redaction(key: str) -> None:
     secret = "supersecretvalue"
     # Test query param style
     msg = f"Request failed with {key}={secret}"
@@ -31,7 +31,7 @@ def test_sensitive_oauth_saml_keys_redaction(key):
     assert secret not in sanitized_header
     assert "***" in sanitized_header
 
-def test_nonce_state_redaction():
+def test_nonce_state_redaction() -> None:
     # Specific test for short keys to ensure no false positives or negatives
     # Note: current implementation is aggressive (substring matching), so we expect redaction.
 

--- a/tests/test_log_sanitization_prefix.py
+++ b/tests/test_log_sanitization_prefix.py
@@ -36,6 +36,6 @@ from src.utils.logging import sanitize_log_message
         ('{"primary_key": "123"}', '{"primary_key": "123"}'),
     ]
 )
-def test_log_sanitization_prefix(input_text, expected_redacted):
+def test_log_sanitization_prefix(input_text: str, expected_redacted: str) -> None:
     sanitized = sanitize_log_message(input_text)
     assert sanitized == expected_redacted

--- a/tests/test_log_sanitization_separators.py
+++ b/tests/test_log_sanitization_separators.py
@@ -29,6 +29,6 @@ from src.utils.logging import sanitize_log_message
         ('X--Api--Key: secret', 'X--Api--Key: ***'),
     ]
 )
-def test_log_sanitization_separators(input_text, expected_redacted):
+def test_log_sanitization_separators(input_text: str, expected_redacted: str) -> None:
     sanitized = sanitize_log_message(input_text)
     assert sanitized == expected_redacted

--- a/tests/test_log_sanitization_variations.py
+++ b/tests/test_log_sanitization_variations.py
@@ -37,7 +37,7 @@ from src.utils.logging import sanitize_log_message
         ("client_id_extra=val", "client_id_extra=***"),
     ]
 )
-def test_log_sanitization_variations(input_text, expected_redacted):
+def test_log_sanitization_variations(input_text: str, expected_redacted: str) -> None:
     sanitized = sanitize_log_message(input_text)
     # Handle the aggressive matching of 'secret' in 'not_a_secret'
     if "not_a_secret" in input_text and expected_redacted == input_text:
@@ -49,14 +49,14 @@ def test_log_sanitization_variations(input_text, expected_redacted):
 
     assert sanitized == expected_redacted
 
-def test_json_escaped_quotes_with_variations():
+def test_json_escaped_quotes_with_variations() -> None:
     # Test that variations work even with complex JSON quoting
     # This exposes the bug in existing regex
     input_json = '{"Client-ID": "secret \\" value"}'
     expected = '{"Client-ID": "***"}'
     assert sanitize_log_message(input_json) == expected
 
-def test_accessId_escaped_quotes_bug():
+def test_accessId_escaped_quotes_bug() -> None:
     # This tests the EXISTING key "accessId" which has a dedicated regex in logging.py
     # If this fails, it confirms the bug is pre-existing.
     input_json = '{"accessId": "secret \\" value"}'


### PR DESCRIPTION
Cluster 5b — log_sanitization parametrize and TestCase tests. 
Annotates 14 test signatures across 8 files. 
 
Patterns: 
- `(input_text: str, expected_redacted: str) -> None` for str/str 
  parametrize tuples (4 functions across 4 files). 
- `(key: str) -> None` for single-string parametrize (4 functions 
  across 3 files). 
- `() -> None` for plain parameterless tests (4 functions across 
  3 files). 
- `(self) -> None` for unittest.TestCase methods (2 methods in 1 
  file). 
 
Files: 
- tests/test_log_sanitization_broad.py (1 function) 
- tests/test_log_sanitization_email_variants.py (1 function) 
- tests/test_log_sanitization_enhancements.py (3 functions) 
- tests/test_log_sanitization_new_keys.py (2 methods) 
- tests/test_log_sanitization_oauth_saml.py (2 functions) 
- tests/test_log_sanitization_prefix.py (1 function) 
- tests/test_log_sanitization_separators.py (1 function) 
- tests/test_log_sanitization_variations.py (3 functions)

---
*PR created automatically by Jules for task [16160894052205867816](https://jules.google.com/task/16160894052205867816) started by @Origamihase*