### PR TITLE
Strict-typing C21: mixed-fixture sweep across 15 test files

### DIFF
--- a/tests/test_cache_freshness_guard.py
+++ b/tests/test_cache_freshness_guard.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
 
 from src import build_feed
 
@@ -13,7 +16,7 @@ def _make_loader(name: str):
     return _loader
 
 
-def test_detect_stale_caches_records_warning(monkeypatch):
+def test_detect_stale_caches_records_warning(monkeypatch: pytest.MonkeyPatch) -> None:
     loader = _make_loader("demo")
 
     class DummySpec:
@@ -38,7 +41,7 @@ def test_detect_stale_caches_records_warning(monkeypatch):
     assert any("demo" in warning.lower() for warning in report.warnings)
 
 
-def test_detect_stale_caches_skips_recent(monkeypatch):
+def test_detect_stale_caches_skips_recent(monkeypatch: pytest.MonkeyPatch) -> None:
     loader = _make_loader("demo")
 
     class DummySpec:
@@ -61,7 +64,7 @@ def test_detect_stale_caches_skips_recent(monkeypatch):
     assert messages == []
     assert not report.warnings
 
-def test_cache_freshness_guard_future(monkeypatch, tmp_path):
+def test_cache_freshness_guard_future(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     import os
     from src.utils.cache import cache_modified_at
 

--- a/tests/test_env_multiline.py
+++ b/tests/test_env_multiline.py
@@ -1,7 +1,9 @@
 
+from pathlib import Path
+
 from src.utils.env import load_env_file
 
-def test_multiline_env_parsing(tmp_path):
+def test_multiline_env_parsing(tmp_path: Path) -> None:
     env_content = """
 SINGLE_LINE="value"
 MULTI_LINE="first line

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -19,7 +19,7 @@ html_text = st.text(
 
 @given(text=html_text, limit=st.integers(min_value=10, max_value=500))
 @settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow])
-def test_truncate_html_validity(text: str, limit: int):
+def test_truncate_html_validity(text: str, limit: int) -> None:
     """Ensure truncate_html always produces valid HTML with balanced tags."""
     # We construct a complex HTML string by wrapping text in tags
     complex_html = f"<div><p><b>{text}</b></p></div>"
@@ -67,7 +67,7 @@ url_text = st.text()
 
 @given(url=url_text)
 @settings(max_examples=200)
-def test_validate_http_url_security(url: str):
+def test_validate_http_url_security(url: str) -> None:
     """Fuzz validate_http_url to ensure it rejects dangerous inputs."""
 
     # We are testing the validator, so we don't expect it to crash.

--- a/tests/test_gtfs_read_stops.py
+++ b/tests/test_gtfs_read_stops.py
@@ -7,7 +7,7 @@ import pytest
 from scripts.gtfs import DEFAULT_GTFS_STOP_PATH, GTFSStop, read_gtfs_stops
 
 
-def test_read_gtfs_stops_reads_sample_file():
+def test_read_gtfs_stops_reads_sample_file() -> None:
     stops = read_gtfs_stops()
 
     assert DEFAULT_GTFS_STOP_PATH.exists()
@@ -31,7 +31,7 @@ def test_read_gtfs_stops_reads_sample_file():
     assert child_without_location.platform_code == "1"
 
 
-def test_read_gtfs_stops_handles_custom_path(tmp_path: Path):
+def test_read_gtfs_stops_handles_custom_path(tmp_path: Path) -> None:
     sample = tmp_path / "stops.txt"
     sample.write_text(
         "stop_id,stop_name,stop_lat,stop_lon,location_type,parent_station,platform_code\n"
@@ -49,7 +49,7 @@ def test_read_gtfs_stops_handles_custom_path(tmp_path: Path):
     assert stops["child"].platform_code is None
 
 
-def test_read_gtfs_stops_requires_stop_id_column(tmp_path: Path):
+def test_read_gtfs_stops_requires_stop_id_column(tmp_path: Path) -> None:
     sample = tmp_path / "stops.txt"
     sample.write_text("stop_name\nFoo\n", encoding="utf-8")
 

--- a/tests/test_hash_chunking.py
+++ b/tests/test_hash_chunking.py
@@ -1,7 +1,9 @@
 import hashlib
+from pathlib import Path
+
 from src.utils.files import get_file_hash
 
-def test_get_file_hash_uses_chunking(tmp_path):
+def test_get_file_hash_uses_chunking(tmp_path: Path) -> None:
     test_file = tmp_path / "test.txt"
     test_content = b"test content " * 1000
     test_file.write_bytes(test_content)

--- a/tests/test_http_security.py
+++ b/tests/test_http_security.py
@@ -3,13 +3,13 @@ import responses
 from unittest.mock import patch
 from src.utils.http import session_with_retries, validate_http_url
 
-def test_redirect_limit_enforcement():
+def test_redirect_limit_enforcement() -> None:
     """Verify that the session redirect limit is securely configured."""
     session = session_with_retries("test-agent")
     # Should be limited to 10 (down from default 30) to mitigate ReDoS/resource exhaustion
     assert session.max_redirects == 10
 
-def test_unsafe_tlds_blocked():
+def test_unsafe_tlds_blocked() -> None:
     """Verify that infrastructure TLDs are blocked."""
     # .arpa (Infrastructure TLD)
     url_arpa = "http://infra.arpa"
@@ -43,7 +43,7 @@ def test_unsafe_tlds_blocked():
     url_consul = "http://db.consul"
     assert validate_http_url(url_consul, check_dns=False) is None
 
-def test_extended_unsafe_tlds_blocked():
+def test_extended_unsafe_tlds_blocked() -> None:
     """Verify that newly added infrastructure TLDs are blocked."""
     # .prod
     assert validate_http_url("http://api.prod", check_dns=False) is None
@@ -68,7 +68,7 @@ def test_extended_unsafe_tlds_blocked():
     # .intra
     assert validate_http_url("http://portal.intra", check_dns=False) is None
 
-def test_unsafe_tlds_blocked_with_dns_check():
+def test_unsafe_tlds_blocked_with_dns_check() -> None:
     """Verify that infrastructure TLDs are blocked even if DNS check is enabled and resolves."""
 
     with patch("src.utils.http._resolve_hostname_safe") as mock_resolve:

--- a/tests/test_log_pruning_safety.py
+++ b/tests/test_log_pruning_safety.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from src.feed.logging import prune_log_file
 
-def test_prune_log_file_preserves_logging_handle(tmp_path: Path):
+def test_prune_log_file_preserves_logging_handle(tmp_path: Path) -> None:
     """
     Verify that prune_log_file modifies the file in-place, allowing
     RotatingFileHandler to continue writing to it.
@@ -59,7 +59,7 @@ def test_prune_log_file_preserves_logging_handle(tmp_path: Path):
         handler.close()
         logger.removeHandler(handler)
 
-def test_prune_log_file_actually_prunes(tmp_path: Path):
+def test_prune_log_file_actually_prunes(tmp_path: Path) -> None:
     """
     Verify that prune_log_file actually removes old lines.
     """

--- a/tests/test_secret_scanner_priority.py
+++ b/tests/test_secret_scanner_priority.py
@@ -1,6 +1,8 @@
+from pathlib import Path
+
 from src.utils.secret_scanner import scan_repository
 
-def test_secret_scanner_priority(tmp_path):
+def test_secret_scanner_priority(tmp_path: Path) -> None:
     # Create a file with a known token assigned to a variable
     # expected: should detect "GitHub Personal Access Token gefunden"
     # actual (before fix): "Verdächtige Zuweisung eines potentiellen Secrets"

--- a/tests/test_secure_temp_files.py
+++ b/tests/test_secure_temp_files.py
@@ -1,9 +1,11 @@
 
+from pathlib import Path
 from unittest.mock import patch
+
 from src.utils.cache import write_cache
 from src.places.quota import MonthlyQuota
 
-def test_cache_file_secure_permissions(tmp_path):
+def test_cache_file_secure_permissions(tmp_path: Path) -> None:
     """Verify that write_cache creates files with secure permissions (0600)."""
     # Setup
     cache_dir = tmp_path / "cache"
@@ -28,7 +30,7 @@ def test_cache_file_secure_permissions(tmp_path):
         perms = mode & 0o077
         assert perms == 0, f"Cache file permissions {oct(mode)} are too loose (expected 0o600)"
 
-def test_quota_file_secure_permissions(tmp_path):
+def test_quota_file_secure_permissions(tmp_path: Path) -> None:
     """Verify that MonthlyQuota.save_atomic creates files with secure permissions (0600)."""
     quota_file = tmp_path / "quota.json"
 

--- a/tests/test_slowloris.py
+++ b/tests/test_slowloris.py
@@ -4,7 +4,7 @@ import time
 from unittest.mock import MagicMock, patch
 from src.utils.http import fetch_content_safe, read_response_safe
 
-def test_read_response_safe_timeout():
+def test_read_response_safe_timeout() -> None:
     """Test that read_response_safe raises Timeout if reading takes too long."""
 
     # Create a mock response with a slow iterator
@@ -79,7 +79,7 @@ def test_fetch_content_safe_slowloris(mock_verify_ip, mock_validate_url):
 
     assert "Read timed out" in str(excinfo.value)
 
-def test_read_response_safe_no_timeout():
+def test_read_response_safe_no_timeout() -> None:
     """Test that read_response_safe works fine without timeout."""
     response = MagicMock(spec=requests.Response)
     response.headers = {}
@@ -88,7 +88,7 @@ def test_read_response_safe_no_timeout():
     content = read_response_safe(response, timeout=None)
     assert content == b"chunk1chunk2"
 
-def test_content_length_malformed():
+def test_content_length_malformed() -> None:
     """Test that malformed Content-Length is ignored."""
     response = MagicMock(spec=requests.Response)
     response.headers = {"Content-Length": "invalid"}

--- a/tests/test_stations_validation_unsafe.py
+++ b/tests/test_stations_validation_unsafe.py
@@ -1,7 +1,9 @@
 import json
+from pathlib import Path
+
 from src.utils.stations_validation import validate_stations
 
-def test_validation_flags_unsafe_chars(tmp_path):
+def test_validation_flags_unsafe_chars(tmp_path: Path) -> None:
     stations_file = tmp_path / "stations.json"
     data = {
         "stations": [
@@ -47,7 +49,7 @@ def test_validation_flags_unsafe_chars(tmp_path):
     ]
     assert len(bidi_issues) >= 3, f"Expected Bidi issues not found. Found: {bidi_issues}"
 
-def test_validation_passes_safe_chars(tmp_path):
+def test_validation_passes_safe_chars(tmp_path: Path) -> None:
     stations_file = tmp_path / "stations.json"
     data = {
         "stations": [

--- a/tests/test_vor_location_name.py
+++ b/tests/test_vor_location_name.py
@@ -1,3 +1,4 @@
+import pytest
 import requests
 import responses
 
@@ -18,7 +19,7 @@ def test_location_name_contains_stoplocation() -> None:
 
 
 @responses.activate
-def test_resolve_station_ids_looks_up_stop_ids(monkeypatch):
+def test_resolve_station_ids_looks_up_stop_ids(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(vor, "refresh_access_credentials", lambda: "token")
     monkeypatch.setattr(vor, "VOR_ACCESS_ID", "token", raising=False)
 
@@ -56,7 +57,7 @@ def test_resolve_station_ids_looks_up_stop_ids(monkeypatch):
     assert ids == ["42"]
 
 
-def test_fetch_events_prefers_configured_station_ids(monkeypatch):
+def test_fetch_events_prefers_configured_station_ids(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(vor, "refresh_access_credentials", lambda: "token")
     monkeypatch.setenv("VOR_MONITOR_STATIONS_WHITELIST", "")
     monkeypatch.setattr(vor, "VOR_ACCESS_ID", "token", raising=False)
@@ -80,7 +81,7 @@ def test_fetch_events_prefers_configured_station_ids(monkeypatch):
     assert called == []
 
 
-def test_fetch_events_uses_station_names_when_ids_missing(monkeypatch):
+def test_fetch_events_uses_station_names_when_ids_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(vor, "refresh_access_credentials", lambda: "token")
     monkeypatch.setenv("VOR_MONITOR_STATIONS_WHITELIST", "")
     monkeypatch.setattr(vor, "VOR_ACCESS_ID", "token", raising=False)
@@ -104,7 +105,7 @@ def test_fetch_events_uses_station_names_when_ids_missing(monkeypatch):
     assert calls == [["Wien"]]
 
 
-def test_collect_from_board_canonicalizes_stop_names(monkeypatch):
+def test_collect_from_board_canonicalizes_stop_names(monkeypatch: pytest.MonkeyPatch) -> None:
     # Mock station info to avoid filter because "Test text" is not "Wien" related.
     # If in_vienna=True, filtering is skipped.
     from src.utils.stations import StationInfo

--- a/tests/test_wl_aggregate_removal.py
+++ b/tests/test_wl_aggregate_removal.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from src.providers import wl_fetch
 
 
@@ -17,7 +19,7 @@ def _make_event(title: str, lines: list[str]) -> dict:
     }
 
 
-def test_aggregate_removed_when_all_singles_present(monkeypatch):
+def test_aggregate_removed_when_all_singles_present(monkeypatch: pytest.MonkeyPatch) -> None:
     aggregate = _make_event("Aggregate", ["U1", "U2"])
     single1 = _make_event("Single1", ["U1"])
     single2 = _make_event("Single2", ["U2"])
@@ -39,7 +41,7 @@ def test_aggregate_removed_when_all_singles_present(monkeypatch):
     assert "U1/U2: Aggregate" not in titles
 
 
-def test_aggregate_retained_when_single_missing(monkeypatch):
+def test_aggregate_retained_when_single_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     # This test checks behavior when NOT all singles are present.
     # Previously, it expected both Aggregate and Single1 to be present.
     # With the new subset removal logic, Single1 (subset of Aggregate) is considered redundant and removed.

--- a/tests/test_wl_date_correction.py
+++ b/tests/test_wl_date_correction.py
@@ -1,4 +1,6 @@
 
+import pytest
+
 from src.providers.wl_fetch import fetch_events
 
 class DummySession:
@@ -41,7 +43,7 @@ def _base_event(**overrides):
     base.update(overrides)
     return base
 
-def test_reproduction_linie_4a_date_mismatch(monkeypatch):
+def test_reproduction_linie_4a_date_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
     # Case 1: Linie 4A: Titel sagt "ab 12.01.2026", API "starts_at" is "2025-12-20"
     # The API start date is in the past/present (Dec 2025), so it's active.
     traffic_info = _base_event(
@@ -67,7 +69,7 @@ def test_reproduction_linie_4a_date_mismatch(monkeypatch):
     assert ev["pubDate"].month == 12
     assert ev["pubDate"].day == 20
 
-def test_reproduction_linie_n62_date_mismatch(monkeypatch):
+def test_reproduction_linie_n62_date_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
     # Case 2: Linie N62: Titel "ab 08.01.2026", API "start" "2025-12-12"
     traffic_info = _base_event(
         title="Linie N62: Umleitung ab 08.01.2026",

--- a/tests/test_wl_line_parsing_regressions.py
+++ b/tests/test_wl_line_parsing_regressions.py
@@ -14,7 +14,7 @@ from src.providers.wl_lines import _detect_line_pairs_from_text
     ("Verspätung Linie 13A", ["13A"]),
     ("Währinger Gürtel 164", ["164"]),          # Current limitation: Space in "Währinger Gürtel" not handled
 ])
-def test_address_masking(text, expected_lines):
+def test_address_masking(text: str, expected_lines: list[str]) -> None:
     pairs = _detect_line_pairs_from_text(text)
     lines = [p[0] for p in pairs]
     # We expect exact match of lines found


### PR DESCRIPTION
Annotates 33 ndef test functions: 
- 8 no-param tests gain '() -> None' 
- 11 single-monkeypatch tests gain '(monkeypatch: pytest.MonkeyPatch) -> None' 
- 11 single-tmp_path tests gain '(tmp_path: Path) -> None' 
- 1 multi-fixture test gains '(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None' 
- 2 parametrize-typed tests gain '-> None' return type only 
- 1 parametrize-untyped test gains '(text: str, expected_lines: list[str]) -> None' 

Adds 'from pathlib import Path' to 6 files and 'import pytest' to 4 files (one file gets both). All annotated lines stay ≤99 chars (no wraps; longest 99). No helpers, fixtures, setUp/tearDown, nested defs, or non-test defs touched. Three files (test_http_security.py, test_slowloris.py, test_vor_location_name.py) are partially annotated; remaining @patch-decorator tests deferred to a future cluster.

---
*PR created automatically by Jules for task [15219257913296682181](https://jules.google.com/task/15219257913296682181) started by @Origamihase*