### PR TITLE
fix: drop empty VOR messages and lowercase PAGES_BASE_URL hostname

### DIFF
--- a/src/feed/config.py
+++ b/src/feed/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from urllib.parse import urlparse, urlunparse
 import logging
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -186,6 +187,17 @@ def _load_from_env() -> None:
         validated_pages_base = validate_http_url(DEFAULT_PAGES_BASE_URL) or DEFAULT_PAGES_BASE_URL
         if raw_pages_base.strip() and raw_pages_base.strip() != DEFAULT_PAGES_BASE_URL:
             log.warning("Invalid PAGES_BASE_URL provided; falling back to default.")
+    # Normalise the hostname to lowercase so feeds built on forks with
+    # mixed-case repository owners (e.g. ``Origamihase``) emit canonical
+    # URLs that GitHub Pages serves without redirect. The path component
+    # is preserved verbatim because GitHub Pages treats paths as
+    # case-sensitive.
+    parsed_pages_base = urlparse(validated_pages_base)
+    if parsed_pages_base.hostname:
+        new_netloc = parsed_pages_base.hostname.lower()
+        if parsed_pages_base.port is not None:
+            new_netloc = f"{new_netloc}:{parsed_pages_base.port}"
+        validated_pages_base = urlunparse(parsed_pages_base._replace(netloc=new_netloc))
     PAGES_BASE_URL = validated_pages_base.rstrip("/")
     FEED_DESC = os.getenv("FEED_DESC", DEFAULT_FEED_DESCRIPTION)
     FEED_TTL = max(get_int_env("FEED_TTL", DEFAULT_FEED_TTL_MINUTES), 0)

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -862,6 +862,19 @@ def _collect_from_board(station_id: str, root: Mapping[str, Any]) -> List[FeedIt
         head = str(message.get("head") or message.get("name") or "").strip()
         text = str(message.get("text") or message.get("description") or "").strip()
 
+        # Skip messages without any human-readable substance. Without head
+        # AND text, the only data we could expose are line/station tags,
+        # which on their own would surface as a generic "Hinweis" item with
+        # an empty description. That is never useful in the feed and would
+        # only add noise.
+        if not head and not text:
+            log.debug(
+                "VOR-Meldung ohne head/text übersprungen (station=%s id=%s)",
+                station_id,
+                message.get("id"),
+            )
+            continue
+
         # FILTER: Bei Pendlerbahnhöfen muss die konkrete Meldung Wien betreffen
         if not is_vienna_station:
             full_text = f"{head} {text}"

--- a/tests/test_build_feed_atom.py
+++ b/tests/test_build_feed_atom.py
@@ -105,6 +105,8 @@ def test_make_rss_lowercases_pages_base_hostname(
     """Forks owned by users with mixed-case logins (e.g. ``Origamihase``)
     must still emit canonical lowercase hostnames so GitHub Pages serves
     them without redirect (regression test for diagnostic §3.3)."""
+    from urllib.parse import urlparse
+
     pages_base_url("https://Origamihase.github.io/wien-oepnv")
     rss_str = _make_rss([], _NOW, {})
 
@@ -116,9 +118,11 @@ def test_make_rss_lowercases_pages_base_hostname(
 
     for link in atom_links:
         href = link.get("href") or ""
-        # The hostname must have been lowercased; the path is preserved.
-        assert "origamihase.github.io" in href
-        assert "Origamihase" not in href
+        # Parse the URL so we check the actual hostname, not just any
+        # substring (urlparse.hostname is the authoritative host segment
+        # and is normalised to lowercase by the stdlib).
+        parsed = urlparse(href)
+        assert parsed.hostname == "origamihase.github.io"
 
 
 def test_make_rss_preserves_pages_base_path_case(
@@ -126,6 +130,8 @@ def test_make_rss_preserves_pages_base_path_case(
 ) -> None:
     """Only the hostname is lowercased; the path stays case-sensitive
     so a fork at ``github.io/My-Repo`` keeps its original path."""
+    from urllib.parse import urlparse
+
     pages_base_url("https://Example.github.io/My-Repo")
     rss_str = _make_rss([], _NOW, {})
 
@@ -133,4 +139,7 @@ def test_make_rss_preserves_pages_base_path_case(
     channel = root.find("channel")
     assert channel is not None
     atom_links = channel.findall(f"{{{_ATOM_NS}}}link")
-    assert any("/My-Repo" in (link.get("href") or "") for link in atom_links)
+    assert any(
+        urlparse(link.get("href") or "").path.startswith("/My-Repo")
+        for link in atom_links
+    )

--- a/tests/test_build_feed_atom.py
+++ b/tests/test_build_feed_atom.py
@@ -97,3 +97,40 @@ def test_make_rss_strips_trailing_slash_from_pages_base_url(
         href = link.get("href") or ""
         assert "//feed.xml" not in href
         assert not href.endswith("//"), f"unexpected double slash in {href!r}"
+
+
+def test_make_rss_lowercases_pages_base_hostname(
+    pages_base_url: Callable[[str], None],
+) -> None:
+    """Forks owned by users with mixed-case logins (e.g. ``Origamihase``)
+    must still emit canonical lowercase hostnames so GitHub Pages serves
+    them without redirect (regression test for diagnostic §3.3)."""
+    pages_base_url("https://Origamihase.github.io/wien-oepnv")
+    rss_str = _make_rss([], _NOW, {})
+
+    root = ET.fromstring(rss_str)
+    channel = root.find("channel")
+    assert channel is not None
+    atom_links = channel.findall(f"{{{_ATOM_NS}}}link")
+    assert atom_links, "expected at least one atom:link"
+
+    for link in atom_links:
+        href = link.get("href") or ""
+        # The hostname must have been lowercased; the path is preserved.
+        assert "origamihase.github.io" in href
+        assert "Origamihase" not in href
+
+
+def test_make_rss_preserves_pages_base_path_case(
+    pages_base_url: Callable[[str], None],
+) -> None:
+    """Only the hostname is lowercased; the path stays case-sensitive
+    so a fork at ``github.io/My-Repo`` keeps its original path."""
+    pages_base_url("https://Example.github.io/My-Repo")
+    rss_str = _make_rss([], _NOW, {})
+
+    root = ET.fromstring(rss_str)
+    channel = root.find("channel")
+    assert channel is not None
+    atom_links = channel.findall(f"{{{_ATOM_NS}}}link")
+    assert any("/My-Repo" in (link.get("href") or "") for link in atom_links)

--- a/tests/test_vor_title.py
+++ b/tests/test_vor_title.py
@@ -65,3 +65,32 @@ def test_collect_from_board_skips_context_if_present(monkeypatch: pytest.MonkeyP
     # Expect no double addition
     assert title == "Wien Mitte: Aufzug defekt"
     assert title.count("Wien Mitte") == 1
+
+
+def test_collect_from_board_skips_message_without_head_or_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A message with neither ``head`` nor ``text`` would surface as a
+    silent "Hinweis" item with an empty description. Such messages must
+    be dropped, not emitted (regression test for diagnostic §4.4)."""
+    monkeypatch.setattr(
+        "src.providers.vor.station_info",
+        lambda x: StationInfo(name="Wien Mitte", in_vienna=True),
+    )
+
+    root = {
+        "DepartureBoard": {
+            "Message": [
+                # Empty: should be skipped
+                {"id": "empty-1"},
+                # head/text both whitespace-only: should also be skipped
+                {"head": "   ", "text": "", "id": "empty-2"},
+                # Valid: should be kept
+                {"head": "Aufzug defekt", "id": "valid-1"},
+            ]
+        }
+    }
+
+    items = vor._collect_from_board("111", root)
+    assert len(items) == 1
+    assert items[0]["title"] == "Wien Mitte: Aufzug defekt"


### PR DESCRIPTION
## Was

Zwei unabhängige, kleine Follow-ups aus dem Diagnostik-Backlog (§4.4 + §3.3). Beide low-risk, kein Verhaltenswechsel an den Hauptpfaden.

## §4.4 — leere VOR-Meldungen verwerfen

**Vorher:** Wenn die VOR-API eine Message ohne `head` UND ohne `text` lieferte (z. B. nur Tag-Felder), produzierte `_collect_from_board` ein Feed-Item mit dem Literal-Fallback `title = "Hinweis"` und leerer Description. Solche stillen Items sind nie nützlich.

**Jetzt:** Wenn beide Felder leer (oder nur Whitespace) sind, wird die Message mit `log.debug(...)` übersprungen, bevor sie zu einem Item wird. Items mit `head` ODER `text` bleiben unverändert.

```python
if not head and not text:
    log.debug("VOR-Meldung ohne head/text übersprungen ...")
    continue
```

## §3.3 — `PAGES_BASE_URL` Hostname lowercase

**Vorher:** `PAGES_BASE_URL` wurde direkt aus `${{ github.repository_owner }}` gelesen — bei Owner mit Großbuchstaben (z. B. `Origamihase`) emittierte der Feed atom:link-URLs wie `https://Origamihase.github.io/wien-oepnv/feed.xml`. GitHub Pages serviert diese per 301 nach lowercase um — Funktion intakt, aber Linkqualität in Feed-Readern leidet.

**Jetzt:** In `_load_from_env` wird der Hostname-Teil lowercase normalisiert; der Pfad bleibt unverändert (GitHub Pages behandelt Pfade case-sensitive — `/My-Repo` ≠ `/my-repo`).

Implementierung über `urlparse`/`urlunparse` mit Beibehaltung von Port falls gesetzt.

## Test plan

- [x] `python -m pytest`: **1004 passed**, 1 skipped (vorher 1001; +3 neue Tests)
  - `test_collect_from_board_skips_message_without_head_or_text`
  - `test_make_rss_lowercases_pages_base_hostname`
  - `test_make_rss_preserves_pages_base_path_case`
- [x] `mypy --strict` Gate: 0 neue Errors
- [x] `ruff check`: passed
- [ ] CI grün

## Bezug zur Diagnose

Schließt §4.4 und §3.3 aus dem [Stand-Bewertungsbericht](https://github.com/Origamihase/wien-oepnv/pull/1180) ab. Verbleibende Backlog-Punkte sind reine Tech-Debt (mypy-Baseline reduzieren, Ruff-Set erweitern) — können später separat angegangen werden.

https://claude.ai/code/session_016CHRX6hg1srVPAnHWXsDzb

---
_Generated by [Claude Code](https://claude.ai/code/session_016CHRX6hg1srVPAnHWXsDzb)_