### PR TITLE
🛡️ Sentinel: detect Anthropic & OpenAI API key leaks in secret scanner

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -132,3 +132,8 @@
 **Vulnerability:** Using `secrets.SystemRandom` instead of `random.Random` when a predictable, seeded state is required.
 **Learning:** Applying cryptographic security libraries where a predictable, seeded state is required constitutes "Security Theater" and actively breaks the intended application logic. It highlights the conceptual difference between true cryptographic randomness and functional determinism.
 **Prevention:** Distinguish between true cryptographic needs and deterministic randomness, using inline comments (`# noqa: S311 # nosec B311`) to suppress security linter warnings where pseudo-randomness is intentionally required.
+
+## 2026-05-05 - AI Provider Tokens Missed by Scanner
+**Vulnerability:** `_KNOWN_TOKENS` in `secret_scanner.py` lacked patterns for Anthropic (`sk-ant-…`) and OpenAI (`sk-proj-…`, `sk-svcacct-…`, legacy `sk-<48 alnum>`) keys, even though this project itself runs on Claude. A leaked key would have been caught only by the generic high-entropy fallback (which is silenced by `is_covered` if any specific token already matches the same span) and would not be reported with a precise reason.
+**Learning:** Secret scanners must include patterns for the AI/cloud services the project itself depends on — those credentials are exactly the ones most likely to end up in this codebase. The legacy OpenAI `sk-<48>` pattern is benign next to `sk-ant-` / `sk-proj-` because the latter contain a hyphen after `sk-`, which is excluded from `[A-Za-z0-9]{48}`.
+**Prevention:** When introducing a new external API integration, also extend `_KNOWN_TOKENS` with the issuer's documented key prefix and length. Order strict patterns before looser ones so `is_covered` correctly attributes findings.

--- a/src/utils/secret_scanner.py
+++ b/src/utils/secret_scanner.py
@@ -79,6 +79,17 @@ _KNOWN_TOKENS = [
     (re.compile(r"(?<![A-Za-z0-9])xoxp-[0-9]{10,}-[0-9]{10,}-[0-9]{10,}-[a-zA-Z0-9]{32}(?![A-Za-z0-9])"), "Slack User Token gefunden"),
     (re.compile(r"(?<![A-Za-z0-9])npm_[0-9a-zA-Z]{36}(?![A-Za-z0-9])"), "NPM Access Token gefunden"),
     (re.compile(r"(?<![A-Za-z0-9])pypi-[0-9a-zA-Z_\-]{20,}(?![A-Za-z0-9])"), "PyPI API Token gefunden"),
+    # Anthropic API keys: sk-ant-api{NN}-... and sk-ant-admin{NN}-...
+    # Standard format: sk-ant-api03-<93 chars>AA. Pattern stays loose to also catch
+    # forthcoming version suffixes (api04, admin02, …) without missing real leaks.
+    (re.compile(r"(?<![A-Za-z0-9])sk-ant-(?:api|admin)[0-9]{2}-[A-Za-z0-9_\-]{32,}(?![A-Za-z0-9])"), "Anthropic API Key gefunden"),
+    # OpenAI Project API keys: sk-proj-...
+    (re.compile(r"(?<![A-Za-z0-9])sk-proj-[A-Za-z0-9_\-]{40,}(?![A-Za-z0-9])"), "OpenAI Project API Key gefunden"),
+    # OpenAI Service Account keys: sk-svcacct-...
+    (re.compile(r"(?<![A-Za-z0-9])sk-svcacct-[A-Za-z0-9_\-]{40,}(?![A-Za-z0-9])"), "OpenAI Service Account Key gefunden"),
+    # OpenAI legacy/user API keys: sk- followed by exactly 48 alphanumeric chars.
+    # The strict 48-char alphanumeric body avoids overlap with sk-ant-/sk-proj-/sk-svcacct- (all contain '-').
+    (re.compile(r"(?<![A-Za-z0-9])sk-[A-Za-z0-9]{48}(?![A-Za-z0-9])"), "OpenAI API Key gefunden"),
 ]
 
 

