### PR TITLE
refactor(types): annotate test-class methods (C32, D bucket)

### DIFF
--- a/tests/places/test_client_error_sanitization.py
+++ b/tests/places/test_client_error_sanitization.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 from src.places.client import GooglePlacesClient, GooglePlacesConfig
 
 class TestClientErrorSanitization(unittest.TestCase):
-    def test_format_error_message_sanitization(self):
+    def test_format_error_message_sanitization(self) -> None:
         config = GooglePlacesConfig(
             api_key="TEST_KEY",
             included_types=[],

--- a/tests/test_atomic_write_security.py
+++ b/tests/test_atomic_write_security.py
@@ -1,11 +1,11 @@
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import MagicMock, mock_open, patch
 from pathlib import Path
 import pytest
 from src.utils.files import atomic_write
 
 class TestAtomicWriteSecurity(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.tmp_path = Path("/tmp/test_dir")
         self.target = self.tmp_path / "target.txt"
         # We will mock uuid to return a fixed value
@@ -22,15 +22,15 @@ class TestAtomicWriteSecurity(unittest.TestCase):
     @patch("src.utils.files.os.unlink")
     def test_overwrite_false_uses_link(
         self,
-        mock_unlink,
-        mock_link,
-        mock_fsync,
-        mock_replace,
-        mock_chmod,
-        mock_file,
-        mock_token_hex,
-        mock_os_open,
-    ):
+        mock_unlink: MagicMock,
+        mock_link: MagicMock,
+        mock_fsync: MagicMock,
+        mock_replace: MagicMock,
+        mock_chmod: MagicMock,
+        mock_file: MagicMock,
+        mock_token_hex: MagicMock,
+        mock_os_open: MagicMock,
+    ) -> None:
         # Setup secrets mock
         mock_token_hex.return_value = self.fixed_uuid_hex
 
@@ -72,15 +72,15 @@ class TestAtomicWriteSecurity(unittest.TestCase):
     @patch("src.utils.files.os.unlink")
     def test_overwrite_true_uses_replace(
         self,
-        mock_unlink,
-        mock_link,
-        mock_fsync,
-        mock_replace,
-        mock_chmod,
-        mock_file,
-        mock_token_hex,
-        mock_os_open,
-    ):
+        mock_unlink: MagicMock,
+        mock_link: MagicMock,
+        mock_fsync: MagicMock,
+        mock_replace: MagicMock,
+        mock_chmod: MagicMock,
+        mock_file: MagicMock,
+        mock_token_hex: MagicMock,
+        mock_os_open: MagicMock,
+    ) -> None:
         mock_token_hex.return_value = self.fixed_uuid_hex
         mock_file.return_value.fileno.return_value = 123
         mock_os_open.return_value = 123
@@ -107,15 +107,15 @@ class TestAtomicWriteSecurity(unittest.TestCase):
     @patch("src.utils.files.os.unlink")
     def test_overwrite_false_race_condition(
         self,
-        mock_unlink,
-        mock_link,
-        mock_fsync,
-        mock_replace,
-        mock_chmod,
-        mock_file,
-        mock_token_hex,
-        mock_os_open,
-    ):
+        mock_unlink: MagicMock,
+        mock_link: MagicMock,
+        mock_fsync: MagicMock,
+        mock_replace: MagicMock,
+        mock_chmod: MagicMock,
+        mock_file: MagicMock,
+        mock_token_hex: MagicMock,
+        mock_os_open: MagicMock,
+    ) -> None:
         mock_token_hex.return_value = self.fixed_uuid_hex
         mock_file.return_value.fileno.return_value = 123
         mock_os_open.return_value = 123

--- a/tests/test_redirect_param_stripping.py
+++ b/tests/test_redirect_param_stripping.py
@@ -7,7 +7,11 @@ from src.utils.http import request_safe
 class TestRedirectParamStripping(unittest.TestCase):
     @patch("src.utils.http._resolve_hostname_safe")
     @patch("src.utils.http.is_ip_safe")
