### PR TITLE
Strict-typing C20: no-param + single-monkey sweep

### DIFF
--- a/tests/test_build_feed_cancelled.py
+++ b/tests/test_build_feed_cancelled.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import src.build_feed as bf
 from src.build_feed import _collect_items, RunReport
 
-def test_collect_items_cancelled_future():
+def test_collect_items_cancelled_future() -> None:
     # Setup configuration
     mock_feed_config = MagicMock()
     mock_feed_config.PROVIDER_TIMEOUT = 0.05  # very short timeout

--- a/tests/test_build_feed_mutation.py
+++ b/tests/test_build_feed_mutation.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 import src.build_feed as bf
 
-def test_build_feed_mutation():
+def test_build_feed_mutation() -> None:
     items = [{"title": "original", "guid": "123"}]
 
     with patch.object(bf, "_invoke_collect_items", return_value=items), \

--- a/tests/test_build_feed_timeout.py
+++ b/tests/test_build_feed_timeout.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 import src.build_feed as bf
 from src.build_feed import _collect_items, RunReport
 
-def test_collect_items_timeout_zero():
+def test_collect_items_timeout_zero() -> None:
     mock_feed_config = MagicMock()
     mock_feed_config.PROVIDER_TIMEOUT = 0
     mock_feed_config.PROVIDER_MAX_WORKERS = 1
@@ -26,7 +26,7 @@ def test_collect_items_timeout_zero():
         assert "Timeout nach 0s" in args[1]
         mock_executor.submit.assert_not_called()
 
-def test_collect_items_timeout_underflow():
+def test_collect_items_timeout_underflow() -> None:
     # If timeout logic works properly, _call_fetch_with_timeout shouldn't be executed
     # when timeout reaches exactly 0
 
@@ -61,7 +61,7 @@ def test_collect_items_timeout_underflow():
         # Let's extract the exact _run_fetch manually without running _collect_items!
 
 # Let's just create a test that directly tests the condition.
-def test_run_fetch_timeout_exactly_zero():
+def test_run_fetch_timeout_exactly_zero() -> None:
     # We will simulate exactly what _run_fetch does
     import threading
     semaphore = threading.BoundedSemaphore(1)

--- a/tests/test_env_secrets.py
+++ b/tests/test_env_secrets.py
@@ -1,8 +1,11 @@
 import os
 from unittest import mock
+
+import pytest
+
 from src.utils.env import read_secret
 
-def test_read_secret_from_env():
+def test_read_secret_from_env() -> None:
     with mock.patch("src.utils.env.Path", new_callable=mock.MagicMock) as MockPath:
         mock_instance = MockPath.return_value
         mock_instance.resolve.return_value = mock_instance
@@ -17,7 +20,7 @@ def test_read_secret_from_env():
             ):
                 assert read_secret("MY_SECRET") == "env_value"
 
-def test_read_secret_default():
+def test_read_secret_default() -> None:
     with mock.patch("src.utils.env.Path", new_callable=mock.MagicMock) as MockPath:
         mock_instance = MockPath.return_value
         mock_instance.resolve.return_value = mock_instance
@@ -28,7 +31,7 @@ def test_read_secret_default():
             assert read_secret("MISSING_SECRET", "default") == "default"
             assert read_secret("MISSING_SECRET") == ""
 
