### PR TITLE
tests: annotate 23 test files for strict mypy (cluster 14)

### DIFF
--- a/tests/test_ansi_sanitization.py
+++ b/tests/test_ansi_sanitization.py
@@ -37,7 +37,7 @@ ANSI_TEST_CASES = [
     ("Line1\nLine2", "Line1\\nLine2", "Line1\nLine2"),
 ]
 
-def test_logging_sanitize_ansi():
+def test_logging_sanitize_ansi() -> None:
     """Verify that src.utils.logging.sanitize_log_message strips ANSI codes."""
     for inp, exp_stripped, exp_no_strip in ANSI_TEST_CASES:
         # Test with default strip_control_chars=True
@@ -47,7 +47,7 @@ def test_logging_sanitize_ansi():
         # This confirms that ANSI stripping happens independently of control char stripping
         assert log_sanitize(inp, strip_control_chars=False) == exp_no_strip
 
-def test_env_sanitize_ansi():
+def test_env_sanitize_ansi() -> None:
     """Verify that src.utils.env.sanitize_log_message (fallback) strips ANSI codes."""
     for inp, exp_stripped, exp_no_strip in ANSI_TEST_CASES:
         # Test with default strip_control_chars=True
@@ -56,7 +56,7 @@ def test_env_sanitize_ansi():
         # Test with strip_control_chars=False
         assert env_sanitize(inp, strip_control_chars=False) == exp_no_strip
 
-def test_complex_osc_injection():
+def test_complex_osc_injection() -> None:
     """Specific test for complex OSC injection attempts."""
     # Attempt to inject a window title change
     attack = "\x1b]2;Malicious Title\x07Log Message"
@@ -66,7 +66,7 @@ def test_complex_osc_injection():
     attack = "\x1b]8;;http://malicious.com\x07Click Me\x1b]8;;\x07"
     assert log_sanitize(attack) == "Click Me"
 
-def test_fe_sequences_exclusion():
+def test_fe_sequences_exclusion() -> None:
     """Verify that Fe sequences are stripped correctly, but [ and ] are handled by CSI/OSC logic."""
     # ESC [ is CSI, handled by CSI regex part
     # ESC ] is OSC, handled by OSC regex part

--- a/tests/test_dns_rebinding_bypass.py
+++ b/tests/test_dns_rebinding_bypass.py
@@ -5,7 +5,7 @@ import requests
 from src.utils.http import session_with_retries
 
 class TestDNSRebindingBypass(unittest.TestCase):
