### PR TITLE
refactor(types): annotate monkeypatch/caplog/tmp_path test funcs (C25)

### DIFF
--- a/tests/scripts/test_generate_sitemap_security.py
+++ b/tests/scripts/test_generate_sitemap_security.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import pytest
 from pathlib import Path
 
 
@@ -13,21 +14,21 @@ def _load_module() -> object:
     return module
 
 
-def test_base_url_rejects_invalid_scheme(monkeypatch) -> None:
+def test_base_url_rejects_invalid_scheme(monkeypatch: pytest.MonkeyPatch) -> None:
     from typing import cast, Any
     module = _load_module()
     monkeypatch.setenv("SITE_BASE_URL", "javascript:alert(1)")
     assert cast(Any, module)._base_url() == cast(Any, module).DEFAULT_BASE_URL.rstrip("/")
 
 
-def test_base_url_rejects_control_characters(monkeypatch) -> None:
+def test_base_url_rejects_control_characters(monkeypatch: pytest.MonkeyPatch) -> None:
     from typing import cast, Any
     module = _load_module()
     monkeypatch.setenv("SITE_BASE_URL", "https://example.com\n/inject")
     assert cast(Any, module)._base_url() == cast(Any, module).DEFAULT_BASE_URL.rstrip("/")
 
 
-def test_base_url_accepts_valid_https(monkeypatch) -> None:
+def test_base_url_accepts_valid_https(monkeypatch: pytest.MonkeyPatch) -> None:
     from typing import cast, Any
     module = _load_module()
     monkeypatch.setenv("SITE_BASE_URL", "https://example.com/base/")

--- a/tests/test_reporting_github.py
+++ b/tests/test_reporting_github.py
@@ -1,13 +1,14 @@
 import json
 import logging
 
+import pytest
 import responses
 
 from feed.reporting import RunReport
 
 
