### PR TITLE
refactor(types): annotate test_func A1 sub-cluster (C29)

### DIFF
--- a/tests/manual/manual_et.py
+++ b/tests/manual/manual_et.py
@@ -1,7 +1,7 @@
 
 from defusedxml import ElementTree as ET
 
-def test_et_generation():
+def test_et_generation() -> None:
     NS_EXT = "https://wien-oepnv.example/schema"
     NS_CONTENT = "http://purl.org/rss/1.0/modules/content/"
 

--- a/tests/manual/manual_reparse.py
+++ b/tests/manual/manual_reparse.py
@@ -1,7 +1,7 @@
 
 from defusedxml import ElementTree as ET
 
-def test_reparse():
+def test_reparse() -> None:
     NS_EXT = "https://wien-oepnv.example/schema"
     ET.register_namespace('ext', NS_EXT)
 

--- a/tests/test_update_station_directory_vor.py
+++ b/tests/test_update_station_directory_vor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 import pytest
 
 from scripts import update_station_directory as usd
@@ -76,7 +77,7 @@ def test_restore_existing_metadata_preserves_additional_fields() -> None:
     assert payload["source"] == "google_places"
 
 
-def test_build_location_index_prefers_wl_coordinates(tmp_path) -> None:
+def test_build_location_index_prefers_wl_coordinates(tmp_path: Path) -> None:
     gtfs_path = tmp_path / "stops.txt"
     wl_path = tmp_path / "wl.csv"
 

--- a/tests/test_vor_accessid_not_logged.py
+++ b/tests/test_vor_accessid_not_logged.py
@@ -21,7 +21,12 @@ import src.providers.vor as vor
         ('boom {"Authorization": "Basic secret"}', '"Authorization": "***"'),
     ],
 )
-def test_accessid_not_logged(monkeypatch, caplog, raw_message, expected_fragment):
+def test_accessid_not_logged(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    raw_message: str,
+    expected_fragment: str,
+) -> None:
     monkeypatch.setenv("VOR_ACCESS_ID", "secret")
     importlib.reload(vor)
 

--- a/tests/test_vor_fetch_events_failures.py
+++ b/tests/test_vor_fetch_events_failures.py
@@ -23,13 +23,15 @@ def _reset_station_ids(monkeypatch):
     monkeypatch.setattr(vor, "load_request_count", lambda: (today, 0))
 
 
