### PR TITLE
strict-typing(tests): cluster 13 — test functions in 10 mixed files

### DIFF
--- a/tests/test_drop_old_items_future.py
+++ b/tests/test_drop_old_items_future.py
@@ -28,7 +28,7 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch, env: dict[str, str] | No
     return module
 
 
-def test_future_ends_at_skips_max_age(monkeypatch):
+def test_future_ends_at_skips_max_age(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(
         monkeypatch,
         {"MAX_ITEM_AGE_DAYS": "365", "ABSOLUTE_MAX_AGE_DAYS": "540"},
@@ -49,7 +49,7 @@ def test_future_ends_at_skips_max_age(monkeypatch):
     assert res == [future]
 
 
-def test_first_seen_used_when_no_dates(monkeypatch):
+def test_first_seen_used_when_no_dates(monkeypatch: pytest.MonkeyPatch) -> None:
     build_feed = _import_build_feed(
         monkeypatch,
         {"MAX_ITEM_AGE_DAYS": "2", "ABSOLUTE_MAX_AGE_DAYS": "10"},

--- a/tests/test_first_seen_cleanup.py
+++ b/tests/test_first_seen_cleanup.py
@@ -37,7 +37,10 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> types
     return importlib.import_module(module_name)
 
 
-def test_state_cleanup_keeps_only_current_identities(monkeypatch, tmp_path):
+def test_state_cleanup_keeps_only_current_identities(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     build_feed = _import_build_feed(monkeypatch, tmp_path)
     now = datetime.now(timezone.utc)
 

--- a/tests/test_first_seen_fuzzy.py
+++ b/tests/test_first_seen_fuzzy.py
@@ -33,7 +33,7 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> types
     return importlib.import_module(module_name)
 
 
-def test_first_seen_fuzzy_identity(monkeypatch, tmp_path):
+def test_first_seen_fuzzy_identity(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     build_feed = _import_build_feed(monkeypatch, tmp_path)
     now = datetime.now(timezone.utc)
     item_a = {

--- a/tests/test_item_age.py
+++ b/tests/test_item_age.py
@@ -26,7 +26,10 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch, env: dict[str, str]) -> 
     return importlib.import_module(module_name)
 
 
-def test_main_filters_items_older_than_max(monkeypatch, tmp_path):
+def test_main_filters_items_older_than_max(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     build_feed = _import_build_feed(
         monkeypatch,
         {"MAX_ITEM_AGE_DAYS": "2", "ABSOLUTE_MAX_AGE_DAYS": "10"},
@@ -55,7 +58,10 @@ def test_main_filters_items_older_than_max(monkeypatch, tmp_path):
     assert captured["items"] == [recent]
 
 
-def test_main_filters_items_older_than_absolute(monkeypatch, tmp_path):
+def test_main_filters_items_older_than_absolute(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     build_feed = _import_build_feed(
         monkeypatch,
         {"MAX_ITEM_AGE_DAYS": "1000", "ABSOLUTE_MAX_AGE_DAYS": "2"},

--- a/tests/test_link_sanitization.py
+++ b/tests/test_link_sanitization.py
@@ -11,7 +11,7 @@ def _emit_item_str(item, now, state):
         xml_str = xml_str.replace(ph, content)
     return ident, xml_str
 
-def test_javascript_link_sanitization():
+def test_javascript_link_sanitization() -> None:
     # Mock date and state
     now = datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     state = {}
@@ -39,7 +39,7 @@ def test_javascript_link_sanitization():
     if FEED_LINK:
         assert f"<link>{FEED_LINK}</link>" in xml
 
-def test_valid_http_link_preserved():
+def test_valid_http_link_preserved() -> None:
     now = datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     state = {}
 

--- a/tests/test_make_guid.py
+++ b/tests/test_make_guid.py
@@ -8,7 +8,7 @@ import hashlib
 from src.utils.ids import make_guid
 
 
-def test_make_guid_matches_sha256_digest_for_parts():
+def test_make_guid_matches_sha256_digest_for_parts() -> None:
     """The GUID uses the SHA256 digest of the pipe-joined parts."""
 
     parts = ("line", "station", "direction")
@@ -17,14 +17,14 @@ def test_make_guid_matches_sha256_digest_for_parts():
     assert make_guid(*parts) == expected
 
 
-def test_make_guid_treats_falsy_values_as_empty_strings():
+def test_make_guid_treats_falsy_values_as_empty_strings() -> None:
     """Falsy values are coerced to empty strings before hashing."""
 
     assert make_guid("line", None, "station") == make_guid("line", "", "station")
     assert make_guid("", "", "") == make_guid(None, None, None)
 
 
-def test_make_guid_is_stable_for_unicode_content():
+def test_make_guid_is_stable_for_unicode_content() -> None:
     """Unicode input is supported and results in stable GUIDs."""
 
     unicode_parts = ("ßtraße", "🚉", "向东")

--- a/tests/test_max_items.py
+++ b/tests/test_max_items.py
@@ -2,9 +2,10 @@ import importlib
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+import pytest
 
 
-def test_max_items_non_negative(monkeypatch):
+def test_max_items_non_negative(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MAX_ITEMS", "-5")
     module_name = "src.build_feed"
     # Ensure 'providers' package can be found
@@ -16,7 +17,7 @@ def test_max_items_non_negative(monkeypatch):
     assert build_feed.feed_config.MAX_ITEMS == 0
 
 
-def test_make_rss_ignores_items_when_max_is_zero(monkeypatch):
+def test_make_rss_ignores_items_when_max_is_zero(monkeypatch: pytest.MonkeyPatch) -> None:
     module_name = "src.build_feed"
     monkeypatch.setenv("MAX_ITEMS", "0")
     monkeypatch.syspath_prepend(str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_oebb_identity.py
+++ b/tests/test_oebb_identity.py
@@ -1,6 +1,6 @@
 from src.build_feed import _identity_for_item
 
-def test_oebb_identity_uses_guid():
+def test_oebb_identity_uses_guid() -> None:
     item = {
         "source": "öbb",
         "guid": "oebb-guid-1234",
@@ -9,7 +9,7 @@ def test_oebb_identity_uses_guid():
     identity = _identity_for_item(item)
     assert identity == "oebb|oebb-guid-1234"
 
-def test_oebb_identity_uses_link_if_no_guid():
+def test_oebb_identity_uses_link_if_no_guid() -> None:
     item = {
         "source": "oebb",
         "link": "https://example.com/oebb/1234",
@@ -18,7 +18,7 @@ def test_oebb_identity_uses_link_if_no_guid():
     identity = _identity_for_item(item)
     assert identity == "oebb|https://example.com/oebb/1234"
 
-def test_oebb_identity_uses_hash_if_neither():
+def test_oebb_identity_uses_hash_if_neither() -> None:
     item = {
         "source": "öbb",
         "title": "Test Title",

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -28,7 +28,7 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     return module
 
 
-def test_state_path_override(monkeypatch, tmp_path):
+def test_state_path_override(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     state_file = tmp_path / "data" / "custom_state.json"
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("STATE_PATH", "data/custom_state.json")
@@ -39,7 +39,7 @@ def test_state_path_override(monkeypatch, tmp_path):
     assert build_feed._load_state() == {"id": {"first_seen": now}}
 
 
-def test_state_repairs_malformed_entries(monkeypatch, tmp_path):
+def test_state_repairs_malformed_entries(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     state_file = tmp_path / "data" / "state.json"
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("STATE_PATH", "data/state.json")
@@ -82,7 +82,10 @@ def test_state_repairs_malformed_entries(monkeypatch, tmp_path):
         assert dt.tzinfo is not None, "Repaired datetime should be timezone-aware"
 
 
-def test_state_retention_discards_old_entries(monkeypatch, tmp_path):
+def test_state_retention_discards_old_entries(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     state_file = tmp_path / "data" / "state.json"
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("STATE_PATH", "data/state.json")
@@ -107,7 +110,7 @@ def test_state_retention_discards_old_entries(monkeypatch, tmp_path):
     assert state == {"fresh": {"first_seen": fresh_dt.isoformat()}}
 
 
-def test_state_cleared_when_feed_empty(monkeypatch, tmp_path):
+def test_state_cleared_when_feed_empty(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     state_file = tmp_path / "data" / "state.json"
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("STATE_PATH", "data/state.json")

--- a/tests/test_xml_ends_at.py
+++ b/tests/test_xml_ends_at.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from src.build_feed import _make_rss
 
 class TestXmlEndsAt(unittest.TestCase):
-    def test_ends_at_xml_generation(self):
+    def test_ends_at_xml_generation(self) -> None:
         # Setup
         now = datetime(2023, 10, 27, 10, 0, 0, tzinfo=timezone.utc)
         start = datetime(2023, 10, 27, 12, 0, 0, tzinfo=timezone.utc)
@@ -46,7 +46,7 @@ class TestXmlEndsAt(unittest.TestCase):
         expected_end = format_datetime(end.astimezone(ZoneInfo("Europe/Vienna")))
         self.assertEqual(ends_at_elem.text, expected_end)
 
-    def test_ends_at_missing_in_xml_when_none(self):
+    def test_ends_at_missing_in_xml_when_none(self) -> None:
         now = datetime(2023, 10, 27, 10, 0, 0, tzinfo=timezone.utc)
         item = {
             "title": "Test Event No Ends",


### PR DESCRIPTION
Adds type annotations to 22 test functions across 10 files.

build_feed family (remaining Cluster-8 Group B/C/D files):
- tests/test_drop_old_items_future.py (2 tests)
- tests/test_first_seen_cleanup.py (1 test)
- tests/test_first_seen_fuzzy.py (1 test)
- tests/test_item_age.py (2 tests)
- tests/test_state.py (4 tests)

Outside build_feed family:
- tests/test_make_guid.py (3 tests)
- tests/test_link_sanitization.py (2 tests)
- tests/test_oebb_identity.py (3 tests)
- tests/test_max_items.py (2 tests, plus `import pytest` added)
- tests/test_xml_ends_at.py (2 unittest methods)

Clears 22 `no-untyped-def` findings.

Nested function definitions (`fake_collect`, `fake_make_rss`, `capture_state`, `fail_emit`) and the first-level helper `_emit_item_str` in tests/test_link_sanitization.py remain unannotated and will be addressed in later clusters.

Part of the strict-typing migration in tests/.

---
*PR created automatically by Jules for task [17133363173571670090](https://jules.google.com/task/17133363173571670090) started by @Origamihase*