### PR TITLE
refactor(types): annotate Mock helper class methods (C26)

### DIFF
--- a/tests/places/test_badrequest_logging.py
+++ b/tests/places/test_badrequest_logging.py
@@ -12,7 +12,7 @@ from src.places.client import FIELD_MASK_NEARBY, GooglePlacesClient, GooglePlace
 
 
 class _ErrorResponse:
-    def __init__(self, status_code: int, payload: Dict[str, Any]):
+    def __init__(self, status_code: int, payload: Dict[str, Any]) -> None:
         self.status_code = status_code
         self._payload = payload
         self.text = json.dumps(payload)
@@ -40,7 +40,7 @@ class _ErrorResponse:
 
 
 class _ErrorSession:
-    def __init__(self, response: Union[_ErrorResponse, _TextErrorResponse]):
+    def __init__(self, response: Union[_ErrorResponse, _TextErrorResponse]) -> None:
         self._response = response
 
     def post(
@@ -56,7 +56,7 @@ class _ErrorSession:
 
 
 class _TextErrorResponse:
-    def __init__(self, status_code: int, text: str):
+    def __init__(self, status_code: int, text: str) -> None:
         self.status_code = status_code
         self.text = text
         self.headers: Dict[str, str] = {}

--- a/tests/places/test_client_logging_security.py
+++ b/tests/places/test_client_logging_security.py
@@ -13,7 +13,7 @@ from src.places.client import GooglePlacesClient, GooglePlacesConfig
 from src.places.tiling import Tile
 
 class _MockResponse:
-    def __init__(self, status_code: int, payload: Dict[str, Any]):
+    def __init__(self, status_code: int, payload: Dict[str, Any]) -> None:
         self.status_code = status_code
         self._payload = payload
         self.headers: Dict[str, str] = {}
@@ -42,7 +42,7 @@ class _MockResponse:
 
 
 class _MockSession:
-    def __init__(self, response: _MockResponse):
+    def __init__(self, response: _MockResponse) -> None:
         self._response = response
 
     def post(

--- a/tests/places/test_client_security.py
+++ b/tests/places/test_client_security.py
@@ -22,24 +22,24 @@ _CONFIG = GooglePlacesConfig(
 )
 
 class MockSocket:
-    def __init__(self, ip: str):
+    def __init__(self, ip: str) -> None:
         self._ip = ip
 
     def getpeername(self) -> tuple[str, int]:
         return (self._ip, 443)
 
 class SimulatedConnection:
-    def __init__(self, ip: str):
+    def __init__(self, ip: str) -> None:
         self.sock = MockSocket(ip)
 
 class MockRaw:
-    def __init__(self, ip: str):
+    def __init__(self, ip: str) -> None:
         self.connection = SimulatedConnection(ip)
         self._connection = self.connection
 
 class InfiniteStreamResponse:
     """A mock response that yields an infinite stream of data."""
-    def __init__(self, ip: str = "1.1.1.1"):
+    def __init__(self, ip: str = "1.1.1.1") -> None:
         self.status_code = 200
         self.headers: Dict[str, str] = {}
         self.raw = MockRaw(ip)
@@ -68,7 +68,7 @@ class InfiniteStreamResponse:
 
 class PrivateIPResponse:
     """A mock response that comes from a private IP."""
-    def __init__(self, ip: str = "127.0.0.1"):
+    def __init__(self, ip: str = "127.0.0.1") -> None:
         self.status_code = 200
         self.headers: Dict[str, str] = {"Content-Length": "2"}
         self.raw = MockRaw(ip)
@@ -92,7 +92,7 @@ class PrivateIPResponse:
 
 class LargeHeaderResponse:
     """A mock response with a Content-Length header exceeding the limit."""
-    def __init__(self, size: int):
+    def __init__(self, size: int) -> None:
         self.status_code = 200
         self.headers = {"Content-Length": str(size)}
         self.raw = MockRaw("1.1.1.1")

--- a/tests/places/test_fieldmask_and_types.py
+++ b/tests/places/test_fieldmask_and_types.py
@@ -16,7 +16,7 @@ from src.places.tiling import Tile
 
 
 class _RecordingResponse:
-    def __init__(self, status_code: int, payload: Dict[str, Any]):
+    def __init__(self, status_code: int, payload: Dict[str, Any]) -> None:
         self.status_code = status_code
         self._payload = payload
         self.text = json.dumps(payload)
@@ -44,7 +44,7 @@ class _RecordingResponse:
 
 
 class _RecordingSession:
-    def __init__(self, response: _RecordingResponse):
+    def __init__(self, response: _RecordingResponse) -> None:
         self._response = response
         self.headers: Dict[str, str] | None = None
         self.body: Dict[str, Any] | None = None

--- a/tests/test_oebb_rate_limit.py
+++ b/tests/test_oebb_rate_limit.py
@@ -1,14 +1,22 @@
 import logging
+from types import TracebackType
+from typing import Any, Iterator
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 
 import src.providers.oebb as oebb
 from tests.mock_utils import get_mock_socket_structure
 
 
 class DummyResponse:
-    def __init__(self, status_code, headers=None, content=b""):
+    def __init__(
+        self,
+        status_code: int,
+        headers: dict[str, str] | None = None,
+        content: bytes = b"",
+    ) -> None:
         self.status_code = status_code
         self.headers = headers or {}
         self.content = content
@@ -19,34 +27,44 @@ class DummyResponse:
         self.raw.connection = conn
         self.raw._connection = conn
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         if self.status_code >= 400:
             import requests
             raise requests.HTTPError(response=self)
 
-    def iter_content(self, chunk_size=8192):
+    def iter_content(self, chunk_size: int = 8192) -> Iterator[bytes]:
         yield self.content
 
-    def __enter__(self):
+    def __enter__(self) -> "DummyResponse":
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         pass
 
 
 class DummySession:
-    def __init__(self, responses, calls):
+    def __init__(self, responses: list["DummyResponse"], calls: list[tuple[str, Any]]) -> None:
         self._responses = iter(responses)
         self._calls = calls
         self.headers: dict[str, str] = {}
 
-    def __enter__(self):
+    def __enter__(self) -> "DummySession":
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         pass
 
-    def prepare_request(self, request):
+    def prepare_request(self, request: requests.Request) -> requests.PreparedRequest:
         from requests.models import PreparedRequest
         p = PreparedRequest()
         p.prepare(
@@ -63,14 +81,28 @@ class DummySession:
         )
         return p
 
-    def merge_environment_settings(self, url, proxies, stream, verify, cert):
+    def merge_environment_settings(
+        self,
+        url: Any,
+        proxies: Any,
+        stream: Any,
+        verify: Any,
+        cert: Any,
+    ) -> dict[str, Any]:
         return {}
 
-    def get(self, url, timeout, stream=False, **kwargs):
+    def get(self, url: str, timeout: Any, stream: bool = False, **kwargs: Any) -> "DummyResponse":
         self._calls.append((url, timeout))
         return next(self._responses)
 
-    def request(self, method, url, timeout=None, stream=False, **kwargs):
+    def request(
+        self,
+        method: str,
+        url: str,
+        timeout: Any = None,
+        stream: bool = False,
+        **kwargs: Any,
+    ) -> "DummyResponse":
         return self.get(url, timeout=timeout, stream=stream, **kwargs)
 
 

--- a/tests/test_retry_after_cap.py
+++ b/tests/test_retry_after_cap.py
@@ -1,4 +1,5 @@
 import logging
+from types import TracebackType
 import pytest
 import requests
 import src.providers.vor as vor
@@ -6,14 +7,19 @@ import src.providers.oebb as oebb
 from datetime import datetime
 
 class DummySession:
-    def __init__(self):
-        self.headers = {}
-    def __enter__(self):
+    def __init__(self) -> None:
+        self.headers: dict[str, str] = {}
+    def __enter__(self) -> "DummySession":
         return self
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         pass
 
-    def close(self):
+    def close(self) -> None:
         pass
 
 def test_vor_retry_after_capped(

--- a/tests/test_update_vor_stations_api.py
+++ b/tests/test_update_vor_stations_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import TracebackType
 
 import pytest
 
@@ -45,7 +46,7 @@ class _FakeResponse:
 
 
 class _FakeSession:
-    def __init__(self, payloads: dict[str, tuple[int, dict]]):
+    def __init__(self, payloads: dict[str, tuple[int, dict]]) -> None:
         self.payloads = payloads
         self.headers: dict[str, str] = {}
         self.calls: list[tuple[str, dict[str, str]]] = []
@@ -71,7 +72,12 @@ class _FakeSession:
     def __enter__(self) -> "_FakeSession":  # pragma: no cover - context management helper
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - context management helper
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:  # pragma: no cover - context management helper
         return None
 
 


### PR DESCRIPTION
## Summary

C26 of the strict-typing migration of `tests/`. Annotates **31 class methods across 7 Mock-helper test modules**, fully eliminating the pure-`class_method` bucket from the Phase-1 inventory. Continues the C14–C25 pattern: `__init__`, `__enter__`, `__exit__`, `close`, `raise_for_status`, `iter_content`, `get`, `request`, `merge_environment_settings`, `prepare_request` get strict signatures using the `TracebackType`/`Iterator[bytes]`/`requests.PreparedRequest` conventions, with `Any` used sparingly for parameters that mirror the unstubbed `requests` library surface.

## Diff stat

```
 tests/places/test_badrequest_logging.py      |  6 +--
 tests/places/test_client_logging_security.py |  4 +-
 tests/places/test_client_security.py         | 12 +++---
 tests/places/test_fieldmask_and_types.py     |  4 +-
 tests/test_oebb_rate_limit.py                | 56 ++++++++++++++++++++++------
 tests/test_retry_after_cap.py                | 16 +++++---
 tests/test_update_vor_stations_api.py        | 10 ++++-
 7 files changed, 76 insertions(+), 32 deletions(-)
```

## Per-file expected vs actual

| File | Expected | Actual | OK |
|---|---|---|---|
| `tests/places/test_badrequest_logging.py` | +3 / −3 | +3 / −3 | ✓ |
| `tests/places/test_client_logging_security.py` | +2 / −2 | +2 / −2 | ✓ |
| `tests/places/test_client_security.py` | +6 / −6 | +6 / −6 | ✓ |
| `tests/places/test_fieldmask_and_types.py` | +2 / −2 | +2 / −2 | ✓ |
| `tests/test_oebb_rate_limit.py` | +44 / −12 | +44 / −12 | ✓ |
| `tests/test_retry_after_cap.py` | +11 / −5 (with proactive var-annotated fix) | +11 / −5 | ✓ |
| `tests/test_update_vor_stations_api.py` | +8 / −2 | +8 / −2 | ✓ |
| **Cluster total** | **+76 / −32** | **+76 / −32** | ✓ |

## Sanity counts

| Metric | Expected | Actual |
|---|---|---|
| single-line `-> None` | 18 | 18 |
| wrap-close `) -> None:` (strict regex) | 5 | 4¹ |
| forward-ref `__enter__` returns | 3 | 3 |
| `-> Iterator[bytes]:` returns | 1 | 1 |
| `-> dict[str, Any]:` returns | 1 | 1 |
| `-> requests.PreparedRequest:` returns | 1 | 1 |
| `-> "DummyResponse":` returns | 3 | 3 |
| `tb: TracebackType \| None` params | 4 | 4 |
| `from types import TracebackType` imports | 3 | 3 |
| `from typing import Any, Iterator` imports | 1 | 1 |
| `import requests` imports | 1 | 1 |
| New `# type: ignore` | 0 | 0 |
| New `Any` annotations | 14–18 (informational) | 9 |

¹ The fifth wrap exists in `tests/test_update_vor_stations_api.py` `_FakeSession.__exit__`, but its closing line ends with `) -> None:  # pragma: no cover - context management helper`, so the strict regex `^\+    \) -> None:$` doesn't match it. All five wrapped `__exit__`/`__init__` blocks are present in the diff.

## Mypy delta

```
before: 622
after:  596
delta:  26  (17 [no-untyped-def] removed + 9 cascading [no-untyped-call] removed)
new:    0
```

- **Gate 4a** (delta == 31) — **DEVIATES from prompt expectation.** Of the 31 AST-detected `class_method` issues, 13 are `__init__` methods with all-typed parameters but missing `-> None`. Mypy `--strict` treats these as implicit-`None` and does **not** flag them in `[no-untyped-def]` (verified via direct probe: `def __init__(self, x: int):` produces no error in strict mode; only `def __init__(self, x):` does). Because mypy's baseline never counted those 13 cases, our annotations cannot reduce the count by 31. Cascading `[no-untyped-call]` removal at the call sites brought the actual delta to 26.
- **Gate 4b** (only `[no-untyped-def]` removed) — **partially deviates.** 17 `[no-untyped-def]` removed plus 9 `[no-untyped-call]` removed; both are expected positive cascades from typing the called methods.
- **Gate 4c** (no new errors) — **passes cleanly.** Zero new errors of any code.

## Any usage

The 9 new `Any` annotations are confined to `tests/test_oebb_rate_limit.py` `DummySession` methods that mirror the unstubbed `requests.Session` surface where mypy's `requests` stubs are not installed in the strict tests run:
- `merge_environment_settings(url, proxies, stream, verify, cert)` (5× `Any`) — these mirror `requests.Session.merge_environment_settings` whose upstream parameter types are sufficiently loose to make `Any` the pragmatic choice.
- `get(timeout, **kwargs)` and `request(timeout, **kwargs)` (2× `Any` each) — `timeout` accepts `float | tuple[float, float] | None | object`, and `**kwargs` is genuinely heterogeneous in the underlying `Session.request` API.
- `DummySession.__init__(calls: list[tuple[str, Any]])` — the inner tuple captures `(url, timeout)` where `timeout` is `Any` per the same convention.

Each is justified by "mock matches a loose external API surface". No inline comments were required; mypy accepts every annotation without complaint.

## Pre-emptive [var-annotated] fix

`tests/test_retry_after_cap.py` `DummySession.__init__`: `self.headers = {}` → `self.headers: dict[str, str] = {}`. Without this, typing `__init__ -> None` would have activated mypy's strict body checking and flagged the empty-dict assignment as `[var-annotated]`. No additional inline fixes turned out to be needed (mypy did not flag `self.headers = headers or {}` in `tests/test_oebb_rate_limit.py` because the parameter is already typed `dict[str, str] | None`, allowing inference).

## Sandbox note

`pytest --collect-only` fails on `import requests` for files 5/6/7 in the local sandbox — same condition as C25, reproducible on baseline `main` (verified by stashing the diff and re-running). Real CI is the authoritative collection check.

## Test plan

- [ ] CI mypy passes (no new errors)
- [ ] CI pytest collects and runs the modified test modules cleanly
- [ ] Diff stat matches the per-file table above
- [ ] No files outside the 7 listed targets changed

https://claude.ai/code/session_01S124bATy45HQ2ac9Bgqws4

---
_Generated by [Claude Code](https://claude.ai/code/session_01S124bATy45HQ2ac9Bgqws4)_