### PR TITLE
refactor(types): annotate test_func A2 sub-cluster (C31)

### DIFF
--- a/tests/test_build_feed_atom.py
+++ b/tests/test_build_feed_atom.py
@@ -36,13 +36,15 @@ def pages_base_url(monkeypatch: pytest.MonkeyPatch) -> Iterator[Callable[[str], 
     src.build_feed.feed_config.refresh_from_env()
 
 
-def test_make_rss_declares_atom_namespace(pages_base_url):
+def test_make_rss_declares_atom_namespace(pages_base_url: Callable[[str], None]) -> None:
     pages_base_url("https://example.github.io/test-repo")
     rss_str = _make_rss([], _NOW, {})
     assert 'xmlns:atom="http://www.w3.org/2005/Atom"' in rss_str
 
 
-def test_make_rss_emits_self_and_alternate_atom_links(pages_base_url):
+def test_make_rss_emits_self_and_alternate_atom_links(
+    pages_base_url: Callable[[str], None],
+) -> None:
     pages_base_url("https://example.github.io/test-repo")
     rss_str = _make_rss([], _NOW, {})
 
@@ -65,7 +67,7 @@ def test_make_rss_emits_self_and_alternate_atom_links(pages_base_url):
     assert self_link.get("href") == "https://example.github.io/test-repo/feed.xml"
 
 
-def test_make_rss_emits_language_de(pages_base_url):
+def test_make_rss_emits_language_de(pages_base_url: Callable[[str], None]) -> None:
     pages_base_url("https://example.github.io/test-repo")
     rss_str = _make_rss([], _NOW, {})
 
@@ -78,7 +80,9 @@ def test_make_rss_emits_language_de(pages_base_url):
     assert language.text == "de"
 
 
-def test_make_rss_strips_trailing_slash_from_pages_base_url(pages_base_url):
+def test_make_rss_strips_trailing_slash_from_pages_base_url(
+    pages_base_url: Callable[[str], None],
+) -> None:
     """A trailing slash in PAGES_BASE_URL must not produce a double slash in href."""
 
     pages_base_url("https://example.github.io/test-repo/")

--- a/tests/test_content_type_validation.py
+++ b/tests/test_content_type_validation.py
@@ -32,7 +32,10 @@ def mock_response() -> requests.Response:
 
     return response
 
-def test_fetch_content_safe_no_validation(mock_session, mock_response):
+def test_fetch_content_safe_no_validation(
+    mock_session: MagicMock,
+    mock_response: requests.Response,
+) -> None:
     """Test that without allowed_content_types, safe content types are accepted but text/html is blocked."""
     mock_response.headers = {"Content-Type": "application/json"}
     mock_session.request.return_value.__enter__.return_value = mock_response
@@ -40,7 +43,10 @@ def test_fetch_content_safe_no_validation(mock_session, mock_response):
     content = fetch_content_safe(mock_session, "http://example.com")
     assert content == b"content"
 
-def test_fetch_content_safe_blocks_html_implicitly(mock_session, mock_response):
+def test_fetch_content_safe_blocks_html_implicitly(
+    mock_session: MagicMock,
+    mock_response: requests.Response,
+) -> None:
     """Test that without allowed_content_types, text/html is blocked to prevent proxy/WAF parsing issues."""
     mock_response.headers = {"Content-Type": "text/html"}
     mock_session.request.return_value.__enter__.return_value = mock_response
@@ -49,7 +55,10 @@ def test_fetch_content_safe_blocks_html_implicitly(mock_session, mock_response):
         fetch_content_safe(mock_session, "http://example.com")
 
 
-def test_fetch_content_safe_valid_json(mock_session, mock_response):
+def test_fetch_content_safe_valid_json(
+    mock_session: MagicMock,
+    mock_response: requests.Response,
+) -> None:
     """Test that matching content type is accepted."""
     mock_response.headers = {"Content-Type": "application/json"}
     mock_session.request.return_value.__enter__.return_value = mock_response
@@ -61,7 +70,10 @@ def test_fetch_content_safe_valid_json(mock_session, mock_response):
     )
     assert content == b"content"
 
-def test_fetch_content_safe_invalid_type(mock_session, mock_response):
+def test_fetch_content_safe_invalid_type(
+    mock_session: MagicMock,
+    mock_response: requests.Response,
+) -> None:
     """Test that mismatching content type raises ValueError."""
     mock_response.headers = {"Content-Type": "text/html"}
     mock_session.request.return_value.__enter__.return_value = mock_response
@@ -73,7 +85,10 @@ def test_fetch_content_safe_invalid_type(mock_session, mock_response):
             allowed_content_types=["application/json"]
         )
 
-def test_fetch_content_safe_charset(mock_session, mock_response):
+def test_fetch_content_safe_charset(
+    mock_session: MagicMock,
+    mock_response: requests.Response,
+) -> None:
     """Test that content type with charset is parsed correctly."""
     mock_response.headers = {"Content-Type": "application/json; charset=utf-8"}
     mock_session.request.return_value.__enter__.return_value = mock_response
