### PR TITLE
docs: refresh README quality-gate section after the diagnostic cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Der Feed-Bau folgt einem klaren Ablauf:
 | `data/`               | Stationsverzeichnis, GTFS-Testdaten und Hilfslisten (z. B. Pendler-Whitelist).                   |
 | `docs/`               | Audit-Berichte, Referenzen, Beispiel-Feeds und das offizielle VAO/VOR-API-Handbuch.              |
 | `.github/workflows/`  | Automatisierte Jobs für Cache-Updates, Stationspflege, Feed-Erzeugung und Tests.                |
-| `tests/`              | Umfangreiche Pytest-Suite (>250 Tests) für Feed-Logik, Provider-Adapter und Utility-Funktionen.  |
+| `tests/`              | Umfangreiche Pytest-Suite (~1000 Tests) für Feed-Logik, Provider-Adapter und Utility-Funktionen.  |
 
 
 > **Hinweis zu Cache-Pfaden:** Die tatsächlichen Verzeichnisse unter `cache/` tragen einen Hash-Suffix zur Cache-Versionierung (Stand Mai 2026: `cache/wl_9d709a/`, `cache/oebb_c40d21/`, `cache/vor_929f1c/`). In dieser Dokumentation werden aus Lesbarkeitsgründen verkürzte Schreibweisen wie `cache/wl/events.json` verwendet — sie verweisen jeweils auf das aktuelle Provider-Verzeichnis.
@@ -342,9 +342,10 @@ Cache-Update-Workflows committen ihre Ergebnisse in den Branch; der Feed-Build l
 
 ## Entwicklung & Qualitätssicherung
 
-- **Tests**: `python -m pytest` führt sämtliche Unit- und Integrationstests aus (`tests/`).
+- **Tests**: `python -m pytest` führt rund 1000 Unit- und Integrationstests aus (`tests/`).
 - **Kontinuierliche Tests**: Die GitHub Action `test.yml` automatisiert die im Audit empfohlene regelmäßige Testausführung und bricht Builds bei fehlschlagender Test-Suite ab.
-- **Statische Analyse & Typprüfung**: `ruff check` (Stil/Konsistenz) und `mypy` (vollständige Typabdeckung über das gesamte Paket `src/`) laufen identisch zur CI via `python -m src.cli checks`. Optional lassen sich über `--fix` Ruff-Autofixes aktivieren oder zusätzliche Argumente an Ruff durchreichen.
+- **Statische Analyse & Typprüfung**: `ruff check` (Stil/Konsistenz, Regelgruppen `E`, `F`, `S`, `B`) und `mypy --strict` (vollständige Typabdeckung über `src/` und `tests/`, derzeit 0 Errors) laufen identisch zur CI via `python -m src.cli checks`. Optional lassen sich über `--fix` Ruff-Autofixes aktivieren oder zusätzliche Argumente an Ruff durchreichen. Ein zusätzlicher `mypy-strict.yml`-Workflow setzt das Allowlist-Gate auf Pull Requests durch.
+- **Pre-Commit-Hooks**: `.pre-commit-config.yaml` aktiviert lokale Checks (Ruff, mypy, Secret-Scan, Whitespace-Hygiene) bei jedem `git commit`. Einmalig nach dem Klonen `pre-commit install` ausführen — Details in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 - **Logging**: Zur Laufzeit entsteht `log/errors.log` mit rotierenden Dateien; Größe und Anzahl sind konfigurierbar.
 
 ## Developer Experience & Observability


### PR DESCRIPTION
## Was

Ein-Datei-Refresh des README-Abschnitts „Entwicklung & Qualitätssicherung" nach den Cleanup-PRs #1176–#1185. Der Block hatte sich faktisch überholt — das ist die Synchronisation:

| Vorher | Nachher |
|---|---|
| „Umfangreiche Pytest-Suite (>250 Tests)" | „Umfangreiche Pytest-Suite (~1000 Tests)" (aktuell: 1004) |
| `ruff check` ohne Regelnennung | nennt die aktiven Regelgruppen `E, F, S, B` (Bugbear in #1182 ergänzt) |
| `mypy` (ohne `--strict`) nur über `src/` | `mypy --strict` über **`src/` UND `tests/`**, derzeit 0 Errors |
| Allowlist-Gate ungenannt | erwähnt den `mypy-strict.yml`-Workflow als PR-Gate |
| Pre-Commit-Hooks (in #1185 hinzugefügt) komplett ungenannt | dedizierter Bullet-Point mit Verweis auf CONTRIBUTING.md |

Repository-Gliederungs-Tabelle: `>250 Tests` → `~1000 Tests`.

## Test plan

- [x] `pre-commit run --all-files`: alle Hooks grün
- [x] `python -m pytest`: 1004 passed, 1 skipped
- [ ] CI grün (es ist nur ein README-Diff — die Tests laufen sowieso)

## Bezug zur Diagnose

Damit ist der ursprüngliche Diagnose-Backlog **vollständig abgearbeitet**. Was bleibt sind drei nicht-Code-Punkte:
- §3.1 Bandit `continue-on-error` — Konfiguration über Branch-Protection (User-Entscheidung)
- §3.4 `--force-with-lease` — durch concurrency mitigiert (Doku-Frage)
- §4.5 OEBB-Filter — bewusster Trade-off

https://claude.ai/code/session_016CHRX6hg1srVPAnHWXsDzb

---
_Generated by [Claude Code](https://claude.ai/code/session_016CHRX6hg1srVPAnHWXsDzb)_