### PR TITLE
tests: migrate 16 test files to strict mypy `disallow_untyped_defs`

### DIFF
--- a/tests/test_dns_timeout.py
+++ b/tests/test_dns_timeout.py
@@ -3,7 +3,7 @@ import time
 from unittest.mock import patch
 from src.utils.http import validate_http_url, DNS_TIMEOUT
 
-def test_validate_http_url_timeout():
+def test_validate_http_url_timeout() -> None:
     """Verify that validate_http_url returns None when DNS resolution times out."""
 
     # We simulate a sleep longer than DNS_TIMEOUT
@@ -36,7 +36,7 @@ def test_validate_http_url_timeout():
         # If I set slow_duration to 10s and DNS_TIMEOUT is 5s, it should return in ~5s.
 
 
-def test_validate_http_url_fast_enough():
+def test_validate_http_url_fast_enough() -> None:
     """Verify that fast DNS resolution still works."""
 
     def mock_resolve_fast(host, record_type, *args, **kwargs):

--- a/tests/test_env_fallback_pass.py
+++ b/tests/test_env_fallback_pass.py
@@ -2,7 +2,7 @@
 import sys
 from unittest.mock import patch
 
-def test_env_fallback_pass_sanitization():
+def test_env_fallback_pass_sanitization() -> None:
     # Save original modules to restore later
     original_env = sys.modules.get('src.utils.env')
     original_logging = sys.modules.get('src.utils.logging')

--- a/tests/test_env_fallback_sync.py
+++ b/tests/test_env_fallback_sync.py
@@ -3,7 +3,7 @@ import sys
 from unittest.mock import patch
 import importlib
 
-def test_fallback_sanitization_missing_keys():
+def test_fallback_sanitization_missing_keys() -> None:
     # Save original modules to restore later
     original_logging = sys.modules.get('src.utils.logging')
     original_env = sys.modules.get('src.utils.env')

--- a/tests/test_env_roundtrip.py
+++ b/tests/test_env_roundtrip.py
@@ -2,7 +2,7 @@
 from src.utils.env import _parse_value
 from src.utils.configuration_wizard import _escape_env_value
 
-def test_env_roundtrip_multiline():
+def test_env_roundtrip_multiline() -> None:
     """Verify that multiline values survive the roundtrip via .env escaping."""
     original = "first line\nsecond line"
 
@@ -16,7 +16,7 @@ def test_env_roundtrip_multiline():
 
     assert parsed == original, f"Expected {repr(original)}, got {repr(parsed)}"
 
-def test_env_roundtrip_control_chars():
+def test_env_roundtrip_control_chars() -> None:
     """Verify that control characters survive the roundtrip."""
     original = "tab\tcr\r"
     escaped = _escape_env_value(original)
@@ -26,19 +26,19 @@ def test_env_roundtrip_control_chars():
     # But it escapes \r to \\r.
     assert parsed == original, f"Expected {repr(original)}, got {repr(parsed)}"
 
-def test_env_unescape_standard():
+def test_env_unescape_standard() -> None:
     """Verify standard escape sequences in double quotes."""
     # "foo\nbar" -> foo followed by newline followed by bar
     input_str = '"foo\\nbar"'
     expected = "foo\nbar"
     assert _parse_value(input_str) == expected
 
-def test_env_unescape_cr():
+def test_env_unescape_cr() -> None:
     input_str = '"foo\\rbar"'
     expected = "foo\rbar"
     assert _parse_value(input_str) == expected
 
-def test_env_unescape_tab():
+def test_env_unescape_tab() -> None:
     input_str = '"foo\\tbar"'
     expected = "foo\tbar"
     assert _parse_value(input_str) == expected

--- a/tests/test_fetch_safe_error.py
+++ b/tests/test_fetch_safe_error.py
@@ -2,7 +2,7 @@
 import pytest
 from src.utils.http import fetch_content_safe, session_with_retries
 
-def test_fetch_content_safe_returns_sanitized_error_url():
+def test_fetch_content_safe_returns_sanitized_error_url() -> None:
     """Verify that fetch_content_safe includes the sanitized URL in the error message."""
     session = session_with_retries("test-agent")
 
@@ -24,7 +24,7 @@ def test_fetch_content_safe_returns_sanitized_error_url():
     assert "token=%2A%2A%2A" in error_msg or "token=***" in error_msg
     assert "tenant_id=%2A%2A%2A" in error_msg or "tenant_id=***" in error_msg
 