-    def test_sensitive_param_stripping_on_redirect(self, mock_is_ip_safe, mock_resolve):
+    def test_sensitive_param_stripping_on_redirect(
+        self,
+        mock_is_ip_safe: MagicMock,
+        mock_resolve: MagicMock,
+    ) -> None:
         # Mock DNS resolution to be safe
         mock_resolve.return_value = [(2, 1, 6, '', ('93.184.216.34', 443))]
         mock_is_ip_safe.return_value = True

--- a/tests/test_vor_fixes.py
+++ b/tests/test_vor_fixes.py
@@ -69,7 +69,11 @@ class TestApplyAuthentication:
     @patch("src.providers.vor.VOR_ACCESS_ID", "global_id")
     @patch("src.providers.vor.VOR_BASE_URL", "https://global.com/")
     @patch("src.providers.vor.refresh_access_credentials")
-    def test_apply_authentication(self, mock_refresh, mock_vor_auth_cls):
+    def test_apply_authentication(
+        self,
+        mock_refresh: MagicMock,
+        mock_vor_auth_cls: MagicMock,
+    ) -> None:
         """
         Test that apply_authentication:
         1. Does NOT set Authorization in session.headers.
@@ -101,7 +105,13 @@ class TestFetchDepartureBoard:
     @patch("src.providers.vor.save_request_count")
     @patch("src.providers.vor.load_request_count")
     @patch("src.providers.vor._QUOTA_LOCK")
-    def test_fetch_departure_board_calls(self, mock_lock, mock_load, mock_save, mock_fetch):
+    def test_fetch_departure_board_calls(
+        self,
+        mock_lock: MagicMock,
+        mock_load: MagicMock,
+        mock_save: MagicMock,
+        mock_fetch: MagicMock,
+    ) -> None:
         """
         Test _fetch_departure_board_for_station:
         1. Calls save_request_count exactly once.

--- a/tests/test_vor_redirect_leak.py
+++ b/tests/test_vor_redirect_leak.py
@@ -4,7 +4,7 @@ import requests
 from src.providers import vor
 
 class TestVorRedirectLeak(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         # Reset VOR_ACCESS_ID for testing
         vor.VOR_ACCESS_ID = "SECRET_TOKEN"
         vor._VOR_AUTHORIZATION_HEADER = ""


### PR DESCRIPTION
## What

Annotates all 9 `[no-untyped-def]` issues on test class methods —
the D bucket of the strict-typing migration.

## Fence

After Phase 1 surfaced 2 leaked methods on pytest-style test classes
(`class TestApplyAuthentication:` / `class TestFetchDepartureBoard:`
in `tests/test_vor_fixes.py`), the fence was widened to cover **all**
test-collection classes (TestCase subclass OR plain `class TestX:`).
Both groups share an identical typing pattern (`(self, [mocks: MagicMock, …]) -> None`), so they belong in the same cluster.

## Convention

- `setUp` / `tearDown` / `test_*` with only `self` → `(self) -> None`
- `@patch`-decorated test methods → mock params typed as `MagicMock`
  (consistent with the C28 patch-decorated convention)

## Wraps

6 of 9 signatures wrap with Black-style trailing-comma layout once
typed (≥100 chars with the 4-space class indent); 3 stay single-line.

## Verification

- AST post-scan: 0 D-bucket issues remain
- Mypy delta: −9 errors, all `[no-untyped-def]`; **zero** new errors
- Net new imports: 0 (the `MagicMock` addition is a line
  modification, not a new line; alphabetical sort within
  `from unittest.mock import …`)
- No new `# type: ignore`, no new `from __future__ import annotations`, no new `cast()` calls
- `git diff --stat` per-file matches the planned table exactly
- All sanity-grep counts match expected values

## Backlog after merge

| Family | Remaining |
|---|---|
| `helper` (bucket E) | 17 |


---
_Generated by [Claude Code](https://claude.ai/code/session_01LjNpne76Yc8rmnqdJPTcx3)_