### PR TITLE
test(typing): cluster 17 — VOR sweep (26 ndef across 13 files)

### DIFF
--- a/tests/test_vor_default_version.py
+++ b/tests/test_vor_default_version.py
@@ -11,7 +11,7 @@ def _restore_env(original: dict[str, str | None]) -> None:
             os.environ[key] = value
 
 
-def test_default_vor_version():
+def test_default_vor_version() -> None:
     module = importlib.import_module("src.providers.vor")
     original = {key: os.environ.get(key) for key in ("VOR_BASE_URL", "VOR_BASE", "VOR_VERSION")}
     try:

--- a/tests/test_vor_departure_board_leak.py
+++ b/tests/test_vor_departure_board_leak.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from src.providers import vor
 
 @responses.activate
-def test_leak():
+def test_leak() -> None:
     os.environ["VOR_ACCESS_ID"] = "secret_token"
     # Set a valid URL to pass validation
     os.environ["VOR_BASE_URL"] = "https://example.com/"

--- a/tests/test_vor_fixes.py
+++ b/tests/test_vor_fixes.py
@@ -8,7 +8,7 @@ from src.providers.vor import (
 )
 
 class TestVorAuth:
-    def test_vor_auth_init_and_call(self):
+    def test_vor_auth_init_and_call(self) -> None:
         """
         Test that VorAuth:
         1. Accepts access_id, auth_header, base_url.

--- a/tests/test_vor_guid_length.py
+++ b/tests/test_vor_guid_length.py
@@ -1,6 +1,6 @@
 from src.providers.vor import _build_guid
 
-def test_vor_guid_bounded_length():
+def test_vor_guid_bounded_length() -> None:
     """
     Verify that the fallback GUID generation produces fixed-length IDs
     even with large input content (using SHA256).

--- a/tests/test_vor_location_name.py
+++ b/tests/test_vor_location_name.py
@@ -5,7 +5,7 @@ import src.providers.vor as vor
 
 
 @responses.activate
-def test_location_name_contains_stoplocation():
+def test_location_name_contains_stoplocation() -> None:
     url = f"{vor.VOR_BASE_URL}location.name"
     payload = {"StopLocation": [{"id": "1", "name": "Wien"}]}
     responses.add(responses.GET, url, json=payload, status=200)

--- a/tests/test_vor_log_injection.py
+++ b/tests/test_vor_log_injection.py
@@ -32,7 +32,7 @@ def test_log_warning_sanitizes_newlines(monkeypatch):
     assert "station_id" in sanitized
     assert "Fake Log Entry" in sanitized
 
-def test_sanitize_message_strips_control_chars():
+def test_sanitize_message_strips_control_chars() -> None:
     # Direct test of _sanitize_message
     text = "Line 1\nLine 2\rLine 3\tTabbed"
     sanitized = vor._sanitize_message(text)
@@ -42,7 +42,7 @@ def test_sanitize_message_strips_control_chars():
     assert "\t" not in sanitized
     assert "Line 1\\nLine 2\\rLine 3\\tTabbed" in sanitized
 
-def test_sanitize_message_strips_ansi_codes():
+def test_sanitize_message_strips_ansi_codes() -> None:
     # Test for ANSI escape codes (e.g. colors)
     red = "\x1b[31m"
     reset = "\x1b[0m"

--- a/tests/test_vor_namespace.py
+++ b/tests/test_vor_namespace.py
@@ -1,7 +1,7 @@
 import src.providers.vor as vor
 
 