-def test_fetch_events_raises_when_all_stationboards_fail(monkeypatch):
+def test_fetch_events_raises_when_all_stationboards_fail(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(vor, "_fetch_departure_board_for_station", lambda sid, now, counter=None, session=None, timeout=None: None)
     with pytest.raises(vor.RequestException):
         vor.fetch_events()
 
 
-def test_fetch_events_returns_results_when_some_stationboards_succeed(monkeypatch):
+def test_fetch_events_returns_results_when_some_stationboards_succeed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     payloads = {"430470800": object(), "490091000": None}
 
     def fake_fetch(station_id: str, now, counter=None, session=None, timeout=None):

--- a/tests/test_vor_retry_after.py
+++ b/tests/test_vor_retry_after.py
@@ -2,6 +2,7 @@ import logging
 from types import TracebackType
 from datetime import datetime, timedelta, timezone
 
+import pytest
 import requests
 import src.providers.vor as vor
 
@@ -25,7 +26,10 @@ class DummySession:
         pass
 
 
-def test_retry_after_invalid_value(monkeypatch, caplog):
+def test_retry_after_invalid_value(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     def fake_fetch(session, url, **kwargs):
         resp = requests.Response()
         resp.status_code = 429
@@ -46,7 +50,10 @@ def test_retry_after_invalid_value(monkeypatch, caplog):
     assert any("Überspringe Station (Fail-Fast)" in message for message in caplog.messages)
 
 
-def test_retry_after_missing_header(monkeypatch, caplog):
+def test_retry_after_missing_header(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     def fake_fetch(session, url, **kwargs):
         resp = requests.Response()
         resp.status_code = 429
@@ -66,7 +73,10 @@ def test_retry_after_missing_header(monkeypatch, caplog):
     assert any("Überspringe Station (Fail-Fast)" in message for message in caplog.messages)
 
 
-def test_retry_after_numeric_value(monkeypatch, caplog):
+def test_retry_after_numeric_value(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     def fake_fetch(session, url, **kwargs):
         resp = requests.Response()
         resp.status_code = 429
@@ -85,7 +95,10 @@ def test_retry_after_numeric_value(monkeypatch, caplog):
     assert any("Retry-After: 3.5s" in message for message in caplog.messages)
 
 
-def test_retry_after_http_date(monkeypatch, caplog):
+def test_retry_after_http_date(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     fixed_now = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
     delay = timedelta(seconds=7)
     retry_dt = fixed_now + delay

--- a/tests/test_vor_title_prefix.py
+++ b/tests/test_vor_title_prefix.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime, timezone
 import xml.etree.ElementTree as ET
 
+import pytest
 import src.build_feed as build_feed
 import src.providers.vor as vor
 
@@ -15,7 +16,7 @@ def _emit_item_str(item, now, state):
     return ident, xml_str
 
 
-def test_title_has_line_prefix(monkeypatch):
+def test_title_has_line_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
     # Mock station info so it doesn't get filtered out
     from src.utils.stations import StationInfo
     monkeypatch.setattr("src.providers.vor.station_info", lambda x: StationInfo(name=None, in_vienna=True, pendler=False))
@@ -46,7 +47,7 @@ def test_title_has_line_prefix(monkeypatch):
     assert items[0]["title"] == "S1: Baustelle …"
 
 
-def test_vor_description_keeps_extra_lines(monkeypatch):
+def test_vor_description_keeps_extra_lines(monkeypatch: pytest.MonkeyPatch) -> None:
     # Mock station info
     from src.utils.stations import StationInfo
     monkeypatch.setattr("src.providers.vor.station_info", lambda x: StationInfo(name="Wien", in_vienna=True, pendler=False))


### PR DESCRIPTION
## What

Annotates 12 of 39 `test_func` issues — the A1 sub-cluster covering
test functions whose unannotated parameters resolve to `no_params`,
standard pytest fixtures (`monkeypatch`, `caplog`, `tmp_path`), or
`@pytest.mark.parametrize` values.

## Why

Closes the safe portion of the test_func bucket without depending on
untyped local fixtures. The remaining 27 `test_func` issues all
inject custom local-fixture parameters whose return types are not yet
annotated, so they are deferred to a follow-up cluster after the
fixtures themselves are typed.

## Conventions

- `monkeypatch: pytest.MonkeyPatch`
- `caplog: pytest.LogCaptureFixture`
- `tmp_path: Path`
- Parametrize-injected `str` literals: `: str`
- Test return: `-> None`
- Wrap threshold: ≥100 chars (Black-style, trailing comma, closing `)`
  at zero indent followed by ` -> None:`)

## Verification

- `git diff --numstat` per-file matches the planned table exactly
  (1/1, 1/1, 17/4, 3/2, 4/2, 2/1, 6/1; Σ 34/12)
- Only the 7 target files changed
- AST post-scan: 0 `test_func` issues remain across the 7 files;
  27 remain in the rest of `tests/` (the deferred A2 set, unchanged)
- Sanity counts: 9× new `: pytest.MonkeyPatch`, 5× new
  `: pytest.LogCaptureFixture`, 1× new `tmp_path: Path`, 2× new `: str`
  (parametrize values), 12× new `-> None:`, 2× new `import pytest`,
  1× new `from pathlib import Path`
- No new `Any`, `# type: ignore`, or `from __future__ import annotations`
- All 7 A1 files parse cleanly via `ast.parse`

## Mypy gate — deviations from prompt criteria (please review)

Note: prompt's `mypy .` aborts immediately on a pre-existing
path-collision (`scripts/fetch_google_places_stations.py` exists under
both module names). Used `mypy src tests` instead, which gives a
564-error baseline. By error code:

| Code | Baseline | After | Δ |
|---|---|---|---|
| `[no-untyped-def]` | 253 | 241 | **−12** ✓ matches 12 annotated test_funcs |
| `[no-untyped-call]` | 40 | 38 | −2 (bonus removal, see below) |
| `[untyped-decorator]` | 47 | 48 | +1 (new, see below) |
| Other | 224 | 224 | 0 |
| **Total** | **564** | **551** | **−13** |

**−2 `[no-untyped-call]` (gates 2e-i & 2e-ii fail favorably):** the
`tests/manual/manual_*.py` files end with a top-level call to the
test function (`test_et_generation()` / `test_reparse()`). Adding
`-> None` to each `def test_*` removed the `[no-untyped-def]` *and*
the downstream `[no-untyped-call]` at the call site. Net favorable.

**+1 `[untyped-decorator]` (gate 2e-iii fails):**
`tests/test_vor_accessid_not_logged.py:11: error: Untyped decorator makes function "test_accessid_not_logged" untyped [untyped-decorator]`.
The previously-untyped function suppressed body- and decorator-level
checks; once typed, mypy now reports that `pytest.mark.parametrize`
returns `Any`, so the typed function is again "untyped" via decorator.
This is a known mypy×pytest interaction; baseline already carries
**47** such errors. The only allowed mitigation in the prompt's
vocabulary (`# type: ignore`) is explicitly forbidden, and net file
error count is unchanged at 7 (1 `[no-untyped-def]` removed,
1 `[untyped-decorator]` added).

If the parametrize artifact is unacceptable, dropping commit-level
edits to `test_vor_accessid_not_logged.py` (1 of 12 annotations)
yields a clean gate: delta = 12, only `[no-untyped-def]` /
`[no-untyped-call]` removed, zero new errors. Happy to follow up with
that revert if preferred.

## Test plan

- [x] `git diff --numstat` per-file matches planned table
- [x] Only target files changed
- [x] AST post-scan: A1 = 0 remaining, A2 = 27 unchanged
- [x] Sanity grep counts (8/8) match expected
- [x] No `Any`, `# type: ignore`, or `from __future__ import annotations` added
- [x] All 7 files parse cleanly via `ast.parse`
- [x] Mypy `[no-untyped-def]`: −12 exactly
- [ ] Mypy `[untyped-decorator]`: +1 (decision pending — see above)
- [ ] Pytest collection sandbox-blocked (pre-existing missing third-party packages)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SomPoJYFHT8bDT9ob29f12)_