-def test_read_secret_docker_priority(monkeypatch):
+def test_read_secret_docker_priority(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CREDENTIALS_DIRECTORY", raising=False)
     monkeypatch.setenv("MY_SECRET", "env_value")
 
@@ -56,7 +59,7 @@ def test_read_secret_docker_priority(monkeypatch):
 
         assert read_secret("MY_SECRET") == "docker_value"
 
-def test_read_secret_systemd_priority(monkeypatch):
+def test_read_secret_systemd_priority(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CREDENTIALS_DIRECTORY", "/custom/creds")
     monkeypatch.setenv("MY_SECRET", "env_value")
 
@@ -85,7 +88,7 @@ def test_read_secret_systemd_priority(monkeypatch):
 
         assert read_secret("MY_SECRET") == "systemd_value"
 
-def test_read_secret_path_traversal(monkeypatch):
+def test_read_secret_path_traversal(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("CREDENTIALS_DIRECTORY", "/custom/creds")
 
     with mock.patch("src.utils.env.Path", new_callable=mock.MagicMock) as MockPath:

--- a/tests/test_http_auth_leak.py
+++ b/tests/test_http_auth_leak.py
@@ -4,7 +4,7 @@ import requests
 from unittest.mock import patch, MagicMock
 from src.utils.http import request_safe, session_with_retries
 
-def test_auth_kwargs_leak_on_redirect():
+def test_auth_kwargs_leak_on_redirect() -> None:
     # Setup session
     s = session_with_retries("test-agent")
 

--- a/tests/test_json_error_handling.py
+++ b/tests/test_json_error_handling.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 from src.providers import vor, wl_fetch
 from src.places import client
 
-def test_wl_fetch_json_error_handling():
+def test_wl_fetch_json_error_handling() -> None:
     # Mock requests session
     mock_session = MagicMock()
 
@@ -19,7 +19,7 @@ def test_wl_fetch_json_error_handling():
             args, _ = mock_log.call_args
             assert "ungültig oder kein JSON" in args[0]
 
-def test_vor_json_error_handling():
+def test_vor_json_error_handling() -> None:
     # Mock requests session
     mock_session = MagicMock()
     mock_response = MagicMock()
@@ -40,7 +40,7 @@ def test_vor_json_error_handling():
                     args, _ = mock_log.call_args
                     assert "ungültig/zu groß" in args[0]
 
-def test_places_client_json_error_handling():
+def test_places_client_json_error_handling() -> None:
     config = client.GooglePlacesConfig(
         api_key="key", included_types=[], language="en", region="US",
         radius_m=1000, timeout_s=5, max_retries=0, max_result_count=1

--- a/tests/test_merge_mutation_order.py
+++ b/tests/test_merge_mutation_order.py
@@ -2,7 +2,7 @@ import sys
 import threading
 from src.feed.merge import deduplicate_fuzzy
 
-def test_mutation_order_in_deduplicate_fuzzy():
+def test_mutation_order_in_deduplicate_fuzzy() -> None:
     """
     Asserts the correct order of operations in deduplicate_fuzzy
     by tracing the execution to ensure `_identity` is set and

--- a/tests/test_oebb_env_var.py
+++ b/tests/test_oebb_env_var.py
@@ -1,9 +1,11 @@
 import importlib
 
+import pytest
+
 import src.providers.oebb as oebb
 
 
-def test_oebb_only_vienna_env_var(monkeypatch):
+def test_oebb_only_vienna_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OEBB_ONLY_VIENNA", "FaLsE")
     importlib.reload(oebb)
     assert oebb.OEBB_ONLY_VIENNA is False

--- a/tests/test_oebb_route_filter.py
+++ b/tests/test_oebb_route_filter.py
@@ -1,4 +1,6 @@
 
+import pytest
+
 from src.providers.oebb import _is_relevant
 
 def test_venezia_is_excluded() -> None:
@@ -94,7 +96,7 @@ def test_wien_bezug_im_zweiten_teil() -> None:
     description = ""
     assert _is_relevant(title, description) is True
 
-def test_stationsname_enthaelt_selbst_doppelpunkt(monkeypatch):
+def test_stationsname_enthaelt_selbst_doppelpunkt(monkeypatch: pytest.MonkeyPatch) -> None:
     title = "RJ 123: Wien 10.: Favoriten ↔ Graz Hbf"
     description = ""
 

--- a/tests/test_oebb_timeout.py
+++ b/tests/test_oebb_timeout.py
@@ -1,9 +1,11 @@
 import xml.etree.ElementTree as ET
 
+import pytest
+
 import src.providers.oebb as oebb
 
 
-def test_fetch_events_passes_timeout(monkeypatch):
+def test_fetch_events_passes_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     recorded = {}
 
     def fake_fetch_xml(url, timeout):
@@ -19,7 +21,7 @@ def test_fetch_events_passes_timeout(monkeypatch):
     assert recorded["timeout"] == 7
 
 
-def test_fetch_xml_passes_timeout_to_session(monkeypatch):
+def test_fetch_xml_passes_timeout_to_session(monkeypatch: pytest.MonkeyPatch) -> None:
     recorded = {}
 
     class DummyResponse:

--- a/tests/test_provider_error.py
+++ b/tests/test_provider_error.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch
 from src.feed.reporting import RunReport
 
-def test_provider_error_unbound_local_error_avoided():
+def test_provider_error_unbound_local_error_avoided() -> None:
     report = RunReport([])
 
     with patch("src.feed.reporting.clean_message", side_effect=Exception("Clean failed")):

--- a/tests/test_reporting_markdown_injection.py
+++ b/tests/test_reporting_markdown_injection.py
@@ -1,7 +1,7 @@
 
 from src.feed.reporting import RunReport, FeedHealthMetrics, render_feed_health_markdown, DuplicateSummary
 
-def test_markdown_injection():
+def test_markdown_injection() -> None:
     # Setup
     report = RunReport(statuses=[("test_provider", True), ("Malicious|Provider", True)])
     # Inject various markdown characters

--- a/tests/test_reporting_table_markdown_injection.py
+++ b/tests/test_reporting_table_markdown_injection.py
@@ -1,7 +1,7 @@
 
 from src.feed.reporting import RunReport, FeedHealthMetrics, render_feed_health_markdown
 
-def test_markdown_injection_in_table_cells():
+def test_markdown_injection_in_table_cells() -> None:
     # Setup
     report = RunReport(statuses=[])
     report.register_provider("Malicious[Link]", True, "test")

--- a/tests/test_request_safe_header_leak.py
+++ b/tests/test_request_safe_header_leak.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from src.utils.http import request_safe, session_with_retries
 
 @responses.activate
-def test_request_safe_strips_session_headers_on_redirect():
+def test_request_safe_strips_session_headers_on_redirect() -> None:
     # Setup
     s = session_with_retries("test-agent")
     s.headers["Authorization"] = "Bearer session-secret"

--- a/tests/test_run_report_collector.py
+++ b/tests/test_run_report_collector.py
@@ -1,7 +1,10 @@
 import logging
+
+import pytest
+
 from src.feed.reporting import RunReport
 
-def test_run_error_collector_emits_error():
+def test_run_error_collector_emits_error() -> None:
     report = RunReport([])
     report.attach_error_collector()
 
@@ -15,7 +18,7 @@ def test_run_error_collector_emits_error():
     report.detach_error_collector()
 
 
-def test_run_error_collector_no_op_when_detached():
+def test_run_error_collector_no_op_when_detached() -> None:
     report = RunReport([])
     report.attach_error_collector()
 
@@ -33,7 +36,7 @@ def test_run_error_collector_no_op_when_detached():
     assert not any("Test error message after detach" in msg for msg in errors)
 
 
-def test_run_report_log_results_concurrent_submission(monkeypatch):
+def test_run_report_log_results_concurrent_submission(monkeypatch: pytest.MonkeyPatch) -> None:
     import threading
     import time
     from src.feed import reporting

--- a/tests/test_serialize_for_cache.py
+++ b/tests/test_serialize_for_cache.py
@@ -4,13 +4,13 @@ import pytest
 from src.utils.serialize import serialize_for_cache
 
 
-def test_serialize_datetime_to_iso_string():
+def test_serialize_datetime_to_iso_string() -> None:
     dt = datetime(2024, 2, 29, 23, 59, 59)
 
     assert serialize_for_cache(dt) == "2024-02-29T23:59:59"
 
 
-def test_serialize_nested_collections_are_json_friendly():
+def test_serialize_nested_collections_are_json_friendly() -> None:
     payload = {
         "created": datetime(2023, 12, 31, 0, 0, 0),
         "items": (
@@ -41,21 +41,21 @@ def test_serialize_nested_collections_are_json_friendly():
     assert all(isinstance(item["tags"], list) for item in result["items"])
     assert isinstance(result["metadata"], list)
 
-def test_serialize_circular_reference_raises_value_error():
+def test_serialize_circular_reference_raises_value_error() -> None:
     circular_dict = {"a": 1}
     circular_dict["b"] = circular_dict
 
     with pytest.raises(ValueError, match="Circular reference detected"):
         serialize_for_cache(circular_dict)
 
-def test_serialize_circular_list_raises_value_error():
+def test_serialize_circular_list_raises_value_error() -> None:
     circular_list = [1, 2]
     circular_list.append(circular_list)
 
     with pytest.raises(ValueError, match="Circular reference detected"):
         serialize_for_cache(circular_list)
 
-def test_serialize_tuple_recursion_check():
+def test_serialize_tuple_recursion_check() -> None:
     # Tuples are immutable but can contain mutable items that recurse
     data = []
     t = (data,)

--- a/tests/test_vienna_regex_numeric.py
+++ b/tests/test_vienna_regex_numeric.py
@@ -2,7 +2,7 @@
 from unittest.mock import patch
 import src.utils.stations as stations_module
 
-def test_vienna_stations_regex_excludes_digits():
+def test_vienna_stations_regex_excludes_digits() -> None:
     # Mock data with a numeric alias
     mock_data = (
         {

--- a/tests/test_vor_default_version.py
+++ b/tests/test_vor_default_version.py
@@ -2,6 +2,8 @@ import importlib
 import os
 import socket
 
+import pytest
+
 
 def _restore_env(original: dict[str, str | None]) -> None:
     for key, value in original.items():
@@ -25,7 +27,7 @@ def test_default_vor_version() -> None:
         importlib.reload(module)
 
 
-def test_base_url_infers_version(monkeypatch):
+def test_base_url_infers_version(monkeypatch: pytest.MonkeyPatch) -> None:
     # Mock DNS resolution to ensure example.com is accepted
     monkeypatch.setattr(
         socket,

--- a/tests/test_vor_log_injection.py
+++ b/tests/test_vor_log_injection.py
@@ -1,8 +1,11 @@
 
 from unittest.mock import MagicMock
+
+import pytest
+
 from src.providers import vor
 
-def test_log_warning_sanitizes_newlines(monkeypatch):
+def test_log_warning_sanitizes_newlines(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_logger = MagicMock()
     monkeypatch.setattr(vor, "log", mock_logger)
 

--- a/tests/test_vor_stations_directory.py
+++ b/tests/test_vor_stations_directory.py
@@ -19,7 +19,7 @@ def test_vor_lookup_by_id() -> None:
     assert info.longitude == pytest.approx(16.376413)
 
 
-def test_vor_bst_code_prefers_directory_entry(monkeypatch):
+def test_vor_bst_code_prefers_directory_entry(monkeypatch: pytest.MonkeyPatch) -> None:
     import src.utils.stations as stations
 
     stations._station_lookup.cache_clear()
@@ -69,7 +69,7 @@ def test_vor_bst_code_prefers_directory_entry(monkeypatch):
         stations.station_info.cache_clear()
 
 
-def test_bst_code_identity_outranks_foreign_alias(monkeypatch):
+def test_bst_code_identity_outranks_foreign_alias(monkeypatch: pytest.MonkeyPatch) -> None:
     """Regression for the '900100' bug class.
 
     Reconstructs the exact configuration that triggered #1082: Wien
@@ -176,7 +176,7 @@ def test_vor_station_ids_only_cover_vienna_or_pendler() -> None:
         assert info.in_vienna or info.pendler, f"unexpected non-pendler VOR id {vor_id}"
 
 
-def test_vor_station_ids_default_prefers_directory(monkeypatch):
+def test_vor_station_ids_default_prefers_directory(monkeypatch: pytest.MonkeyPatch) -> None:
     import src.providers.vor as vor
 
     monkeypatch.setattr(vor, "vor_station_ids", lambda: ("430470800", "490091000"))

--- a/tests/test_wl_stations_directory.py
+++ b/tests/test_wl_stations_directory.py
@@ -13,7 +13,7 @@ def _stop(info: StationInfo, stop_id: str):
     raise AssertionError(f"Stop {stop_id} not found in {info.wl_stops!r}")
 
 
-def test_wl_stop_lookup_by_stop_id():
+def test_wl_stop_lookup_by_stop_id() -> None:
     info = station_info("60201076")
     assert info is not None
     assert info.name == "Wien Karlsplatz"
@@ -25,7 +25,7 @@ def test_wl_stop_lookup_by_stop_id():
     assert any(s.stop_id == "60201077" for s in info.wl_stops)
 
 
-def test_wl_alias_matching_by_name():
+def test_wl_alias_matching_by_name() -> None:
     info = station_info("Schottentor U (Richtung Karlsplatz)")
     assert info is not None
     assert info.name == "Wien Schottentor"
@@ -35,5 +35,5 @@ def test_wl_alias_matching_by_name():
     assert any("Heiligenstadt" in (stop.name or "") for stop in info.wl_stops)
 
 
-def test_wl_canonical_name_for_diva():
+def test_wl_canonical_name_for_diva() -> None:
     assert canonical_name("Stephansplatz U") == "Wien Stephansplatz"


### PR DESCRIPTION
Annotates 40 parameterless and `monkeypatch` test functions with strict typing across 21 files. All annotated functions return `-> None` and `monkeypatch` arguments are explicitly typed as `pytest.MonkeyPatch`. `pytest` is imported in 7 files that require it for typing. No other unrequested formatting or modification was performed.

---
*PR created automatically by Jules for task [3832859291904891998](https://jules.google.com/task/3832859291904891998) started by @Origamihase*