### PR TITLE
refactor(types): annotate @patch-decorated tests (C28)

### DIFF
--- a/tests/places/test_client_read_timeout.py
+++ b/tests/places/test_client_read_timeout.py
@@ -18,7 +18,11 @@ def client_config():
 
 @patch("src.places.client.verify_response_ip")
 @patch("src.places.client.read_response_safe")
-def test_post_passes_read_timeout(mock_read_response_safe, mock_verify_ip, client_config):
+def test_post_passes_read_timeout(
+    mock_read_response_safe: MagicMock,
+    mock_verify_ip: MagicMock,
+    client_config: GooglePlacesConfig,
+) -> None:
     """Verify that _post calculates and passes a read timeout to read_response_safe."""
     # Setup mock session and response
     mock_session = MagicMock(spec=requests.Session)

--- a/tests/test_http_security.py
+++ b/tests/test_http_security.py
@@ -1,6 +1,6 @@
 
 import responses
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from src.utils.http import session_with_retries, validate_http_url
 
 def test_redirect_limit_enforcement() -> None:
@@ -86,7 +86,10 @@ def test_unsafe_tlds_blocked_with_dns_check() -> None:
 
 @patch("src.utils.http.verify_response_ip")
 @patch("src.utils.http.validate_http_url")
-def test_strip_headers_on_scheme_downgrade(mock_validate_url, mock_verify_ip):
+def test_strip_headers_on_scheme_downgrade(
+    mock_validate_url: MagicMock,
+    mock_verify_ip: MagicMock,
+) -> None:
     """Verify that sensitive headers are stripped when redirecting from HTTPS to HTTP (Downgrade Attack)."""
     # Allow any URL for this test
     mock_validate_url.side_effect = lambda url, **kwargs: url
@@ -128,7 +131,10 @@ def test_strip_headers_on_scheme_downgrade(mock_validate_url, mock_verify_ip):
 
 @patch("src.utils.http.verify_response_ip")
 @patch("src.utils.http.validate_http_url")
-def test_strip_headers_on_port_change(mock_validate_url, mock_verify_ip):
+def test_strip_headers_on_port_change(
+    mock_validate_url: MagicMock,
+    mock_verify_ip: MagicMock,
+) -> None:
     """Verify that sensitive headers are stripped when redirecting to a different port on the same host."""
     # Allow any URL for this test
     mock_validate_url.side_effect = lambda url, **kwargs: url

--- a/tests/test_http_session_headers.py
+++ b/tests/test_http_session_headers.py
@@ -1,11 +1,14 @@
 
 import responses
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from src.utils.http import session_with_retries
 
 @patch("src.utils.http.verify_response_ip")
 @patch("src.utils.http.validate_http_url")
-def test_strip_session_headers_on_scheme_downgrade(mock_validate_url, mock_verify_ip):
+def test_strip_session_headers_on_scheme_downgrade(
+    mock_validate_url: MagicMock,
+    mock_verify_ip: MagicMock,
+) -> None:
     """Verify that sensitive headers set on the SESSION are stripped when redirecting to insecure scheme."""
     mock_validate_url.side_effect = lambda url, **kwargs: url
     mock_verify_ip.return_value = None

--- a/tests/test_oebb_title_fallback.py
+++ b/tests/test_oebb_title_fallback.py
@@ -1,5 +1,5 @@
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from src.providers.oebb import fetch_events
 from defusedxml import ElementTree as ET
 
@@ -33,7 +33,12 @@ def mock_xml_response(items):
 @patch("src.providers.oebb.station_by_oebb_id")
 @patch("src.providers.oebb.canonical_name")
 @patch("src.providers.oebb.station_info")
-def test_oebb_title_fallback_id(mock_station_info, mock_canon, mock_station_lookup, mock_fetch):
+def test_oebb_title_fallback_id(
+    mock_station_info: MagicMock,
+    mock_canon: MagicMock,
+    mock_station_lookup: MagicMock,
+    mock_fetch: MagicMock,
+) -> None:
     mock_station_info.return_value.in_vienna = True
     # Setup
     mock_station_lookup.return_value = "Wien ID-Station"
