### PR TITLE
fix(oebb,places): strict route filter and Places quota safety

### DIFF
--- a/src/places/client.py
+++ b/src/places/client.py
@@ -332,6 +332,25 @@ class GooglePlacesClient:
 
         while attempt <= self._config.max_retries:
             attempt += 1
+            # Quota: count each HTTP attempt up-front. Google bills per request
+            # regardless of HTTP status, so we must not wait for a 200 before
+            # incrementing — otherwise retries on 429/5xx would silently eat
+            # additional quota that we never tracked. On retries we re-check
+            # the cap so the second attempt is skipped if the first one
+            # exhausted the budget.
+            if quota_kind and self._quota_active:
+                quota = cast(MonthlyQuota, self._quota)
+                cfg = cast(QuotaConfig, self._quota_config)
+                if not quota.can_consume(quota_kind, cfg):
+                    if quota_kind not in self._quota_skipped_kinds:
+                        LOGGER.warning(
+                            "Places free cap reached for %s during retries; aborting further attempts.",
+                            quota_kind,
+                        )
+                    self._quota_skipped_kinds.add(quota_kind)
+                    return {"places": [], "skipped_due_to_quota": True}
+                self._record_successful_request(quota_kind)
+
             start_time = time.monotonic()
             try:
                 with self._session.post(
@@ -369,8 +388,6 @@ class GooglePlacesClient:
                             raise GooglePlacesError(
                                 "Invalid JSON payload received from Places API"
                             ) from exc
-                        if quota_kind and self._quota_active:
-                            self._record_successful_request(quota_kind)
                         return cast(Dict[str, object], payload)
 
                     if response.status_code in {429, 500, 502, 503, 504}:
@@ -539,6 +556,13 @@ class GooglePlacesClient:
         return set(self._quota_skipped_kinds)
 
     def _record_successful_request(self, kind: str) -> None:
+        """Increment and persist the quota counter for *kind*.
+
+        Despite the legacy name, this is now invoked for every HTTP attempt
+        (not only on 200 responses) so that retries on 429/5xx don't silently
+        exceed the configured Places budget. Google bills per request, not
+        per success.
+        """
         if not self._quota_active:
             return
         try:

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -23,7 +23,7 @@ import os
 import re
 import time
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from email.utils import parsedate_to_datetime
 
 import requests
@@ -31,7 +31,14 @@ import requests
 from ..feed_types import FeedItem
 from ..utils.env import get_bool_env
 from ..utils.ids import make_guid
-from ..utils.stations import canonical_name, station_by_oebb_id, is_in_vienna, station_info, text_has_vienna_connection
+from ..utils.stations import (
+    StationInfo,
+    canonical_name,
+    is_in_vienna,
+    station_by_oebb_id,
+    station_info,
+    text_has_vienna_connection,
+)
 from ..utils.http import session_with_retries, validate_http_url, fetch_content_safe
 from ..utils.logging import sanitize_log_arg
 
@@ -233,94 +240,228 @@ def _strip_oebb_prefixes(text: str) -> str:
     Daher iterieren wir und entfernen von vorne nur bekannte Präfixe, bis keines mehr matcht.
     """
     # Sucht nach Linien (z.B. REX 51, RJX 123) oder Wörtern gefolgt von Doppelpunkt
-    base_pattern = (r"^(?:(?:REX|S|U|RJ|RJX|EC|IC|ICE|WB|NJ|D|R)\s*\d+|Störung|Verspätung|Zugausfall"
-                    r"|Bauarbeiten|Info|Information|Einschränkung|Unterbrechung)\s*:\s*")
+    base_pattern = (r"^(?:(?:REX|RJX|RJ|S|U|EC|ICE|IC|WB|NJ|CJX|D|R)\s*\d+|Störung|Verspätung|Zugausfall"
+                    r"|DB-Bauarbeiten|Bauarbeiten|Info|Information|Einschränkung|Unterbrechung"
+                    r"|Umleitung|Haltausfall|Schienenersatzverkehr|geänderte\s+Fahrzeiten"
+                    r"|Verkehrsmeldung|Hinweis)\s*:\s*")
     while re.search(base_pattern, text, re.IGNORECASE):
         text = re.sub(base_pattern, "", text, flags=re.IGNORECASE)
     return text.strip()
 
-def _is_relevant(title: str, description: str) -> bool:
+
+# ---------------- Route extraction ("zwischen X und Y") ----------------
+
+# HTML-tolerant: a description usually contains entries like
+# "zwischen <b>Flughafen Wien Bahnhof</b> und <b>Wien Mitte-Landstraße Bahnhof</b>".
+# We strip HTML before matching so we only need a single plain-text pattern.
+_ZWISCHEN_PLAIN_RE = re.compile(
+    r"zwischen\s+(?P<a>.+?)\s+und\s+(?P<b>.+?)"
+    r"(?=\s+(?:von|bis|am|im|in\s+der|jeweils|nicht|der\s+Zug|halten|fahren|"
+    r"kommt|f[äa]hrt|fallen|k[öo]nnen|sowie|werden|ab|seit|um|gegen)\b|[,;.!?]|\s*$)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Suffixes that should be stripped before looking up a station name.
+_BAHNHOF_TRAILING_RE = re.compile(
+    r"\s*\b(?:Hauptbahnhof|Bahnhof|Bahnhst|Hbf|Bhf|Bf)\b\.?",
+    re.IGNORECASE,
+)
+_PARENS_TRAILING_RE = re.compile(r"\s*\(\s*[A-Za-z]\d*\s*\)\s*$")
+
+
+def _normalize_endpoint_name(name: str) -> str:
+    """Strip HTML, trailing parenthetical markers and Bahnhof-suffixes.
+
+    The result is suitable as input to :func:`station_info` for canonical
+    classification.
     """
-    Entscheidet über Relevanz für Wien-Pendler.
+    if not name:
+        return ""
+    cleaned = re.sub(r"<[^>]+>", " ", name)
+    cleaned = html.unescape(cleaned)
+    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip()
+    # Iteratively strip trailing parens like (U), (S), (R)
+    while True:
+        new = _PARENS_TRAILING_RE.sub("", cleaned).strip()
+        if new == cleaned:
+            break
+        cleaned = new
+    # Strip a single trailing Bahnhof/Hbf/Bf suffix (only at the end, so we
+    # don't mangle names like "Wiener Neustadt Hauptbahnhof" → "Wiener Neustadt"
+    # — which is actually what we want for lookup).
+    cleaned = re.sub(_BAHNHOF_TRAILING_RE.pattern + r"\s*$", "", cleaned, flags=re.IGNORECASE).strip()
+    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip()
+    return cleaned
 
-    Mehrstufiger Filter-Prozess:
-    1. Guard für völlig unbekannte Fernverkehrsstationen: Sind beide Endpunkte `None`
-       (und keine bekannten Kategorie-Schlüsselwörter), wird die Meldung verworfen
-       (z.B. bei Verbindungen wie "Budapest ↔ Bratislava").
-    2. Strikter Modus (OEBB_ONLY_VIENNA): Falls aktiviert, müssen alle bekannten
-       Endpunkte explizit in Wien liegen.
-    3. Asymmetrischer Pendler-Check: Wenn mindestens ein Endpunkt bekannt ist
-       (`at_least_one_known`), muss zwingend auch mindestens ein Endpunkt in Wien liegen
-       (`vienna_endpoint`), sonst wird die Strecke verworfen.
-    4. Fallback auf `text_has_vienna_connection`: Für Meldungen ohne "↔" im Titel
-       (z.B. allgemeine Meldungen ohne explizites Routing) fällt die Logik auf einen
-       generischen Text-Check zurück.
+
+def _looks_like_station_name(text: str) -> bool:
+    """Reject pure dates/numbers; require at least one alphabetic character."""
+    if not text:
+        return False
+    if not re.search(r"[A-Za-zÄÖÜäöüß]", text):
+        return False
+    # Reject things like "13.04.2026" (pure date) — they have no letters anyway,
+    # but this guard is here for defence in depth.
+    if re.fullmatch(r"[\d.\-/\s]+", text):
+        return False
+    return True
+
+
+def _extract_zwischen_routes(description: str) -> List[Tuple[str, str]]:
+    """Find all 'zwischen X und Y' route mentions in *description*.
+
+    Returns a list of normalised ``(name_a, name_b)`` tuples. Names are
+    deduplicated regardless of order (so ``A ↔ B`` and ``B ↔ A`` count once).
     """
-    text = f"{title} {description}"
-    text_lower = text.lower()
+    if not description:
+        return []
 
-    # Check 0: Globales Fernverkehrs-Veto
-    stations_in_text = _find_stations_in_text(text)
-    has_distant_station = False
-    has_pendler_station = False
+    # Strip HTML tags and unescape entities; we want plain text for matching.
+    plain = re.sub(r"<[^>]+>", " ", description)
+    plain = html.unescape(plain)
+    plain = re.sub(r"\s+", " ", plain).strip()
 
-    for s in stations_in_text:
-        info = station_info(s)
-        if info:
-            if not info.in_vienna and not info.pendler:
-                has_distant_station = True
-            if info.pendler:
-                has_pendler_station = True
+    routes: List[Tuple[str, str]] = []
+    seen: set[Tuple[str, str]] = set()
 
-    if has_distant_station:
-        has_local_train = bool(re.search(r"\b(rex|s-bahn|s\s*\d+|u\s*\d+|cjx|r\s+\d+)\b", text_lower))
-        if not has_pendler_station and not has_local_train:
-            return False
+    for match in _ZWISCHEN_PLAIN_RE.finditer(plain):
+        a_norm = _normalize_endpoint_name(match.group("a"))
+        b_norm = _normalize_endpoint_name(match.group("b"))
+        if not _looks_like_station_name(a_norm) or not _looks_like_station_name(b_norm):
+            continue
+        # Deduplicate regardless of A/B order
+        sorted_pair = sorted([a_norm.casefold(), b_norm.casefold()])
+        key: Tuple[str, str] = (sorted_pair[0], sorted_pair[1])
+        if key in seen:
+            continue
+        seen.add(key)
+        routes.append((a_norm, b_norm))
 
-    # Check 0: Strecken-Filter für explizite Routen A ↔ B
-    if "↔" in title:
+    return routes
+
+
+def _extract_routes(title: str, description: str) -> List[Tuple[str, str]]:
+    """Collect route endpoint pairs from title (split on ↔) and description.
+
+    Pure category words like "Bauarbeiten ↔ Umleitung" are filtered out so
+    they don't drag a real station-mention message into the strict-route path
+    incorrectly.
+    """
+    routes: List[Tuple[str, str]] = []
+    seen: set[Tuple[str, str]] = set()
+
+    # 1. Parse title — split on ↔
+    if title and "↔" in title:
         parts = [p.strip() for p in title.split("↔")]
-        if len(parts) >= 2:
-            # Entferne eventuelle Präfixe wie "REX 51: " aus den Stationsnamen
-            part0 = _strip_oebb_prefixes(parts[0])
-            part1 = _strip_oebb_prefixes(parts[1])
+        for i in range(len(parts) - 1):
+            a_raw = _strip_oebb_prefixes(parts[i])
+            b_raw = _strip_oebb_prefixes(parts[i + 1])
+            if _is_category(a_raw) or _is_category(b_raw):
+                continue
+            a_norm = _normalize_endpoint_name(a_raw)
+            b_norm = _normalize_endpoint_name(b_raw)
+            if not _looks_like_station_name(a_norm) or not _looks_like_station_name(b_norm):
+                continue
+            sorted_pair = sorted([a_norm.casefold(), b_norm.casefold()])
+            key: Tuple[str, str] = (sorted_pair[0], sorted_pair[1])
+            if key in seen:
+                continue
+            seen.add(key)
+            routes.append((a_norm, b_norm))
 
-            info0 = station_info(part0)
-            info1 = station_info(part1)
+    # 2. Parse description — "zwischen X und Y" patterns
+    for raw_a, raw_b in _extract_zwischen_routes(description):
+        sorted_pair = sorted([raw_a.casefold(), raw_b.casefold()])
+        desc_key: Tuple[str, str] = (sorted_pair[0], sorted_pair[1])
+        if desc_key in seen:
+            continue
+        seen.add(desc_key)
+        routes.append((raw_a, raw_b))
 
-            # Check if these are actually station names. If they are known category keywords
-            # that were incorrectly joined with ↔ (like "Bauarbeiten ↔ Umleitung"), they might
-            # evaluate to None. We only treat them as strict unknown stations if they don't look
-            # like category keywords.
-            if info0 is None and info1 is None and not _is_category(part0) and not _is_category(part1):
-                # Wenn beide Stationen völlig unbekannt sind, ist es Fernverkehr -> verwerfen
-                return False
+    return routes
 
-            if OEBB_ONLY_VIENNA:
-                if (info0 and not info0.in_vienna) or (info1 and not info1.in_vienna):
-                    return False
 
-            # Neuer, strikter Streckenabgleich:
-            # Wenn mindestens ein Endpunkt bekannt ist, MUSS mindestens einer in Wien liegen.
-            at_least_one_known = (info0 is not None) or (info1 is not None)
-            vienna_endpoint = (info0 and info0.in_vienna) or (info1 and info1.in_vienna)
+def _classify_endpoint(name: str) -> Tuple[Optional[StationInfo], str]:
+    """Look up *name* and return ``(info, category)``.
 
-            if at_least_one_known:
-                return bool(vienna_endpoint)
+    Categories are one of ``vienna``, ``pendler``, ``distant`` (known but not
+    relevant) or ``unknown``.
+    """
+    info = station_info(name)
+    if info is None:
+        return None, "unknown"
+    if info.in_vienna:
+        return info, "vienna"
+    if info.pendler:
+        return info, "pendler"
+    return info, "distant"
 
-    # Check 1: Asymmetrischer Pendler-Check für unstrukturierte Meldungen (Veto-Logik)
+
+def _route_is_wien_relevant(name_a: str, name_b: str) -> bool:
+    """Strict-spec route check.
+
+    Per project specification a route is relevant if both endpoints are known
+    Vienna or Pendler stations and at least one of them is in Vienna. Pendler
+    ↔ Pendler routes and routes with unknown/distant endpoints are excluded.
+
+    When ``OEBB_ONLY_VIENNA`` is enabled, the rule is tightened further: both
+    endpoints must lie inside Vienna.
+    """
+    _, cat_a = _classify_endpoint(name_a)
+    _, cat_b = _classify_endpoint(name_b)
+    if OEBB_ONLY_VIENNA:
+        return cat_a == "vienna" and cat_b == "vienna"
+    if cat_a not in ("vienna", "pendler") or cat_b not in ("vienna", "pendler"):
+        return False
+    return cat_a == "vienna" or cat_b == "vienna"
+
+
+def _is_relevant(title: str, description: str) -> bool:
+    """Decide whether an ÖBB message is relevant for Wien-Pendler.
+
+    Strict rules:
+
+    1. **Connection messages (A ↔ B / "zwischen X und Y")** – at least one
+       extracted route must be Vienna ↔ Vienna or Vienna ↔ Pendler. If the
+       message describes routes but none of them is Wien-relevant (e.g.
+       Pendler ↔ Pendler, Wien ↔ Distant, or unknown endpoints), the message
+       is dropped.
+    2. **Single-station / general messages** – if no route can be parsed, the
+       message must mention at least one Vienna or Pendler station. If only
+       distant stations are mentioned, drop. Otherwise fall back to the
+       generic Vienna-text heuristic for U-Bahn references.
+    """
+    routes = _extract_routes(title, description)
+
+    if routes:
+        for raw_a, raw_b in routes:
+            if _route_is_wien_relevant(raw_a, raw_b):
+                return True
+        return False
+
+    # No identifiable connection — single-station / general announcement path.
+    text = f"{title} {description}"
     found_stations = _find_stations_in_text(text)
-    if found_stations:
-        has_vienna_or_pendler = False
-        for s in found_stations:
-            info = station_info(s)
-            if info and (info.in_vienna or info.pendler):
-                has_vienna_or_pendler = True
-                break
 
-        # Veto: Wir haben Stationen gefunden, aber KEINE davon ist in Wien oder Pendler
-        if not has_vienna_or_pendler:
-            return False
+    has_relevant = False
+    has_distant = False
+    for s in found_stations:
+        info = station_info(s)
+        if not info:
+            continue
+        if info.in_vienna or info.pendler:
+            has_relevant = True
+        else:
+            has_distant = True
+
+    if has_relevant:
+        return True
+    if has_distant:
+        return False
+
+    # OEBB_ONLY_VIENNA narrows the fallback to text-detected Vienna references.
+    if OEBB_ONLY_VIENNA:
+        return False
 
     return text_has_vienna_connection(text)
 
@@ -342,6 +483,30 @@ def _extract_id_from_url(url: str) -> Optional[int]:
         return int(match.group(1))
     return None
 
+# Single-token chunks that should not be treated as stations on their own
+# (they would otherwise alias-match high-profile stations such as "Wien
+# Hauptbahnhof" via the directory's expansion rules).
+_GENERIC_STATION_TOKENS = frozenset({
+    "hbf",
+    "bhf",
+    "bf",
+    "bahnhof",
+    "bahnhst",
+    "hauptbahnhof",
+    "westbahnhof",
+    "westbf",
+    "ostbahnhof",
+    "ostbf",
+    "südbahnhof",
+    "suedbahnhof",
+    "südbf",
+    "suedbf",
+    "nordbahnhof",
+    "nordbf",
+    "station",
+})
+
+
 def _find_stations_in_text(blob: str) -> List[str]:
     """
     Scans text for known station names using a sliding window.
@@ -357,6 +522,10 @@ def _find_stations_in_text(blob: str) -> List[str]:
     for size in range(window, 0, -1):
         for idx in range(len(tokens) - size + 1):
             chunk = " ".join(tokens[idx : idx + size])
+            # Skip generic single-token aliases ("Hbf", "Bahnhof", …) that
+            # would otherwise spuriously canonicalise to a flagship station.
+            if size == 1 and chunk.casefold().rstrip(".:,;") in _GENERIC_STATION_TOKENS:
+                continue
             canon = canonical_name(chunk)
             if canon:
                 found.add(canon)
@@ -436,6 +605,88 @@ def _parse_dt_rfc2822(s: str) -> Optional[datetime]:
 def _is_poor_title(t: str) -> bool:
     return not t or not any(c.isalnum() for c in t) or t == "-"
 
+
+# ---------------- Title formatting helpers ----------------
+
+# Recognises a leading line marker (REX 7, S 50, RJX 12, …) so we can preserve
+# it even when we rebuild the title from extracted endpoints.
+_LINE_PREFIX_RE = re.compile(
+    r"^\s*((?:REX|RJX|RJ|EC|ICE|IC|WB|NJ|CJX|S-Bahn|S|U|R|D)\s*\d+[A-Za-z]?)\s*:?\s*",
+    re.IGNORECASE,
+)
+
+
+def _extract_line_prefix(title: str) -> Tuple[str, str]:
+    """Split off a leading line marker from *title*.
+
+    Returns ``(line_prefix, remaining_title)``. The line prefix is empty when
+    *title* doesn't start with a recognised marker.
+    """
+    if not title:
+        return "", ""
+    match = _LINE_PREFIX_RE.match(title)
+    if not match:
+        return "", title.strip()
+    return match.group(1).strip(), title[match.end():].strip()
+
+
+# Compact directory names sometimes use abbreviations (Westbf, Hbf, …) that
+# look truncated in the feed. We expand them only for the user-facing title.
+_STATION_NAME_EXPANSIONS: Tuple[Tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\bWestbf\b"), "Westbahnhof"),
+    (re.compile(r"\bOstbf\b"), "Ostbahnhof"),
+    (re.compile(r"\bNordbf\b"), "Nordbahnhof"),
+    (re.compile(r"\bSüdbf\b"), "Südbahnhof"),
+    (re.compile(r"\bHbf\b"), "Hauptbahnhof"),
+    (re.compile(r"-Bf\b"), "-Bahnhof"),
+)
+
+
+def _expand_station_abbreviations(name: str) -> str:
+    """Expand common Bf/Hbf abbreviations for readability."""
+    for pattern, replacement in _STATION_NAME_EXPANSIONS:
+        name = pattern.sub(replacement, name)
+    return name
+
+
+def _format_route_title(routes: List[Tuple[str, str]], line_prefix: str = "") -> str:
+    """Build a clean ``A ↔ B`` title from extracted route(s).
+
+    For each route we use the canonical station name from the directory when
+    available (so ``Wien Westbf`` → ``Wien Westbahnhof``). The Vienna endpoint
+    is placed first to keep the feed visually consistent. Multiple routes are
+    joined with ``" / "`` to indicate that several segments are affected.
+    """
+    if not routes:
+        return ""
+
+    formatted: List[str] = []
+    for raw_a, raw_b in routes:
+        info_a = station_info(raw_a)
+        info_b = station_info(raw_b)
+        name_a = info_a.name if info_a else raw_a
+        name_b = info_b.name if info_b else raw_b
+        # Canonical names from the directory may carry a "(VOR)" suffix that
+        # is irrelevant for the user-facing title.
+        name_a = re.sub(r"\s+\(VOR\)$", "", name_a).strip()
+        name_b = re.sub(r"\s+\(VOR\)$", "", name_b).strip()
+        name_a = _expand_station_abbreviations(name_a)
+        name_b = _expand_station_abbreviations(name_b)
+
+        # Vienna endpoint always goes first when only one side is in Vienna.
+        a_in_vienna = bool(info_a and info_a.in_vienna)
+        b_in_vienna = bool(info_b and info_b.in_vienna)
+        if b_in_vienna and not a_in_vienna:
+            name_a, name_b = name_b, name_a
+
+        formatted.append(f"{name_a} ↔ {name_b}")
+
+    title = " / ".join(formatted)
+    if line_prefix:
+        title = f"{line_prefix}: {title}"
+    return title
+
+
 # ---------------- Public ----------------
 def fetch_events(timeout: int = 25) -> List[FeedItem]:
     root = _fetch_xml(OEBB_URL, timeout=timeout)
@@ -462,13 +713,24 @@ def fetch_events(timeout: int = 25) -> List[FeedItem]:
         desc = _clean_description(desc_html)
         pub = _parse_dt_rfc2822(_get_text(item, "pubDate"))
 
-        # Attempt to extract affected line from description (e.g. "REX 1", "S 50", "S-Bahn 1", "U1")
+        # Reconstruct a clean "A ↔ B" title from the authoritative endpoints
+        # in the description ("zwischen X und Y") whenever possible. This
+        # supersedes the messy raw title (e.g. "Bauarbeiten: Flughafen Wien
+        # Wien Mitte-Landstraße") with canonical station names and drops
+        # category prefixes such as "Bauarbeiten:" or "DB-Bauarbeiten:".
+        existing_line_prefix, _ = _extract_line_prefix(title)
+        routes = _extract_routes(title, desc)
+        relevant_routes = [
+            (a, b) for (a, b) in routes if _route_is_wien_relevant(a, b)
+        ]
+        if relevant_routes:
+            title = _format_route_title(relevant_routes, existing_line_prefix)
+
+        # Append affected line from description (e.g. "REX 1", "S 50", "U1")
         # if not already present in the title.
-        # Regex covers common Austrian train types + digit.
         line_match = re.search(r"\b((?:REX|S(?:-Bahn)?|U)\s*\d+)\b", desc)
         if line_match:
             line_str = line_match.group(1)
-            # Prepend if not already in title (simple check)
             if line_str not in title:
                 title = f"{line_str}: {title}"
 
@@ -497,7 +759,10 @@ def fetch_events(timeout: int = 25) -> List[FeedItem]:
                 if snippet:
                     title = snippet
 
-        # Region-Filter: Neue Logik (Wien-Bezug strikt)
+        # Region-Filter: Strict — drop messages that don't describe a
+        # Wien-relevant connection or station. Run AFTER title fallback so
+        # that fallback-derived titles (e.g. resolved via OEBB station ID)
+        # contribute to the relevance check.
         if not _is_relevant(title, desc):
             continue
 

--- a/tests/places/test_client_quota_retries.py
+++ b/tests/places/test_client_quota_retries.py
@@ -1,0 +1,148 @@
+"""Quota safety tests for the Places client retry path.
+
+Google Places bills per request, regardless of HTTP response status. The
+client must therefore consume budget BEFORE each HTTP attempt — otherwise a
+429/5xx retry storm could silently exceed the configured monthly cap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterator
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from src.places.client import GooglePlacesClient, GooglePlacesConfig
+from src.places.quota import MonthlyQuota, QuotaConfig
+
+_CONFIG = GooglePlacesConfig(
+    api_key="dummy",
+    included_types=["bus_station"],
+    language="de",
+    region="AT",
+    radius_m=1000,
+    timeout_s=1.0,
+    max_retries=3,
+    max_result_count=20,
+)
+
+
+class _MockSocket:
+    def getpeername(self) -> tuple[str, int]:
+        return ("8.8.8.8", 443)
+
+
+class _MockRaw:
+    def __init__(self) -> None:
+        self.connection = MagicMock()
+        self.connection.sock = _MockSocket()
+        self._connection = self.connection
+
+
+class _MockResponse:
+    def __init__(self, status: int, body: bytes = b"{}") -> None:
+        self.status_code = status
+        self.headers: Dict[str, str] = {}
+        self.raw = _MockRaw()
+        self.url = "https://places.googleapis.com/v1/places:searchNearby"
+        self._content = body
+        self._content_consumed = False
+        self.text = body.decode("utf-8", errors="replace")
+
+    def iter_content(self, chunk_size: int = 1) -> Iterator[bytes]:
+        yield self._content
+
+    def json(self) -> Any:
+        import json
+
+        return json.loads(self._content)
+
+    def close(self) -> None:
+        pass
+
+    def __enter__(self) -> "_MockResponse":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+def _make_client(tmp_path: Path, session: MagicMock, *, daily_limit: int = 10) -> tuple[
+    GooglePlacesClient, MonthlyQuota, QuotaConfig
+]:
+    quota = MonthlyQuota(month_key="2024-05")
+    cfg = QuotaConfig(
+        limit_total=None,
+        limit_nearby=None,
+        limit_text=None,
+        limit_details=None,
+        limit_daily=daily_limit,
+    )
+    state = tmp_path / "quota.json"
+    client = GooglePlacesClient(
+        _CONFIG,
+        session=session,
+        quota=quota,
+        quota_config=cfg,
+        quota_state_path=state,
+        enforce_quota=True,
+    )
+    return client, quota, cfg
+
+
+def test_quota_increments_per_attempt_on_retries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 429 followed by 200 must consume two units of quota, not one.
+
+    Google bills per request, so silently masking the failed first attempt
+    would let the retry loop exceed the configured cap.
+    """
+    monkeypatch.setattr("src.places.client.time.sleep", lambda _s: None)
+    session = MagicMock(spec=requests.Session)
+    session.post.side_effect = [
+        _MockResponse(429),
+        _MockResponse(200, b'{"places": []}'),
+    ]
+    client, quota, _ = _make_client(tmp_path, session)
+    client._post("places:searchNearby", {}, quota_kind="nearby")
+
+    # One attempt was 429 (still counted), one was 200 — two consumed.
+    assert quota.counts["nearby"] == 2
+    assert quota.daily_total == 2
+
+
+def test_quota_aborts_when_daily_cap_reached_during_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If retries would exceed the daily cap the client must stop early."""
+    monkeypatch.setattr("src.places.client.time.sleep", lambda _s: None)
+    session = MagicMock(spec=requests.Session)
+    # Provide several 429s so the loop wants to keep retrying.
+    session.post.side_effect = [_MockResponse(429) for _ in range(5)]
+    # daily_limit=2 lets exactly two attempts run; the third must short-circuit.
+    client, quota, _ = _make_client(tmp_path, session, daily_limit=2)
+    result = client._post("places:searchNearby", {}, quota_kind="nearby")
+
+    assert quota.counts["nearby"] == 2
+    assert quota.daily_total == 2
+    # The client signals that the call was skipped due to quota exhaustion.
+    assert result.get("skipped_due_to_quota") is True
+    # Only two HTTP attempts actually went out.
+    assert session.post.call_count == 2
+
+
+def test_quota_increments_on_single_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A clean 200 still increments by exactly one (regression guard)."""
+    monkeypatch.setattr("src.places.client.time.sleep", lambda _s: None)
+    session = MagicMock(spec=requests.Session)
+    session.post.return_value = _MockResponse(200, b'{"places": []}')
+    client, quota, _ = _make_client(tmp_path, session)
+    client._post("places:searchNearby", {}, quota_kind="nearby")
+
+    assert quota.counts["nearby"] == 1
+    assert quota.daily_total == 1

--- a/tests/providers/test_google_places_quota_integration.py
+++ b/tests/providers/test_google_places_quota_integration.py
@@ -149,7 +149,13 @@ def test_successful_request_updates_quota_state(tmp_path: Path) -> None:
     assert updated["total"] == 1
 
 
-def test_rate_limit_does_not_consume_quota(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_rate_limited_attempts_consume_quota(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each HTTP attempt consumes one unit of quota — retries included.
+
+    Google bills per request regardless of HTTP status, so the client must
+    pre-charge every attempt against the budget. This guards against silent
+    over-consumption when 429/5xx responses trigger retries.
+    """
     quota_path = tmp_path / "quota.json"
     quota = MonthlyQuota(month_key="2024-05")
     _save_quota(quota_path, quota)
@@ -178,8 +184,9 @@ def test_rate_limit_does_not_consume_quota(tmp_path: Path, monkeypatch: pytest.M
     list(client.iter_nearby([Tile(latitude=48.2, longitude=16.3)]))
 
     data = json.loads(quota_path.read_text(encoding="utf-8"))
-    assert data["counts"]["nearby"] == 1
-    assert data["total"] == 1
+    # Two HTTP attempts (429 then 200) → two units of quota recorded.
+    assert data["counts"]["nearby"] == 2
+    assert data["total"] == 2
 
 
 def _configure_env(monkeypatch: pytest.MonkeyPatch, base_dir: Path, quota_path: Path) -> None:

--- a/tests/test_oebb_route_filter.py
+++ b/tests/test_oebb_route_filter.py
@@ -6,11 +6,12 @@ import pytest
 from src.providers.oebb import _is_relevant
 
 def test_venezia_is_excluded() -> None:
-    # Long distance train to unknown station (Venezia)
-    # RELAXED: This route mentions "Wien", so it is now RELEVANT for Vienna commuters.
+    # Per spec: routes between a Wiener Bahnhof and a foreign/unknown
+    # destination (Vienna ↔ Distant) are NOT relevant — only Wien-Wien and
+    # Wien-Pendler routes belong in the feed.
     title = "Wien Hauptbahnhof ↔ Venezia Santa Lucia"
     description = "Wegen Bauarbeiten..."
-    assert _is_relevant(title, description) is True
+    assert _is_relevant(title, description) is False
 
 def test_wien_st_poelten_included() -> None:
     # St. Pölten is in the Pendler list
@@ -31,11 +32,12 @@ def test_unknown_route_excluded() -> None:
     assert _is_relevant(title, description) is False
 
 def test_one_end_unknown_excluded() -> None:
-    # One end unknown (but mentions Wien in text)
+    # Per spec: one endpoint unknown means we cannot verify the connection
+    # ends at a Wiener Bahnhof or Pendlerbahnhof — drop it. A loose Wien
+    # mention in the body must not override the strict route check.
     title = "Wien Hbf ↔ Unknown City"
     description = "Wien Hauptbahnhof ist betroffen."
-    # RELAXED: Because "Wien" is in text, it is now RELEVANT.
-    assert _is_relevant(title, description) is True
+    assert _is_relevant(title, description) is False
 
 def test_bauarbeiten_category_included() -> None:
     # Not a route "A ↔ B" but a category "Category: Detail"
@@ -89,9 +91,11 @@ def test_fernverkehr_mit_prefix_negativ() -> None:
     assert _is_relevant(title, description) is False
 
 def test_einseitiger_wien_bezug_mit_prefix() -> None:
+    # Per strict spec: Wien ↔ Distant (Budapest-Keleti is foreign, not Pendler)
+    # is NOT relevant. The feed targets Wien-Wien and Wien-Pendler routes only.
     title = "REX 51: Störung: Wien Meidling ↔ Budapest-Keleti"
     description = ""
-    assert _is_relevant(title, description) is True
+    assert _is_relevant(title, description) is False
 
 def test_wien_bezug_im_zweiten_teil() -> None:
     title = "Störung: Verspätung: Mödling ↔ Wien Hbf"
@@ -99,11 +103,14 @@ def test_wien_bezug_im_zweiten_teil() -> None:
     assert _is_relevant(title, description) is True
 
 def test_stationsname_enthaelt_selbst_doppelpunkt(monkeypatch: pytest.MonkeyPatch) -> None:
-    title = "RJ 123: Wien 10.: Favoriten ↔ Graz Hbf"
+    # Verifies that a station name containing a colon (e.g. "Wien 10.: Favoriten")
+    # is preserved through prefix stripping and recognised as Vienna.
+    # Paired with a Pendler endpoint (Mödling) so that the strict route filter
+    # keeps the message — the focus of this test is the colon handling, not
+    # the destination classification.
+    title = "RJ 123: Wien 10.: Favoriten ↔ Mödling"
     description = ""
 
-    # Wir mocken station_info, um zu beweisen, dass der gesamte String "Wien 10.: Favoriten"
-    # intakt übergeben wird und nicht mehr fälschlicherweise durch split(":") zerstört wird.
     from src.providers.oebb import station_info
     original_station_info = station_info
 

--- a/tests/test_oebb_user_examples.py
+++ b/tests/test_oebb_user_examples.py
@@ -1,0 +1,166 @@
+"""Regression tests for the user-reported feed examples.
+
+These cases reflect the strict route filter spec:
+
+- Wien ↔ Wien → keep
+- Wien ↔ Pendler → keep
+- Pendler ↔ Pendler → drop
+- Wien ↔ Distant/Unknown → drop
+- Distant ↔ Distant → drop
+
+The titles are also checked: route messages must be rendered as a clean
+``A ↔ B`` form with canonical (and expanded) station names, without category
+prefixes such as "Bauarbeiten:" or "DB-Bauarbeiten:".
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import (
+    _clean_title_keep_places,
+    _extract_line_prefix,
+    _extract_routes,
+    _format_route_title,
+    _is_relevant,
+    _route_is_wien_relevant,
+)
+
+
+def _build_title(raw_title: str, description: str) -> str:
+    """Reproduce the title pipeline used inside ``fetch_events``."""
+    cleaned = _clean_title_keep_places(raw_title)
+    line_prefix, _ = _extract_line_prefix(cleaned)
+    routes = _extract_routes(cleaned, description)
+    relevant_routes = [(a, b) for (a, b) in routes if _route_is_wien_relevant(a, b)]
+    if relevant_routes:
+        return _format_route_title(relevant_routes, line_prefix)
+    return cleaned
+
+
+class TestUserReportedDropExamples:
+    """Examples that the user reported as wrongly KEPT in the feed."""
+
+    def test_passau_wien_hauptbahnhof_dropped(self) -> None:
+        # User example #1: DB long-distance disruption Passau ↔ Wien Hbf.
+        # Passau is not a Wiener Bahnhof and not in the Pendler list, so
+        # this Wien ↔ Distant connection must be dropped from the feed.
+        title = "DB-Bauarbeiten: geänderte Fahrzeiten: Passau Wien Hauptbahnhof"
+        desc = (
+            "Wegen Bauarbeiten der Deutschen Bahn (DB) fährt<br>"
+            "zwischen <b>Passau Hbf</b> und <b>Wien Hbf<br>in der Nacht</b> "
+            "von <b>18.05.</b> auf <b>19.05.2026<br></b>der Zug NJ 491 nicht"
+        )
+        cleaned = _clean_title_keep_places(title)
+        assert _is_relevant(cleaned, desc) is False
+
+    def test_pendler_pendler_route_dropped(self) -> None:
+        # Flughafen Wien (Pendler) ↔ Wolfsthal (Pendler) — neither is in
+        # Vienna, so the connection must be dropped per spec.
+        title = "Bauarbeiten: Flughafen Wien Wolfsthal"
+        desc = (
+            "Wegen Bauarbeiten können<br>zwischen <b>Flughafen Wien Bahnhof</b>"
+            " und <b>Wolfsthal Bahnhof</b><br>am 17.09.2026"
+        )
+        cleaned = _clean_title_keep_places(title)
+        assert _is_relevant(cleaned, desc) is False
+
+    def test_rex7_pendler_pendler_segment_dropped(self) -> None:
+        # The full line REX 7 stops at several Wiener Bahnhöfe but the
+        # actually disrupted segment is Flughafen Wien ↔ Wolfsthal — both
+        # Pendler, no Wien.
+        title = "REX 7: Bauarbeiten: Wien Floridsdorf/Flughafen Wien Wolfsthal"
+        desc = (
+            "Wegen Bauarbeiten können <br>"
+            "zwischen <b>Flughafen Wien Bahnhof</b> und <b>Wolfsthal Bahnhof </b><br>"
+            "am 19.02.2026 ..."
+        )
+        cleaned = _clean_title_keep_places(title)
+        assert _is_relevant(cleaned, desc) is False
+
+
+class TestUserReportedKeepExamples:
+    """Examples the user wants kept, with cleaner titles."""
+
+    def test_flughafen_wien_mitte_kept_with_clean_title(self) -> None:
+        title = "Bauarbeiten: Flughafen Wien Wien Mitte-Landstraße"
+        desc = (
+            "Wegen Bauarbeiten können<br>"
+            "von <b>13.04.2026</b> bis <b>28.05.2026</b><br>"
+            "zwischen <b>Flughafen Wien Bahnhof</b> und <b>Wien Mitte-Landstraße Bahnhof</b>"
+        )
+        cleaned = _clean_title_keep_places(title)
+        assert _is_relevant(cleaned, desc) is True
+        # Vienna endpoint comes first; Pendler endpoint after the arrow.
+        assert _build_title(title, desc) == "Wien Mitte-Landstraße ↔ Flughafen Wien"
+
+    def test_wien_westbf_huetteldorf_kept_with_expanded_title(self) -> None:
+        title = "Bauarbeiten: Wien Westbf Wien Hütteldorf"
+        desc = (
+            "Wegen Bauarbeiten können<br>"
+            "zwischen <b>Wien Westbahnhof (U)</b> und <b>Wien Hütteldorf Bahnhof (U)</b><br>"
+            "von <b>03.06.2026</b>"
+        )
+        cleaned = _clean_title_keep_places(title)
+        assert _is_relevant(cleaned, desc) is True
+        # 'Westbf' is expanded to 'Westbahnhof' for readability.
+        assert _build_title(title, desc) == "Wien Westbahnhof ↔ Wien Hütteldorf"
+
+    def test_wien_hbf_flughafen_wien_kept_with_clean_title(self) -> None:
+        title = "Bauarbeiten: Wien Hauptbahnhof Flughafen Wien"
+        desc = (
+            "Wegen Bauarbeiten können zwischen <b>Wien Hbf (U)</b>"
+            " und <b>Flughafen Wien Bahnhof</b> von <b>10.07.2026</b>"
+        )
+        cleaned = _clean_title_keep_places(title)
+        assert _is_relevant(cleaned, desc) is True
+        assert _build_title(title, desc) == "Wien Hauptbahnhof ↔ Flughafen Wien"
+
+    def test_s50_line_prefix_preserved_in_title(self) -> None:
+        title = "S 50: Bauarbeiten: Wien Westbf Wien Hütteldorf/Tullnerbach-Pressbaum"
+        desc = (
+            "Wegen Bauarbeiten können<br>"
+            "von <b>03.06.2026</b> (23:00 Uhr) bis <b>08.06.2026</b><br>"
+            "zwischen <b>Wien Westbahnhof (U) </b>und <b>Wien Hütteldorf Bahnhof (U)</b>"
+        )
+        cleaned = _clean_title_keep_places(title)
+        assert _is_relevant(cleaned, desc) is True
+        # Line prefix 'S 50' must survive the rebuild.
+        assert _build_title(title, desc) == "S 50: Wien Westbahnhof ↔ Wien Hütteldorf"
+
+    def test_multi_route_message_kept(self) -> None:
+        title = "Bauarbeiten: Wien Praterstern Wien Meidling/ Wien Hauptbahnhof Wien Hütteldorf"
+        desc = (
+            "Wegen Bauarbeiten können<br>"
+            "zwischen <b>Wien Praterstern Bahnhof (U)</b> und <b>Wien Meidling Bahnhof (U)</b>, und<br>"
+            "zwischen <b>Wien Hbf (U)</b> und <b>Wien Hütteldorf Bahnhof (U)</b>"
+        )
+        cleaned = _clean_title_keep_places(title)
+        assert _is_relevant(cleaned, desc) is True
+        rebuilt = _build_title(title, desc)
+        # Both routes are surfaced separated by ' / '.
+        assert "Wien Praterstern ↔ Wien Meidling" in rebuilt
+        assert "Wien Hauptbahnhof ↔ Wien Hütteldorf" in rebuilt
+
+
+class TestStrictRouteSpec:
+    """Narrow unit tests for the strict route classification rule."""
+
+    def test_vienna_to_vienna_relevant(self) -> None:
+        assert _route_is_wien_relevant("Wien Westbahnhof", "Wien Hütteldorf") is True
+
+    def test_vienna_to_pendler_relevant(self) -> None:
+        assert _route_is_wien_relevant("Wien Hauptbahnhof", "Mödling") is True
+        assert _route_is_wien_relevant("Mödling", "Wien Hauptbahnhof") is True
+
+    def test_pendler_to_pendler_dropped(self) -> None:
+        assert _route_is_wien_relevant("Mödling", "Baden") is False
+
+    def test_vienna_to_distant_dropped(self) -> None:
+        # München is in stations.json with in_vienna=False, pendler=False.
+        assert _route_is_wien_relevant("Wien Hauptbahnhof", "München Hbf") is False
+
+    def test_vienna_to_unknown_dropped(self) -> None:
+        # Passau is not in stations.json — treated as unknown/distant.
+        assert _route_is_wien_relevant("Wien Hauptbahnhof", "Passau Hbf") is False
+
+    def test_unknown_to_unknown_dropped(self) -> None:
+        assert _route_is_wien_relevant("Bratislava", "Budapest") is False


### PR DESCRIPTION
## Summary

Schließt mehrere Lücken in der Filterlogik und der API-Budget-Verwaltung, die im Feed zu nicht-relevanten Einträgen bzw. potenziellen Quota-Überschreitungen geführt haben.

### Behobene Probleme

#### 1. ÖBB: Wien ↔ Distant rutschte durch
**Beispiel aus dem Feed:** `DB-Bauarbeiten: geänderte Fahrzeiten: Passau Wien Hauptbahnhof` (Description: „zwischen Passau Hbf und Wien Hbf").

`_is_relevant` ließ das durch, weil Passau nicht in `stations.json` steht — kein „distant"-Match — und der `text_has_vienna_connection`-Fallback bei jedem „Wien" im Text True liefert.

#### 2. ÖBB: Titel-Cleanup ohne Separator
Titel wie `Bauarbeiten: Flughafen Wien Wien Mitte-Landstraße` (Stationen aneinandergehängt, keine `↔`/`-`-Trennung) blieben mit Kategorie-Präfix im Feed, weil `_clean_title_keep_places` die Endpunkte nicht erkennen konnte.

#### 3. Google Places: Retries überschritten Quota
Quota wurde nur bei `200 OK` inkrementiert. 429/5xx-Retries verbrauchten Google-Budget, ohne dass der Counter mitgezählt hat — Risiko für Sperrungen oder Mehrkosten.

### Neue Filterlogik (Spec-konform)

```
Wien ↔ Wien        → keep
Wien ↔ Pendler     → keep
Pendler ↔ Pendler  → drop  (z.B. Flughafen Wien ↔ Wolfsthal)
Wien ↔ Distant     → drop  (z.B. Wien Hbf ↔ Passau)
Wien ↔ Unknown     → drop
Distant ↔ Distant  → drop
```

`OEBB_ONLY_VIENNA` engt das auf Wien ↔ Wien ein. Einzelstation-/Allgemeinmeldungen bleiben gleich behandelt (mind. eine Wien- oder Pendlerstation).

### Wichtige Änderungen

**`src/providers/oebb.py`**
- Neue Helper `_extract_zwischen_routes`, `_extract_routes`, `_classify_endpoint`, `_route_is_wien_relevant`: extrahieren Endpunkte aus Titel (`↔`) und Description (`zwischen X und Y`, HTML-tolerant) und klassifizieren sie via `stations.json`.
- `_is_relevant` strikt umgebaut: bei extrahierten Routen striktes Matching, sonst Fallback auf Stationsmention.
- Neue Title-Rebuild-Stufe in `fetch_events`: bei relevanter Route wird ein sauberer `A ↔ B`-Titel mit kanonischen Namen gebaut. Wien-Endpunkt zuerst, Linien-Präfix (REX 7, S 50) erhalten, Kategorie-Präfix (Bauarbeiten, DB-Bauarbeiten, geänderte Fahrzeiten) entfernt. Westbf/Hbf/Bf werden ausgeschrieben.
- `_find_stations_in_text` ignoriert generische Einzeltoken wie „Hbf"/„Bahnhof" — die kanonisierten zuvor fälschlich auf „Wien Hauptbahnhof".
- `_strip_oebb_prefixes` erkennt zusätzlich „DB-Bauarbeiten", „geänderte Fahrzeiten", „Schienenersatzverkehr", „Haltausfall" usw.

**`src/places/client.py`**
- Quota wird jetzt vor jedem HTTP-Versuch geprüft und konsumiert. Re-Check bei Retries vermeidet Cap-Überschreitung. Docstring-Update auf `_record_successful_request` (Name aus Kompatibilität erhalten).

### Beispiele aus dem User-Bericht

| Original-Titel | Vorher | Nachher |
| --- | --- | --- |
| `DB-Bauarbeiten: geänderte Fahrzeiten: Passau Wien Hauptbahnhof` | im Feed | gefiltert |
| `Bauarbeiten: Flughafen Wien Wien Mitte-Landstraße` | unverändert | `Wien Mitte-Landstraße ↔ Flughafen Wien` |
| `Bauarbeiten: Wien Westbf Wien Hütteldorf` | unverändert | `Wien Westbahnhof ↔ Wien Hütteldorf` |
| `S 50: Bauarbeiten: Wien Westbf Wien Hütteldorf/Tullnerbach-Pressbaum` | unverändert | `S 50: Wien Westbahnhof ↔ Wien Hütteldorf` |
| `Bauarbeiten: Flughafen Wien Wolfsthal` | im Feed | gefiltert (Pendler ↔ Pendler) |

## Test plan

- [x] `pytest tests/` — 1021 passed, 1 skipped
- [x] `mypy --strict src/ tests/` — clean
- [x] `ruff check src/ tests/` — clean
- [x] Neue Tests `tests/test_oebb_user_examples.py` (14 Cases) — die User-Beispiele 1:1 als Regressionsschutz
- [x] Neue Tests `tests/places/test_client_quota_retries.py` (3 Cases) — Quota-Inkrement bei Retries und Daily-Cap-Abbruch
- [x] Bestehende ÖBB-Tests aktualisiert: `test_venezia_is_excluded`, `test_one_end_unknown_excluded`, `test_einseitiger_wien_bezug_mit_prefix` jetzt auf strikte Erwartung; `test_stationsname_enthaelt_selbst_doppelpunkt` mit Pendler-Endpunkt umgebaut, damit der eigentliche Test-Fokus (Doppelpunkt-Handling) erhalten bleibt
- [x] `test_rate_limited_attempts_consume_quota` ersetzt `test_rate_limit_does_not_consume_quota` (invertiert auf Pre-Charge-Semantik)

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_