### PR TITLE
strict-typing(tests): cluster 9 — _import_build_feed_without_providers helper

### DIFF
--- a/tests/test_build_feed_cache.py
+++ b/tests/test_build_feed_cache.py
@@ -2,10 +2,12 @@ import builtins
 import importlib
 import logging
 import sys
+import types
+import pytest
 from pathlib import Path
 from datetime import datetime, timezone
 
-def _import_build_feed_without_providers(monkeypatch):
+def _import_build_feed_without_providers(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
     root = Path(__file__).resolve().parents[1]
     monkeypatch.syspath_prepend(str(root))


### PR DESCRIPTION
Adds type annotations to the `_import_build_feed_without_providers` helper in tests/test_build_feed_cache.py. 
 
Clears 1 `no-untyped-def` finding. 
 
Part of the strict-typing migration in tests/.

---
*PR created automatically by Jules for task [11281209243820601348](https://jules.google.com/task/11281209243820601348) started by @Origamihase*