@@ -66,7 +71,12 @@ def test_oebb_title_fallback_id(mock_station_info, mock_canon, mock_station_look
 @patch("src.providers.oebb.station_by_oebb_id")
 @patch("src.providers.oebb.canonical_name")
 @patch("src.providers.oebb.station_info")
-def test_oebb_title_fallback_text(mock_station_info, mock_canon, mock_station_lookup, mock_fetch):
+def test_oebb_title_fallback_text(
+    mock_station_info: MagicMock,
+    mock_canon: MagicMock,
+    mock_station_lookup: MagicMock,
+    mock_fetch: MagicMock,
+) -> None:
     mock_station_info.return_value.in_vienna = True
     # Setup
     mock_station_lookup.return_value = None # No ID match
@@ -99,7 +109,12 @@ def test_oebb_title_fallback_text(mock_station_info, mock_canon, mock_station_lo
 @patch("src.providers.oebb.station_by_oebb_id")
 @patch("src.providers.oebb.canonical_name")
 @patch("src.providers.oebb.station_info")
-def test_oebb_title_fallback_truncation(mock_station_info, mock_canon, mock_station_lookup, mock_fetch):
+def test_oebb_title_fallback_truncation(
+    mock_station_info: MagicMock,
+    mock_canon: MagicMock,
+    mock_station_lookup: MagicMock,
+    mock_fetch: MagicMock,
+) -> None:
     pass
     mock_station_lookup.return_value = None
     mock_canon.return_value = None # No stations found in text

--- a/tests/test_sensitive_headers_dynamic.py
+++ b/tests/test_sensitive_headers_dynamic.py
@@ -1,10 +1,13 @@
 import responses
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from src.utils.http import session_with_retries
 
 @patch("src.utils.http.verify_response_ip")
 @patch("src.utils.http.validate_http_url")
-def test_strip_dynamic_sensitive_headers(mock_validate_url, mock_verify_ip):
+def test_strip_dynamic_sensitive_headers(
+    mock_validate_url: MagicMock,
+    mock_verify_ip: MagicMock,
+) -> None:
     """Verify that dynamically detected sensitive headers are stripped on cross-origin redirects."""
     mock_validate_url.side_effect = lambda url, **kwargs: url
     mock_verify_ip.return_value = None

--- a/tests/test_sensitive_headers_extended.py
+++ b/tests/test_sensitive_headers_extended.py
@@ -1,10 +1,13 @@
 import responses
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from src.utils.http import session_with_retries
 
 @patch("src.utils.http.verify_response_ip")
 @patch("src.utils.http.validate_http_url")
-def test_strip_extended_sensitive_headers(mock_validate_url, mock_verify_ip):
+def test_strip_extended_sensitive_headers(
+    mock_validate_url: MagicMock,
+    mock_verify_ip: MagicMock,
+) -> None:
     """Verify that an extended list of sensitive headers are stripped on cross-origin redirects."""
     # Allow any URL for this test
     mock_validate_url.side_effect = lambda url, **kwargs: url

--- a/tests/test_slowloris.py
+++ b/tests/test_slowloris.py
@@ -28,7 +28,10 @@ def test_read_response_safe_timeout() -> None:
 
 @patch("src.utils.http.validate_http_url")
 @patch("src.utils.http.verify_response_ip")
-def test_fetch_content_safe_slowloris(mock_verify_ip, mock_validate_url):
+def test_fetch_content_safe_slowloris(
+    mock_verify_ip: MagicMock,
+    mock_validate_url: MagicMock,
+) -> None:
     """Test that fetch_content_safe handles total timeout correctly."""
 
     # Setup mocks
@@ -100,7 +103,10 @@ def test_content_length_malformed() -> None:
 
 @patch("src.utils.http.validate_http_url")
 @patch("src.utils.http.verify_response_ip")
-def test_fetch_content_safe_default_timeout(mock_verify_ip, mock_validate_url):
+def test_fetch_content_safe_default_timeout(
+    mock_verify_ip: MagicMock,
+    mock_validate_url: MagicMock,
+) -> None:
     """Test that fetch_content_safe uses default timeout if None provided."""
 
     # Setup mocks

--- a/tests/test_vor_concurrency.py
+++ b/tests/test_vor_concurrency.py
@@ -9,7 +9,15 @@ from src.providers.vor import fetch_vor_disruptions, VOR_MAX_WORKERS
 @patch("src.providers.vor.get_configured_stations", return_value=["id_" + str(i) for i in range(50)])
 @patch("src.providers.vor.select_stations_for_run", side_effect=lambda x: x) # Return all
 @patch("src.providers.vor.session_with_retries")
-def test_vor_concurrency_limit(mock_session, mock_select, mock_get_stations, mock_load, mock_refresh, mock_executor, mock_as_completed):
+def test_vor_concurrency_limit(
+    mock_session: MagicMock,
+    mock_select: MagicMock,
+    mock_get_stations: MagicMock,
+    mock_load: MagicMock,
+    mock_refresh: MagicMock,
+    mock_executor: MagicMock,
+    mock_as_completed: MagicMock,
+) -> None:
     """Verify that VOR fetch limits the number of threads even with many stations."""
 
     # Mock context manager for executor
@@ -37,8 +45,14 @@ def test_vor_concurrency_limit(mock_session, mock_select, mock_get_stations, moc
 @patch("src.providers.vor.select_stations_for_run", side_effect=lambda x: x)
 @patch("src.providers.vor.session_with_retries")
 def test_vor_concurrency_small_list(
-    mock_session, mock_select, mock_get_stations, mock_load, mock_refresh, mock_executor, mock_as_completed
-):
+    mock_session: MagicMock,
+    mock_select: MagicMock,
+    mock_get_stations: MagicMock,
+    mock_load: MagicMock,
+    mock_refresh: MagicMock,
+    mock_executor: MagicMock,
+    mock_as_completed: MagicMock,
+) -> None:
     """Verify that VOR fetch uses fewer threads for small station lists."""
 
     mock_executor_instance = MagicMock()


### PR DESCRIPTION
## What

Annotates all 13 `patch_decorated` tests across 8 files with
`MagicMock` mock-params and `-> None` returns. Every typed signature
exceeds 100 chars and wraps one-param-per-line with a trailing comma.

## Why

Closes the `patch_decorated` bucket of the strict-typing migration
(0 remaining after this merge). Continues the C25 → C26 → C27 sequence
(test funcs → pure class_method files → mixed class_method residue).

## Scope

Strictly the 13 `@patch`-decorated test functions. **Untouched** in
the same files:
- `client_config` fixture body (`tests/places/test_client_read_timeout.py`)
- `mock_xml_response` helper (`tests/test_oebb_title_fallback.py`)
- 4 non-patched tests in `tests/test_http_security.py` and
  `tests/test_slowloris.py`

These belong to future clusters (fixtures, helpers).

## Conventions

- `@patch`-injected mock params: `: MagicMock`
- Pytest-fixture-injected param `client_config`: `: GooglePlacesConfig`
  (matches the existing import; fixture body unchanged)
- Test return: `-> None`
- Wrap form: Black-style, one param per line, trailing comma, closing
  `)` at zero indent followed by ` -> None:`
- Wrap threshold: ≥100 chars (every typed signature here qualifies)
- Imports: 5 files modify the existing `from unittest.mock import patch`
  line in place to alphabetically add `MagicMock` (no new lines)

## Verification

- AST post-scan: 0 `patch_decorated` issues remain across the 8 files
- Mypy delta (`mypy --no-pretty src tests`): 577 → 564 (−13), every
  removed error ends in `[no-untyped-def]`; **zero** new errors of any
  kind
- No new `Any`, `# type: ignore`, or `from __future__ import annotations`
- Sanity counts (vs working tree pre-commit): 42× new `: MagicMock`,
  1× new `: GooglePlacesConfig`, 5× import-mod, 13× wrap-close `) -> None:`
- `git diff --stat` per-file matches the planned table exactly
  (73 insertions, 19 deletions across 8 files)
- AST parses cleanly for all 8 target files; the only pytest collection
  errors are pre-existing `ModuleNotFoundError` for sandbox-missing
  third-party deps (`requests`, `responses`, `defusedxml`), documented
  across C25 – C27 as non-blocking

## Test plan

- [x] AST inventory pre-edit confirms 13 `patch_decorated` issues across the 8 files
- [x] AST inventory post-edit confirms 0 `patch_decorated` issues remain
- [x] Mypy `[no-untyped-def]` count drops by exactly 13; no new errors of any code
- [x] No `Any`, `# type: ignore`, or `from __future__ import annotations` introduced
- [x] All 8 files AST-parse cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_015jDshyYUZrd5tvKjDatwmz)_