-    def test_dns_rebinding_bypass_prevented(self):
+    def test_dns_rebinding_bypass_prevented(self) -> None:
         """
         Verify that session.get() verifies the connected IP for the final response,
         preventing a DNS rebinding attack even if initial validation passes.

--- a/tests/test_exception_sanitization.py
+++ b/tests/test_exception_sanitization.py
@@ -5,7 +5,7 @@ import socket
 from src.utils.http import session_with_retries, request_safe
 
 class TestExceptionSanitization(unittest.TestCase):
-    def test_request_safe_sanitizes_exception_message(self):
+    def test_request_safe_sanitizes_exception_message(self) -> None:
         """
         Verify that request_safe sanitizes secrets from exception messages.
         """

--- a/tests/test_fragment_leak.py
+++ b/tests/test_fragment_leak.py
@@ -1,7 +1,7 @@
 
 from src.utils.http import _sanitize_url_for_error
 
-def test_sanitize_url_redacts_fragment_secrets():
+def test_sanitize_url_redacts_fragment_secrets() -> None:
     """Verify that URL fragments are entirely stripped."""
     # OIDC implicit flow example
     url = "https://example.com/callback#access_token=SUPER_SECRET_TOKEN&state=xyz&token_type=Bearer"
@@ -11,13 +11,13 @@ def test_sanitize_url_redacts_fragment_secrets():
     assert "access_token" not in sanitized
     assert "#" not in sanitized
 
-def test_sanitize_url_leaves_benign_fragments():
+def test_sanitize_url_leaves_benign_fragments() -> None:
     """Verify that URL fragments are stripped entirely (benign or not)."""
     url = "https://example.com/docs#section-1"
     sanitized = _sanitize_url_for_error(url)
     assert sanitized == "https://example.com/docs"
 
-def test_sanitize_url_fragment_mixed_case():
+def test_sanitize_url_fragment_mixed_case() -> None:
     """Verify that URL fragments are stripped entirely regardless of case."""
     url = "https://example.com/#Token=secret"
     sanitized = _sanitize_url_for_error(url)

--- a/tests/test_fuzzy_merge_identity.py
+++ b/tests/test_fuzzy_merge_identity.py
@@ -1,6 +1,6 @@
 from src.feed.merge import deduplicate_fuzzy
 
-def test_fuzzy_merge_identity():
+def test_fuzzy_merge_identity() -> None:
     # Two items with significant overlap
     items = [
         {

--- a/tests/test_fuzzy_merge_stopwords.py
+++ b/tests/test_fuzzy_merge_stopwords.py
@@ -1,6 +1,6 @@
 from src.feed.merge import _has_significant_overlap
 
-def test_has_significant_overlap_stopwords():
+def test_has_significant_overlap_stopwords() -> None:
     # Only stopwords in both, they SHOULD merge because there's nothing else to distinguish them.
     # The requirement is to avoid false-positive merge on single generic tokens when they refer to different things.
     # i.e., "Störung" shouldn't merge with "Störung am Schottentor".

--- a/tests/test_guid_collision_repro.py
+++ b/tests/test_guid_collision_repro.py
@@ -1,7 +1,7 @@
 import hashlib
 from src.utils.ids import make_guid
 
-def test_guid_collision_vulnerability():
+def test_guid_collision_vulnerability() -> None:
     """Verify that current implementation PREVENTS GUID collisions via pipe injection."""
     guid1 = make_guid("a|b", "c")
     guid2 = make_guid("a", "b|c")
@@ -9,7 +9,7 @@ def test_guid_collision_vulnerability():
     # After fix, these should be different
     assert guid1 != guid2, "Collision detected! Pipe injection vulnerability persists."
 
-def test_guid_backward_compatibility():
+def test_guid_backward_compatibility() -> None:
     """Verify that safe inputs produce the expected hash (compatibility check)."""
     # "foo|bar" -> sha256
     # If inputs contain no special chars, the behavior should be the same as simple join

--- a/tests/test_guid_security.py
+++ b/tests/test_guid_security.py
@@ -1,6 +1,6 @@
 from src.providers.vor import _build_guid
 
-def test_vor_guid_dos_protection():
+def test_vor_guid_dos_protection() -> None:
     """
     Verify that _build_guid bounds the length of external IDs to prevent DoS.
     """

--- a/tests/test_http_dos.py
+++ b/tests/test_http_dos.py
@@ -2,7 +2,7 @@ import unittest
 from src.utils.http import _sanitize_url_for_error, MAX_URL_LENGTH
 
 class TestHttpDoS(unittest.TestCase):
-    def test_sanitize_url_truncation(self):
+    def test_sanitize_url_truncation(self) -> None:
         # Create a URL that is definitely longer than MAX_URL_LENGTH
         long_url = "https://example.com/" + "a" * (MAX_URL_LENGTH + 100)
 

--- a/tests/test_http_request_safe.py
+++ b/tests/test_http_request_safe.py
@@ -5,7 +5,7 @@ import socket
 from src.utils.http import session_with_retries, request_safe
 
 class TestHTTPRequestSafe(unittest.TestCase):
-    def test_request_safe_post_redirect_method_handling(self):
+    def test_request_safe_post_redirect_method_handling(self) -> None:
         """
         Verify that request_safe handles POST redirects correctly (switching to GET for 302, staying POST for 307).
         And ensures data is dropped when switching to GET.
@@ -74,7 +74,7 @@ class TestHTTPRequestSafe(unittest.TestCase):
                 self.assertIsNone(kwargs2.get('json')) # Data dropped
                 self.assertFalse(kwargs2['allow_redirects']) # Explicitly disabled
 
-    def test_request_safe_post_redirect_307_preserves_method(self):
+    def test_request_safe_post_redirect_307_preserves_method(self) -> None:
         """
         Verify that 307 Temporary Redirect preserves POST method and data.
         """

