### PR TITLE
refactor(types): annotate fixture bucket (C30)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,7 +214,7 @@ def _ensure_streckendaten(streckendaten_dataset: Path) -> Iterator[None]:  # noq
 
 
 @pytest.fixture(autouse=True)
-def reset_vor_request_count(tmp_path, monkeypatch):
+def reset_vor_request_count(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     import src.providers.vor as vor
 
     path = tmp_path / "vor_request_count.json"
@@ -229,7 +229,7 @@ def reset_vor_request_count(tmp_path, monkeypatch):
         path.unlink()
 
 @pytest.fixture(autouse=True)
-def reset_build_feed_state():
+def reset_build_feed_state() -> None:
     import src.build_feed as build_feed
     from src.feed.providers import reset_registry
     build_feed.reset_module_state()

--- a/tests/places/test_client_read_timeout.py
+++ b/tests/places/test_client_read_timeout.py
@@ -4,7 +4,7 @@ import requests
 from src.places.client import GooglePlacesClient, GooglePlacesConfig
 
 @pytest.fixture
-def client_config():
+def client_config() -> GooglePlacesConfig:
     return GooglePlacesConfig(
         api_key="test-key",
         included_types=["train_station"],

--- a/tests/scripts/test_verify_google_places_access.py
+++ b/tests/scripts/test_verify_google_places_access.py
@@ -13,7 +13,7 @@ from src.places.client import GooglePlacesError, GooglePlacesPermissionError, Pl
 
 
 @pytest.fixture(autouse=True)
-def _reset_logging():
+def _reset_logging() -> Iterator[None]:
     logging.getLogger(verify.LOGGER.name).handlers.clear()
     yield
     logging.getLogger(verify.LOGGER.name).handlers.clear()

--- a/tests/test_build_feed_atom.py
+++ b/tests/test_build_feed_atom.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from typing import Callable, Iterator
 from defusedxml import ElementTree as ET
 import pytest
 
@@ -21,7 +22,7 @@ _ATOM_NS = "http://www.w3.org/2005/Atom"
 
 
 @pytest.fixture
-def pages_base_url(monkeypatch):
+def pages_base_url(monkeypatch: pytest.MonkeyPatch) -> Iterator[Callable[[str], None]]:
     """Set PAGES_BASE_URL via env and refresh feed config; restore on teardown."""
 
     import src.build_feed

--- a/tests/test_content_type_validation.py
+++ b/tests/test_content_type_validation.py
@@ -4,12 +4,12 @@ import requests
 from src.utils.http import fetch_content_safe
 
 @pytest.fixture
-def mock_session():
+def mock_session() -> MagicMock:
     session = MagicMock(spec=requests.Session)
     return session
 
 @pytest.fixture
-def mock_response():
+def mock_response() -> requests.Response:
     response = requests.Response()
     response.url = "http://example.com"
     response.status_code = 200

--- a/tests/test_env_fallback_security.py
+++ b/tests/test_env_fallback_security.py
@@ -1,10 +1,11 @@
 import sys
 import logging
+from typing import Any, Iterator
 import pytest
 from unittest.mock import patch
 
 @pytest.fixture
-def fallback_env():
+def fallback_env() -> Iterator[Any]:  # yields a dynamically-imported module
     """
     Fixture that forces src.utils.env to be imported in fallback mode
     (simulating missing src.utils.logging).

--- a/tests/test_oebb_whitelist.py
+++ b/tests/test_oebb_whitelist.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+from typing import Any
 import pytest
 
 import src.providers.oebb as oebb
@@ -10,7 +11,7 @@ _STATIONS_PATH = Path(__file__).resolve().parents[1] / "data" / "stations.json"
 
 
 @pytest.fixture(scope="module")
-def station_entries():
+def station_entries() -> Any:  # JSON-derived list of dicts; full typing requires body refactor
     with _STATIONS_PATH.open("r", encoding="utf-8") as handle:
         data = json.load(handle)
     if isinstance(data, dict):
@@ -30,7 +31,7 @@ def station_entries():
 
 
 @pytest.fixture(scope="module")
-def pendler_station(station_entries):
+def pendler_station(station_entries: Any) -> Any:  # entry["name"] narrowing to str needs cast
     for entry in station_entries:
         if entry.get("pendler") and not entry.get("in_vienna"):
             return entry["name"]
@@ -38,7 +39,7 @@ def pendler_station(station_entries):
 
 
 @pytest.fixture(scope="module")
-def vienna_station(station_entries):
+def vienna_station(station_entries: Any) -> Any:  # entry["name"] narrowing to str needs cast
     for entry in station_entries:
         if entry.get("in_vienna"):
             return entry["name"]

--- a/tests/test_resolve_env_path.py
+++ b/tests/test_resolve_env_path.py
@@ -7,7 +7,7 @@ from src.feed import config as feed_config
 
 
 @pytest.fixture(autouse=True)
-def _restore_env(monkeypatch):
+def _restore_env(monkeypatch: pytest.MonkeyPatch) -> None:
     # Ensure custom environment variable is always removed after a test
     monkeypatch.delenv("CUSTOM_PATH", raising=False)
 

--- a/tests/test_secure_permissions.py
+++ b/tests/test_secure_permissions.py
@@ -2,11 +2,12 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+from typing import Iterator
 import pytest
 import src.build_feed
 
 @pytest.fixture
-def mock_feed_config(monkeypatch):
+def mock_feed_config(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Mock the feed config to avoid environment validation issues."""
     with patch("src.feed.config.validate_path", side_effect=lambda p, n: Path(p).resolve()):
         yield

--- a/tests/test_sitemap_generation.py
+++ b/tests/test_sitemap_generation.py
@@ -1,4 +1,6 @@
 import os
+from pathlib import Path
+from typing import Iterator
 from defusedxml import ElementTree as ET
 from unittest.mock import patch
 import pytest
@@ -6,7 +8,7 @@ from scripts import generate_sitemap
 
 # Mock data directory for tests
 @pytest.fixture
-def mock_docs_dir(tmp_path):
+def mock_docs_dir(tmp_path: Path) -> Iterator[Path]:
     docs_dir = tmp_path / "docs"
     docs_dir.mkdir()
     (docs_dir / "index.md").touch()

--- a/tests/test_tld_bypass.py
+++ b/tests/test_tld_bypass.py
@@ -1,4 +1,5 @@
 
+from typing import Iterator
 from unittest.mock import patch
 import pytest
 
@@ -10,7 +11,7 @@ from src.utils.http import validate_http_url
 SAFE_IP_INFO = [(2, 1, 6, '', ('8.8.8.8', 80))]
 
 @pytest.fixture
-def mock_dns_safe():
+def mock_dns_safe() -> Iterator[None]:
     with patch("src.utils.http._resolve_hostname_safe", return_value=SAFE_IP_INFO):
         yield
 

--- a/tests/test_vor_fetch_events_failures.py
+++ b/tests/test_vor_fetch_events_failures.py
@@ -10,7 +10,7 @@ def _today_vienna_iso() -> str:
 
 
 @pytest.fixture(autouse=True)
-def _reset_station_ids(monkeypatch):
+def _reset_station_ids(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(vor, "refresh_access_credentials", lambda: "token")
     monkeypatch.setattr(vor, "VOR_ACCESS_ID", "token", raising=False)
     # Clear the whitelist to force usage of VOR_STATION_IDS


### PR DESCRIPTION
## What

Annotates all 16 `@pytest.fixture` issues across 12 files. Signatures
only — no fixture bodies are modified.

## Why

Closes the fixture bucket of the strict-typing migration. Unlocks the
deferred A2 sub-cluster (27 `test_func` issues whose unannotated
parameters resolve to these fixtures).

## Conventions

| Pattern | Annotation |
|---|---|
| yield-fixture (side-effect only) | `-> Iterator[None]` |
| yield-fixture with value | `-> Iterator[T]` |
| value-returning fixture | `-> T` |
| side-effect fixture (no yield) | `-> None` |
| `monkeypatch` param | `: pytest.MonkeyPatch` |
| `tmp_path` param | `: Path` |

## Any introductions (4 fixtures)

- `fallback_env -> Iterator[Any]` — yields a dynamically-imported
  module; matches project precedent for module-yielding fixtures
- `station_entries`, `pendler_station`, `vienna_station` in
  `tests/test_oebb_whitelist.py` — JSON-derived data; full strict
  typing of `entry["name"]` requires `cast(str, ...)` (body refactor)
  which is out of cluster scope. Each gets an inline justification
  comment on the `def` line per project rules.

## Verification

- AST post-scan: 0 fixture issues remain across the 12 files
- Sanity counts hit exact expected values (7 `Iterator[...]` returns,
  3 `-> None:` returns, 1 each for `GooglePlacesConfig` /
  `MagicMock` / `requests.Response`, 3 `-> Any` returns, 5 new
  `pytest.MonkeyPatch` annotations, 2 new `tmp_path: Path`
  annotations, 6 new `typing` imports, 1 new `pathlib.Path` import,
  4 Any-justification comments)
- `git diff --stat` per-file matches the planned table exactly
  (+23/−16 cluster total)
- No new `# type: ignore`, no new `from __future__ import annotations`,
  no new `cast()` calls
- Any count in additions: exactly 8 (3 fixture returns, 1 fixture
  param, 1 in `Iterator[Any]`, 3 in `from typing import` lines)

## Mypy delta

The plan's `mypy .` invocation halts on a pre-existing duplicate-module
collision in `scripts/fetch_google_places_stations.py`. Used `mypy src tests`
which exercises the same `[tool.mypy]` config and includes both the
strict-typed `src` tree and the fixture targets:

```
                       baseline    after    delta
[no-untyped-def]:        241  ->   225      −16   (the 16 typed fixtures)
[untyped-decorator]:      48  ->    64      +16   (one per typed fixture)
[no-any-return]:          16  ->    16        0   (Any fixtures clean)
TOTAL:                   551  ->   551        0
```

**Note on the `[untyped-decorator]` shift:** when a `@pytest.fixture`-decorated
function gets typed under `strict = true`, mypy moves the diagnostic
from `[no-untyped-def]` on the function to `[untyped-decorator]` on the
decorator itself (`@pytest.fixture` returns `Any` from pytest's stubs in
this project's setup). This is the standard pytest+strict-mypy
trade-off — the project already tolerates 48 such errors across 33
files in baseline, and the only project-wide fix would be a global
`disable_error_code = ["untyped-decorator"]` or a typed `pytest_fixture`
wrapper, both out of cluster scope. The 16-for-16 swap reflects real
progress: typed fixture signatures unlock A2 test_func annotation that
was blocked on these 16 fixtures.

## Test plan

- [ ] Mypy: `[no-untyped-def]` count drops by 16 in `tests/`
- [ ] Mypy: no new `[no-any-return]` from the 4 `Any` fixtures
- [ ] Pytest collection succeeds for the 12 modified files
- [ ] CI green

https://claude.ai/code/session_01Cov1a4nfmrgvr3uhzoRJCG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cov1a4nfmrgvr3uhzoRJCG)_