### PR TITLE
tests: annotate VOR backlog tests (C24)

### DIFF
--- a/tests/test_vor_env.py
+++ b/tests/test_vor_env.py
@@ -1,12 +1,14 @@
 import base64
 import importlib
 import logging
+import pytest
 import requests
+from pathlib import Path
 
 import src.providers.vor as vor
 
 
-def test_access_id_env_normalization(monkeypatch):
+def test_access_id_env_normalization(monkeypatch: pytest.MonkeyPatch) -> None:
     # VOR_ACCESS_ID mit Leerzeichen wird entfernt und deaktiviert den Provider
     monkeypatch.setenv("VOR_ACCESS_ID", "   ")
     importlib.reload(vor)
@@ -29,7 +31,10 @@ def test_access_id_env_normalization(monkeypatch):
     assert vor.VOR_ACCESS_ID == ""
 
 
-def test_invalid_int_env_uses_defaults(monkeypatch, caplog):
+def test_invalid_int_env_uses_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     monkeypatch.setenv("VOR_BOARD_DURATION_MIN", "foo")
     monkeypatch.setenv("VOR_HTTP_TIMEOUT", "bar")
     monkeypatch.setenv("VOR_MAX_STATIONS_PER_RUN", "baz")
@@ -62,7 +67,10 @@ def test_invalid_int_env_uses_defaults(monkeypatch, caplog):
     importlib.reload(vor)
 
 
-def test_invalid_bus_regex_falls_back_to_defaults(monkeypatch, caplog):
+def test_invalid_bus_regex_falls_back_to_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     monkeypatch.setenv("VOR_BUS_INCLUDE_REGEX", "(")
     monkeypatch.setenv("VOR_BUS_EXCLUDE_REGEX", "(")
 
@@ -80,7 +88,7 @@ def test_invalid_bus_regex_falls_back_to_defaults(monkeypatch, caplog):
     importlib.reload(vor)
 
 
-def test_station_ids_fallback_from_file(monkeypatch, tmp_path):
+def test_station_ids_fallback_from_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv("VOR_STATION_IDS", raising=False)
     monkeypatch.delenv("VOR_STATION_NAMES", raising=False)
 
@@ -102,7 +110,7 @@ def test_station_ids_fallback_from_file(monkeypatch, tmp_path):
     importlib.reload(vor)
 
 