--- a/tests/test_secret_scanner_ai_keys.py
+++ b/tests/test_secret_scanner_ai_keys.py
@@ -1,0 +1,84 @@
+"""Tests for detection of modern AI provider API keys (Anthropic, OpenAI)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.utils.secret_scanner import scan_repository
+
+
+def test_secret_scanner_detects_anthropic_api_key(tmp_path: Path) -> None:
+    file_path = tmp_path / "config.py"
+    # Realistic Anthropic API key: sk-ant-api03-<93 chars>AA
+    secret = (
+        "sk-ant-api03-AaBbCcDdEeFfGgHhIiJjKkLlMmNn"
+        "OoPpQqRrSsTtUuVvWwXxYyZz0123456789-_aA-bB"
+        "0123456789abcdefAA"
+    )
+    file_path.write_text(f'ANTHROPIC_API_KEY = "{secret}"', encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+
+    assert findings, "Should detect Anthropic API Key"
+    # Ensure raw secret never appears in findings (redaction)
+    assert secret not in [f.match for f in findings]
+    reasons = [f.reason for f in findings]
+    assert "Anthropic API Key gefunden" in reasons
+
+
+def test_secret_scanner_detects_anthropic_admin_key(tmp_path: Path) -> None:
+    file_path = tmp_path / "admin.py"
+    secret = (
+        "sk-ant-admin01-Z9Y8X7W6V5U4T3S2R1Q0POMLK"
+        "JIHGFEDCBA0123456789-_abcdefghijklmnopqrs"
+        "tuvwxyz0123456789AA"
+    )
+    file_path.write_text(f'ADMIN_KEY = "{secret}"', encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+
+    assert findings, "Should detect Anthropic Admin key"
+    assert secret not in [f.match for f in findings]
+    reasons = [f.reason for f in findings]
+    assert "Anthropic API Key gefunden" in reasons
+
+
+def test_secret_scanner_detects_openai_project_key(tmp_path: Path) -> None:
+    file_path = tmp_path / "config.py"
+    # OpenAI project keys start with sk-proj- and are long alphanumeric/underscore/hyphen strings.
+    secret = "sk-proj-" + "A" * 40 + "BcDeFgHiJk"
+    file_path.write_text(f'OPENAI_API_KEY = "{secret}"', encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+
+    assert findings, "Should detect OpenAI Project API key"
+    assert secret not in [f.match for f in findings]
+    reasons = [f.reason for f in findings]
+    assert "OpenAI Project API Key gefunden" in reasons
+
+
+def test_secret_scanner_detects_openai_service_account_key(tmp_path: Path) -> None:
+    file_path = tmp_path / "svc.py"
+    secret = "sk-svcacct-" + "1B" * 25 + "abcDEF"
+    file_path.write_text(f'svc_token = "{secret}"', encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+
+    assert findings, "Should detect OpenAI Service Account key"
+    assert secret not in [f.match for f in findings]
+    reasons = [f.reason for f in findings]
+    assert "OpenAI Service Account Key gefunden" in reasons
+
+
+def test_secret_scanner_detects_openai_legacy_key(tmp_path: Path) -> None:
+    file_path = tmp_path / "legacy.py"
+    # Legacy OpenAI key is sk- followed by exactly 48 alphanumeric chars (51 total).
+    secret = "sk-" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8S9t0U1v2W3x4"
+    assert len(secret) == 51
+    file_path.write_text(f'openai_api_key = "{secret}"', encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+
+    assert findings, "Should detect legacy OpenAI key"
+    assert secret not in [f.match for f in findings]
+    reasons = [f.reason for f in findings]
+    assert "OpenAI API Key gefunden" in reasons


### PR DESCRIPTION
## 🛡️ Sentinel Security Enhancement

🚨 **Severity:** MEDIUM (defense-in-depth gap)

### 💡 Vulnerability
`src/utils/secret_scanner.py::_KNOWN_TOKENS` lacked patterns for two of the most commonly leaked API key families today:

- **Anthropic** keys (`sk-ant-api{NN}-…`, `sk-ant-admin{NN}-…`)
- **OpenAI** keys (`sk-proj-…`, `sk-svcacct-…`, legacy `sk-<48 alnum>`)

A leaked AI provider key would only be caught by the generic high-entropy fallback — which is silenced by the `is_covered` overlap-suppression if any other specific token already matched the same span — and would not be reported with a precise reason.

### 🎯 Impact
This repository orchestrates Claude (Anthropic) agents in CI, so Anthropic credentials are exactly the kind of secret most likely to surface accidentally in commits, logs, or local config dumps. Without specific patterns:

- Findings would be vague (`"Hochentropischer Token-String"`) instead of actionable.
- Edge-cases (e.g. keys with embedded hyphens that fall below the entropy threshold) could be missed entirely.

### 🔧 Fix
Added four bounded regexes to `_KNOWN_TOKENS`, each with an explicit reason string:

| Pattern | Detects |
|---|---|
| `sk-ant-(?:api\|admin)[0-9]{2}-[A-Za-z0-9_\-]{32,}` | Anthropic API/Admin keys (api01, api02, api03, …) |
| `sk-proj-[A-Za-z0-9_\-]{40,}` | OpenAI Project API keys |
| `sk-svcacct-[A-Za-z0-9_\-]{40,}` | OpenAI Service Account keys |
| `sk-[A-Za-z0-9]{48}` | OpenAI legacy/user API keys |

The strict 48-char alphanumeric body of the legacy OpenAI pattern intentionally avoids collision with `sk-ant-` / `sk-proj-` / `sk-svcacct-` (which all contain a hyphen after `sk-`, excluded from `[A-Za-z0-9]`).

### ✅ Verification
- `tests/test_secret_scanner_ai_keys.py` — 5 new unit tests, one per pattern, each asserting both detection and redaction (raw secret never appears in `Finding.match`).
- All 46 secret-scanner tests pass: `pytest tests/test_secret_scanner*.py` ✓
- Full suite green: 991 passed, 1 skipped ✓
- `ruff check` clean, `mypy` clean ✓
- Manual test on synthetic leaked keys produced correctly redacted findings:
  ```
  Anthropic API Key gefunden -> sk-a***efAA
  OpenAI Project API Key gefunden -> sk-p***AAAA
  ```
- `python -m cli security scan` against the repo: no false positives.

### 📝 Journal
Added a `.jules/sentinel.md` entry capturing **why** these patterns were missing (scanner inventory drifted from the project's actual external dependencies) and the ordering constraint vs. the legacy OpenAI pattern.

### 🔍 Files Changed
- `src/utils/secret_scanner.py` (+11)
- `tests/test_secret_scanner_ai_keys.py` (+84, new)
- `.jules/sentinel.md` (+5)

🤖 Generated by Sentinel.

https://claude.ai/code/session_01RT1hFFdnU1oczw3dXp4Ym3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RT1hFFdnU1oczw3dXp4Ym3)_