@@ -85,7 +100,10 @@ def test_fetch_content_safe_charset(mock_session, mock_response):
     )
     assert content == b"content"
 
-def test_fetch_content_safe_missing_header(mock_session, mock_response):
+def test_fetch_content_safe_missing_header(
+    mock_session: MagicMock,
+    mock_response: requests.Response,
+) -> None:
     """Test that missing header raises ValueError when validation is requested."""
     mock_response.headers = {}
     mock_session.request.return_value.__enter__.return_value = mock_response
@@ -97,7 +115,10 @@ def test_fetch_content_safe_missing_header(mock_session, mock_response):
             allowed_content_types=["application/json"]
         )
 
-def test_fetch_content_safe_ignore_validation(mock_session, mock_response):
+def test_fetch_content_safe_ignore_validation(
+    mock_session: MagicMock,
+    mock_response: requests.Response,
+) -> None:
     """Test that missing header is ignored if no validation requested."""
     mock_response.headers = {}
     mock_session.request.return_value.__enter__.return_value = mock_response

--- a/tests/test_env_fallback_security.py
+++ b/tests/test_env_fallback_security.py
@@ -36,7 +36,7 @@ def fallback_env() -> Iterator[Any]:  # yields a dynamically-imported module
     elif "src.utils.logging" in sys.modules:
         del sys.modules["src.utils.logging"]
 
-def test_secure_fallback(caplog, fallback_env):
+def test_secure_fallback(caplog: pytest.LogCaptureFixture, fallback_env: Any) -> None:
     """Verify that env.py fallback logging masks basic secrets."""
     caplog.set_level(logging.WARNING, logger="build_feed")
 
@@ -52,7 +52,7 @@ def test_secure_fallback(caplog, fallback_env):
     assert "accessId=***" in caplog.text
     assert "accessId=SuperSecretKey123" not in caplog.text
 