-def test_iter_messages_handles_nested_containers():
+def test_iter_messages_handles_nested_containers() -> None:
     payload = {
         "DepartureBoard": {
             "Messages": {

--- a/tests/test_vor_parse_dt.py
+++ b/tests/test_vor_parse_dt.py
@@ -3,7 +3,7 @@ from datetime import timezone
 import src.providers.vor as vor
 
 
-def test_parse_dt_converts_vienna_to_utc():
+def test_parse_dt_converts_vienna_to_utc() -> None:
     dt = vor._parse_dt("2024-07-01", "12:00")
     assert dt is not None
     assert dt.tzinfo == timezone.utc

--- a/tests/test_vor_race_condition.py
+++ b/tests/test_vor_race_condition.py
@@ -5,7 +5,7 @@ from zoneinfo import ZoneInfo
 import src.providers.vor as vor
 
 class TestVorRaceCondition(unittest.TestCase):
-    def test_fetch_aborts_if_limit_reached_concurrently(self):
+    def test_fetch_aborts_if_limit_reached_concurrently(self) -> None:
         """
         Verify that _fetch_departure_board_for_station checks the request limit
         (via load_request_count) BEFORE making the network request.

--- a/tests/test_vor_redirect_leak.py
+++ b/tests/test_vor_redirect_leak.py
@@ -9,7 +9,7 @@ class TestVorRedirectLeak(unittest.TestCase):
         vor.VOR_ACCESS_ID = "SECRET_TOKEN"
         vor._VOR_AUTHORIZATION_HEADER = ""
 
-    def test_redirect_leaks_credentials(self):
+    def test_redirect_leaks_credentials(self) -> None:
         """
         Verify that VorAuth injects credentials only for VOR URLs and not for external URLs.
         Using VorAuth directly avoids mocking session internals which can be fragile.

--- a/tests/test_vor_stationboard_json.py
+++ b/tests/test_vor_stationboard_json.py
@@ -1,7 +1,7 @@
 import src.providers.vor as vor
 
 
-def test_iter_messages_returns_dict():
+def test_iter_messages_returns_dict() -> None:
     payload = {
         "DepartureBoard": {
             "Messages": {

--- a/tests/test_vor_stations_directory.py
+++ b/tests/test_vor_stations_directory.py
@@ -9,7 +9,7 @@ import pytest
 from src.utils.stations import station_info, vor_station_ids
 
 
-def test_vor_lookup_by_id():
+def test_vor_lookup_by_id() -> None:
     info = station_info("900100")
     assert info is not None
     assert info.name == "Wien Hauptbahnhof"
@@ -135,7 +135,7 @@ def test_bst_code_identity_outranks_foreign_alias(monkeypatch):
         stations.station_info.cache_clear()
 
 
-def test_vor_lookup_by_alias():
+def test_vor_lookup_by_alias() -> None:
     info = station_info("Vienna Airport")
     assert info is not None
     assert info.name == "Flughafen Wien"
@@ -149,7 +149,7 @@ def test_vor_lookup_by_alias():
     assert info.longitude == pytest.approx(16.563659)
 
 
-def test_vor_alias_with_municipality_prefix():
+def test_vor_alias_with_municipality_prefix() -> None:
     info = station_info("Schwechat Flughafen Wien Bahnhof")
     assert info is not None
     assert info.name == "Flughafen Wien"
@@ -159,14 +159,14 @@ def test_vor_alias_with_municipality_prefix():
     )
 
 
-def test_vor_does_not_override_station_directory():
+def test_vor_does_not_override_station_directory() -> None:
     info = station_info("Wiener Neustadt Hbf")
     assert info is not None
     assert info.vor_id == "900300"
     assert info.name == "Wiener Neustadt Hbf"
 
 
-def test_vor_station_ids_only_cover_vienna_or_pendler():
+def test_vor_station_ids_only_cover_vienna_or_pendler() -> None:
     ids = vor_station_ids()
     assert ids, "expected VOR station ids"
 
@@ -186,7 +186,7 @@ def test_vor_station_ids_default_prefers_directory(monkeypatch):
     assert ids == ["430470800", "490091000"]
 
 
-def test_vor_entries_have_bst_id_and_code():
+def test_vor_entries_have_bst_id_and_code() -> None:
     with Path("data/stations.json").open(encoding="utf-8") as handle:
         data = json.load(handle)
         stations = data.get("stations", []) if isinstance(data, dict) else data
@@ -199,7 +199,7 @@ def test_vor_entries_have_bst_id_and_code():
         assert "bst_code" in entry and entry["bst_code"], f"missing bst_code for {entry['name']}"
 
 
-def test_wl_aliases_take_precedence_over_vor_text_aliases():
+def test_wl_aliases_take_precedence_over_vor_text_aliases() -> None:
     info = station_info("Wien Karlsplatz U")
     assert info is not None
     assert info.name == "Wien Karlsplatz"

--- a/tests/test_vor_token_parsing.py
+++ b/tests/test_vor_token_parsing.py
@@ -5,20 +5,20 @@ from src.providers.vor import _normalise_access_token
 class TestVorTokenParsing(unittest.TestCase):
     """Test the parsing logic for VOR access credentials."""
 
-    def test_bare_token(self):
+    def test_bare_token(self) -> None:
         """Test that a bare token becomes a Bearer token."""
         token, header = _normalise_access_token("mytoken")
         self.assertEqual(token, "mytoken")
         self.assertEqual(header, "Bearer mytoken")
 
-    def test_user_pass_encoding(self):
+    def test_user_pass_encoding(self) -> None:
         """Test that 'user:pass' is auto-encoded to Basic Auth."""
         token, header = _normalise_access_token("user:pass")
         self.assertEqual(token, "user:pass")
         expected_b64 = base64.b64encode(b"user:pass").decode("ascii")
         self.assertEqual(header, f"Basic {expected_b64}")
 
-    def test_prefixed_basic_header(self):
+    def test_prefixed_basic_header(self) -> None:
         """Test that an existing 'Basic ...' header is preserved."""
         raw = "Basic dXNlcjpwYXNz"
         token, header = _normalise_access_token(raw)
@@ -27,7 +27,7 @@ class TestVorTokenParsing(unittest.TestCase):
         self.assertEqual(token, "dXNlcjpwYXNz")
         self.assertEqual(header, raw)
 
-    def test_prefixed_basic_header_unencoded(self):
+    def test_prefixed_basic_header_unencoded(self) -> None:
         """Test that 'Basic user:pass' (unencoded) is detected and encoded."""
         # This supports legacy behavior/user error where they prefix but forget to encode
         raw = "Basic user:pass"
@@ -36,19 +36,19 @@ class TestVorTokenParsing(unittest.TestCase):
         expected_b64 = base64.b64encode(b"user:pass").decode("ascii")
         self.assertEqual(header, f"Basic {expected_b64}")
 
-    def test_prefixed_bearer_header(self):
+    def test_prefixed_bearer_header(self) -> None:
         """Test that an existing 'Bearer ...' header is preserved."""
         raw = "Bearer mytoken"
         token, header = _normalise_access_token(raw)
         self.assertEqual(token, "mytoken")
         self.assertEqual(header, raw)
 
-    def test_empty(self):
+    def test_empty(self) -> None:
         token, header = _normalise_access_token("")
         self.assertEqual(token, "")
         self.assertEqual(header, "")
 
-    def test_whitespace(self):
+    def test_whitespace(self) -> None:
         token, header = _normalise_access_token("  mytoken  ")
         self.assertEqual(token, "mytoken")
         self.assertEqual(header, "Bearer mytoken")


### PR DESCRIPTION
Adds -> None return annotations to 26 unannotated test functions across
13 VOR test files. Single-line signature edits only; no imports added,
no test bodies modified.

Files:
- test_vor_default_version.py (1)
- test_vor_departure_board_leak.py (1)
- test_vor_fixes.py (1, TestVorAuth only)
- test_vor_guid_length.py (1)
- test_vor_location_name.py (1)
- test_vor_log_injection.py (2)
- test_vor_namespace.py (1)
- test_vor_parse_dt.py (1)
- test_vor_race_condition.py (1)
- test_vor_redirect_leak.py (1)
- test_vor_stationboard_json.py (1)
- test_vor_stations_directory.py (7)
- test_vor_token_parsing.py (7)

Part of strict-typing migration (mypy disallow_untyped_defs).

---
*PR created automatically by Jules for task [12934852091697868299](https://jules.google.com/task/12934852091697868299) started by @Origamihase*