### PR TITLE
strict-typing(tests): cluster 8 — _import_build_feed helpers

### DIFF
--- a/tests/test_build_feed_date_logic.py
+++ b/tests/test_build_feed_date_logic.py
@@ -1,13 +1,14 @@
 import importlib
 import logging
 import sys
+import pytest
 import types
 import datetime as dt_module
 from datetime import timezone
 from pathlib import Path
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_build_feed_io.py
+++ b/tests/test_build_feed_io.py
@@ -1,10 +1,11 @@
 import importlib
 import sys
+import pytest
 import types
 from pathlib import Path
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_build_feed_lock.py
+++ b/tests/test_build_feed_lock.py
@@ -1,11 +1,12 @@
 import sys
 import json
 import importlib
+import pytest
 import types
 from pathlib import Path
 from contextlib import contextmanager
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     # Ensure we can import src modules
     root = Path(__file__).resolve().parents[1]

--- a/tests/test_build_feed_sort.py
+++ b/tests/test_build_feed_sort.py
@@ -1,10 +1,11 @@
 import sys
 import importlib
+import pytest
 import types
 from pathlib import Path
 from datetime import datetime, timezone
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     # Ensure we can import src modules
     root = Path(__file__).resolve().parents[1]

--- a/tests/test_collect_items_bad_return.py
+++ b/tests/test_collect_items_bad_return.py
@@ -1,9 +1,10 @@
 import importlib
 import sys
 from pathlib import Path
+import pytest
 import types
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_collect_items_env.py
+++ b/tests/test_collect_items_env.py
@@ -5,7 +5,7 @@ import types
 import pytest
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_collect_items_timeout.py
+++ b/tests/test_collect_items_timeout.py
@@ -3,10 +3,11 @@ import sys
 import threading
 import time
 from pathlib import Path
+import pytest
 import types
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_dedupe_items.py
+++ b/tests/test_dedupe_items.py
@@ -1,10 +1,11 @@
 import importlib
 import sys
 from pathlib import Path
+import pytest
 import types
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_dedupe_prefers_longer_end.py
+++ b/tests/test_dedupe_prefers_longer_end.py
@@ -2,11 +2,12 @@ from datetime import timezone
 import importlib
 import sys
 from pathlib import Path
+import pytest
 import types
 from datetime import datetime
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -5,7 +5,7 @@ import types
 import pytest
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_drop_old_items_future.py
+++ b/tests/test_drop_old_items_future.py
@@ -2,10 +2,11 @@ import importlib
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import pytest
 import types
 
 
-def _import_build_feed(monkeypatch, env=None):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch, env: dict[str, str] | None = None) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_ends_at.py
+++ b/tests/test_ends_at.py
@@ -2,10 +2,11 @@ import importlib
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import pytest
 import types
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_first_seen_cleanup.py
+++ b/tests/test_first_seen_cleanup.py
@@ -1,11 +1,12 @@
 import importlib
 import sys
+import pytest
 import types
 from pathlib import Path
 from datetime import datetime, timezone
 
 
-def _import_build_feed(monkeypatch, tmp_path):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_first_seen_fuzzy.py
+++ b/tests/test_first_seen_fuzzy.py
@@ -1,11 +1,12 @@
 import importlib
 import sys
+import pytest
 import types
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
 
 
-def _import_build_feed(monkeypatch, tmp_path):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_identity_no_lines.py
+++ b/tests/test_identity_no_lines.py
@@ -1,11 +1,12 @@
 import importlib
 import sys
 from pathlib import Path
+import pytest
 import types
 from datetime import datetime, timezone
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_item_age.py
+++ b/tests/test_item_age.py
@@ -1,11 +1,12 @@
 import importlib
 import sys
 from pathlib import Path
+import pytest
 import types
 from datetime import datetime, timedelta, timezone
 
 
-def _import_build_feed(monkeypatch, env):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch, env: dict[str, str]) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_path_guard.py
+++ b/tests/test_path_guard.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_pubdate.py
+++ b/tests/test_pubdate.py
@@ -2,11 +2,12 @@ import importlib
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import pytest
 import types
 from defusedxml import ElementTree as ET
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3,10 +3,11 @@ import sys
 import json
 from pathlib import Path
 from datetime import datetime, timezone, timedelta
+import pytest
 import types
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_state_save_readonly.py
+++ b/tests/test_state_save_readonly.py
@@ -1,12 +1,13 @@
 import importlib
 import sys
+import pytest
 import types
 import logging
 from pathlib import Path
 from datetime import datetime, timezone
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))

--- a/tests/test_to_utc.py
+++ b/tests/test_to_utc.py
@@ -2,10 +2,11 @@ import importlib
 import sys
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
+import pytest
 import types
 
 
-def _import_build_feed(monkeypatch):
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))


### PR DESCRIPTION
Cluster 8 of the strict-typing migration on tests/.

Scope: annotate the _import_build_feed helper in 21 test files of the
build_feed family.

Mechanical change only — signatures plus missing `import pytest`. No
test logic touched.

Findings cleared:
- 21 no-untyped-def (one per helper)
- ~80 no-untyped-call (cascading from typed callers in same files)

Out of scope: the test functions themselves — handled in later per-file
clusters.

---
*PR created automatically by Jules for task [8850442164588210959](https://jules.google.com/task/8850442164588210959) started by @Origamihase*