### PR TITLE
strict-typing(tests): cluster 11 — test functions in 8 build_feed files

### DIFF
--- a/tests/test_dedupe_prefers_longer_end.py
+++ b/tests/test_dedupe_prefers_longer_end.py
@@ -28,7 +28,7 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return importlib.import_module(module_name)
 
 
-def test_prefers_later_ends_at(monkeypatch):
+def test_prefers_later_ends_at(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     earlier = {
@@ -46,7 +46,7 @@ def test_prefers_later_ends_at(monkeypatch):
     assert out == [later]
 
 
-def test_prefers_newer_even_if_ends_at_shorter(monkeypatch):
+def test_prefers_newer_even_if_ends_at_shorter(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     previous = {
@@ -67,7 +67,7 @@ def test_prefers_newer_even_if_ends_at_shorter(monkeypatch):
     assert out == [previous]
 
 
-def test_prefers_newer_when_starts_at_changes(monkeypatch):
+def test_prefers_newer_when_starts_at_changes(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     base = {

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -33,7 +33,7 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
         ("ABSOLUTE_MAX_AGE_DAYS", 540),
     ],
 )
-def test_default_age_and_ttl(monkeypatch, attr, expected):
+def test_default_age_and_ttl(monkeypatch: pytest.MonkeyPatch, attr: str, expected: int) -> None:
     monkeypatch.delenv("FEED_TTL", raising=False)
     monkeypatch.delenv("MAX_ITEM_AGE_DAYS", raising=False)
     monkeypatch.delenv("ABSOLUTE_MAX_AGE_DAYS", raising=False)

--- a/tests/test_ends_at.py
+++ b/tests/test_ends_at.py
@@ -23,7 +23,10 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return importlib.import_module(module_name)
 
 
-def test_item_with_past_ends_at_is_dropped(monkeypatch, tmp_path):
+def test_item_with_past_ends_at_is_dropped(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     build_feed = _import_build_feed(monkeypatch)
     now = datetime.now(timezone.utc)
     future = {"title": "future", "ends_at": now + timedelta(hours=1)}

--- a/tests/test_identity_no_lines.py
+++ b/tests/test_identity_no_lines.py
@@ -26,7 +26,7 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return importlib.import_module(module_name)
 
 
-def test_identity_distinguishes_items_without_lines(monkeypatch):
+def test_identity_distinguishes_items_without_lines(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     day = datetime(2024, 1, 1, tzinfo=timezone.utc)
@@ -41,7 +41,7 @@ def test_identity_distinguishes_items_without_lines(monkeypatch):
     assert ident2.startswith("wl|störung|L=|D=2024-01-01|T=")
 
 
-def test_identity_includes_line_tokens_and_is_cosmetic_stable(monkeypatch):
+def test_identity_includes_line_tokens_and_is_cosmetic_stable(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     day = datetime(2024, 1, 1, tzinfo=timezone.utc)

--- a/tests/test_path_guard.py
+++ b/tests/test_path_guard.py
@@ -24,7 +24,10 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return module
 
 
-def test_out_path_rejects_outside_whitelist(monkeypatch, tmp_path):
+def test_out_path_rejects_outside_whitelist(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     build_feed = _import_build_feed(monkeypatch)
     monkeypatch.chdir(tmp_path)
     # Set env var so refresh_from_env picks it up and validation fails
@@ -38,14 +41,20 @@ def test_out_path_rejects_outside_whitelist(monkeypatch, tmp_path):
         build_feed.main()
 
 
-def test_state_path_rejects_outside_whitelist(monkeypatch, tmp_path):
+def test_state_path_rejects_outside_whitelist(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("STATE_PATH", "../evil.json")
     with pytest.raises(ValueError):
         _import_build_feed(monkeypatch)
 
 
-def test_log_dir_outside_whitelist_falls_back(monkeypatch, tmp_path):
+def test_log_dir_outside_whitelist_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("LOG_DIR", "../evil")
     build_feed = _import_build_feed(monkeypatch)

--- a/tests/test_pubdate.py
+++ b/tests/test_pubdate.py
@@ -32,7 +32,7 @@ def _emit_item_str(build_feed, item, now, state):
     return ident, xml_str
 
 
-def test_pubdate_added_for_fresh_item(monkeypatch):
+def test_pubdate_added_for_fresh_item(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
     now = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
     state = {}
@@ -42,7 +42,7 @@ def test_pubdate_added_for_fresh_item(monkeypatch):
     assert build_feed._fmt_rfc2822(now) in xml
 
 
-def test_pubdate_not_added_after_window(monkeypatch):
+def test_pubdate_not_added_after_window(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
     now = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
     old = now - timedelta(minutes=build_feed.feed_config.FRESH_PUBDATE_WINDOW_MIN + 1)
@@ -52,7 +52,7 @@ def test_pubdate_not_added_after_window(monkeypatch):
     assert "<pubDate>" not in xml
 
 
-def test_fresh_pubdate_window_min_rejects_negative_values(monkeypatch):
+def test_fresh_pubdate_window_min_rejects_negative_values(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("FRESH_PUBDATE_WINDOW_MIN", "-10")
     # Need to reload config to pick up the env var change
     from src.feed import config

--- a/tests/test_state_save_readonly.py
+++ b/tests/test_state_save_readonly.py
@@ -24,7 +24,10 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return importlib.import_module(module_name)
 
 
-def test_make_rss_logs_warning_when_state_readonly(monkeypatch, caplog):
+def test_make_rss_logs_warning_when_state_readonly(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     def fail_save(_):
@@ -47,7 +50,10 @@ def test_make_rss_logs_warning_when_state_readonly(monkeypatch, caplog):
 
 
 
-def test_make_rss_saves_empty_state_when_no_identities(monkeypatch, caplog):
+def test_make_rss_saves_empty_state_when_no_identities(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     captured = {"state": None}

--- a/tests/test_to_utc.py
+++ b/tests/test_to_utc.py
@@ -23,7 +23,7 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return importlib.import_module(module_name)
 
 
-def test_to_utc_converts_timezone(monkeypatch):
+def test_to_utc_converts_timezone(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
     cet = timezone(timedelta(hours=2))
     dt = datetime(2025, 1, 1, 12, 0, tzinfo=cet)
@@ -32,7 +32,7 @@ def test_to_utc_converts_timezone(monkeypatch):
     assert result.hour == 10
 
 
-def test_fmt_rfc2822_outputs_vienna(monkeypatch):
+def test_fmt_rfc2822_outputs_vienna(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
     cet = timezone(timedelta(hours=2))
     dt = datetime(2025, 1, 1, 12, 0, tzinfo=cet)
@@ -42,7 +42,7 @@ def test_fmt_rfc2822_outputs_vienna(monkeypatch):
     assert "11:00:00" in formatted
 
 
-def test_fmt_rfc2822_fallback_locale_independent(monkeypatch):
+def test_fmt_rfc2822_fallback_locale_independent(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     # Force the fallback by breaking format_datetime


### PR DESCRIPTION
Adds type annotations to 18 test functions across 8 files in the build_feed Cluster-8 family. 
 
Files: 
- tests/test_dedupe_prefers_longer_end.py (3 tests) 
- tests/test_defaults.py (1 parametrized test) 
- tests/test_ends_at.py (1 test) 
- tests/test_identity_no_lines.py (2 tests) 
- tests/test_path_guard.py (3 tests) 
- tests/test_pubdate.py (3 tests) 
- tests/test_state_save_readonly.py (2 tests) 
- tests/test_to_utc.py (3 tests) 
 
Clears 18 `no-untyped-def` findings. 
 
Nested function definitions and first-level helpers (`_emit_item_str`, `fail_save`, `marker`, `fake_collect`, `fake_make_rss`, `broken_formatter`) remain unannotated and will be addressed in later clusters. 
 
Part of the strict-typing migration in tests/.

---
*PR created automatically by Jules for task [8489320129465934737](https://jules.google.com/task/8489320129465934737) started by @Origamihase*