### PR TITLE
strict-typing/cluster18-pure-none-sweep

### DIFF
--- a/tests/test_deduplication_quality.py
+++ b/tests/test_deduplication_quality.py
@@ -17,7 +17,7 @@ class TestDeduplicationQuality(unittest.TestCase):
     3. 'Better' items (longer description, more recent) are preferred.
     """
 
-    def test_exact_duplicates(self):
+    def test_exact_duplicates(self) -> None:
         """Scenario: Two identical items."""
         item1 = {
             "guid": "123",
@@ -30,7 +30,7 @@ class TestDeduplicationQuality(unittest.TestCase):
         result = _dedupe_items([item1, item2])
         self.assertEqual(len(result), 1, "Should reduce exact duplicates to 1")
 
-    def test_update_behavior_same_guid(self):
+    def test_update_behavior_same_guid(self) -> None:
         """Scenario: Item updates with same GUID. New item has longer description."""
         item_old = {
             "guid": "123",
@@ -58,7 +58,7 @@ class TestDeduplicationQuality(unittest.TestCase):
         self.assertEqual(len(result2), 1)
         self.assertEqual(result2[0]["description"], "Kurz aber länger", "Should keep the 'better' item regardless of order")
 
-    def test_update_behavior_later_end_date(self):
+    def test_update_behavior_later_end_date(self) -> None:
         """Scenario: Item updates with extended end time."""
         item_short = {
             "guid": "123",
@@ -75,7 +75,7 @@ class TestDeduplicationQuality(unittest.TestCase):
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["ends_at"], item_long["ends_at"], "Should prefer item with later end date")
 
-    def test_fallback_identity_collision(self):
+    def test_fallback_identity_collision(self) -> None:
         """Scenario: No GUID, same content -> Deduplication (Good)."""
         item1 = {
             "source": "Src",
@@ -96,7 +96,7 @@ class TestDeduplicationQuality(unittest.TestCase):
         result = _dedupe_items([item1, item2])
         self.assertEqual(len(result), 1)
 
-    def test_fallback_identity_failure(self):
+    def test_fallback_identity_failure(self) -> None:
         """Scenario: No GUID, content update -> Duplication (Expected limitation)."""
         item1 = {
             "source": "Src",

--- a/tests/test_feed_formatting.py
+++ b/tests/test_feed_formatting.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 
 from src.build_feed import _emit_item
 
-def test_emit_item_formatting_html_stripping():
+def test_emit_item_formatting_html_stripping() -> None:
     # Setup
     now = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
     state = {}
@@ -58,7 +58,7 @@ def test_emit_item_formatting_html_stripping():
     # Check that HTML layout exists in content:encoded
     assert "<br/>" in content_html
 
-def test_emit_item_formatting_plain_text():
+def test_emit_item_formatting_plain_text() -> None:
     # Setup
     now = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
     state = {}
@@ -84,7 +84,7 @@ def test_emit_item_formatting_plain_text():
     # No time line -> No <br/>
     assert "<br/>" not in inner_content
 
-def test_emit_item_formatting_multiline_collapsed():
+def test_emit_item_formatting_multiline_collapsed() -> None:
     # Setup
     now = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
     state = {}
@@ -112,7 +112,7 @@ def test_emit_item_formatting_multiline_collapsed():
 
     assert "Line 1. • Line 2." in inner_content or "Line 1. Line 2." in inner_content
 
-def test_emit_item_timeframe_formatting():
+def test_emit_item_timeframe_formatting() -> None:
     # Setup
     now = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
     state = {}

--- a/tests/test_feed_merge.py
+++ b/tests/test_feed_merge.py
@@ -1,6 +1,6 @@
 from src.feed.merge import deduplicate_fuzzy
 
-def test_fuzzy_merge_silvester():
+def test_fuzzy_merge_silvester() -> None:
     items = [
         {
             "title": "1/2/71/74A/D: Wiener Silvesterlauf Event",
@@ -35,7 +35,7 @@ def test_fuzzy_merge_silvester():
     assert item["guid"] != "guid1"
     assert item["guid"] != "guid2"
 
-def test_fuzzy_merge_pubdate_update():
+def test_fuzzy_merge_pubdate_update() -> None:
     items = [
         {
             "title": "U1: Störung",
@@ -61,7 +61,7 @@ def test_fuzzy_merge_pubdate_update():
     assert "Zweite Meldung." in item["description"]
 
 
-def test_fuzzy_no_merge_different_events():
+def test_fuzzy_no_merge_different_events() -> None:
     items = [
         {
             "title": "1/2: Demo Ring",
@@ -78,7 +78,7 @@ def test_fuzzy_no_merge_different_events():
     merged = deduplicate_fuzzy(items)
     assert len(merged) == 2
 
-def test_fuzzy_no_merge_lines_disjoint():
+def test_fuzzy_no_merge_lines_disjoint() -> None:
     items = [
         {
             "title": "1: Silvesterlauf",
@@ -95,7 +95,7 @@ def test_fuzzy_no_merge_lines_disjoint():
     merged = deduplicate_fuzzy(items)
     assert len(merged) == 2
 
-def test_fuzzy_merge_lines_overlap_threshold():
+def test_fuzzy_merge_lines_overlap_threshold() -> None:
     # Overlap must be > 0.3
     # Items: A={1,2,3,4}, B={4,5,6,7}. Intersection={4}. Union={1..7} (7 items). 1/7 = 0.14. No merge.
     items = [
@@ -126,7 +126,7 @@ def test_fuzzy_merge_lines_overlap_threshold():
     assert len(merged2) == 1
     assert "1/2/3" in merged2[0]["title"]
 
-def test_fuzzy_merge_description_containment():
+def test_fuzzy_merge_description_containment() -> None:
     items = [
         {
             "title": "1/2: Event",
@@ -145,7 +145,7 @@ def test_fuzzy_merge_description_containment():
     assert merged[0]["description"] == "This is a Long desc containing Short desc inside it."
     assert "Short desc\n\n" not in merged[0]["description"]
 
-def test_fuzzy_merge_name_combining():
+def test_fuzzy_merge_name_combining() -> None:
     items = [
         {
             "title": "1/2: Event Special Run",
@@ -161,7 +161,7 @@ def test_fuzzy_merge_name_combining():
     assert len(merged) == 1
     assert "Event Special Run & Event Special Walk" in merged[0]["title"] or "Event Special Walk & Event Special Run" in merged[0]["title"]
 
-def test_fuzzy_merge_recursive():
+def test_fuzzy_merge_recursive() -> None:
     # A merges with B, result merges with C?
     # Current implementation is iterative.
     # If list is [A, B, C].
@@ -192,7 +192,7 @@ def test_fuzzy_merge_recursive():
     assert "1/2/3/4/5" in merged[0]["title"]
 
 
-def test_fuzzy_merge_provider_priority_vor_over_oebb():
+def test_fuzzy_merge_provider_priority_vor_over_oebb() -> None:
     """Verify that VOR data is prioritized over ÖBB data."""
     items = [
         {
@@ -224,7 +224,7 @@ def test_fuzzy_merge_provider_priority_vor_over_oebb():
     assert "VOR Details." in item["description"]
     assert "ÖBB Details." in item["description"]
 
-def test_fuzzy_merge_provider_priority_oebb_over_vor_order():
+def test_fuzzy_merge_provider_priority_oebb_over_vor_order() -> None:
     """Verify that even if ÖBB comes first, VOR wins the merge but keeps VOR data."""
     items = [
         {

--- a/tests/test_feed_merge_priority.py
+++ b/tests/test_feed_merge_priority.py
@@ -1,6 +1,6 @@
 from src.feed.merge import deduplicate_fuzzy
 
-def test_fuzzy_merge_provider_priority_vor_wins_over_oebb():
+def test_fuzzy_merge_provider_priority_vor_wins_over_oebb() -> None:
     """
     Test that a VOR event overrides an ÖBB event when they are duplicates.
     The VOR metadata (start time, etc.) should be preserved.