-def test_fallback_extended_keys(caplog, fallback_env):
+def test_fallback_extended_keys(caplog: pytest.LogCaptureFixture, fallback_env: Any) -> None:
     """
     Verify that env.py fallback logging masks vendor-specific and extended secrets.
     This protects against cloud provider keys (AWS, Azure, etc).

--- a/tests/test_oebb_whitelist.py
+++ b/tests/test_oebb_whitelist.py
@@ -46,24 +46,32 @@ def vienna_station(station_entries: Any) -> Any:  # entry["name"] narrowing to s
     pytest.fail("No Vienna station found in stations.json")
 
 
-def test_station_flags_match_utils(pendler_station, vienna_station):
+def test_station_flags_match_utils(pendler_station: Any, vienna_station: Any) -> None:
     assert station_utils.is_pendler(pendler_station)
     assert not station_utils.is_in_vienna(pendler_station)
     assert station_utils.is_in_vienna(vienna_station)
 
 
 @pytest.mark.parametrize("arrow", ["↔", "<->", "->", "—", "–", "→"])
-def test_pendler_station_is_whitelisted(arrow: str, pendler_station, vienna_station) -> None:
+def test_pendler_station_is_whitelisted(
+    arrow: str,
+    pendler_station: Any,
+    vienna_station: Any,
+) -> None:
     # "Pendler" logic is now: If it has ANY Vienna station, it's kept.
     # So matching "Wien" -> Keep.
     assert oebb._is_relevant(f"{vienna_station} {arrow} {pendler_station}", "")
 
 
-def test_vienna_station_is_whitelisted(vienna_station):
+def test_vienna_station_is_whitelisted(vienna_station: Any) -> None:
     assert oebb._is_relevant(f"{vienna_station} ↔ {vienna_station}", "")
 
 
-def test_only_vienna_env(monkeypatch, pendler_station, vienna_station):
+def test_only_vienna_env(
+    monkeypatch: pytest.MonkeyPatch,
+    pendler_station: Any,
+    vienna_station: Any,
+) -> None:
     # Test that setting OEBB_ONLY_VIENNA correctly filters out connections
     # that are not strictly inside Vienna.
     monkeypatch.setattr(oebb, "OEBB_ONLY_VIENNA", True)

--- a/tests/test_secure_permissions.py
+++ b/tests/test_secure_permissions.py
@@ -12,7 +12,7 @@ def mock_feed_config(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     with patch("src.feed.config.validate_path", side_effect=lambda p, n: Path(p).resolve()):
         yield
 
-def test_save_state_secure_permissions(tmp_path, mock_feed_config):
+def test_save_state_secure_permissions(tmp_path: Path, mock_feed_config: None) -> None:
     """Verify that _save_state creates files with secure permissions (0600)."""
     # Import inside the test to ensure patches are active
     from src.build_feed import _save_state

--- a/tests/test_sitemap_generation.py
+++ b/tests/test_sitemap_generation.py
@@ -25,7 +25,7 @@ def mock_docs_dir(tmp_path: Path) -> Iterator[Path]:
     with patch("scripts.generate_sitemap.DOCS_DIR", docs_dir):
         yield docs_dir
 
-def test_sitemap_xml_validity(mock_docs_dir):
+def test_sitemap_xml_validity(mock_docs_dir: Path) -> None:
     """Test that the generated sitemap is valid XML and contains expected URLs."""
     with patch.dict(os.environ, {"SITE_BASE_URL": "https://example.com/base"}):
         generate_sitemap.main()
@@ -47,7 +47,7 @@ def test_sitemap_xml_validity(mock_docs_dir):
     # Ensure excluded files are not present
     assert not any("_includes" in url for url in urls)
 
-def test_sitemap_escaping(mock_docs_dir):
+def test_sitemap_escaping(mock_docs_dir: Path) -> None:
     """Test that special characters in base URL are escaped."""
     # This URL triggers invalid XML if not escaped
     risky_url = "https://example.com/foo&bar"

--- a/tests/test_tld_bypass.py
+++ b/tests/test_tld_bypass.py
@@ -15,27 +15,27 @@ def mock_dns_safe() -> Iterator[None]:
     with patch("src.utils.http._resolve_hostname_safe", return_value=SAFE_IP_INFO):
         yield
 
-def test_tld_local_blocked_standard(mock_dns_safe):
+def test_tld_local_blocked_standard(mock_dns_safe: None) -> None:
     """Verify that standard .local domain is blocked."""
     url = "http://foo.local"
     assert validate_http_url(url) is None
 
-def test_tld_local_blocked_with_trailing_dot(mock_dns_safe):
+def test_tld_local_blocked_with_trailing_dot(mock_dns_safe: None) -> None:
     """Verify that .local. domain is blocked (prevent bypass)."""
     url = "http://foo.local."
     assert validate_http_url(url) is None
 
-def test_tld_internal_blocked(mock_dns_safe):
+def test_tld_internal_blocked(mock_dns_safe: None) -> None:
     """Verify that .internal. domain is blocked."""
     url = "http://foo.internal."
     assert validate_http_url(url) is None
 
-def test_tld_localhost_blocked(mock_dns_safe):
+def test_tld_localhost_blocked(mock_dns_safe: None) -> None:
     """Verify that localhost. is blocked."""
     url = "http://localhost."
     assert validate_http_url(url) is None
 
-def test_tld_valid_allowed(mock_dns_safe):
+def test_tld_valid_allowed(mock_dns_safe: None) -> None:
     """Verify that valid domain with trailing dot is allowed."""
     url = "http://google.com."
     # Should return the stripped URL or the original?
@@ -45,12 +45,12 @@ def test_tld_valid_allowed(mock_dns_safe):
     result = validate_http_url(url)
     assert result == "http://google.com."
 
-def test_tld_valid_standard(mock_dns_safe):
+def test_tld_valid_standard(mock_dns_safe: None) -> None:
     """Verify that valid domain is allowed."""
     url = "http://google.com"
     assert validate_http_url(url) == "http://google.com"
 
-def test_tld_empty_check(mock_dns_safe):
+def test_tld_empty_check(mock_dns_safe: None) -> None:
     """Verify behavior with root domain (dot)."""
     # http://. is invalid hostname usually
     assert validate_http_url("http://.") is None


### PR DESCRIPTION
## What

Annotates all 27 fixture-dependent `test_func` issues across 7 files —
the A2 sub-cluster of the test_func bucket. Closes the test_func bucket
(A1 + A2 = 39 issues = 12 + 27, 0 remaining).

## How

Each consumer-param type derives mechanically from the fixture registry
built after C30:

| Fixture (post-C30 return) | Consumer-param type |
|---|---|
| `pages_base_url -> Iterator[Callable[[str], None]]` | `Callable[[str], None]` |
| `mock_session -> MagicMock` | `MagicMock` |
| `mock_response -> requests.Response` | `requests.Response` |
| `fallback_env -> Iterator[Any]` | `Any` |
| `pendler_station / vienna_station -> Any` | `Any` |
| `mock_feed_config -> Iterator[None]` | `None` |
| `mock_docs_dir -> Iterator[Path]` | `Path` |
| `mock_dns_safe -> Iterator[None]` | `None` |
| `caplog` (stdlib) | `pytest.LogCaptureFixture` |
| `tmp_path` (stdlib) | `Path` |
| `monkeypatch` (stdlib) | `pytest.MonkeyPatch` |

11 signatures wrap (>=100 chars, Black-style with trailing comma);
16 stay single-line.

## Verification

- AST post-scan: 0 A2 issues remain
- Mypy delta (`mypy src tests`): 551 -> 524, exactly **-27** errors,
  all `[no-untyped-def]`; **zero** new errors; every other error code
  unchanged
- No new imports, no new `# type: ignore`, no new
  `from __future__ import annotations`, no new `cast()` calls
- `git diff --stat` per-file matches the planned table exactly
  (+60/-27 across 7 files)
- All 17 sanity-grep counts match expected values
- `python3 -m py_compile` passes for all 7 files

## Backlog after merge

| Family | Remaining |
|---|---|
| `unittest_method` (bucket D) | 9 |
| `helper` (bucket E) | 17 |


---
_Generated by [Claude Code](https://claude.ai/code/session_01R6q2TL3FWJxh4K4x5QtQj3)_