### PR TITLE
strict-typing(cluster19): annotate 30 fixture-based test fns across 6 files

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -16,14 +16,18 @@ def _prepare_cache(tmp_path: Path, monkeypatch, provider: str) -> Path:
     return target / "events.json"
 
 
-def test_read_cache_returns_list(tmp_path, monkeypatch):
+def test_read_cache_returns_list(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     cache_file = _prepare_cache(tmp_path, monkeypatch, "provider")
     cache_file.write_text(json.dumps([{"id": 1}]), encoding="utf-8")
 
     assert cache.read_cache("provider") == [{"id": 1}]
 
 
-def test_read_cache_warns_on_non_list(tmp_path, monkeypatch, caplog):
+def test_read_cache_warns_on_non_list(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     cache_file = _prepare_cache(tmp_path, monkeypatch, "provider")
     cache_file.write_text(json.dumps({"id": 1}), encoding="utf-8")
 
@@ -35,7 +39,11 @@ def test_read_cache_warns_on_non_list(tmp_path, monkeypatch, caplog):
 
 
 @pytest.mark.parametrize("pretty", [False, True])
-def test_write_cache_explicit_pretty_flag(tmp_path, monkeypatch, pretty):
+def test_write_cache_explicit_pretty_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pretty: bool,
+) -> None:
     cache_file = _prepare_cache(tmp_path, monkeypatch, f"provider-{pretty}")
 
     cache.write_cache(f"provider-{pretty}", [{"id": 1}], pretty=pretty)
@@ -49,7 +57,7 @@ def test_write_cache_explicit_pretty_flag(tmp_path, monkeypatch, pretty):
     assert cache_file.read_text(encoding="utf-8") == expected
 
 
-def test_write_cache_env_compact(tmp_path, monkeypatch):
+def test_write_cache_env_compact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     cache_file = _prepare_cache(tmp_path, monkeypatch, "env-provider")
     monkeypatch.setenv("WIEN_OEPNV_CACHE_PRETTY", "0")
 

--- a/tests/test_cache_degradation_guard.py
+++ b/tests/test_cache_degradation_guard.py
@@ -1,9 +1,10 @@
 import json
+from pathlib import Path
 import pytest
 from unittest.mock import patch
 from src.utils.cache import write_cache, DataDegradationError
 
-def test_cache_degradation_guard_bypass_on_new_cache(tmp_path):
+def test_cache_degradation_guard_bypass_on_new_cache(tmp_path: Path) -> None:
     """Verify that writing to a non-existent cache works normally."""
     provider = "test_new"
     cache_dir = tmp_path / "cache"
@@ -20,7 +21,7 @@ def test_cache_degradation_guard_bypass_on_new_cache(tmp_path):
             saved_data = json.load(f)
         assert len(saved_data) == 1
 
-def test_cache_degradation_guard_bypass_on_empty_existing(tmp_path):
+def test_cache_degradation_guard_bypass_on_empty_existing(tmp_path: Path) -> None:
     """Verify that writing empty items to an empty existing cache works."""
     provider = "test_empty_existing"
     cache_dir = tmp_path / "cache"
@@ -41,7 +42,7 @@ def test_cache_degradation_guard_bypass_on_empty_existing(tmp_path):
             saved_data = json.load(f)
         assert len(saved_data) == 0
 
-def test_cache_degradation_guard_raises_on_empty_payload(tmp_path):
+def test_cache_degradation_guard_raises_on_empty_payload(tmp_path: Path) -> None:
     """Verify that writing empty items to a populated cache raises DataDegradationError."""
     provider = "test_empty_payload"
     cache_dir = tmp_path / "cache"
@@ -58,7 +59,7 @@ def test_cache_degradation_guard_raises_on_empty_payload(tmp_path):
         with pytest.raises(DataDegradationError, match="Empty payload rejected"):
             write_cache(provider, items)
 
-def test_cache_degradation_guard_raises_on_drastic_drop(tmp_path):
+def test_cache_degradation_guard_raises_on_drastic_drop(tmp_path: Path) -> None:
     """Verify that writing drastically fewer items raises DataDegradationError."""
     provider = "test_drastic_drop"
     cache_dir = tmp_path / "cache"
@@ -76,7 +77,7 @@ def test_cache_degradation_guard_raises_on_drastic_drop(tmp_path):
         with pytest.raises(DataDegradationError, match="Degraded payload rejected"):
             write_cache(provider, items)
 
-def test_cache_degradation_guard_bypass_on_slight_drop(tmp_path):
+def test_cache_degradation_guard_bypass_on_slight_drop(tmp_path: Path) -> None:
     """Verify that a drop < 80% bypasses the degradation guard."""
     provider = "test_slight_drop"
     cache_dir = tmp_path / "cache"
@@ -97,7 +98,7 @@ def test_cache_degradation_guard_bypass_on_slight_drop(tmp_path):
             saved_data = json.load(f)
         assert len(saved_data) == 50
 
-def test_cache_degradation_guard_bypass_on_corrupt_cache(tmp_path):
+def test_cache_degradation_guard_bypass_on_corrupt_cache(tmp_path: Path) -> None:
     """Verify that if the existing cache is corrupt, it's bypassed and overwritten."""
     provider = "test_corrupt"
     cache_dir = tmp_path / "cache"

--- a/tests/test_config_validate_path.py
+++ b/tests/test_config_validate_path.py
@@ -2,7 +2,7 @@ import pytest
 from pathlib import Path
 from src.feed.config import validate_path, InvalidPathError, REPO_ROOT
 
-def test_validate_path_foreign_cwd(tmp_path, monkeypatch):
+def test_validate_path_foreign_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Change cwd to a temporary directory outside the repo root
     monkeypatch.chdir(tmp_path)
 
@@ -19,7 +19,7 @@ def test_validate_path_foreign_cwd(tmp_path, monkeypatch):
     with pytest.raises(InvalidPathError):
         validate_path(foreign_path, "TEST_PATH")
 
-def test_validate_path_repo_root():
+def test_validate_path_repo_root() -> None:
     # A path inside the REPO_ROOT's allowed dirs should succeed
     repo_docs = REPO_ROOT / "docs" / "feed.xml"
     resolved = validate_path(repo_docs, "TEST_PATH")

--- a/tests/test_resolve_env_path.py
+++ b/tests/test_resolve_env_path.py
@@ -12,7 +12,7 @@ def _restore_env(monkeypatch):
     monkeypatch.delenv("CUSTOM_PATH", raising=False)
 
 
-def test_resolve_env_path_uses_default_for_whitespace(monkeypatch):
+def test_resolve_env_path_uses_default_for_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CUSTOM_PATH", "   \t   ")
     default = Path("log/fallback.log")
 
@@ -22,7 +22,7 @@ def test_resolve_env_path_uses_default_for_whitespace(monkeypatch):
     assert os.getenv("CUSTOM_PATH") == "   \t   "
 
 
-def test_resolve_env_path_normalizes_valid_input(monkeypatch):
+def test_resolve_env_path_normalizes_valid_input(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CUSTOM_PATH", "  log/custom.log  ")
     default = Path("log/default.log")
 
@@ -33,7 +33,9 @@ def test_resolve_env_path_normalizes_valid_input(monkeypatch):
     assert os.getenv("CUSTOM_PATH") == "  log/custom.log  "
 
 
-def test_resolve_env_path_does_not_overwrite_env_on_refresh(monkeypatch):
+def test_resolve_env_path_does_not_overwrite_env_on_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("CUSTOM_PATH", "data/feed.rss")
     default = Path("data/default.rss")
 
@@ -49,7 +51,9 @@ def test_resolve_env_path_does_not_overwrite_env_on_refresh(monkeypatch):
     assert os.getenv("CUSTOM_PATH") == "data/feed.rss"
 
 
-def test_resolve_env_path_raises_for_invalid_without_fallback(monkeypatch):
+def test_resolve_env_path_raises_for_invalid_without_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("CUSTOM_PATH", "../evil/outside.log")
     default = Path("log/default.log")
 
@@ -60,7 +64,9 @@ def test_resolve_env_path_raises_for_invalid_without_fallback(monkeypatch):
     assert os.getenv("CUSTOM_PATH") == "../evil/outside.log"
 
 
-def test_resolve_env_path_suffix_collision_requires_fallback(monkeypatch):
+def test_resolve_env_path_suffix_collision_requires_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("CUSTOM_PATH", "/tmp/docs/feed.xml")
     default = Path("docs/feed.xml")
 
@@ -70,7 +76,7 @@ def test_resolve_env_path_suffix_collision_requires_fallback(monkeypatch):
     assert os.getenv("CUSTOM_PATH") == "/tmp/docs/feed.xml"
 
 
-def test_resolve_env_path_falls_back_when_allowed(monkeypatch):
+def test_resolve_env_path_falls_back_when_allowed(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CUSTOM_PATH", "../evil/outside.log")
     default = Path("log/default.log")
 

--- a/tests/test_utils_env.py
+++ b/tests/test_utils_env.py
@@ -7,7 +7,7 @@ import pytest
 from src.utils.env import get_bool_env, load_default_env_files
 
 
-def test_get_bool_env_default(monkeypatch):
+def test_get_bool_env_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("BOOL_TEST", raising=False)
     assert get_bool_env("BOOL_TEST", True) is True
     assert get_bool_env("BOOL_TEST", False) is False
@@ -17,7 +17,7 @@ def test_get_bool_env_default(monkeypatch):
     "value",
     ["1", "true", "True", " YES ", "on", "Y", "t"],
 )
-def test_get_bool_env_truthy(monkeypatch, value):
+def test_get_bool_env_truthy(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
     monkeypatch.setenv("BOOL_TEST", value)
     assert get_bool_env("BOOL_TEST", False) is True
 
@@ -26,25 +26,28 @@ def test_get_bool_env_truthy(monkeypatch, value):
     "value",
     ["0", "false", "False", " no ", "OFF", "n", "F"],
 )
-def test_get_bool_env_falsy(monkeypatch, value):
+def test_get_bool_env_falsy(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
     monkeypatch.setenv("BOOL_TEST", value)
     assert get_bool_env("BOOL_TEST", True) is False
 
 
-def test_get_bool_env_empty_uses_default(monkeypatch):
+def test_get_bool_env_empty_uses_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("BOOL_TEST", "   ")
     assert get_bool_env("BOOL_TEST", True) is True
     assert get_bool_env("BOOL_TEST", False) is False
 
 
-def test_get_bool_env_invalid_logs_warning(monkeypatch, caplog):
+def test_get_bool_env_invalid_logs_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     monkeypatch.setenv("BOOL_TEST", "maybe")
     with caplog.at_level(logging.WARNING, logger="build_feed"):
         assert get_bool_env("BOOL_TEST", False) is False
     assert "Ungültiger boolescher Wert" in caplog.text
 
 
-def test_load_default_env_files_uses_repo_root(monkeypatch):
+def test_load_default_env_files_uses_repo_root(monkeypatch: pytest.MonkeyPatch) -> None:
     repo_root = Path(__file__).resolve().parents[1]
     temp_env = repo_root / "temp_test_env.env"
     temp_env.write_text("FOO=bar\n", encoding="utf-8")

--- a/tests/test_utils_files.py
+++ b/tests/test_utils_files.py
@@ -1,8 +1,9 @@
 import os
+from pathlib import Path
 import pytest
 from src.utils.files import atomic_write
 
-def test_atomic_write_creates_file(tmp_path):
+def test_atomic_write_creates_file(tmp_path: Path) -> None:
     target = tmp_path / "test.txt"
     with atomic_write(target, mode="w", encoding="utf-8") as f:
         f.write("Hello")
@@ -10,7 +11,7 @@ def test_atomic_write_creates_file(tmp_path):
     assert target.exists()
     assert target.read_text(encoding="utf-8") == "Hello"
 
-def test_atomic_write_overwrites_existing(tmp_path):
+def test_atomic_write_overwrites_existing(tmp_path: Path) -> None:
     target = tmp_path / "overwrite.txt"
     target.write_text("Old", encoding="utf-8")
 
@@ -19,7 +20,7 @@ def test_atomic_write_overwrites_existing(tmp_path):
 
     assert target.read_text(encoding="utf-8") == "New"
 
-def test_atomic_write_no_overwrite(tmp_path):
+def test_atomic_write_no_overwrite(tmp_path: Path) -> None:
     target = tmp_path / "protected.txt"
     target.write_text("Old", encoding="utf-8")
 
@@ -29,7 +30,7 @@ def test_atomic_write_no_overwrite(tmp_path):
 
     assert target.read_text(encoding="utf-8") == "Old"
 
-def test_atomic_write_cleanup_on_error(tmp_path):
+def test_atomic_write_cleanup_on_error(tmp_path: Path) -> None:
     target = tmp_path / "fail.txt"
 
     with pytest.raises(RuntimeError):
@@ -41,7 +42,7 @@ def test_atomic_write_cleanup_on_error(tmp_path):
     # Check that no temp files are left
     assert len(list(tmp_path.glob("fail.txt.*.tmp"))) == 0
 
-def test_atomic_write_binary(tmp_path):
+def test_atomic_write_binary(tmp_path: Path) -> None:
     target = tmp_path / "binary.bin"
     data = b"\x00\x01\x02"
 
@@ -50,7 +51,7 @@ def test_atomic_write_binary(tmp_path):
 
     assert target.read_bytes() == data
 
-def test_atomic_write_permissions(tmp_path):
+def test_atomic_write_permissions(tmp_path: Path) -> None:
     if os.name == 'nt':
         pytest.skip("Permissions not fully supported on Windows")
 


### PR DESCRIPTION
Add type annotations to test functions using monkeypatch, tmp_path, caplog, and parametrized fixture parameters across 6 files.

---
*PR created automatically by Jules for task [4157679642396906209](https://jules.google.com/task/4157679642396906209) started by @Origamihase*