--- a/tests/test_http_sanitization_new_keys.py
+++ b/tests/test_http_sanitization_new_keys.py
@@ -4,7 +4,7 @@ from urllib.parse import unquote
 from src.utils.http import _sanitize_url_for_error
 
 class TestHttpSanitizationNewKeys(unittest.TestCase):
-    def test_new_keys_redaction(self):
+    def test_new_keys_redaction(self) -> None:
         # Test that glpat and ghp are redacted in query params
         url = "https://example.com/api?glpat=glpat-123456&ghp=ghp_abcdef&otp=123456&token=secret"
         sanitized = _sanitize_url_for_error(url)

--- a/tests/test_json_log_leak.py
+++ b/tests/test_json_log_leak.py
@@ -3,7 +3,7 @@ import unittest
 from src.utils.logging import sanitize_log_message
 
 class TestJsonLogLeak(unittest.TestCase):
-    def test_json_newline_leak(self):
+    def test_json_newline_leak(self) -> None:
         # This case fails if newlines are escaped before redaction
         # because \s* in regex doesn't match literal \n
         msg = '{"password":\n"secret"}'
@@ -15,7 +15,7 @@ class TestJsonLogLeak(unittest.TestCase):
         self.assertNotIn("secret", sanitized)
         self.assertIn("***", sanitized)
 
-    def test_json_escaped_newline_leak(self):
+    def test_json_escaped_newline_leak(self) -> None:
         # Case where the input already has escaped newlines (e.g. from another logger)
         # This might be tricky, but let's see.
         # If input is '{"password":\\n"secret"}', then \\n is literal backslash n.

--- a/tests/test_leak_repro.py
+++ b/tests/test_leak_repro.py
@@ -1,6 +1,6 @@
 from src.utils.logging import sanitize_log_message
 
-def test_aws_credential_leak():
+def test_aws_credential_leak() -> None:
     # This currently fails (leaks)
     secret = "x-amz-credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request"
     sanitized = sanitize_log_message(secret)

--- a/tests/test_logging_sanitize.py
+++ b/tests/test_logging_sanitize.py
@@ -1,7 +1,7 @@
 
 from src.utils.logging import sanitize_log_message
 