@@ -48,7 +48,7 @@ def test_fuzzy_merge_provider_priority_vor_wins_over_oebb():
     assert item["_identity"] == "vor_guid_1"
     assert "_calculated_identity" not in item
 
-def test_fuzzy_merge_provider_priority_vor_wins_reverse_order():
+def test_fuzzy_merge_provider_priority_vor_wins_reverse_order() -> None:
     """
     Same as above, but items are processed in reverse order (VOR exists, ÖBB comes later).
     """
@@ -83,7 +83,7 @@ def test_fuzzy_merge_provider_priority_vor_wins_reverse_order():
     assert item["_identity"] == "vor_guid_1"
     assert "_calculated_identity" not in item
 
-def test_fuzzy_merge_provider_priority_no_provider_field():
+def test_fuzzy_merge_provider_priority_no_provider_field() -> None:
     """
     Ensure no crash if 'provider' field is missing, falls back to normal merge.
     """

--- a/tests/test_safe_json_formatter.py
+++ b/tests/test_safe_json_formatter.py
@@ -6,7 +6,7 @@ import sys
 from src.feed.logging_safe import SafeJSONFormatter, SafeFormatter
 
 class TestSafeJSONFormatter(unittest.TestCase):
-    def test_format_exception_does_not_clear_frames(self):
+    def test_format_exception_does_not_clear_frames(self) -> None:
         try:
             1 / 0
         except ZeroDivisionError:
