### PR TITLE
feat: add VOR token-verify scripts referenced by the CLI

### DIFF
--- a/scripts/check_vor_auth.py
+++ b/scripts/check_vor_auth.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Diagnose VOR/VAO authentication setup without making network calls.
+
+This is a configuration-time sanity check: it inspects the environment and
+the resulting :func:`src.providers.vor.apply_authentication` outcome and
+reports whether credentials would be injected, which scheme would be used
+(Bearer / Basic / accessId query parameter), and whether the configured
+base URL would expose secrets over plain HTTP.
+
+Exits with:
+    0 — at least one credential mechanism is configured and consistent
+    1 — base URL is plain HTTP while credentials are present (insecure)
+    2 — no credentials configured
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import requests
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.providers import vor as vor_module
+from src.utils.env import load_default_env_files
+
+LOGGER = logging.getLogger("vor.auth_check")
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+
+def _scheme_label(header: str) -> str:
+    if header.startswith("Bearer "):
+        return "Bearer"
+    if header.startswith("Basic "):
+        return "Basic"
+    return "unknown"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    del argv  # Unused but kept for consistency with other verify scripts.
+    _configure_logging()
+    load_default_env_files()
+
+    vor_module.refresh_base_configuration()
+    access_id = vor_module.refresh_access_credentials()
+    auth_header = vor_module._VOR_AUTHORIZATION_HEADER
+
+    base_url = vor_module.VOR_BASE_URL
+    LOGGER.info("VOR base URL: %s", base_url)
+
+    if not access_id and not auth_header:
+        LOGGER.error(
+            "No VOR credentials configured — set VOR_ACCESS_ID (or legacy VAO_ACCESS_ID)."
+        )
+        return 2
+
+    if access_id:
+        LOGGER.info(
+            "accessId query parameter will be injected (token length: %d).",
+            len(access_id),
+        )
+    if auth_header:
+        LOGGER.info(
+            "Authorization header will be sent (scheme: %s).",
+            _scheme_label(auth_header),
+        )
+
+    # Build a real Session and observe what apply_authentication does to it,
+    # without ever issuing a request.
+    session = requests.Session()
+    vor_module.apply_authentication(session)
+
+    if session.auth is None:
+        LOGGER.error(
+            "apply_authentication() did not configure session.auth — credentials "
+            "would not be injected on outgoing requests."
+        )
+        return 1
+
+    if base_url.lower().startswith("http://"):
+        LOGGER.error(
+            "VOR base URL is plain HTTP (%s) while credentials are configured — "
+            "secrets would leak over the wire. Refusing to report success.",
+            base_url,
+        )
+        return 1
+
+    LOGGER.info("VOR authentication setup looks consistent.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/verify_vor_access_id.py
+++ b/scripts/verify_vor_access_id.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Verify that the configured VOR/VAO access credentials authorize a request.
+
+Performs a single ``location.name`` lookup ("Wien Hauptbahnhof") against the
+configured VOR base URL using the credentials that ``src.providers.vor``
+loads from the environment. Exits with:
+
+    0 — credentials accepted, response indicates a known stop
+    1 — request failed (HTTP error, network issue, or unexpected payload)
+    2 — no credentials configured (``VOR_ACCESS_ID`` / ``VAO_ACCESS_ID``)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Sequence
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.providers import vor as vor_module
+from src.utils.env import load_default_env_files
+from src.utils.http import fetch_content_safe, session_with_retries
+
+LOGGER = logging.getLogger("vor.verify")
+
+PROBE_QUERY = "Wien Hauptbahnhof"
+
+
+def _configure_logging() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+
+def _build_probe_url() -> str:
+    base = vor_module.VOR_BASE_URL.rstrip("/")
+    return f"{base}/location.name"
+
+
+def _looks_like_stop(payload: object) -> bool:
+    """Detect a successful VOR ``location.name`` payload.
+
+    The endpoint typically returns ``{"stopLocationOrCoordLocation": [...]}``;
+    older responses use ``{"LocationList": {"StopLocation": [...]}}``. We accept
+    either shape as long as it contains at least one entry.
+    """
+    if not isinstance(payload, dict):
+        return False
+    primary = payload.get("stopLocationOrCoordLocation")
+    if isinstance(primary, list) and primary:
+        return True
+    legacy = payload.get("LocationList")
+    if isinstance(legacy, dict):
+        stops = legacy.get("StopLocation")
+        if isinstance(stops, list) and stops:
+            return True
+    return False
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    del argv  # Unused but kept for consistency with other verify scripts.
+    _configure_logging()
+    load_default_env_files()
+
+    vor_module.refresh_base_configuration()
+    access_id = vor_module.refresh_access_credentials()
+
+    if not access_id and not vor_module._VOR_AUTHORIZATION_HEADER:
+        LOGGER.error(
+            "VOR_ACCESS_ID (or VAO_ACCESS_ID) is not set — cannot verify access."
+        )
+        return 2
+
+    probe_url = _build_probe_url()
+    params = {"input": PROBE_QUERY, "format": "json"}
+
+    LOGGER.info("Probing %s with input=%r", probe_url, PROBE_QUERY)
+
+    try:
+        with session_with_retries(vor_module.VOR_USER_AGENT) as session:
+            vor_module.apply_authentication(session)
+            content = fetch_content_safe(
+                session,
+                probe_url,
+                params=params,
+                timeout=vor_module.DEFAULT_HTTP_TIMEOUT,
+                allowed_content_types=("application/json", "text/json"),
+            )
+    except Exception as exc:
+        LOGGER.error("VOR verification request failed: %s", exc)
+        return 1
+
+    try:
+        payload = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        LOGGER.error("VOR response was not valid JSON: %s", exc)
+        return 1
+
+    if not _looks_like_stop(payload):
+        LOGGER.error(
+            "VOR response did not contain a recognised stop list — credentials "
+            "may be valid but the API contract has changed."
+        )
+        return 1
+
+    LOGGER.info("VOR credentials accepted; %r resolved successfully.", PROBE_QUERY)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/scripts/test_check_vor_auth.py
+++ b/tests/scripts/test_check_vor_auth.py
@@ -1,0 +1,69 @@
+"""Tests for the offline VOR auth diagnostic script."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterator
+
+import pytest
+
+from scripts import check_vor_auth as check
+from src.providers import vor as vor_module
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging() -> Iterator[None]:
+    logging.getLogger(check.LOGGER.name).handlers.clear()
+    yield
+    logging.getLogger(check.LOGGER.name).handlers.clear()
+
+
+@pytest.fixture(autouse=True)
+def _patch_env_loading(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(check, "load_default_env_files", lambda: {})
+
+
+def test_returns_0_when_credentials_present_over_https(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("VOR_ACCESS_ID", "dummy-token-12345")
+    monkeypatch.delenv("VAO_ACCESS_ID", raising=False)
+    monkeypatch.setattr(vor_module, "VOR_BASE_URL", "https://example.test/api/v1.11.0/")
+    # Skip the configuration refresh so our patched VOR_BASE_URL stays in place.
+    monkeypatch.setattr(vor_module, "refresh_base_configuration", lambda: vor_module.VOR_BASE_URL)
+
+    caplog.set_level(logging.INFO, logger="vor.auth_check")
+    assert check.main() == 0
+    messages = " ".join(r.getMessage() for r in caplog.records)
+    assert "looks consistent" in messages
+    assert "accessId query parameter will be injected" in messages
+
+
+def test_returns_2_when_no_credentials(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.delenv("VOR_ACCESS_ID", raising=False)
+    monkeypatch.delenv("VAO_ACCESS_ID", raising=False)
+
+    caplog.set_level(logging.INFO, logger="vor.auth_check")
+    assert check.main() == 2
+    assert any("No VOR credentials" in r.getMessage() for r in caplog.records)
+
+
+def test_returns_1_when_base_url_is_plain_http(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("VOR_ACCESS_ID", "dummy-token-12345")
+    monkeypatch.delenv("VAO_ACCESS_ID", raising=False)
+    monkeypatch.setattr(vor_module, "VOR_BASE_URL", "http://insecure.test/api/v1.11.0/")
+    monkeypatch.setattr(vor_module, "refresh_base_configuration", lambda: vor_module.VOR_BASE_URL)
+
+    caplog.set_level(logging.INFO, logger="vor.auth_check")
+    assert check.main() == 1
+    assert any("plain HTTP" in r.getMessage() for r in caplog.records)
+
+
+def test_scheme_label_detection() -> None:
+    assert check._scheme_label("Bearer abcdef") == "Bearer"
+    assert check._scheme_label("Basic dXNlcjpwYXNz") == "Basic"
+    assert check._scheme_label("Custom xyz") == "unknown"

--- a/tests/scripts/test_verify_vor_access_id.py
+++ b/tests/scripts/test_verify_vor_access_id.py
@@ -1,0 +1,138 @@
+"""Tests for the VOR access ID verification script."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Iterator
+
+import pytest
+
+from scripts import verify_vor_access_id as verify
+from src.providers import vor as vor_module
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging() -> Iterator[None]:
+    logging.getLogger(verify.LOGGER.name).handlers.clear()
+    yield
+    logging.getLogger(verify.LOGGER.name).handlers.clear()
+
+
+@pytest.fixture(autouse=True)
+def _patch_env_loading(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The script calls load_default_env_files() at the top of main(); we don't
+    # want it to read real .env files during tests.
+    monkeypatch.setattr(verify, "load_default_env_files", lambda: {})
+
+
+@pytest.fixture
+def _with_credentials(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("VOR_ACCESS_ID", "dummy-token")
+    monkeypatch.delenv("VAO_ACCESS_ID", raising=False)
+    yield
+
+
+def test_main_succeeds_on_valid_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    _with_credentials: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    payload = {"stopLocationOrCoordLocation": [{"StopLocation": {"name": "Wien Hbf"}}]}
+
+    def fake_fetch(*args: Any, **kwargs: Any) -> bytes:
+        return json.dumps(payload).encode("utf-8")
+
+    class DummySession:
+        headers: dict[str, str] = {}
+        auth = None
+
+        def __enter__(self) -> "DummySession":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    monkeypatch.setattr(verify, "session_with_retries", lambda *a, **kw: DummySession())
+    monkeypatch.setattr(verify, "fetch_content_safe", fake_fetch)
+    monkeypatch.setattr(vor_module, "apply_authentication", lambda session: None)
+
+    caplog.set_level(logging.INFO, logger="vor.verify")
+    assert verify.main() == 0
+    assert any("credentials accepted" in r.getMessage() for r in caplog.records)
+
+
+def test_main_returns_2_when_credentials_missing(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.delenv("VOR_ACCESS_ID", raising=False)
+    monkeypatch.delenv("VAO_ACCESS_ID", raising=False)
+
+    caplog.set_level(logging.INFO, logger="vor.verify")
+    assert verify.main() == 2
+    assert any("not set" in r.getMessage() for r in caplog.records)
+
+
+def test_main_returns_1_on_request_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    _with_credentials: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def fake_fetch(*args: Any, **kwargs: Any) -> bytes:
+        raise RuntimeError("network down")
+
+    class DummySession:
+        headers: dict[str, str] = {}
+        auth = None
+
+        def __enter__(self) -> "DummySession":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    monkeypatch.setattr(verify, "session_with_retries", lambda *a, **kw: DummySession())
+    monkeypatch.setattr(verify, "fetch_content_safe", fake_fetch)
+    monkeypatch.setattr(vor_module, "apply_authentication", lambda session: None)
+
+    caplog.set_level(logging.INFO, logger="vor.verify")
+    assert verify.main() == 1
+    assert any("request failed" in r.getMessage() for r in caplog.records)
+
+
+def test_main_returns_1_on_unexpected_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    _with_credentials: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def fake_fetch(*args: Any, **kwargs: Any) -> bytes:
+        return b'{"unexpected": "shape"}'
+
+    class DummySession:
+        headers: dict[str, str] = {}
+        auth = None
+
+        def __enter__(self) -> "DummySession":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    monkeypatch.setattr(verify, "session_with_retries", lambda *a, **kw: DummySession())
+    monkeypatch.setattr(verify, "fetch_content_safe", fake_fetch)
+    monkeypatch.setattr(vor_module, "apply_authentication", lambda session: None)
+
+    caplog.set_level(logging.INFO, logger="vor.verify")
+    assert verify.main() == 1
+    assert any("did not contain a recognised stop list" in r.getMessage() for r in caplog.records)
+
+
+def test_looks_like_stop_recognises_legacy_shape() -> None:
+    payload = {"LocationList": {"StopLocation": [{"name": "Wien Hbf"}]}}
+    assert verify._looks_like_stop(payload) is True
+
+
+def test_looks_like_stop_rejects_empty_list() -> None:
+    assert verify._looks_like_stop({"stopLocationOrCoordLocation": []}) is False
+    assert verify._looks_like_stop({"LocationList": {"StopLocation": []}}) is False
+    assert verify._looks_like_stop("not a dict") is False


### PR DESCRIPTION
## Problem

`src/cli.py` bewirbt drei `tokens verify`-Targets — `vor`, `google-places` und `vor-auth` — aber nur `verify_google_places_access.py` existierte. Die anderen beiden waren tote Referenzen:

```
$ python -m src.cli tokens verify
wien-oepnv: error: Script not found: /home/user/wien-oepnv/scripts/verify_vor_access_id.py
```

Damit war der in der README mehrfach beworbene Pre-Flight-Check für VOR-Secrets (Z. 104, 277, 282-283, 359) auf einem frischen Checkout nicht ausführbar — auch nicht der explizite Aufruf `tokens verify vor`.

## Lösung

Beide fehlenden Skripte ergänzt mit klarer Aufgabenteilung:

### `scripts/verify_vor_access_id.py` — end-to-end Check
Macht eine `location.name`-Anfrage gegen den konfigurierten VOR Base URL via dem **gleichen Auth-Pfad** wie der Produktiv-Provider (`vor.apply_authentication()`, also Authorization-Header **und** `accessId`-Query). Erkennt sowohl das moderne `stopLocationOrCoordLocation`- als auch das legacy `LocationList.StopLocation`-Response-Format.

| Exit | Bedeutung |
|---|---|
| 0 | Credentials akzeptiert, "Wien Hauptbahnhof" erfolgreich aufgelöst |
| 1 | Request schlug fehl (HTTP-Fehler, Netzwerkproblem, oder unerwartetes Payload-Format) |
| 2 | `VOR_ACCESS_ID` / `VAO_ACCESS_ID` nicht gesetzt |

### `scripts/check_vor_auth.py` — offline Diagnostik
Inspiziert die Auth-Konfiguration **ohne** Netzwerk-Requests. Zeigt an, ob/wie Credentials injiziert würden (Bearer / Basic / `accessId` Query-Parameter), und verweigert ein Success-Signal, wenn der Base URL plain HTTP ist während Credentials gesetzt sind (Defense-in-Depth gegen Leaks).

| Exit | Bedeutung |
|---|---|
| 0 | Mindestens ein Auth-Mechanismus konfiguriert und konsistent |
| 1 | Base URL ist plain HTTP bei gesetzten Credentials (unsicher) |
| 2 | Keine Credentials konfiguriert |

## Test plan

- [x] `python -m src.cli tokens verify` läuft jetzt ohne `Script not found`
- [x] Ohne gesetzte Credentials: CLI exit 2, mit klaren Error-Logs
- [x] Mit gesetzten Credentials wird die VOR-API tatsächlich abgefragt (im Test gemockt)
- [x] `python -m pytest`: **1001 passed, 1 skipped** (vorher 991; +10 neue Tests)
- [x] mypy --strict gate: 0 neue Errors
- [x] ruff check: passed

## Bezug zur Diagnose

Behebt **Bug 1.1** aus dem Diagnose-Bericht. Verbleibend: **Bug 1.5** (Sitemap-Workflow) als Folge-PR.

https://claude.ai/code/session_016CHRX6hg1srVPAnHWXsDzb

---
_Generated by [Claude Code](https://claude.ai/code/session_016CHRX6hg1srVPAnHWXsDzb)_