-def test_fetch_content_safe_malformed_url():
+def test_fetch_content_safe_malformed_url() -> None:
     """Verify handling of malformed URLs."""
     session = session_with_retries("test-agent")
     malformed_url = "http://["

--- a/tests/test_http_fixes.py
+++ b/tests/test_http_fixes.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 from src.utils.http import verify_response_ip, request_safe, _is_sensitive_header, _sanitize_url_for_error
 
 # 1. Socket Access Tests
-def test_verify_response_ip_new_urllib3():
+def test_verify_response_ip_new_urllib3() -> None:
     """Test verify_response_ip with newer urllib3 using _connection."""
     response = MagicMock(spec=requests.Response)
     response.url = "http://example.com"
@@ -25,7 +25,7 @@ def test_verify_response_ip_new_urllib3():
     # This should pass without raising ValueError or AttributeError
     verify_response_ip(response)
 
-def test_verify_response_ip_old_urllib3():
+def test_verify_response_ip_old_urllib3() -> None:
     """Test verify_response_ip with older urllib3 using connection."""
     response = MagicMock(spec=requests.Response)
     response.url = "http://example.com"
@@ -45,7 +45,7 @@ def test_verify_response_ip_old_urllib3():
     verify_response_ip(response)
 
 # 2. Case-sensitivity Tests
-def test_request_safe_headers_case_sensitivity():
+def test_request_safe_headers_case_sensitivity() -> None:
     """Test that request_safe handles case-insensitive headers correctly."""
     session = requests.Session()
 
@@ -114,7 +114,7 @@ def test_request_safe_headers_case_sensitivity():
             assert "content-type" not in sent_keys
             assert "content-length" not in sent_keys
 
-def test_is_sensitive_header_case_sensitivity_explicit():
+def test_is_sensitive_header_case_sensitivity_explicit() -> None:
     """Test that _is_sensitive_header is case-insensitive for explicit headers."""
     # We pick a header from _SENSITIVE_HEADERS and test mixed case.
     # "X-CSRF-Token" is in _SENSITIVE_HEADERS.
@@ -130,7 +130,7 @@ def test_is_sensitive_header_case_sensitivity_explicit():
     assert _is_sensitive_header("X-Csrf-Token")
 
 # 3. Regex Robustness Tests
-def test_sanitize_url_missing_slash_group():
+def test_sanitize_url_missing_slash_group() -> None:
     """Test _sanitize_url_for_error with URL missing slashes (https:user:pass@...)."""
     url = "https:user:password@example.com/foo"
     sanitized = _sanitize_url_for_error(url)
@@ -144,7 +144,7 @@ def test_sanitize_url_missing_slash_group():
     assert "password" not in sanitized
     assert "user" not in sanitized # Should be stripped too
 
-def test_sanitize_url_standard():
+def test_sanitize_url_standard() -> None:
     url = "https://user:password@example.com/foo"
     sanitized = _sanitize_url_for_error(url)
     assert "password" not in sanitized

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,15 +1,15 @@
 import src
 
-def test_init_version():
+def test_init_version() -> None:
     assert hasattr(src, "__version__")
     assert src.__version__ == "0.1.0"
 
-def test_init_exports_main():
+def test_init_exports_main() -> None:
     assert hasattr(src, "main")
     from src.build_feed import main as build_feed_main
     # Using == for function names to avoid proxy object/import issues with 'is'
     assert src.main.__name__ == build_feed_main.__name__
 
-def test_feed_health_path_in_all():
+def test_feed_health_path_in_all() -> None:
     import src.feed.config as config
     assert "FEED_HEALTH_PATH" in config.__all__

--- a/tests/test_log_truncation_fix.py
+++ b/tests/test_log_truncation_fix.py
@@ -1,7 +1,7 @@
 
 from src.utils.logging import sanitize_log_message
 
