### PR TITLE
test: C22 hidden-category type annotation sweep

### DIFF
--- a/tests/test_update_baustellen_cache.py
+++ b/tests/test_update_baustellen_cache.py
@@ -38,7 +38,7 @@ def test_collect_events_from_sample_payload() -> None:
     assert "location" in first
 
 
-def test_main_uses_fallback_when_remote_fails(monkeypatch) -> None:
+def test_main_uses_fallback_when_remote_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[tuple[str, list[dict[str, Any]]]] = []
 
     def fake_fetch_remote(url: str, timeout: int) -> None:

--- a/tests/test_update_vor_cache.py
+++ b/tests/test_update_vor_cache.py
@@ -6,11 +6,13 @@ from datetime import datetime
 from unittest.mock import Mock
 from zoneinfo import ZoneInfo
 
+import pytest
+
 from scripts import update_vor_cache
 from requests.exceptions import RequestException
 
 
-def test_cache_written_when_limit_reached(monkeypatch) -> None:
+def test_cache_written_when_limit_reached(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure the cache is written even if the final request hits the limit."""
 
     now = datetime(2024, 1, 1, 12, tzinfo=ZoneInfo("Europe/Vienna"))
@@ -29,7 +31,7 @@ def test_cache_written_when_limit_reached(monkeypatch) -> None:
 
     calls: list[int] = []
 
-    def fake_fetch_events(*args, **kwargs) -> list[dict[str, str]]:
+    def fake_fetch_events(*args: object, **kwargs: object) -> list[dict[str, str]]:
         remaining_state["count"] += 1
         calls.append(remaining_state["count"])
         return [{"id": "event"}]
@@ -57,7 +59,7 @@ def test_cache_written_when_limit_reached(monkeypatch) -> None:
     save_request_count_mock.assert_not_called()
 
 
-def test_main_returns_success_when_fetch_fails(monkeypatch) -> None:
+def test_main_returns_success_when_fetch_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     """Network failures must not cause a non-zero exit status."""
 
     # Mock safety check dependencies to ensure it passes
@@ -76,7 +78,7 @@ def test_main_returns_success_when_fetch_fails(monkeypatch) -> None:
     assert exit_code == 0
 
 
-def test_cache_written_when_empty_list_returned(monkeypatch) -> None:
+def test_cache_written_when_empty_list_returned(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure an empty list is cached and returns success."""
 
     # Mock safety check dependencies to ensure it passes


### PR DESCRIPTION
Completes the C22 hidden-category strict-typing migration.

- Added `pytest.MonkeyPatch` annotation to 4 test signatures in `tests/test_update_baustellen_cache.py` and `tests/test_update_vor_cache.py`.
- Added missing `import pytest` to `tests/test_update_vor_cache.py`.
- Annotated nested helper function `fake_fetch_events` with `*args: object, **kwargs: object` in `tests/test_update_vor_cache.py`.
- Verified changes with `mypy --strict` and the project test suite. Expected preexisting out-of-scope mypy errors remain.

---
*PR created automatically by Jules for task [13210710792167847002](https://jules.google.com/task/13210710792167847002) started by @Origamihase*