### PR TITLE
chore: enable ruff bugbear (B) rule and fix surfaced findings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ select = [
   "E",
   "F",
   "S",
+  "B",
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -29,7 +30,14 @@ select = [
 "scripts/run_static_checks.py" = ["S603"]
 "scripts/update_all_stations.py" = ["S603"]
 "scripts/update_station_directory.py" = ["S603"]
-"tests/**/*.py" = ["S101", "S113", "S314", "S105", "S108", "S110", "S310", "F841"]
+"tests/**/*.py" = [
+  "S101", "S113", "S314", "S105", "S108", "S110", "S310", "F841",
+  # bugbear rules deliberately allowed in tests:
+  "B007",  # parametrize-style loops where one variable is intentionally unused
+  "B010",  # Module mocks: setattr(mock_module, "fetch_events", ...) is the natural form
+  "B011",  # `assert False` is fine in tests; it never runs under `python -O`
+  "B018",  # bare-expression style is sometimes used to assert no exception
+]
 
 [tool.mypy]
 python_version = "3.11"

--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -325,7 +325,7 @@ def build_wl_entries(
         grouped.setdefault(key, []).append(halt)
 
     entries: list[dict[str, object]] = []
-    for diva, stops in grouped.items():
+    for stops in grouped.values():
         if not stops:
             continue
         station = haltestellen.get(stops[0].station_id)

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -1469,7 +1469,7 @@ def _make_rss(
     item_replacements: Dict[str, str] = {}
     identities_in_feed: List[str] = []
     emitted = 0
-    for i, it in enumerate(items):
+    for it in items:
         if emitted >= feed_config.MAX_ITEMS:
             break
         ident, elem, repl = _emit_item(it, now, state)

--- a/src/feed/providers.py
+++ b/src/feed/providers.py
@@ -49,7 +49,7 @@ def register_provider(env_var: str, loader: ProviderLoader, *, cache_key: str) -
     except (AttributeError, TypeError):  # pragma: no cover - defensive only
         pass
     try:
-        setattr(loader, "_provider_cache_name", cache_key)
+        loader._provider_cache_name = cache_key  # type: ignore[attr-defined]
     except (AttributeError, TypeError):  # pragma: no cover - defensive only
         pass
 

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -1389,7 +1389,7 @@ def _fetch_departure_board_for_station(
                     with counter["lock"]:
                         counter["consecutive_5xx"] = counter.get("consecutive_5xx", 0) + 1
                         if counter["consecutive_5xx"] >= 5:
-                            raise RuntimeError("Emergency Stop: Circuit Breaker Open (too many consecutive 5xx errors)!")
+                            raise RuntimeError("Emergency Stop: Circuit Breaker Open (too many consecutive 5xx errors)!") from exc
 
             if response is not None:
                 _log_warning(

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -88,8 +88,8 @@ def atomic_write(
                 os.link(tmp_path, target)
                 # Hard link successful, now remove the temp file
                 os.unlink(tmp_path)
-            except FileExistsError:
-                raise FileExistsError(f"File {target} already exists")
+            except FileExistsError as exc:
+                raise FileExistsError(f"File {target} already exists") from exc
 
     except Exception:
         # Close if still open (e.g. exception during yield)

--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -1563,7 +1563,7 @@ def request_safe(
                     # Duck-typing check for mocks that might lack is_redirect
                     # Some mocks implement is_redirect as a MagicMock, which evaluates to True. We explicitly check bool.
                     is_redirect = getattr(r, "is_redirect", False)
-                    if hasattr(is_redirect, "__call__") or type(is_redirect).__name__ == "MagicMock":
+                    if callable(is_redirect) or type(is_redirect).__name__ == "MagicMock":
                         is_redirect = False
 
                     if is_redirect:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,20 +192,19 @@ def streckendaten_dataset() -> Iterator[Path]:
     try:
         yield archive_path
     finally:
-        if keep_created:
-            return
-        if not archive_existed and archive_path.exists():
-            archive_path.unlink()
-        if not geojson_existed:
-            _cleanup_created_paths(extracted_paths)
-        if not dir_existed and _STRECKENDATEN_DIR.exists():
-            shutil.rmtree(_STRECKENDATEN_DIR, ignore_errors=True)
-        elif _STRECKENDATEN_DIR.exists():
-            try:
-                next(_STRECKENDATEN_DIR.iterdir())
-            except StopIteration:
-                with contextlib.suppress(OSError):
-                    _STRECKENDATEN_DIR.rmdir()
+        if not keep_created:
+            if not archive_existed and archive_path.exists():
+                archive_path.unlink()
+            if not geojson_existed:
+                _cleanup_created_paths(extracted_paths)
+            if not dir_existed and _STRECKENDATEN_DIR.exists():
+                shutil.rmtree(_STRECKENDATEN_DIR, ignore_errors=True)
+            elif _STRECKENDATEN_DIR.exists():
+                try:
+                    next(_STRECKENDATEN_DIR.iterdir())
+                except StopIteration:
+                    with contextlib.suppress(OSError):
+                        _STRECKENDATEN_DIR.rmdir()
 
 
 @pytest.fixture(scope="session", autouse=True)


### PR DESCRIPTION
## Was

Aktiviert die `B`-Regelgruppe (flake8-bugbear) im ruff-Config (`pyproject.toml: select = [..., "B"]`). Bugbear erkennt eine Reihe häufiger Bug-Quellen, die `E`/`F`/`S` nicht abdecken — z. B. nicht-chained Exception re-raises, ungenutzte Loop-Variablen, oder `hasattr(__call__)` statt `callable()`.

Erstlauf produzierte 72 Findings (60 in tests, 6 in src/scripts). Alle sind hier aufgelöst.

## Source-Code-Fixes (echte Verbesserungen, nicht nur Regel-Bedienung)

| Datei | Regel | Fix |
|---|---|---|
| `src/utils/http.py:1566` | B004 | `hasattr(x, "__call__")` → `callable(x)` — verlässlicher über Python-Implementierungen hinweg |
| `src/utils/files.py:92` | B904 | `raise FileExistsError(...)` → `raise FileExistsError(...) from exc` — Original-Traceback bleibt erhalten |
| `src/providers/vor.py:1392` | B904 | Circuit-Breaker `RuntimeError` chained jetzt den auslösenden `HTTPError` |
| `src/build_feed.py:1472` | B007 | `for i, it in enumerate(items)` → `for it in items` — Index war ungenutzt |
| `scripts/update_wl_stations.py:328` | B007 | `for diva, stops in grouped.items()` → `for stops in grouped.values()` — `diva` war ungenutzt |
| `src/feed/providers.py:52` | B010 | `setattr(loader, "_provider_cache_name", cache_key)` → direkter Zugriff mit `# type: ignore[attr-defined]`. Das try/except bleibt für Loader ohne `__dict__` (Lambdas etc.) |

## Test-Suite-Policy (`per-file-ignores` in pyproject.toml)

`tests/**/*.py` ignoriert zusätzlich `B007`, `B010`, `B011`, `B018` mit Begründung im Config-Kommentar:

- **B010**: `monkeypatch.setitem(sys.modules, "providers.X", ...)` und `setattr(mock_module, "fetch_events", lambda: [])` sind die natürliche Form für Modul-Mocks. Direkte Zuweisung würde die dynamisch erzeugten Module aus mypy's Reachability-Analyse fallen lassen.
- **B007**: Parametrize-Loops, in denen eine Variable gewollt unbenutzt ist (`for raw, expected in test_cases:` wo nur `raw` benötigt wird).
- **B011**: `assert False, "Found ..."` in zwei expliziten Regression-Tests. `python -O` würde diese verschlucken — in Tests akzeptabel, da Tests sowieso nie unter `-O` laufen.
- **B018**: Bare-Expression-Style für „assert no exception" in einem Edge-Case.

## Sonstige Korrekturen

- **`tests/conftest.py:194`** (B012): `if keep_created: return` innerhalb eines `finally`-Blocks → `if not keep_created:` Guard. Der `return` aus `finally` kann sonst Exceptions aus dem `yield`-Block verschlucken.

## Test plan

- [x] `ruff check`: passed
- [x] `mypy --strict` Gate: 0 neue Errors
- [x] `python -m pytest`: **1004 passed**, 1 skipped (unverändert zu vorher)
- [x] `scan_secrets.py`: clean
- [ ] CI grün

## Bezug zur Diagnose

Schließt **§6.2** aus dem Diagnose-Backlog. Verbleibend nur noch reine Tech-Debt-Punkte (mypy-Baseline reduzieren, ggf. weitere Ruff-Regelgruppen wie `UP`/`I` testen) — alles funktional unkritisch.

https://claude.ai/code/session_016CHRX6hg1srVPAnHWXsDzb

---
_Generated by [Claude Code](https://claude.ai/code/session_016CHRX6hg1srVPAnHWXsDzb)_