### PR TITLE
tests: annotate 5 OEBB test files for strict mypy (cluster 15)

### DIFF
--- a/tests/test_oebb_filtering.py
+++ b/tests/test_oebb_filtering.py
@@ -6,7 +6,7 @@ class TestOebbFiltering:
     Ensures that irrelevant messages (far from Vienna) are excluded.
     """
 
-    def test_irrelevant_routes_excluded(self):
+    def test_irrelevant_routes_excluded(self) -> None:
         # Case 1: Route between unknown foreign/remote stations (Ljubljana -> Schwarzach)
         # Should be excluded because neither station is known, and title has arrow (Route Heuristic).
         assert _is_relevant(
@@ -14,7 +14,7 @@ class TestOebbFiltering:
             "Wegen Bauarbeiten der Slowenischen Eisenbahnen (SZ) werden von 24.01.2026 bis 25.01.2026 ..."
         ) is False
 
-    def test_irrelevant_generic_title_with_remote_stations(self):
+    def test_irrelevant_generic_title_with_remote_stations(self) -> None:
         # Case 2: Generic title with arrow, stations in description (Innsbruck -> Feldkirch)
         # "Innsbruck Hbf" should NOT match "Hbf" (generic alias excluded).
         assert _is_relevant(
@@ -22,7 +22,7 @@ class TestOebbFiltering:
             "Wegen Bauarbeiten werden zwischen Innsbruck Hbf und Feldkirch Bahnhof von 07.01.2026 ..."
         ) is False
 
-    def test_irrelevant_badly_formatted_title(self):
+    def test_irrelevant_badly_formatted_title(self) -> None:
         # Case 3: Badly formatted title with extra angle brackets (Villach -> Jesenice)
         # "Villach Hbf" should NOT match "Hbf".
         assert _is_relevant(
@@ -30,28 +30,28 @@ class TestOebbFiltering:
             "Wegen Bauarbeiten der Slowenischen Eisenbahnen (SZ) können zwischen Villach Hbf und Jesenice(SL)..."
         ) is False
 
-    def test_irrelevant_vorarlberg_route(self):
+    def test_irrelevant_vorarlberg_route(self) -> None:
         # Case 4: Bregenz -> Dornbirn (Vorarlberg)
         assert _is_relevant(
             "Bregenz < ↔ > Dornbirn",
             "Wegen Bauarbeiten fährt zwischen Bregenz Bahnhof und Dornbirn Bahnhof..."
         ) is False
 
-    def test_relevant_vienna_explicit(self):
+    def test_relevant_vienna_explicit(self) -> None:
         # Explicit Vienna mention
         assert _is_relevant(
             "Wien Hauptbahnhof ↔ St. Pölten",
             "Zugausfall wegen technischer Störung."
         ) is True
 
-    def test_relevant_vienna_alias(self):
+    def test_relevant_vienna_alias(self) -> None:
         # "Meidling" is a known alias for "Wien Meidling"
         assert _is_relevant(
             "Meidling ↔ Mödling",
             "Verzögerungen."
         ) is True
 
-    def test_relevant_general_disruption(self):
+    def test_relevant_general_disruption(self) -> None:
         # General disruption without station or arrow
         # Strict Mode: Excluded unless explicitly mentioning Vienna.
         assert _is_relevant(
@@ -59,14 +59,14 @@ class TestOebbFiltering:
             "Es kommt zu Verzögerungen im gesamten Netz."
         ) is False
 
-    def test_relevant_general_disruption_with_vienna(self):
+    def test_relevant_general_disruption_with_vienna(self) -> None:
         # General disruption WITH Vienna reference -> Keep
         assert _is_relevant(
             "Sturm im Raum Wien",
             "Verzögerungen bei der S-Bahn Wien."
         ) is True
 
-    def test_irrelevant_outer_only(self):
+    def test_irrelevant_outer_only(self) -> None:
         # Route strictly within Outer region (e.g. Baden -> Wr. Neustadt)
         # Should be excluded by Check C (Ausschluss Umland)
         # Assuming Baden and Wr. Neustadt are in Outer set.
@@ -75,7 +75,7 @@ class TestOebbFiltering:
             "Zugausfall."
         ) is False
 
-    def test_hbf_alias_exclusion(self):
+    def test_hbf_alias_exclusion(self) -> None:
         # Ensure "Hbf" alone does not trigger Vienna relevance
         # "Hbf" is in excluded generic aliases.
         # "Innsbruck Hbf" -> should be excluded (unless Innsbruck is in Vienna/Outer, which it isn't).
@@ -92,7 +92,7 @@ class TestOebbFiltering:
             "Verspätung."
         ) is False
 
-    def test_marchegg_bratislava_excluded(self):
+    def test_marchegg_bratislava_excluded(self) -> None:
         # Regression test for user report: "Marchegg ↔ Bratislava hl.st."
         # Marchegg is in Outer region (pendler=True).
         # Bratislava is foreign (not Vienna).
@@ -104,7 +104,7 @@ class TestOebbFiltering:
             "von 04.05.2026 (07:50 Uhr) bis 08.05.2026 (16:00 Uhr) keine REX8-Züge …[04.05.2026 – 08.05.2026]"
         ) is False
 
-    def test_irrelevant_st_margrethen_sg(self):
+    def test_irrelevant_st_margrethen_sg(self) -> None:
         # Regression test for "Lindau (Bodensee) Reutin ↔ ST. MARGRETHEN SG"
         # "SG" (St. Gallen) used to match "Sg" (alias for Wien Grillgasse).
         # We now filter out 2-letter aliases to prevent this.
@@ -113,7 +113,7 @@ class TestOebbFiltering:
             "Wegen Bauarbeiten der Deutschen Bahn (DB) können zwischen Lindau (Bodensee) Reutin Bahnhof und ST. MARGRETHEN SG..."
         ) is False
 
-    def test_neulengbach_tullnerbach_excluded(self):
+    def test_neulengbach_tullnerbach_excluded(self) -> None:
         # Regression test for "Neulengbach ↔ Tullnerbach-Pressbaum"
         # User reported this as irrelevant (neither Vienna nor commuter stations).
         # We updated metadata to set pendler=False for these stations.
@@ -131,7 +131,7 @@ class TestSigmundsherbergRegression:
     Previously, 'Hadersdorf am Kamp' triggered a false positive for 'Wien Hadersdorf'.
     """
 
