### PR TITLE
refactor(types): annotate class_method residue across mixed files (C27)

### DIFF
--- a/tests/scripts/test_verify_google_places_access.py
+++ b/tests/scripts/test_verify_google_places_access.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Iterable, Iterator
+from typing import Any, Iterable, Iterator
 
 import pytest
 
@@ -27,7 +27,7 @@ def _set_default_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 
 class _SuccessClient:
-    def __init__(self, config):
+    def __init__(self, config: Any) -> None:
         self.config = config
         self.request_count = 0
 
@@ -44,7 +44,7 @@ class _SuccessClient:
 
 
 class _PermissionDeniedClient:
-    def __init__(self, config):
+    def __init__(self, config: Any) -> None:
         self.config = config
         self.request_count = 0
 
@@ -55,7 +55,7 @@ class _PermissionDeniedClient:
 
 
 class _ErrorClient:
-    def __init__(self, config):
+    def __init__(self, config: Any) -> None:
         self.config = config
         self.request_count = 0
 

--- a/tests/test_vor_retry_after.py
+++ b/tests/test_vor_retry_after.py
@@ -1,4 +1,5 @@
 import logging
+from types import TracebackType
 from datetime import datetime, timedelta, timezone
 
 import requests
@@ -6,16 +7,21 @@ import src.providers.vor as vor
 
 
 class DummySession:
-    def __init__(self):
-        self.headers = {}
+    def __init__(self) -> None:
+        self.headers: dict[str, str] = {}
 
-    def __enter__(self):
+    def __enter__(self) -> "DummySession":
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
         pass
 
-    def close(self):
+    def close(self) -> None:
         pass
 
 

--- a/tests/test_wl_date_correction.py
+++ b/tests/test_wl_date_correction.py
@@ -1,16 +1,23 @@
+from types import TracebackType
+from typing import Literal
 
 import pytest
 
 from src.providers.wl_fetch import fetch_events
 
 class DummySession:
-    def __init__(self):
+    def __init__(self) -> None:
         self.headers: dict[str, str] = {}
 
-    def __enter__(self):
+    def __enter__(self) -> "DummySession":
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Literal[False]:
         return False
 
 def _setup_fetch(monkeypatch, traffic_infos=None, news=None):

--- a/tests/test_wl_fetch.py
+++ b/tests/test_wl_fetch.py
@@ -1,5 +1,7 @@
 import logging
 from datetime import datetime, timezone
+from types import TracebackType
+from typing import Literal
 
 import pytest
 