-@responses.activate
-def test_run_report_creates_github_issue(monkeypatch):
+@responses.activate  # type: ignore[untyped-decorator]
+def test_run_report_creates_github_issue(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("FEED_GITHUB_CREATE_ISSUES", "1")
     monkeypatch.setenv("FEED_GITHUB_REPOSITORY", "demo/repo")
     monkeypatch.setenv("FEED_GITHUB_TOKEN", "secret-token")
@@ -44,8 +45,11 @@ def test_run_report_creates_github_issue(monkeypatch):
     assert "Unbekannter Fehler im Test" in payload["body"]
 
 
-@responses.activate
-def test_run_report_logs_warning_when_credentials_missing(monkeypatch, caplog):
+@responses.activate  # type: ignore[untyped-decorator]
+def test_run_report_logs_warning_when_credentials_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     monkeypatch.setenv("FEED_GITHUB_CREATE_ISSUES", "1")
     monkeypatch.delenv("FEED_GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
@@ -66,8 +70,11 @@ def test_run_report_logs_warning_when_credentials_missing(monkeypatch, caplog):
     assert any("Token oder Repository fehlen" in message for message in warning_messages)
 
 
-@responses.activate
-def test_run_report_sanitizes_github_error_details(monkeypatch, caplog):
+@responses.activate  # type: ignore[untyped-decorator]
+def test_run_report_sanitizes_github_error_details(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     monkeypatch.setenv("FEED_GITHUB_CREATE_ISSUES", "1")
     monkeypatch.setenv("FEED_GITHUB_REPOSITORY", "demo/repo")
     monkeypatch.setenv("FEED_GITHUB_TOKEN", "secret-token")

--- a/tests/test_vor_auth_leak.py
+++ b/tests/test_vor_auth_leak.py
@@ -1,8 +1,9 @@
 import importlib
+import pytest
 import src.providers.vor as vor
 from typing import Any
 
-def test_vor_sends_param_when_header_present(monkeypatch):
+def test_vor_sends_param_when_header_present(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Verify that currently VOR provider sends BOTH header and query param.
     This test serves as a reproduction of the "leak" behavior (param injection).

--- a/tests/test_vor_circuit_breaker.py
+++ b/tests/test_vor_circuit_breaker.py
@@ -1,7 +1,8 @@
 import time
+import pytest
 from src.providers import vor
 
-def test_fetch_events_graceful_shutdown_on_emergency_stop(monkeypatch):
+def test_fetch_events_graceful_shutdown_on_emergency_stop(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Verify that if one thread triggers an 'Emergency Stop', the executor shuts down,
     the loop breaks, and partial results are returned (graceful degradation),

--- a/tests/test_vor_https_warning.py
+++ b/tests/test_vor_https_warning.py
@@ -1,8 +1,12 @@
 import logging
+import pytest
 from unittest.mock import MagicMock
 from src.providers import vor
 
-def test_vor_warns_on_insecure_http_with_credentials(monkeypatch, caplog):
+def test_vor_warns_on_insecure_http_with_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """
     Test that a warning is logged when VOR credentials are sent over an insecure HTTP connection.
     """
@@ -23,7 +27,10 @@ def test_vor_warns_on_insecure_http_with_credentials(monkeypatch, caplog):
     assert "Sending VOR credentials over insecure HTTP connection!" in caplog.text
 
 
-def test_vor_does_not_warn_on_secure_https(monkeypatch, caplog):
+def test_vor_does_not_warn_on_secure_https(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """
     Test that NO warning is logged when using HTTPS.
     """

--- a/tests/test_vor_monitor_whitelist.py
+++ b/tests/test_vor_monitor_whitelist.py
@@ -1,8 +1,12 @@
+import pytest
 import src.providers.vor as vor
 
 # --- Test Case ---
 
-def test_fetch_events_uses_whitelist_by_default(monkeypatch, caplog):
+def test_fetch_events_uses_whitelist_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """
     Verify that fetch_events uses the default whitelist (Hbf, Airport)
     when no env var is set, and resolves their IDs properly.
@@ -54,7 +58,7 @@ def test_fetch_events_uses_whitelist_by_default(monkeypatch, caplog):
     assert "99999" not in captured_ids
 
 
-def test_fetch_events_uses_configured_whitelist(monkeypatch):
+def test_fetch_events_uses_configured_whitelist(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Verify that setting VOR_MONITOR_STATIONS_WHITELIST overrides default.
     """
@@ -85,7 +89,7 @@ def test_fetch_events_uses_configured_whitelist(monkeypatch):
     assert "Wien Hauptbahnhof" not in resolved_names
 
 
-def test_fetch_events_disabled_whitelist_fallback(monkeypatch):
+def test_fetch_events_disabled_whitelist_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Verify that setting VOR_MONITOR_STATIONS_WHITELIST to empty string
     disables the whitelist and falls back to VOR_STATION_IDS.
@@ -116,7 +120,10 @@ def test_fetch_events_disabled_whitelist_fallback(monkeypatch):
     assert "12345" in fetched_ids
 
 
-def test_whitelist_respects_request_limits(monkeypatch, caplog):
+def test_whitelist_respects_request_limits(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """
     Verify request limits apply even when using whitelist.
     """

--- a/tests/test_vor_parallel.py
+++ b/tests/test_vor_parallel.py
@@ -1,9 +1,10 @@
 import threading
+import pytest
 
 import src.providers.vor as vor
 
 
-def test_fetch_events_parallel(monkeypatch):
+def test_fetch_events_parallel(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(vor, "refresh_access_credentials", lambda: "test")
     monkeypatch.setenv("VOR_MONITOR_STATIONS_WHITELIST", "")
     vor.VOR_ACCESS_ID = "test"
@@ -34,7 +35,10 @@ def test_fetch_events_parallel(monkeypatch):
     assert {it["guid"] for it in items} == {"1", "2"}
 
 
-def test_fetch_events_logs_and_continues(monkeypatch, caplog):
+def test_fetch_events_logs_and_continues(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     monkeypatch.setattr(vor, "refresh_access_credentials", lambda: "test")
     monkeypatch.setenv("VOR_MONITOR_STATIONS_WHITELIST", "")
     vor.VOR_ACCESS_ID = "test"

--- a/tests/test_vor_ssrf_protection.py
+++ b/tests/test_vor_ssrf_protection.py
@@ -1,9 +1,10 @@
 import json
 from unittest.mock import MagicMock
+import pytest
 
 from src.providers import vor
 
-def test_resolve_station_ids_uses_fetch_content_safe(monkeypatch):
+def test_resolve_station_ids_uses_fetch_content_safe(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Test that resolve_station_ids uses fetch_content_safe to prevent SSRF.
     This ensures that we don't regress to using session.get() directly.
@@ -40,7 +41,7 @@ def test_resolve_station_ids_uses_fetch_content_safe(monkeypatch):
     assert "location.name" in args[1]
     assert kwargs['params']['input'] == "PhantasiaHauptbahnhof"
 
-def test_resolve_station_ids_handles_unsafe_url_error(monkeypatch):
+def test_resolve_station_ids_handles_unsafe_url_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     Test that ValueError (from fetch_content_safe for unsafe URLs) is caught and handled.
     """

--- a/tests/test_vor_timezone.py
+++ b/tests/test_vor_timezone.py
@@ -1,7 +1,8 @@
+import pytest
 import src.providers.vor as vor
 
 
-def test_fetch_events_passes_local_timezone(monkeypatch):
+def test_fetch_events_passes_local_timezone(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(vor, "refresh_access_credentials", lambda: "test")
     vor.VOR_ACCESS_ID = "test"
     vor.VOR_STATION_IDS = ["123"]

--- a/tests/test_vor_title.py
+++ b/tests/test_vor_title.py
@@ -1,10 +1,11 @@
 from collections import namedtuple
 
+import pytest
 from src.providers import vor
 
 StationInfo = namedtuple("StationInfo", ["name", "in_vienna"])
 
-def test_collect_from_board_adds_station_context(monkeypatch):
+def test_collect_from_board_adds_station_context(monkeypatch: pytest.MonkeyPatch) -> None:
     # Mock station_info
     monkeypatch.setattr("src.providers.vor.station_info", lambda x: StationInfo(name="Mödling", in_vienna=False))
 
@@ -25,7 +26,9 @@ def test_collect_from_board_adds_station_context(monkeypatch):
     # Expect: "Mödling: Zugausfall" (since no lines)
     assert title == "Mödling: Zugausfall"
 
-def test_collect_from_board_adds_station_context_with_lines(monkeypatch):
+def test_collect_from_board_adds_station_context_with_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr("src.providers.vor.station_info", lambda x: StationInfo(name="Baden", in_vienna=False))
 
     root = {
@@ -44,7 +47,7 @@ def test_collect_from_board_adds_station_context_with_lines(monkeypatch):
     # Expect: "S3: Verspätung (Baden)"
     assert title == "S3: Verspätung (Baden)"
 
-def test_collect_from_board_skips_context_if_present(monkeypatch):
+def test_collect_from_board_skips_context_if_present(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("src.providers.vor.station_info", lambda x: StationInfo(name="Wien Mitte", in_vienna=True))
 
     root = {


### PR DESCRIPTION
## Summary

Annotates 22 plain pytest-style test functions across 10 files that take `monkeypatch`, `caplog`, or `tmp_path` and were missing parameter or return annotations. Applies `pytest.MonkeyPatch` / `pytest.LogCaptureFixture` for fixture parameters, adds `-> None` returns where missing, and inserts `import pytest` in the 10 affected files. Wrapped Black-style with trailing comma where the total signature length is ≥ 100 ch.

Continuation of the strict-typing migration of `tests/`. C14–C24 are merged (latest: PR #1142, commit `1bcf4b0`).

## Diff stat

```
 tests/scripts/test_generate_sitemap_security.py |  7 ++++---
 tests/test_reporting_github.py                  | 19 +++++++++++++------
 tests/test_vor_auth_leak.py                     |  3 ++-
 tests/test_vor_circuit_breaker.py               |  3 ++-
 tests/test_vor_https_warning.py                 | 11 +++++++++--
 tests/test_vor_monitor_whitelist.py             | 15 +++++++++++----
 tests/test_vor_parallel.py                      |  8 ++++++--
 tests/test_vor_ssrf_protection.py               |  5 +++--
 tests/test_vor_timezone.py                      |  3 ++-
 tests/test_vor_title.py                         |  9 ++++++---
 10 files changed, 58 insertions(+), 25 deletions(-)
```

## Sanity counts

| Pattern | Expected | Actual |
|---|---|---|
| Single-line `def test_*(...) -> None:` | 14 | 14 |
| Wrap-close `) -> None:` | 8 | 8 |
| `: pytest.MonkeyPatch` | 22 | 22 |
| `: pytest.LogCaptureFixture` | 7 | 7 |
| `tmp_path: Path` | 0 | 0 |
| `import pytest` | 10 | 10 |
| `# type: ignore[untyped-decorator]` | 3 | 3 |

## Mypy

- `before=644 / after=622 / delta=22`
- Gate 4b: every removed error is `[no-untyped-def]` (22/22) ✓
- Gate 4c: zero new mypy errors introduced ✓

## Decorator type-ignores

Three narrowly-scoped `# type: ignore[untyped-decorator]` were added on `@responses.activate` in `tests/test_reporting_github.py` (lines 9, 47, 72). Once the test functions become fully typed, mypy advances past `disallow_untyped_defs` to `disallow_untyped_decorators`, and `responses.activate` is unstubbed by the `responses` library. Suppressing on the decorator is the minimal local fix; annotating the decorator itself or migrating away from `@responses.activate` is out of scope for a strict-typing test cluster.

## Sandbox note

`pytest --collect-only` reports `ModuleNotFoundError: No module named 'requests'` in the development sandbox where this PR was authored. The error is reproducible against pre-edit `main` (not introduced by this PR); CI, where `requests` is installed, is the authoritative collection check.

## File 1 substitution

`tests/scripts/test_generate_sitemap_security.py` was rewritten on `main` between the C25 inventory scan (commit `1bcf4b0`) and this PR. The original cluster description targeted three `tmp_path` tests (`test_validate_path_security_traversal`, `test_validate_path_security_symlinks`, `test_process_template_xss`), which no longer exist on current `main`. The file 1 edits were re-targeted to the three actual functions present on current `main`: `test_base_url_rejects_invalid_scheme`, `test_base_url_rejects_control_characters`, `test_base_url_accepts_valid_https`. The cluster size of 22 issues across 10 files is preserved; only the per-function identity in file 1 changed.

## Test plan

- [ ] CI mypy job: confirm strict-mode passes with delta = 22
- [ ] CI pytest collection: confirm the 10 files collect cleanly with `requests` installed
- [ ] CI pytest run: confirm no behavioural regression in the 22 annotated tests

---
_Generated by [Claude Code](https://claude.ai/code/session_018hyRq3twQ9QX2UnCyjJ7fA)_