-    def test_sigmundsherberg_hadersdorf_excluded(self):
+    def test_sigmundsherberg_hadersdorf_excluded(self) -> None:
         title = "Sigmundsherberg ↔ Hadersdorf am Kamp"
         description = (
             "Wegen Bauarbeiten können zwischen Sigmundsherberg Bahnhof und Hadersdorf am Kamp "
@@ -141,7 +141,7 @@ class TestSigmundsherbergRegression:
         # Should be False (excluded)
         assert _is_relevant(title, description) is False
 
-    def test_irrelevant_outer_to_outer_neulengbach_kledering(self):
+    def test_irrelevant_outer_to_outer_neulengbach_kledering(self) -> None:
         # Regression test for disruption between two outer stations
         # Even if the description mentions "Wien", it should be rejected
         # because neither station is physically inside Vienna.

--- a/tests/test_oebb_filtering_strict.py
+++ b/tests/test_oebb_filtering_strict.py
@@ -42,7 +42,7 @@ Details finden Sie hier... ]]>
 """
 
 @responses.activate
-def test_oebb_filtering_strict_route():
+def test_oebb_filtering_strict_route() -> None:
     """
     Ensures that a route between two Outer stations (Gmünd NÖ <-> Ceske Velenice) is filtered out.
     This requires 'Gmünd NÖ' and 'Ceske Velenice' to be in stations.json (as non-Vienna, non-Pendler).