@@ -104,13 +106,18 @@ def test_fetch_events_handles_invalid_json(
 
 
 class DummySession:
-    def __init__(self):
+    def __init__(self) -> None:
         self.headers: dict[str, str] = {}
 
-    def __enter__(self):
+    def __enter__(self) -> "DummySession":
         return self
 
-    def __exit__(self, exc_type, exc, tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> Literal[False]:
         return False
 
 


### PR DESCRIPTION
## Summary

Closes the `class_method` bucket of the strict-typing migration by typing the **13 remaining mock-class methods** across **4 files** that also contain non-class issues (helpers, fixtures, test_funcs). Those non-class items remain on both sides of the diff for future clusters — the mypy gate is allowlist-based, so their pre-existing `[no-untyped-def]` errors are unchanged.

## Diff stat

```
 tests/scripts/test_verify_google_places_access.py |  8 ++++----
 tests/test_vor_retry_after.py                     | 16 +++++++++++-----
 tests/test_wl_date_correction.py                  | 13 ++++++++++---
 tests/test_wl_fetch.py                            | 13 ++++++++++---
 4 files changed, 35 insertions(+), 15 deletions(-)
```

## Per-file expected vs actual

| File | spec expected | actual | delta vs spec |
|---|---|---|---|
| `tests/scripts/test_verify_google_places_access.py` | +4/−4 | **+4/−4** | ✓ |
| `tests/test_vor_retry_after.py` | +11/−5 | **+11/−5** | ✓ |
| `tests/test_wl_date_correction.py` | +9/−3 | **+10/−3** | +1 (Literal import) |
| `tests/test_wl_fetch.py` | +9/−3 | **+10/−3** | +1 (Literal import) |
| **Σ** | **+33/−15** | **+35/−15** | **+2 (Literal imports)** |

The +2 deviation is documented under "`__exit__` return types" below.

## Sanity counts

| # | Pattern | Expected | Actual |
|---|---|---|---|
| 1 | Single-line `def … -> None:` | 7 | **7** |
| 2 | Wrapped `__exit__` ending `-> None:` (file 2) | 1 | **1** |
| 3 | Wrapped `__exit__` ending `-> Literal[False]:` (files 3, 4) | 2 | **2** |
| 3b | Wrapped `__exit__` ending `-> bool \| None:` (spec original) | 0 | **0** |
| 4 | `def __enter__(self) -> "DummySession":` | 3 | **3** |
| 5 | `def __init__(self, config: Any) -> None:` | 3 | **3** |
| 6 | `tb: TracebackType \| None,` param | 3 | **3** |
| 7 | `from types import TracebackType` | 3 | **3** |
| 8 | `from typing import Any, Iterable, Iterator` | 1 | **1** |
| 9 | `from typing import Literal` (deviation) | 2 | **2** |
| 10 | `self.headers: dict[str, str] = {}` (var-annotated fix) | 1 | **1** |

Negative regressions: no new `# type: ignore`, exactly 3 new `: Any` annotations (the three `config: Any`), nested `DummySession` inside `test_fetch_events_handles_invalid_json` left untouched.

## Mypy delta

```
before: 596
after:  577
delta:  -19
```

Per-error-code histogram (all 4 files combined, repo-wide):

| code | before | after | Δ |
|---|---|---|---|
| `[no-untyped-def]` | 279 | 266 | **−13** ← exactly the 13 typed methods |
| `[no-untyped-call]` | 46 | 40 | **−6** ← cascade: now-typed `DummySession()` calls |
| every other code (`[arg-type]`, `[assignment]`, `[attr-defined]`, `[misc]`, `[name-defined]`, `[no-redef]`, `[unused-ignore]`, `[var-annotated]`) | unchanged | unchanged | 0 |

The −19 exceeds the spec's expected −13 because typing `DummySession.__init__` removes the cascading `[no-untyped-call]` errors at every call site (`session_with_retries=lambda *a, **kw: DummySession()` lambdas in files 2, 3, 4 plus 4 calls inside `fake_fetch` helpers in file 2). All 6 cascades are net-positive removals; no error code appears in the after run that wasn't in baseline.

Gate verdict: 4a relaxed to delta ≥ 13 (cascades are wins, not regressions); 4b satisfied (every removal is from the `[no-untyped-def]` / `[no-untyped-call]` family); 4c clean (the diff line `> tests/test_vor_retry_after.py: error: Function is missing a type annotation` is a text-wrapping artifact at the same test_func error whose line number shifted from 99→105, narrowing the wrap column by one — substantively unchanged).

## `Any` usage (3×)

The three `config: Any` annotations on `_SuccessClient.__init__`, `_PermissionDeniedClient.__init__`, and `_ErrorClient.__init__` in `tests/scripts/test_verify_google_places_access.py` follow the C26 Mock-surface convention: each mock stores `config` on `self` but never introspects it (the parameter exists only to satisfy the `GooglePlacesClient` constructor signature). Typing it as `verify.GooglePlacesConfig` would couple these test mocks to the production class's exact name and force re-imports if it ever moves; `Any` keeps the mocks isolated from the production type surface, matching the C25/C26 precedent for `requests`-library mock surfaces.

## `__exit__` return types

`tests/test_vor_retry_after.py`'s `__exit__` body is `pass`, so the return type is `-> None` (matches C26's universal pattern).

`tests/test_wl_date_correction.py` and `tests/test_wl_fetch.py` have `__exit__` bodies of `return False`. The spec originally prescribed `-> bool | None`. **mypy 1.19.1 specifically rejects this**:

```
error: "bool" is invalid as return type for "__exit__"  [misc]
note: Use "typing.Literal[False]" as the return type or change it to "None"
note: If return type of "__exit__" implies that it may return True, the context manager may swallow exceptions
```

mypy now special-cases `__exit__` to forbid return types that admit `True` (such returns silently swallow exceptions). Since the spec forbids body changes, the only valid options are `-> Literal[False]` or `-> Literal[False] | None`. Adopted **`-> Literal[False]`** because it precisely matches the function's only return path (`return False`) and aligns with mypy's first hint verbatim. This requires `from typing import Literal` in files 3 and 4 — the only deviation from the spec's prescribed import set, accounting for the +2 line cluster total delta.

## Pre-emptive [var-annotated] fix

`tests/test_vor_retry_after.py` `DummySession.__init__` had `self.headers = {}` (untyped empty-dict assignment, would surface as `[var-annotated]` once the method is typed). Pre-empted to `self.headers: dict[str, str] = {}`, mirroring the C26 `test_retry_after_cap.py` treatment. Files 3 and 4 already had this typed; file 1's mocks have no untyped empty containers.

## Sandbox note

`pytest --collect-only` cannot run in this sandbox: `pytest-timeout` is configured in `pyproject.toml` (`addopts = … --timeout=60`) but the plugin isn't installed. Same kind of pre-existing environment artefact as the `requests` import gap noted in C25/C26 — not a C27 regression. All four target files parse cleanly via `ast.parse`.

## Test plan

- [ ] CI: mypy `--strict` on `tests/` reports exactly 13 fewer `[no-untyped-def]` errors and 6 fewer `[no-untyped-call]` errors (total −19 from 596 → 577); no new error codes anywhere
- [ ] CI: pytest collects and runs the 4 target test modules
- [ ] AST post-verify: zero remaining unannotated class methods in the 4 files
- [ ] Confirm the nested `DummySession` inside `test_fetch_events_handles_invalid_json` (test_wl_fetch.py L46-80) is unchanged — left for a future cluster

---
_Generated by [Claude Code](https://claude.ai/code/session_01AA2JgZhBVGRvz65QfDphyR)_