### PR TITLE
strict-typing(tests): cluster 12 — test functions in 8 more build_feed files

### DIFF
--- a/tests/test_build_feed_date_logic.py
+++ b/tests/test_build_feed_date_logic.py
@@ -25,7 +25,10 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return importlib.import_module(module_name)
 
 
-def test_format_local_times_end_before_start_future(monkeypatch, caplog):
+def test_format_local_times_end_before_start_future(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     # Mock datetime.now inside build_feed to have a fixed "today"
@@ -52,7 +55,10 @@ def test_format_local_times_end_before_start_future(monkeypatch, caplog):
     assert "Enddatum liegt vor Startdatum" in warnings
 
 
-def test_format_local_times_end_before_start_past(monkeypatch, caplog):
+def test_format_local_times_end_before_start_past(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     # Mock datetime.now inside build_feed to have a fixed "today"

--- a/tests/test_build_feed_io.py
+++ b/tests/test_build_feed_io.py
@@ -27,7 +27,11 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return importlib.import_module(module_name)
 
 
-def test_main_does_not_save_state_on_io_error(monkeypatch, tmp_path, caplog):
+def test_main_does_not_save_state_on_io_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     monkeypatch.chdir(tmp_path)

--- a/tests/test_build_feed_lock.py
+++ b/tests/test_build_feed_lock.py
@@ -28,7 +28,10 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module.refresh_from_env()
     return module
 
-def test_save_state_uses_separate_lock_file(monkeypatch, tmp_path):
+def test_save_state_uses_separate_lock_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     """
     Verify that _save_state creates a .lock file instead of locking the target file directly.
     """

--- a/tests/test_build_feed_sort.py
+++ b/tests/test_build_feed_sort.py
@@ -27,7 +27,7 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module.refresh_from_env()
     return module
 
-def test_sort_key_handles_none_guid(monkeypatch, tmp_path):
+def test_sort_key_handles_none_guid(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """
     Verify that _sort_key handles cases where 'guid' is explicitly None in the item dict.
     """
@@ -76,7 +76,7 @@ def test_sort_key_handles_none_guid(monkeypatch, tmp_path):
     assert isinstance(key3[2], str)
     assert key3[2] == "some-guid"
 
-def test_deterministic_sorting_fallback(monkeypatch, tmp_path):
+def test_deterministic_sorting_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 
     build_feed = _import_build_feed(monkeypatch)
 

--- a/tests/test_collect_items_bad_return.py
+++ b/tests/test_collect_items_bad_return.py
@@ -24,7 +24,10 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return importlib.import_module(module_name)
 
 
-def test_collect_items_logs_and_skips_invalid_return(monkeypatch, caplog):
+def test_collect_items_logs_and_skips_invalid_return(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     def good_provider(timeout=None):

--- a/tests/test_collect_items_env.py
+++ b/tests/test_collect_items_env.py
@@ -33,7 +33,11 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
         ("VOR_ENABLE", [{"p": "wl"}, {"p": "oebb"}]),
     ],
 )
-def test_disabling_provider_suppresses_items(monkeypatch, disabled_env, expected):
+def test_disabling_provider_suppresses_items(
+    monkeypatch: pytest.MonkeyPatch,
+    disabled_env: str,
+    expected: list[dict[str, str]],
+) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     monkeypatch.setattr(
@@ -59,7 +63,10 @@ def test_disabling_provider_suppresses_items(monkeypatch, disabled_env, expected
     "value",
     ["0", " 0 ", "false", " False ", "FALSE", "\t0\n", "\nfalse\t"],
 )
-def test_env_disabling_ignores_whitespace_and_case(monkeypatch, value):
+def test_env_disabling_ignores_whitespace_and_case(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     monkeypatch.setattr(
@@ -78,7 +85,7 @@ def test_env_disabling_ignores_whitespace_and_case(monkeypatch, value):
     assert items == [{"p": "oebb"}]
 
 
-def test_enabling_vor_yields_items(monkeypatch):
+def test_enabling_vor_yields_items(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     monkeypatch.setattr(

--- a/tests/test_collect_items_timeout.py
+++ b/tests/test_collect_items_timeout.py
@@ -29,7 +29,7 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return module
 
 
-def test_slow_provider_does_not_block(monkeypatch):
+def test_slow_provider_does_not_block(monkeypatch: pytest.MonkeyPatch) -> None:
     # Use 1s timeout
     monkeypatch.setenv("PROVIDER_TIMEOUT", "1")
     build_feed = _import_build_feed(monkeypatch)
@@ -61,7 +61,7 @@ def test_slow_provider_does_not_block(monkeypatch):
     assert items == [{"guid": "fast"}]
 
 
-def test_provider_specific_timeout_override(monkeypatch):
+def test_provider_specific_timeout_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PROVIDER_TIMEOUT", "2")
     build_feed = _import_build_feed(monkeypatch)
 
@@ -99,7 +99,7 @@ def test_provider_specific_timeout_override(monkeypatch):
     assert items == [{"guid": "fast"}]
 
 
-def test_cache_providers_run_sequentially(monkeypatch):
+def test_cache_providers_run_sequentially(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     calls = []
@@ -139,7 +139,7 @@ def test_cache_providers_run_sequentially(monkeypatch):
     assert calls == ["wl", "oebb"]
 
 
-def test_provider_worker_limit(monkeypatch):
+def test_provider_worker_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
     monkeypatch.setenv("PROVIDER_MAX_WORKERS", "4")
     monkeypatch.setenv("PROVIDER_MAX_WORKERS_GROUP", "1")

--- a/tests/test_dedupe_items.py
+++ b/tests/test_dedupe_items.py
@@ -26,7 +26,7 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return importlib.import_module(module_name)
 
 
-def test_main_dedupes_items(monkeypatch, tmp_path):
+def test_main_dedupes_items(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     sample_items = [
@@ -67,7 +67,7 @@ def test_main_dedupes_items(monkeypatch, tmp_path):
     ]
 
 
-def test_items_without_identifier_are_unique(monkeypatch):
+def test_items_without_identifier_are_unique(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     items = [
@@ -78,7 +78,7 @@ def test_items_without_identifier_are_unique(monkeypatch):
     assert build_feed._dedupe_items(items) == items
 
 
-def test_items_with_same_text_but_different_source(monkeypatch):
+def test_items_with_same_text_but_different_source(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(monkeypatch)
 
     items = [


### PR DESCRIPTION
Adds type annotations to 17 test functions across 8 files in the build_feed Cluster-8 family.

Files:
- tests/test_build_feed_date_logic.py (2 tests)
- tests/test_build_feed_io.py (1 test)
- tests/test_build_feed_lock.py (1 test)
- tests/test_build_feed_sort.py (2 tests)
- tests/test_collect_items_bad_return.py (1 test)
- tests/test_collect_items_env.py (3 tests, 2 parametrized)
- tests/test_collect_items_timeout.py (4 tests)
- tests/test_dedupe_items.py (3 tests)

Clears 17 `no-untyped-def` findings.

Nested function definitions and nested class methods (`MockDatetime.now`, `FailingContextManager.__enter__`/`__exit__`, plus various nested helper functions) remain unannotated and will be addressed in a later cluster.

Part of the strict-typing migration in tests/.

---
*PR created automatically by Jules for task [3360401114371791886](https://jules.google.com/task/3360401114371791886) started by @Origamihase*