-def test_sanitize_log_message_truncation():
+def test_sanitize_log_message_truncation() -> None:
     """Verify that sanitize_log_message does not truncate subsequent lines."""
     # A log message with a sensitive header followed by other headers
     log_msg = (
@@ -21,7 +21,7 @@ def test_sanitize_log_message_truncation():
     assert "User-Agent: my-app/1.0" in sanitized, "User-Agent header was truncated!"
     assert "Accept: application/json" in sanitized, "Accept header was truncated!"
 
-def test_sanitize_log_message_multiline_secret_indented():
+def test_sanitize_log_message_multiline_secret_indented() -> None:
     """Verify that indented multiline secrets are still redacted."""
     # A log message with a multiline secret (indented)
     log_msg = (
@@ -35,7 +35,7 @@ def test_sanitize_log_message_multiline_secret_indented():
     assert "eyJhbGci" not in sanitized
     assert "Authorization: ***" in sanitized
 
-def test_cookie_truncation():
+def test_cookie_truncation() -> None:
     """Verify that Cookie header does not truncate subsequent lines."""
     log_msg = "Cookie: session=123\nReferer: https://example.com"
     sanitized = sanitize_log_message(log_msg)
@@ -43,7 +43,7 @@ def test_cookie_truncation():
     assert "Cookie: ***" in sanitized
     assert "Referer: https://example.com" in sanitized
 
-def test_authorization_truncation():
+def test_authorization_truncation() -> None:
     """Verify that Authorization header does not truncate subsequent lines."""
     log_msg = "Authorization: Bearer 123\nContent-Type: application/json"
     sanitized = sanitize_log_message(log_msg)

--- a/tests/test_pagination_guards.py
+++ b/tests/test_pagination_guards.py
@@ -3,7 +3,7 @@ from src.places.tiling import Tile
 import requests
 from unittest.mock import MagicMock
 
-def test_infinite_pagination_guard():
+def test_infinite_pagination_guard() -> None:
     config = GooglePlacesConfig(
         api_key="TEST_KEY",
         included_types=["train_station"],

--- a/tests/test_provider_protocol.py
+++ b/tests/test_provider_protocol.py
@@ -3,7 +3,7 @@ from typing import get_type_hints, List
 from src.providers import vor, oebb
 from src.feed_types import FeedItem
 
-def test_vor_provider_interface():
+def test_vor_provider_interface() -> None:
     """Verify that vor module exposes fetch_events matching the Provider protocol."""
     assert hasattr(vor, "fetch_events")
     hints = get_type_hints(vor.fetch_events)
@@ -11,7 +11,7 @@ def test_vor_provider_interface():
     # Note: Depending on how FeedItem is imported/defined, we check equality
     assert hints['return'] == List[FeedItem]
 
-def test_oebb_provider_interface():
+def test_oebb_provider_interface() -> None:
     """Verify that oebb module exposes fetch_events matching the Provider protocol."""
     assert hasattr(oebb, "fetch_events")
     hints = get_type_hints(oebb.fetch_events)

--- a/tests/test_proxy_bypass.py
+++ b/tests/test_proxy_bypass.py
@@ -3,7 +3,7 @@ import pytest
 from unittest.mock import Mock, patch
 from src.utils.http import verify_response_ip
 
-def test_verify_response_ip_normal_fail():
+def test_verify_response_ip_normal_fail() -> None:
     """Verify that private IPs raise error normally."""
     response = Mock()
     # Mock the connection/socket structure
@@ -14,7 +14,7 @@ def test_verify_response_ip_normal_fail():
         with pytest.raises(ValueError, match="Connected to unsafe IP"):
             verify_response_ip(response)
 
-def test_verify_response_ip_proxy_bypass():
+def test_verify_response_ip_proxy_bypass() -> None:
     """Verify that private IPs are allowed when proxy envs are set."""
     response = Mock()
     response.raw._connection.sock.getpeername.return_value = ('192.168.1.1', 80)

--- a/tests/test_redaction_edge_cases.py
+++ b/tests/test_redaction_edge_cases.py
@@ -6,7 +6,7 @@ from src.utils.env import sanitize_log_message as sanitize_env_log_message
 class TestRedactionEdgeCases:
     """Test suite for edge cases in secret redaction (dots, spaces, mixed casing)."""
 
-    def test_sanitize_url_dots_and_spaces(self):
+    def test_sanitize_url_dots_and_spaces(self) -> None:
         """Test URL parameter sanitization with dots and spaces in keys."""
         cases = [
             ("https://example.com/api?api.key=secret", "https://example.com/api?api.key=%2A%2A%2A"),
@@ -18,7 +18,7 @@ class TestRedactionEdgeCases:
         for url, expected in cases:
             assert _sanitize_url_for_error(url) == expected
 
-    def test_sanitize_log_message_dots_and_spaces(self):
+    def test_sanitize_log_message_dots_and_spaces(self) -> None:
         """Test log message sanitization with dots and spaces in keys."""
         cases = [
             # Query params in string
@@ -41,7 +41,7 @@ class TestRedactionEdgeCases:
             # Also test the fallback implementation in env.py
             assert sanitize_env_log_message(msg) == expected
 
-    def test_sanitize_log_message_complex_separators(self):
+    def test_sanitize_log_message_complex_separators(self) -> None:
         """Test keys with mixed separators."""
         cases = [
             ('{"access.token": "secret"}', '{"access.token": "***"}'),

--- a/tests/test_secret_scanner_deduplication.py
+++ b/tests/test_secret_scanner_deduplication.py
@@ -1,7 +1,7 @@
 
 from src.utils.secret_scanner import _scan_content
 
-def test_deduplication_high_entropy_assignment():
+def test_deduplication_high_entropy_assignment() -> None:
     """
     Verify that a high-entropy secret in a sensitive assignment
     is reported only once (by the assignment scanner).
@@ -18,7 +18,7 @@ def test_deduplication_high_entropy_assignment():
     assert match == secret
     assert "Verdächtige Zuweisung" in reason
 
-def test_deduplication_bearer_token():
+def test_deduplication_bearer_token() -> None:
     """
     Verify that a high-entropy Bearer token is reported only once
     (by the Bearer scanner).
@@ -35,7 +35,7 @@ def test_deduplication_bearer_token():
     assert match == token
     assert "Bearer-Token" in reason
 
-def test_distinct_secrets_same_line():
+def test_distinct_secrets_same_line() -> None:
     """
     Verify that two distinct secrets on the same line are both reported.
     """
@@ -52,7 +52,7 @@ def test_distinct_secrets_same_line():
     assert secret1 in matches
     assert secret2 in matches
 
-def test_aws_key_assignment_deduplication():
+def test_aws_key_assignment_deduplication() -> None:
     """
     Verify that an AWS key in an assignment is reported once
     (likely by assignment scanner if variable name matches, or AWS scanner if not).
@@ -82,7 +82,7 @@ def test_aws_key_assignment_deduplication():
     assert findings2[0][1] == aws_id
     assert "AWS Access Key ID" in findings2[0][2]
 
-def test_overlapping_matches():
+def test_overlapping_matches() -> None:
     """
     Test complex overlap scenarios.
     """

--- a/tests/test_secret_scanner_enhancement.py
+++ b/tests/test_secret_scanner_enhancement.py
@@ -68,7 +68,7 @@ def test_secret_scanner_detects_webhook_without_underscore(tmp_path: Path) -> No
     assert secret not in [f.match for f in findings]
 
 
-def test_secret_scanner_detects_multiline_assignment():
+def test_secret_scanner_detects_multiline_assignment() -> None:
     """Test that a secret assigned across multiple lines is detected."""
     content = """
     my_secret =
@@ -79,7 +79,7 @@ def test_secret_scanner_detects_multiline_assignment():
     assert findings[0][1] == "super_secret_value_that_should_be_detected"
     assert "Verdächtige Zuweisung eines potentiellen Secrets" in findings[0][2]
 
-def test_secret_scanner_detects_triple_quoted_string():
+def test_secret_scanner_detects_triple_quoted_string() -> None:
     """Test that a secret in triple quotes is detected."""
     content = """
     my_secret = \"\"\"
@@ -92,7 +92,7 @@ def test_secret_scanner_detects_triple_quoted_string():
     assert "super_secret_value_in_triple_quotes" in findings[0][1]
     assert "Verdächtige Zuweisung eines potentiellen Secrets" in findings[0][2]
 
-def test_secret_scanner_detects_triple_single_quoted_string():
+def test_secret_scanner_detects_triple_single_quoted_string() -> None:
     """Test that a secret in triple single quotes is detected."""
     content = """
     my_secret = '''
@@ -103,7 +103,7 @@ def test_secret_scanner_detects_triple_single_quoted_string():
     assert len(findings) == 1
     assert "another_secret_value_in_triple_quotes" in findings[0][1]
 
-def test_secret_scanner_detects_mixed_newlines_and_spaces():
+def test_secret_scanner_detects_mixed_newlines_and_spaces() -> None:
     """Test flexible whitespace around assignment."""
     content = """
     api_key
@@ -114,7 +114,7 @@ def test_secret_scanner_detects_mixed_newlines_and_spaces():
     assert len(findings) == 1
     assert findings[0][1] == "my_api_key_value_12345"
 
-def test_secret_scanner_ignores_short_values_in_triple_quotes():
+def test_secret_scanner_ignores_short_values_in_triple_quotes() -> None:
     """Test that short/low entropy values in triple quotes are ignored."""
     content = """
     description = \"\"\"
@@ -126,7 +126,7 @@ def test_secret_scanner_ignores_short_values_in_triple_quotes():
     # Should be 0 because it doesn't look like a secret (low entropy/too short per line logic?)
     assert len(findings) == 0
 
-def test_secret_scanner_detects_multiline_with_keyword():
+def test_secret_scanner_detects_multiline_with_keyword() -> None:
     """Test that a keyword variable with multiline text is flagged if it looks like a secret."""
     content = """
     private_key = \"\"\"

--- a/tests/test_session_cookie_sanitization.py
+++ b/tests/test_session_cookie_sanitization.py
@@ -2,49 +2,49 @@
 from src.utils.http import _sanitize_url_for_error
 from src.utils.logging import sanitize_log_message
 
-def test_http_sanitize_session_id():
+def test_http_sanitize_session_id() -> None:
     url = "http://example.com?session_id=secret123"
     sanitized = _sanitize_url_for_error(url)
     assert "secret" not in sanitized
     assert "%2A%2A%2A" in sanitized or "***" in sanitized
 
-def test_http_sanitize_sessionid():
+def test_http_sanitize_sessionid() -> None:
     url = "http://example.com?sessionid=secret123"
     sanitized = _sanitize_url_for_error(url)
     assert "secret" not in sanitized
     assert "%2A%2A%2A" in sanitized or "***" in sanitized
 
-def test_http_sanitize_cookie():
+def test_http_sanitize_cookie() -> None:
     url = "http://example.com?cookie=secret123"
     sanitized = _sanitize_url_for_error(url)
     assert "secret" not in sanitized
     assert "%2A%2A%2A" in sanitized or "***" in sanitized
 
-def test_logging_sanitize_session_id():
+def test_logging_sanitize_session_id() -> None:
     msg = "session_id=secret123"
     sanitized = sanitize_log_message(msg)
     assert "secret" not in sanitized
     assert "***" in sanitized
 
-def test_logging_sanitize_session_id_with_space():
+def test_logging_sanitize_session_id_with_space() -> None:
     msg = "session id=secret123"
     sanitized = sanitize_log_message(msg)
     assert "secret" not in sanitized
     assert "***" in sanitized
 
-def test_logging_sanitize_cookie():
+def test_logging_sanitize_cookie() -> None:
     msg = "cookie=secret123"
     sanitized = sanitize_log_message(msg)
     assert "secret" not in sanitized
     assert "***" in sanitized
 
-def test_logging_sanitize_json_session_id():
+def test_logging_sanitize_json_session_id() -> None:
     msg = '{"session_id": "secret123"}'
     sanitized = sanitize_log_message(msg)
     assert "secret" not in sanitized
     assert "***" in sanitized
 
-def test_logging_sanitize_json_cookie():
+def test_logging_sanitize_json_cookie() -> None:
     msg = '{"cookie": "secret123"}'
     sanitized = sanitize_log_message(msg)
     assert "secret" not in sanitized

--- a/tests/test_thread_pool_cleanup.py
+++ b/tests/test_thread_pool_cleanup.py
@@ -1,7 +1,7 @@
 
 from unittest.mock import patch
 
-def test_thread_pool_cleanup():
+def test_thread_pool_cleanup() -> None:
     # Import build_feed here to ensure we get the current module from sys.modules
     # This guards against other tests (like test_collect_items_timeout) reloading the module
     from src import build_feed


### PR DESCRIPTION
Migrated exactly 16 files in `tests/` to strict mypy `disallow_untyped_defs`. 
Applied 52 single-line signature edits (`-> None`) across pure no-param test functions and simple pytest class methods, strictly adhering to the requested scope. Verified via diff to ensure zero logic, formatting, or outer-scope alterations.

---
*PR created automatically by Jules for task [37761487955419202](https://jules.google.com/task/37761487955419202) started by @Origamihase*