-def test_sanitize_log_message_new_keys():
+def test_sanitize_log_message_new_keys() -> None:
     # Test cases for new sensitive keys
     test_cases = [
         ("https://example.com?token=SECRET123", "https://example.com?token=***"),
@@ -21,12 +21,12 @@ def test_sanitize_log_message_new_keys():
         assert "***" in sanitized, f"Secret not masked in '{input_str}'"
         assert "SECRET123" not in sanitized, f"Secret leaked in '{input_str}'"
 
-def test_sanitize_log_message_existing_functionality():
+def test_sanitize_log_message_existing_functionality() -> None:
     # Ensure regressions are not introduced
     assert sanitize_log_message("Authorization: Bearer SECRET") == "Authorization: ***"
     assert sanitize_log_message("accessId=12345") == "accessId=***"
 
-def test_sanitize_log_message_enhanced_keys():
+def test_sanitize_log_message_enhanced_keys() -> None:
     # Verify that new keys are redacted in query parameters
     test_cases = [
         ("https://example.com?bearer_token=SECRET123", "https://example.com?bearer_token=***"),
@@ -45,7 +45,7 @@ def test_sanitize_log_message_enhanced_keys():
         assert key in sanitized
 
 
-def test_sanitize_log_message_extended_identity_keys():
+def test_sanitize_log_message_extended_identity_keys() -> None:
     # Verify that extended identity keys (tenant, oid, etc) are redacted
     test_cases = [
         ("https://example.com?tenant=SECRET123", "tenant"),
@@ -64,7 +64,7 @@ def test_sanitize_log_message_extended_identity_keys():
         assert "SECRET123" not in sanitized, f"Secret leaked in '{input_str}'"
         assert key in sanitized, f"Key '{key}' should remain visible"
 
-def test_sanitize_log_message_quoted_spaces():
+def test_sanitize_log_message_quoted_spaces() -> None:
     """Verify that secrets with spaces in quotes are fully masked."""
     test_cases = [
         # Double quotes with space

--- a/tests/test_logging_security.py
+++ b/tests/test_logging_security.py
@@ -1,6 +1,6 @@
 from src.utils.logging import sanitize_log_message
 
-def test_sanitize_x_goog_api_key_header():
+def test_sanitize_x_goog_api_key_header() -> None:
     """Verify that X-Goog-Api-Key headers are redacted in log messages."""
     secret = "AIzaSyD-SecretKey123"
     message = f"Sending request with header X-Goog-Api-Key: {secret}"
@@ -8,7 +8,7 @@ def test_sanitize_x_goog_api_key_header():
     assert secret not in sanitized
     assert "X-Goog-Api-Key: ***" in sanitized
 
-def test_sanitize_x_api_key_header():
+def test_sanitize_x_api_key_header() -> None:
     """Verify that generic X-Api-Key headers are redacted."""
     secret = "secret-value"
     message = f"Header X-Api-Key: {secret}"

--- a/tests/test_merge_logic_fix.py
+++ b/tests/test_merge_logic_fix.py
@@ -2,7 +2,7 @@ import unittest
 from src.feed.merge import _has_significant_overlap
 
 class TestMergeLogic(unittest.TestCase):
-    def test_single_token_overlap_false_positive(self):
+    def test_single_token_overlap_false_positive(self) -> None:
         # "Zug" matches, but "fällt aus" vs "verspätet" are different contexts (though arguably similar event).
         # Better example: "U1: Störung" vs "U1: Bauarbeiten" -> "Störung" and "Bauarbeiten" are disjoint.
         # But "Störung in Station X" vs "Aufzug in Station X defekt".
@@ -18,7 +18,7 @@ class TestMergeLogic(unittest.TestCase):
         self.assertFalse(_has_significant_overlap(name1, name2),
                          f"Should not merge '{name1}' and '{name2}' just because of 'Zug'")
 
-    def test_significant_overlap_true(self):
+    def test_significant_overlap_true(self) -> None:
         # "Störung Wien Mitte" vs "Störung in Wien Mitte"
         # T1: {störung, wien, mitte}
         # T2: {störung, in, wien, mitte}

--- a/tests/test_merge_regex.py
+++ b/tests/test_merge_regex.py
@@ -1,6 +1,6 @@
 from src.feed.merge import _parse_title
 
-def test_parse_title_whitespace_tolerance():
+def test_parse_title_whitespace_tolerance() -> None:
     title = "U1 / U2 : Störung am Schottentor"
     lines, name = _parse_title(title)
 

--- a/tests/test_otp_false_positive.py
+++ b/tests/test_otp_false_positive.py
@@ -1,7 +1,7 @@
 
 from src.utils.logging import sanitize_log_message
 
-def test_otp_false_positive():
+def test_otp_false_positive() -> None:
     msg = "hotpot=delicious"
     sanitized = sanitize_log_message(msg)
     print(f"'{msg}' -> '{sanitized}'")

--- a/tests/test_pass_sanitization.py
+++ b/tests/test_pass_sanitization.py
@@ -2,14 +2,14 @@
 from src.utils.http import _sanitize_url_for_error
 from src.utils.logging import sanitize_log_message
 
-def test_sanitize_url_missing_keys():
+def test_sanitize_url_missing_keys() -> None:
     """Test that pass and pwd are redacted in URLs."""
     # Note: urlencode encodes *** as %2A%2A%2A
     assert _sanitize_url_for_error("https://example.com?pass=secret") == "https://example.com?pass=%2A%2A%2A"
     assert _sanitize_url_for_error("https://example.com?pwd=secret") == "https://example.com?pwd=%2A%2A%2A"
     assert _sanitize_url_for_error("https://example.com?user_pass=secret") == "https://example.com?user_pass=%2A%2A%2A"
 
-def test_sanitize_log_missing_keys():
+def test_sanitize_log_missing_keys() -> None:
     """Test that pass and pwd are redacted in logs."""
     # Note: assignment sanitization strips quotes
     assert sanitize_log_message("pass='secret'") == "pass=***"

--- a/tests/test_secret_scanner_new_keys.py
+++ b/tests/test_secret_scanner_new_keys.py
@@ -3,7 +3,7 @@ import unittest
 from src.utils.secret_scanner import _SENSITIVE_ASSIGN_RE, _looks_like_secret
 
 class TestSecretScannerNewKeys(unittest.TestCase):
-    def test_new_keys_detection(self):
+    def test_new_keys_detection(self) -> None:
         # We want to detect these new patterns
         test_cases = [
             'webhook_url = "https://discord.com/api/webhooks/123/abc"',
@@ -23,7 +23,7 @@ class TestSecretScannerNewKeys(unittest.TestCase):
             is_secret = _looks_like_secret(candidate, is_assignment=True)
             self.assertTrue(is_secret, f"Candidate {candidate} rejected by _looks_like_secret")
 
-    def test_specific_keywords(self):
+    def test_specific_keywords(self) -> None:
         # These should match the regex
         keywords = ["glpat", "ghp"]
         for kw in keywords:

--- a/tests/test_secret_scanner_pem.py
+++ b/tests/test_secret_scanner_pem.py
@@ -3,7 +3,7 @@ import unittest
 from src.utils.secret_scanner import _scan_content
 
 class TestSecretScannerPEM(unittest.TestCase):
-    def test_pem_private_key_detection(self):
+    def test_pem_private_key_detection(self) -> None:
         pem_content = """-----BEGIN RSA PRIVATE KEY-----
 MIIEpQIBAAKCAQEA3Tz2mr7SZiAMfQyuvBjM9Oi..
 ... (lots of base64) ...
@@ -17,7 +17,7 @@ MIIEpQIBAAKCAQEA3Tz2mr7SZiAMfQyuvBjM9Oi..
         # Verify deduplication: should not also detect as High Entropy
         self.assertEqual(len(findings), 1, "Should detect PEM as a single finding")
 
-    def test_pem_with_newlines(self):
+    def test_pem_with_newlines(self) -> None:
         # A real-looking PEM with 64-char lines
         pem_content = """-----BEGIN RSA PRIVATE KEY-----
 MIIEpQIBAAKCAQEA3Tz2mr7SZiAMfQyuvBjM9OiMIIEpQIBAAKCAQEA3Tz2mr7SZ

--- a/tests/test_sentinel_redaction.py
+++ b/tests/test_sentinel_redaction.py
@@ -3,7 +3,7 @@ import pytest
 from src.utils.http import _sanitize_url_for_error
 
 @pytest.mark.parametrize("key", ["jwt", "dsn", "otp", "my_webhook_url"])
-def test_sensitive_keys_redaction(key):
+def test_sensitive_keys_redaction(key: str) -> None:
     """Verify that these sensitive keys are now correctly redacted."""
     secret = "secret123"
     url = f"https://example.com/api?{key}={secret}"
@@ -13,7 +13,7 @@ def test_sensitive_keys_redaction(key):
     # The value '***' is URL-encoded as '%2A%2A%2A'
     assert "%2A%2A%2A" in sanitized or "***" in sanitized
 
-def test_harmless_param():
+def test_harmless_param() -> None:
     """Verify harmless parameters remain untouched."""
     url = "https://example.com/api?page=1&sort=desc"
     sanitized = _sanitize_url_for_error(url)

--- a/tests/test_vor_error.py
+++ b/tests/test_vor_error.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from src.providers.vor import load_request_count
 
 class TestVorError(unittest.TestCase):
-    def test_load_request_count_permission_error(self):
+    def test_load_request_count_permission_error(self) -> None:
         # Mock Path.read_text to raise PermissionError
         # Note: We need to patch pathlib.Path.read_text where it's defined/used
         with patch("pathlib.Path.read_text", side_effect=PermissionError("Mock Permission Denied")):


### PR DESCRIPTION
Migrate to strict mypy disallow_untyped_defs for 23 files in tests/.
Applied 41 single-line signature edits.

---
*PR created automatically by Jules for task [200925317881542647](https://jules.google.com/task/200925317881542647) started by @Origamihase*