--- a/tests/test_oebb_marchegg.py
+++ b/tests/test_oebb_marchegg.py
@@ -27,7 +27,7 @@ class TestOebbMarchegg:
     Reproduces the issue with 'Marchegg < ↔ > Bratislava hl.st.'.
     """
 
-    def test_fetch_events_formatting_and_filtering(self):
+    def test_fetch_events_formatting_and_filtering(self) -> None:
         # Verify that fetch_events processes the item
         # Current behavior (buggy): Title has < >, and it might NOT be filtered (per user report).
         # Expected behavior (fixed): Title matches "Marchegg" (Outer) so it should be filtered.
@@ -54,7 +54,7 @@ class TestOebbMarchegg:
                 assert "&lt;" not in title, "Title contains encoded entity"
                 assert "Marchegg ↔ Bratislava hl.st." in title or "Marchegg ↔ Bratislava" in title
 
-    def test_filtering_logic_marchegg(self):
+    def test_filtering_logic_marchegg(self) -> None:
         # Verify that _is_relevant correctly identifies this as irrelevant (Outer)
         # "Marchegg" is in data/stations.json as "in_vienna": false.
 

--- a/tests/test_oebb_route_filter.py
+++ b/tests/test_oebb_route_filter.py
@@ -1,39 +1,39 @@
 
 from src.providers.oebb import _is_relevant
 
-def test_venezia_is_excluded():
+def test_venezia_is_excluded() -> None:
     # Long distance train to unknown station (Venezia)
     # RELAXED: This route mentions "Wien", so it is now RELEVANT for Vienna commuters.
     title = "Wien Hauptbahnhof ↔ Venezia Santa Lucia"
     description = "Wegen Bauarbeiten..."
     assert _is_relevant(title, description) is True
 
-def test_wien_st_poelten_included():
+def test_wien_st_poelten_included() -> None:
     # St. Pölten is in the Pendler list
     title = "Wien Hauptbahnhof ↔ St. Pölten Hbf"
     description = "Verzögerungen..."
     assert _is_relevant(title, description) is True
 
-def test_wien_west_meidling_included():
+def test_wien_west_meidling_included() -> None:
     # Both in Vienna
     title = "Wien Westbahnhof ↔ Wien Meidling"
     description = "Technische Störung..."
     assert _is_relevant(title, description) is True
 
-def test_unknown_route_excluded():
+def test_unknown_route_excluded() -> None:
     # Both unknown
     title = "Paris Gare de l'Est ↔ München Hbf"
     description = "Streik..."
     assert _is_relevant(title, description) is False
 
-def test_one_end_unknown_excluded():
+def test_one_end_unknown_excluded() -> None:
     # One end unknown (but mentions Wien in text)
     title = "Wien Hbf ↔ Unknown City"
     description = "Wien Hauptbahnhof ist betroffen."
     # RELAXED: Because "Wien" is in text, it is now RELEVANT.
     assert _is_relevant(title, description) is True
 
-def test_bauarbeiten_category_included():
+def test_bauarbeiten_category_included() -> None:
     # Not a route "A ↔ B" but a category "Category: Detail"
     # _is_relevant checks for "↔" in title.
     # If title is "Bauarbeiten: Wien Hbf", no "↔".
@@ -41,7 +41,7 @@ def test_bauarbeiten_category_included():
     description = "Wartungsarbeiten..."
     assert _is_relevant(title, description) is True
 
-def test_bauarbeiten_arrow_umleitung_excluded_if_no_station():
+def test_bauarbeiten_arrow_umleitung_excluded_if_no_station() -> None:
     # "Bauarbeiten ↔ Umleitung"
     # If these are not stations, they return None for station_info.
     # RELAXED: But if "Wien Hbf" is in description, it is RELEVANT.
@@ -49,13 +49,13 @@ def test_bauarbeiten_arrow_umleitung_excluded_if_no_station():
     description = "In Wien Hbf..."
     assert _is_relevant(title, description) is True
 
-def test_flughafen_wien_included():
+def test_flughafen_wien_included() -> None:
     # Flughafen Wien is a pendler station
     title = "Wien Hbf ↔ Flughafen Wien"
     description = "..."
     assert _is_relevant(title, description) is True
 
-def test_rex51_neulengbach_tullnerbach_irrelevant():
+def test_rex51_neulengbach_tullnerbach_irrelevant() -> None:
     # REX 51: Neulengbach ↔ Tullnerbach-Pressbaum
     # Should be IRRELEVANT (False).
     # Currently might be True if "51" matches Vienna regex OR if "Neulengbach" is not parsed correctly.
@@ -64,7 +64,7 @@ def test_rex51_neulengbach_tullnerbach_irrelevant():
     description = "Wegen einer Oberleitungsstörung..."
     assert _is_relevant(title, description) is False
 
-def test_prefix_outer_outer_with_wien_in_title_irrelevant():
+def test_prefix_outer_outer_with_wien_in_title_irrelevant() -> None:
     # If the title has "Wien" inside the prefix (e.g. "REX (Wien): ...")
     # but the stations are outer-outer, it should be irrelevant.
     # _is_relevant checks `text = f"{title} {description}"`.
@@ -79,17 +79,17 @@ def test_prefix_outer_outer_with_wien_in_title_irrelevant():
     description = "Oberleitungsstörung."
     assert _is_relevant(title, description) is False
 
-def test_fernverkehr_mit_prefix_negativ():
+def test_fernverkehr_mit_prefix_negativ() -> None:
     title = "REX 51: Störung: Salzburg Hbf ↔ Linz/Donau Hbf"
     description = ""
     assert _is_relevant(title, description) is False
 
-def test_einseitiger_wien_bezug_mit_prefix():
+def test_einseitiger_wien_bezug_mit_prefix() -> None:
     title = "REX 51: Störung: Wien Meidling ↔ Budapest-Keleti"
     description = ""
     assert _is_relevant(title, description) is True
 
-def test_wien_bezug_im_zweiten_teil():
+def test_wien_bezug_im_zweiten_teil() -> None:
     title = "Störung: Verspätung: Mödling ↔ Wien Hbf"
     description = ""
     assert _is_relevant(title, description) is True

--- a/tests/test_oebb_verkehrseinschrankung.py
+++ b/tests/test_oebb_verkehrseinschrankung.py
@@ -1,11 +1,11 @@
 from src.providers.oebb import _clean_title_keep_places
 
-def test_verkehrseinschaenkung_title():
+def test_verkehrseinschaenkung_title() -> None:
     t = "Verkehrseinschränkung: Wien Meidling und Tullnerfeld"
     res = _clean_title_keep_places(t)
     assert res == "Wien Meidling ↔ Tullnerfeld"
 
-def test_verkehrseinschaenkung_with_other_stations():
+def test_verkehrseinschaenkung_with_other_stations() -> None:
     t = "Wien Hbf und St. Pölten Hbf"
     res = _clean_title_keep_places(t)
     # The clean title keep places canonicalizes "Wien Hbf" to "Wien Hauptbahnhof" and "St. Pölten Hbf" to "St.Pölten Hbf"


### PR DESCRIPTION
Added 33 `-> None` type annotations to 5 specific test files in `tests/` (`test_oebb_filtering.py`, `test_oebb_filtering_strict.py`, `test_oebb_marchegg.py`, `test_oebb_route_filter.py`, and `test_oebb_verkehrseinschrankung.py`) for `disallow_untyped_defs` migration (Cluster 15). The deferred `monkeypatch` function remains untouched as instructed. Verified using `grep` and `git diff`.

---
*PR created automatically by Jules for task [18367037865957081474](https://jules.google.com/task/18367037865957081474) started by @Origamihase*