-def test_station_ids_fallback_from_directory(monkeypatch):
+def test_station_ids_fallback_from_directory(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("VOR_STATION_IDS", raising=False)
     monkeypatch.delenv("VOR_STATION_NAMES", raising=False)
     monkeypatch.delenv("VOR_STATION_IDS_FILE", raising=False)
@@ -114,7 +122,7 @@ def test_station_ids_fallback_from_directory(monkeypatch):
     assert {"490009400", "430310100", "430470800"}.issubset(ids)
 
 
-def test_refresh_access_credentials_reloads_from_env(monkeypatch):
+def test_refresh_access_credentials_reloads_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VOR_ACCESS_ID", "first")
     importlib.reload(vor)
     assert vor.VOR_ACCESS_ID == "first"
@@ -129,7 +137,7 @@ def test_refresh_access_credentials_reloads_from_env(monkeypatch):
     importlib.reload(vor)
 
 
-def test_base_url_prefers_secret(monkeypatch):
+def test_base_url_prefers_secret(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 
@@ -173,7 +181,7 @@ def test_base_url_prefers_secret(monkeypatch):
     )
 
 
-def test_apply_authentication_sets_header(monkeypatch):
+def test_apply_authentication_sets_header(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VOR_ACCESS_ID", "secret")
     importlib.reload(vor)
 
@@ -204,7 +212,7 @@ def test_apply_authentication_sets_header(monkeypatch):
     importlib.reload(vor)
 
 
-def test_apply_authentication_basic_auth(monkeypatch):
+def test_apply_authentication_basic_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VOR_ACCESS_ID", "user:secret")
     importlib.reload(vor)
 
@@ -228,7 +236,7 @@ def test_apply_authentication_basic_auth(monkeypatch):
     importlib.reload(vor)
 
 
-def test_apply_authentication_basic_with_prefix(monkeypatch):
+def test_apply_authentication_basic_with_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VOR_ACCESS_ID", "Basic user:secret")
     importlib.reload(vor)
 

--- a/tests/test_vor_request_limit.py
+++ b/tests/test_vor_request_limit.py
@@ -4,6 +4,7 @@ import multiprocessing
 import os
 import threading
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 from zoneinfo import ZoneInfo
@@ -32,7 +33,10 @@ def _save_request_count_in_process(count_file: str, iso_timestamp: str, iteratio
         vor_module._QUOTA_CACHE["date"] = None
 
 
-def test_fetch_events_respects_daily_limit(monkeypatch, caplog):
+def test_fetch_events_respects_daily_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     monkeypatch.setattr(vor, "refresh_access_credentials", lambda: "test")
     monkeypatch.setattr(vor, "VOR_ACCESS_ID", "test", raising=False)
     monkeypatch.setattr(vor, "VOR_STATION_IDS", ["1"])
@@ -70,7 +74,10 @@ def test_fetch_events_respects_daily_limit(monkeypatch, caplog):
     assert any("Tageslimit" in record.getMessage() for record in caplog.records)
 
 
-def test_save_request_count_flushes_and_fsyncs(monkeypatch, tmp_path):
+def test_save_request_count_flushes_and_fsyncs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     # Reset cache to ensure we hit the write path
     monkeypatch.setitem(vor._QUOTA_CACHE, "count", 0)
     monkeypatch.setitem(vor._QUOTA_CACHE, "date", None)
@@ -122,7 +129,10 @@ def test_save_request_count_flushes_and_fsyncs(monkeypatch, tmp_path):
     assert fsync_called
 
 
-def test_save_request_count_returns_previous_on_lock_failure(monkeypatch, tmp_path):
+def test_save_request_count_returns_previous_on_lock_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     # Reset cache to ensure we try to acquire lock
     monkeypatch.setitem(vor._QUOTA_CACHE, "count", 0)
     monkeypatch.setitem(vor._QUOTA_CACHE, "date", None)
@@ -158,7 +168,10 @@ def test_save_request_count_returns_previous_on_lock_failure(monkeypatch, tmp_pa
     assert stored["requests"] == 7
 
 
-def test_save_request_count_returns_previous_on_replace_failure(monkeypatch, tmp_path):
+def test_save_request_count_returns_previous_on_replace_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     # Reset cache to ensure we try to replace file
     monkeypatch.setitem(vor._QUOTA_CACHE, "count", 0)
     monkeypatch.setitem(vor._QUOTA_CACHE, "date", None)
@@ -185,7 +198,10 @@ def test_save_request_count_returns_previous_on_replace_failure(monkeypatch, tmp
     assert stored["requests"] == 3
 
 
-def test_save_request_count_is_safe_across_processes(monkeypatch, tmp_path):
+def test_save_request_count_is_safe_across_processes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     count_file = tmp_path / "vor_request_count.json"
     monkeypatch.setattr(vor, "REQUEST_COUNT_FILE", count_file)
 
@@ -221,13 +237,16 @@ def test_save_request_count_is_safe_across_processes(monkeypatch, tmp_path):
 
 
 @pytest.fixture(autouse=True)
-def reset_vor_quota_cache(monkeypatch):
+def reset_vor_quota_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure memory cache is reset before every test."""
     monkeypatch.setitem(vor._QUOTA_CACHE, "count", 0)
     monkeypatch.setitem(vor._QUOTA_CACHE, "date", None)
 
 
-def test_fetch_events_stops_submitting_when_limit_reached(monkeypatch, tmp_path):
+def test_fetch_events_stops_submitting_when_limit_reached(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     monkeypatch.setattr(vor, "refresh_access_credentials", lambda: "test")
     monkeypatch.setattr(vor, "VOR_ACCESS_ID", "test", raising=False)
     monkeypatch.setattr(vor, "VOR_STATION_IDS", ["1", "2", "3"])
@@ -271,7 +290,11 @@ def test_fetch_events_stops_submitting_when_limit_reached(monkeypatch, tmp_path)
 
 
 @pytest.mark.parametrize("status_code, headers", [(429, {"Retry-After": "0"}), (503, {})])
-def test_fetch_departure_board_for_station_counts_unsuccessful_requests(monkeypatch, status_code, headers):
+def test_fetch_departure_board_for_station_counts_unsuccessful_requests(
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
+    headers: dict[str, str],
+) -> None:
     called = 0
 
     def fake_save(now_local):
@@ -316,7 +339,7 @@ def test_fetch_departure_board_for_station_counts_unsuccessful_requests(monkeypa
     assert called == 1
 
 
-def test_fetch_departure_board_fails_gracefully_on_error(monkeypatch):
+def test_fetch_departure_board_fails_gracefully_on_error(monkeypatch: pytest.MonkeyPatch) -> None:
     from requests import ConnectionError
 
     call_count = 0
@@ -359,7 +382,10 @@ def test_fetch_departure_board_fails_gracefully_on_error(monkeypatch):
     assert call_count == 1
 
 
-def test_load_request_count_resets_on_legacy_integer(monkeypatch, tmp_path):
+def test_load_request_count_resets_on_legacy_integer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     target_file = tmp_path / "vor_request_count.json"
     monkeypatch.setattr(vor, "REQUEST_COUNT_FILE", target_file)
 
@@ -371,7 +397,10 @@ def test_load_request_count_resets_on_legacy_integer(monkeypatch, tmp_path):
     assert count == 0
 
 
-def test_load_request_count_resets_on_legacy_dict(monkeypatch, tmp_path):
+def test_load_request_count_resets_on_legacy_dict(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     target_file = tmp_path / "vor_request_count.json"
     monkeypatch.setattr(vor, "REQUEST_COUNT_FILE", target_file)
 


### PR DESCRIPTION
Add pytest.MonkeyPatch / pytest.LogCaptureFixture / Path annotations and -> None return types to 21 functions across 2 files (10 tests in test_vor_env.py; 10 tests + 1 autouse fixture in test_vor_request_limit.py). 11 signatures exceed 100 chars after annotation and use Black-style wrapping with trailing commas. The parametrized signature gets concrete status_code: int and headers: dict[str, str] annotations matching the parametrize tuple. 

Adds 'import pytest' and 'from pathlib import Path' to test_vor_env.py; adds 'from pathlib import Path' to test_vor_request_limit.py (pytest already present).

---
*PR created automatically by Jules for task [17079855754418898432](https://jules.google.com/task/17079855754418898432) started by @Origamihase*