### PR TITLE
tests: annotate ndef tests in 8 backlog files (C23 wrap cluster)

### DIFF
--- a/tests/test_feed_seo_metadata.py
+++ b/tests/test_feed_seo_metadata.py
@@ -8,6 +8,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 
 def _load_build_feed(monkeypatch):
     module_name = "src.build_feed"
@@ -24,7 +26,9 @@ def _emit_item_str(bf, item, now, state):
     return ident, xml_str
 
 
-def test_emit_item_generates_stable_anchor_when_link_missing(monkeypatch):
+def test_emit_item_generates_stable_anchor_when_link_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     bf = _load_build_feed(monkeypatch)
     monkeypatch.setattr(bf.feed_config, "FEED_LINK", "https://example.com/wien-oepnv/")
     now = datetime(2025, 1, 1, tzinfo=timezone.utc)
@@ -41,7 +45,9 @@ def test_emit_item_generates_stable_anchor_when_link_missing(monkeypatch):
     assert 'isPermaLink="false"' in guid_match.group(1)
 
 
-def test_emit_item_keeps_permalink_guid_when_matching_link(monkeypatch):
+def test_emit_item_keeps_permalink_guid_when_matching_link(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     bf = _load_build_feed(monkeypatch)
     now = datetime(2025, 1, 1, tzinfo=timezone.utc)
 

--- a/tests/test_oebb_rate_limit.py
+++ b/tests/test_oebb_rate_limit.py
@@ -1,6 +1,8 @@
 import logging
 from unittest.mock import MagicMock
 
+import pytest
+
 import src.providers.oebb as oebb
 from tests.mock_utils import get_mock_socket_structure
 
@@ -72,7 +74,10 @@ class DummySession:
         return self.get(url, timeout=timeout, stream=stream, **kwargs)
 
 
-def test_rate_limit_retries_once_after_wait(monkeypatch, caplog):
+def test_rate_limit_retries_once_after_wait(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     responses = [
         DummyResponse(429, {"Retry-After": "1.5"}),
         DummyResponse(200, {"Content-Type": "application/xml"}, b"<root></root>"),
@@ -107,7 +112,7 @@ def test_rate_limit_retries_once_after_wait(monkeypatch, caplog):
     assert "Rate-Limit" in log_text
 
 
-def test_rate_limit_raises_http_error_after_retry(monkeypatch):
+def test_rate_limit_raises_http_error_after_retry(monkeypatch: pytest.MonkeyPatch) -> None:
 
     responses = [
         DummyResponse(429, {"Retry-After": "1.5"}),

--- a/tests/test_provider_plugins.py
+++ b/tests/test_provider_plugins.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any, cast
 
+import pytest
+
 
 def _make_plugin_module(name: str, *, register_callable=None, providers=None) -> ModuleType:
     module = ModuleType(name)
@@ -20,7 +22,7 @@ def _make_plugin_module(name: str, *, register_callable=None, providers=None) ->
     return module
 
 
-def test_load_provider_plugins_not_called_on_import():
+def test_load_provider_plugins_not_called_on_import() -> None:
     # To properly test that importing doesn't call load_provider_plugins,
     # we launch a subprocess that imports the module and exits without failure.
     # We can inspect what it did by mocking it or checking side effects,
@@ -52,7 +54,7 @@ def test_load_provider_plugins_not_called_on_import():
             assert False, "Found top-level call to load_provider_plugins()"
 
 
-def test_load_provider_plugins_via_callable(monkeypatch):
+def test_load_provider_plugins_via_callable(monkeypatch: pytest.MonkeyPatch) -> None:
     from src.feed import providers as provider_mod
 
     def loader() -> list[str]:
@@ -80,7 +82,7 @@ def test_load_provider_plugins_via_callable(monkeypatch):
         sys.modules.pop(module_name, None)
 
 
-def test_collect_items_uses_plugin_provider(monkeypatch):
+def test_collect_items_uses_plugin_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     from src.feed import providers as provider_mod
 
     module_name = "tests.fake_plugin_list"
@@ -132,7 +134,10 @@ def test_collect_items_uses_plugin_provider(monkeypatch):
         importlib.reload(build_feed)
 
 
-def test_main_generates_feed_and_health_with_plugin(monkeypatch, tmp_path):
+def test_main_generates_feed_and_health_with_plugin(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     from src.feed import providers as provider_mod
 
     module_name = "tests.fake_plugin_e2e"
@@ -239,7 +244,7 @@ def test_main_generates_feed_and_health_with_plugin(monkeypatch, tmp_path):
         sys.modules.pop(module_name, None)
         importlib.reload(build_feed)
 
-def test_full_build_loads_plugins_subprocess(tmp_path):
+def test_full_build_loads_plugins_subprocess(tmp_path: Path) -> None:
     import subprocess
     import sys
     import os

--- a/tests/test_retry_after_cap.py
+++ b/tests/test_retry_after_cap.py
@@ -1,4 +1,5 @@
 import logging
+import pytest
 import requests
 import src.providers.vor as vor
 import src.providers.oebb as oebb
@@ -15,7 +16,10 @@ class DummySession:
     def close(self):
         pass
 
-def test_vor_retry_after_capped(monkeypatch, caplog):
+def test_vor_retry_after_capped(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Verify that VOR provider caps the Retry-After delay."""
 
     # Mock response with extremely large Retry-After
@@ -39,7 +43,10 @@ def test_vor_retry_after_capped(monkeypatch, caplog):
     assert any("Retry-After: 99999.0s" in message for message in caplog.messages)
     assert any("Überspringe Station (Fail-Fast)" in message for message in caplog.messages)
 
-def test_oebb_retry_after_capped(monkeypatch, caplog):
+def test_oebb_retry_after_capped(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Verify that OEBB provider caps the Retry-After delay."""
 
     def fake_fetch_safe(session, url, **kwargs):

--- a/tests/test_station_alias_collision.py
+++ b/tests/test_station_alias_collision.py
@@ -1,10 +1,17 @@
 import json
 import logging
+from pathlib import Path
+
+import pytest
 
 from src.utils import stations
 
 
-def test_station_alias_collision_logs_warning(tmp_path, caplog, monkeypatch):
+def test_station_alias_collision_logs_warning(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     data = [
         {
             "name": "First Station",

--- a/tests/test_wl_fetch.py
+++ b/tests/test_wl_fetch.py
@@ -1,10 +1,12 @@
 import logging
 from datetime import datetime, timezone
 
+import pytest
+
 from src.providers.wl_fetch import _stop_names_from_related, fetch_events
 
 
-def test_stop_names_from_related_uses_canonical_names():
+def test_stop_names_from_related_uses_canonical_names() -> None:
     rel_stops = [
         {"name": "Wien Franz Josefs Bahnhof"},
         {"stopName": "Wien Franz-Josefs-Bf"},
@@ -16,7 +18,10 @@ def test_stop_names_from_related_uses_canonical_names():
     assert names == ["Wien Franz-Josefs-Bf"]
 
 
-def test_fetch_events_handles_invalid_json(monkeypatch, caplog):
+def test_fetch_events_handles_invalid_json(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     class DummyResponse:
         headers = {"Content-Type": "application/json"}
         def raise_for_status(self):
@@ -136,7 +141,7 @@ def _base_event(**overrides):
     return base
 
 
-def test_fetch_events_adds_stop_context_when_no_lines(monkeypatch):
+def test_fetch_events_adds_stop_context_when_no_lines(monkeypatch: pytest.MonkeyPatch) -> None:
     rel_stops = [
         {"name": "Karlsplatz"},
         {"name": "Museumsquartier"},
@@ -162,7 +167,7 @@ def test_fetch_events_adds_stop_context_when_no_lines(monkeypatch):
     assert events[0]["description"] == "Testbeschreibung | Haltestelle: Museumsquartier, Wien Karlsplatz"
 
 
-def test_fetch_events_uses_extra_context_when_no_stops(monkeypatch):
+def test_fetch_events_uses_extra_context_when_no_stops(monkeypatch: pytest.MonkeyPatch) -> None:
     traffic_info = _base_event(
         attributes={
             "station": "Karlsplatz",

--- a/tests/test_wl_fetch_dos.py
+++ b/tests/test_wl_fetch_dos.py
@@ -3,7 +3,10 @@ import pytest
 from unittest.mock import MagicMock
 from src.providers import wl_fetch
 
-def test_fetch_events_response_too_large(monkeypatch, caplog):
+def test_fetch_events_response_too_large(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that fetch_events handles oversized responses gracefully (using fetch_content_safe)."""
 
     # Create a mock session that returns a huge response
@@ -25,7 +28,7 @@ def test_fetch_events_response_too_large(monkeypatch, caplog):
             return HugeResponse()
 
     class MockSessionContext:
-        headers = {}
+        headers: dict[str, str] = {}
         def __enter__(self):
             return HugeSession()
         def __exit__(self, *args):
@@ -51,7 +54,10 @@ def test_fetch_events_response_too_large(monkeypatch, caplog):
     # Check logs
     assert "ungültig oder kein JSON" in caplog.text
 
-def test_wl_fetch_uses_fetch_content_safe(monkeypatch, caplog):
+def test_wl_fetch_uses_fetch_content_safe(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Verify that wl_fetch calls fetch_content_safe."""
 
     # Mock fetch_content_safe to track calls
@@ -60,7 +66,7 @@ def test_wl_fetch_uses_fetch_content_safe(monkeypatch, caplog):
 
     # Mock session
     class DummySession:
-        headers = {}
+        headers: dict[str, str] = {}
         def mount(self, *args): pass
         def get(self, *args, **kwargs): return MagicMock()
         def request(self, *args, **kwargs): pass

--- a/tests/test_wl_title.py
+++ b/tests/test_wl_title.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
 
+import pytest
+
 from src.providers.wl_fetch import fetch_events
 from src.providers.wl_lines import (
     _detect_line_pairs_from_text,
@@ -8,7 +10,9 @@ from src.providers.wl_lines import (
 from src.providers.wl_text import _tidy_title_wl
 
 
-def test_bucket_merge_prefers_informative_title_and_description(monkeypatch):
+def test_bucket_merge_prefers_informative_title_and_description(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     now_iso = datetime.now(timezone.utc).isoformat()
     detailed_desc = (
         "Störung zwischen Siebenhirten und Perfektastraße. Ersatzverkehr im Einsatz."
@@ -69,16 +73,16 @@ def test_bucket_merge_prefers_informative_title_and_description(monkeypatch):
     assert len(event["description"]) > len("Störung")
 
 
-def test_line_prefix_and_house_number_false_positive():
+def test_line_prefix_and_house_number_false_positive() -> None:
     assert _ensure_line_prefix("Falschparker", ["5"]) == "5: Falschparker"
     assert _detect_line_pairs_from_text("Neubaugasse 69") == []
 
 
-def test_line_prefix_empty_title():
+def test_line_prefix_empty_title() -> None:
     assert _ensure_line_prefix("5:", ["5"]) == "5"
     assert _ensure_line_prefix("5: ", ["5"]) == "5"
 
 
-def test_tidy_title_wl_strips_label():
+def test_tidy_title_wl_strips_label() -> None:
     assert _tidy_title_wl("Störung: U1 steht") == "U1 steht"
 


### PR DESCRIPTION
This PR resolves the typing migration for Cluster C23 by addressing 22 missing return type annotations (`[no-untyped-def]`) across 8 specific test files.

Included changes:
- Adds `import pytest` and `from pathlib import Path` where missing.
- Refactors 11 signatures exceeding 100 characters to use Black-style multi-line wrapping with trailing commas.
- Fully annotates 22 target `test_*` functions using types such as `pytest.MonkeyPatch`, `pytest.LogCaptureFixture`, and `Path`.
- Includes inline body-level fixes in `test_wl_fetch_dos.py` for variables inside strictly checked functions that surfaced `[var-annotated]` errors once the outer functions were typed.
- Successfully verified error diff via line-shift-tolerant normalization to ensure exact semantic precision.

---
*PR created automatically by Jules for task [8169509040712478535](https://jules.google.com/task/8169509040712478535) started by @Origamihase*