@@ -22,7 +22,7 @@ class TestSafeJSONFormatter(unittest.TestCase):
         self.assertIsNotNone(tb.tb_frame.f_locals)
         self.assertTrue(len(tb.tb_frame.f_locals) > 0)
 
-    def test_safe_formatter_format_does_not_mutate_record(self):
+    def test_safe_formatter_format_does_not_mutate_record(self) -> None:
         record = logging.LogRecord(
             name="test",
             level=logging.INFO,
@@ -39,7 +39,7 @@ class TestSafeJSONFormatter(unittest.TestCase):
         self.assertEqual(record.msg, "Hello %s")
         self.assertEqual(record.args, ("world",))
 
-    def test_extra_dict_leak(self):
+    def test_extra_dict_leak(self) -> None:
         """Test that secrets in nested dictionaries in 'extra' are redacted."""
         logger = logging.getLogger("test_json_leak")
         logger.setLevel(logging.INFO)
@@ -72,7 +72,7 @@ class TestSafeJSONFormatter(unittest.TestCase):
         self.assertIn("api_key", log_record["extra"]["data"]["context"])
         self.assertEqual(log_record["extra"]["data"]["context"]["api_key"], "***")
 
-    def test_value_redaction_in_json(self):
+    def test_value_redaction_in_json(self) -> None:
         """Test that values looking like secrets (e.g. key=value pattern) are redacted even in JSON strings."""
         logger = logging.getLogger("test_json_value")
         logger.setLevel(logging.INFO)

--- a/tests/test_serialize_depth_limit.py
+++ b/tests/test_serialize_depth_limit.py
@@ -2,7 +2,7 @@ from src.utils.serialize import serialize_for_cache
 
 import pytest
 
-def test_serialize_deep_nesting_fails_gracefully():
+def test_serialize_deep_nesting_fails_gracefully() -> None:
     # Construct a deeply nested structure exceeding the proposed limit (e.g., 200)
     # but within Python's recursion limit (1000) to ensure we hit our check first.
     deep_structure = {"val": 1}
@@ -12,7 +12,7 @@ def test_serialize_deep_nesting_fails_gracefully():
     with pytest.raises(RecursionError, match="Maximum recursion depth 50 exceeded"):
         serialize_for_cache(deep_structure)
 
-def test_serialize_reasonable_depth_works():
+def test_serialize_reasonable_depth_works() -> None:
     # Construct a moderately nested structure (e.g., 40 levels)
     # This should pass without error (limit is 50, but testing 40 to be safe with counting)
     deep_structure = {"val": 1}

--- a/tests/test_stations_utils_security.py
+++ b/tests/test_stations_utils_security.py
@@ -1,6 +1,6 @@
 from src.utils.stations import _coerce_float, is_in_vienna
 
-def test_coerce_float_rejects_non_finite():
+def test_coerce_float_rejects_non_finite() -> None:
     # These should return None for security/safety
     assert _coerce_float("Infinity") is None
     assert _coerce_float("-Infinity") is None
@@ -8,7 +8,7 @@ def test_coerce_float_rejects_non_finite():
     assert _coerce_float(float("inf")) is None
     assert _coerce_float(float("nan")) is None
 
-def test_is_in_vienna_handles_non_finite_gracefully():
+def test_is_in_vienna_handles_non_finite_gracefully() -> None:
     # Should be False (not in Vienna) rather than crashing or weird behavior
     # Note: Currently _coerce_float returns float('inf'), so is_in_vienna might behave unexpectedly.
     # We assert False because that is the safe default.

--- a/tests/test_weak_hash_usage.py
+++ b/tests/test_weak_hash_usage.py
@@ -1,7 +1,7 @@
 
 from src.build_feed import _identity_for_item, _dedupe_key_for_item
 
-def test_identity_for_item_uses_strong_hash():
+def test_identity_for_item_uses_strong_hash() -> None:
     item = {
         "title": "Test Title",
         "starts_at": "2023-01-01T12:00:00Z",
@@ -30,7 +30,7 @@ def test_identity_for_item_uses_strong_hash():
     # Assert it is SHA256 (64 chars) and NOT SHA1 (40 chars)
     assert len(hash_val) == 64, f"Hash length is {len(hash_val)}, expected 64 (SHA256). Likely still using SHA1."
 
-def test_dedupe_key_for_item_uses_strong_hash():
+def test_dedupe_key_for_item_uses_strong_hash() -> None:
     item = {
         "title": "Test Title",
         "description": "Test Description",

--- a/tests/test_wl_iso_timezone.py
+++ b/tests/test_wl_iso_timezone.py
@@ -3,7 +3,7 @@ from datetime import timezone
 from src.providers.wl_fetch import _iso
 
 
-def test_iso_returns_utc_aware():
+def test_iso_returns_utc_aware() -> None:
     dt = _iso("2024-07-01T12:00:00")
     assert dt is not None
     assert dt.tzinfo == timezone.utc

--- a/tests/test_wl_lines_pairs.py
+++ b/tests/test_wl_lines_pairs.py
@@ -1,11 +1,11 @@
 from src.providers.wl_lines import _tok, _make_line_pairs_from_related
 
 
-def test_tok_returns_empty_for_none_and_empty():
+def test_tok_returns_empty_for_none_and_empty() -> None:
     assert _tok(None) == ""
     assert _tok("") == ""
 
 
-def test_make_line_pairs_from_related_ignores_none():
+def test_make_line_pairs_from_related_ignores_none() -> None:
     pairs = _make_line_pairs_from_related(["5", None, "U1", ""])
     assert pairs == [("5", "5"), ("U1", "U1")]

--- a/tests/test_wl_lines_redos.py
+++ b/tests/test_wl_lines_redos.py
@@ -2,7 +2,7 @@
 import time
 from src.providers.wl_lines import LINES_COMPLEX_PREFIX_RE
 
-def test_lines_complex_prefix_correctness():
+def test_lines_complex_prefix_correctness() -> None:
     """Verify that the regex matches valid complex line prefixes."""
     valid_inputs = [
         "L1, L2: Message",
@@ -19,7 +19,7 @@ def test_lines_complex_prefix_correctness():
         # Ensure it captured the prefix including the colon
         assert match.group(0).strip().endswith(":")
 
-def test_lines_complex_prefix_redos_performance():
+def test_lines_complex_prefix_redos_performance() -> None:
     """Verify that the regex is not vulnerable to ReDoS."""
     # Construct an attack string that triggers catastrophic backtracking in the vulnerable regex
     # The vulnerable regex had nested quantifiers around optional spaces and 'und'
@@ -36,7 +36,7 @@ def test_lines_complex_prefix_redos_performance():
     # This string is length ~8000.
     assert duration < 0.5, f"Regex took too long: {duration:.4f}s"
 
-def test_lines_complex_prefix_no_match():
+def test_lines_complex_prefix_no_match() -> None:
     """Verify non-matching inputs."""
     invalid_inputs = [
         "Simple Prefix: Text", # Doesn't start with multiple comma separated parts


### PR DESCRIPTION
- Addressed strict-typing requirements by adding `-> None` annotations to 38 unannotated zero-param/self test functions.
- The edits were performed across a precise 11-file scope in the `tests/` directory as requested in the revised prompt.
- All modifications are single-line signature updates without any body logic or import changes.
- Checked via pre-verification bash script and verification scripts that assert exactly 38 additions/removals and zero negative regressions.

---
*PR created automatically by Jules for task [18212171288774676007](https://jules.google.com/task/18212171288774676007) started by @Origamihase*