### PR TITLE
fix(stations): enforce mutual exclusivity of in_vienna and pendler flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ verhindert Drift.
 | ---- | ------- | ------------ |
 | `name` | ✓ | Kanonischer Anzeige-Name (eindeutig, wird im Feed verwendet). |
 | `in_vienna` | ✓ | `true` wenn die Koordinaten innerhalb des LANDESGRENZEOGD-Polygons liegen. |
-| `pendler` | ✓ | `true` für Pendler-Knoten außerhalb Wiens (siehe `data/pendler_bst_ids.json`). |
+| `pendler` | ✓ | `true` für Pendler-Knoten **außerhalb** Wiens (siehe `data/pendler_bst_ids.json`). **Mutual exclusive zu `in_vienna`**: jede Station ist entweder Wien-Station ODER Pendler, niemals beides. Einzige Ausnahme: `type: manual_foreign_city` (München, Roma) — beide Flags `false`. Verstöße werden vom Validator als NamingIssue gemeldet und vom Updater automatisch korrigiert (in_vienna gewinnt). |
 | `aliases` | ✓ | Schreibvarianten und IDs zur Erkennung in Provider-Texten. |
 | `latitude` / `longitude` | ✓ | WGS84-Koordinaten (validiert gegen das Wien-Polygon für `in_vienna`-Einträge). |
 | `source` | ✓ | Komma-getrennte Provider-Tokens (kein Whitespace) aus `oebb,vor,wl,google_places,manual`. |

--- a/docs/schema/stations.schema.json
+++ b/docs/schema/stations.schema.json
@@ -32,11 +32,11 @@
         },
         "in_vienna": {
           "type": "boolean",
-          "description": "True wenn die Stations-Koordinaten innerhalb des LANDESGRENZEOGD-Polygons liegen."
+          "description": "True wenn die Stations-Koordinaten innerhalb des LANDESGRENZEOGD-Polygons liegen. Mutual exclusive zu 'pendler' — siehe allOf-Constraint."
         },
         "pendler": {
           "type": "boolean",
-          "description": "True wenn die Station als Pendler-Knoten konfiguriert ist (siehe data/pendler_bst_ids.json)."
+          "description": "True wenn die Station als Pendler-Knoten konfiguriert ist (siehe data/pendler_bst_ids.json). Mutual exclusive zu 'in_vienna' — siehe allOf-Constraint."
         },
         "aliases": {
           "type": "array",
@@ -136,6 +136,30 @@
           "description": "ÖBB-Einträge müssen bst_id und bst_code tragen.",
           "if": {"properties": {"source": {"pattern": "(?:^|,)oebb(?:,|$)"}}},
           "then": {"required": ["bst_id", "bst_code"]}
+        },
+        {
+          "description": "in_vienna und pendler dürfen nicht beide true sein. Eine Station ist entweder Wien-Station oder Pendler-Knoten, niemals beides.",
+          "not": {
+            "properties": {
+              "in_vienna": {"const": true},
+              "pendler": {"const": true}
+            },
+            "required": ["in_vienna", "pendler"]
+          }
+        },
+        {
+          "description": "Mindestens eines von in_vienna oder pendler muss true sein, außer bei manuell gepflegten Auslandsknoten (type: manual_foreign_city).",
+          "if": {
+            "properties": {
+              "in_vienna": {"const": false},
+              "pendler": {"const": false}
+            },
+            "required": ["in_vienna", "pendler"]
+          },
+          "then": {
+            "properties": {"type": {"const": "manual_foreign_city"}},
+            "required": ["type"]
+          }
         }
       ]
     }

--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -1070,6 +1070,14 @@ def _annotate_station_flags(
     pendler_ids: set[str],
     locations: Mapping[str, LocationInfo],
 ) -> None:
+    """Set ``in_vienna`` and ``pendler`` mutually exclusively.
+
+    A station is either inside the Vienna city limits *or* a commuter-belt
+    station outside; never both. If a Vienna station's bst_id is mistakenly
+    listed in ``data/pendler_bst_ids.json``, the ``in_vienna`` flag wins and
+    the pendler flag stays ``False`` — a warning is logged so the entry can
+    be removed from the whitelist.
+    """
     for station in stations:
         info: LocationInfo | None = None
         for key in _normalize_location_keys(station.name):
@@ -1080,10 +1088,18 @@ def _annotate_station_flags(
             station.in_vienna = _is_point_in_vienna(info.latitude, info.longitude)
         else:
             station.in_vienna = _is_vienna_station(station.name)
-        pendler = station.bst_id in pendler_ids
+        pendler_candidate = station.bst_id in pendler_ids
         if info and not station.in_vienna and "wl" in info.sources:
-            pendler = True
-        station.pendler = pendler
+            pendler_candidate = True
+        if station.in_vienna and pendler_candidate:
+            logger.warning(
+                "Station %s (bst_id=%s) is inside Vienna; ignoring pendler "
+                "marker — remove the entry from data/pendler_bst_ids.json",
+                station.name,
+                station.bst_id,
+            )
+            pendler_candidate = False
+        station.pendler = pendler_candidate
 
 
 def _filter_relevant_stations(stations: list[Station]) -> list[Station]:

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -592,9 +592,9 @@ def _find_provider_issues(
 def _find_naming_issues(
     stations: Sequence[Mapping[str, object]]
 ) -> Iterator[NamingIssue]:
-    """Validate canonical-name policy.
+    """Validate canonical-name policy and flag-consistency invariants.
 
-    Two checks:
+    Three checks:
 
     1. **Uniqueness** – the ``name`` field is the canonical display label
        for a station and must not be shared between two distinct entries.
@@ -602,6 +602,11 @@ def _find_naming_issues(
        string must not contain whitespace inside tokens (e.g.
        ``"google_places, vor"``). Whitespace breaks naive ``==``-based
        lookup branches and signals an unnormalized write path.
+    3. **Vienna/pendler mutual exclusivity** – ``in_vienna`` and ``pendler``
+       partition the directory: every entry is *either* inside the city
+       limits *or* a commuter-belt station outside, never both. The single
+       exception is ``type: manual_foreign_city`` (München, Roma) where
+       both flags may legitimately be ``false``.
     """
     name_to_identifiers: dict[str, list[str]] = defaultdict(list)
     for entry in stations:
@@ -640,6 +645,34 @@ def _find_naming_issues(
                 identifier=identifier,
                 name=name,
                 reason=f"source field has whitespace: {source!r} (expected comma-separated, no spaces)",
+            )
+
+    for entry in stations:
+        in_vienna = bool(entry.get("in_vienna"))
+        pendler = bool(entry.get("pendler"))
+        identifier = _format_identifier(entry)
+        name = str(entry.get("name", "")).strip() or "<unknown>"
+        entry_type = entry.get("type")
+
+        if in_vienna and pendler:
+            yield NamingIssue(
+                identifier=identifier,
+                name=name,
+                reason=(
+                    "in_vienna and pendler are both true — flags must be "
+                    "mutually exclusive (a Vienna station cannot also be a "
+                    "commuter-belt station)"
+                ),
+            )
+        elif not in_vienna and not pendler and entry_type != "manual_foreign_city":
+            yield NamingIssue(
+                identifier=identifier,
+                name=name,
+                reason=(
+                    "in_vienna and pendler are both false — entry should "
+                    "either be classified as a Vienna station, a commuter "
+                    "station, or marked with type='manual_foreign_city'"
+                ),
             )
 
 

--- a/tests/test_station_validation.py
+++ b/tests/test_station_validation.py
@@ -275,6 +275,8 @@ def test_naming_validation_clean_data_yields_no_issues(tmp_path: Path) -> None:
             "latitude": 48.2,
             "longitude": 16.4,
             "source": "oebb",
+            "in_vienna": True,
+            "pendler": False,
         },
     ]
     path = tmp_path / "stations.json"
@@ -283,3 +285,88 @@ def test_naming_validation_clean_data_yields_no_issues(tmp_path: Path) -> None:
     report = validate_stations(path)
     assert report.naming_issues == ()
     assert isinstance(NamingIssue("x", "y", "z"), NamingIssue)
+
+
+def test_naming_validation_flags_in_vienna_and_pendler_combination(tmp_path: Path) -> None:
+    """A station classified both as in_vienna and pendler is invalid.
+
+    The two flags partition the directory: every entry is either inside
+    the Vienna city limits (in_vienna=true) or a commuter-belt station
+    outside (pendler=true), never both.
+    """
+    stations = [
+        {
+            "bst_id": 500,
+            "bst_code": "Q1",
+            "name": "Wien Verwirrt",
+            "aliases": ["Wien Verwirrt"],
+            "latitude": 48.2,
+            "longitude": 16.4,
+            "source": "oebb",
+            "in_vienna": True,
+            "pendler": True,
+        },
+    ]
+    path = tmp_path / "stations.json"
+    path.write_text(json.dumps(stations), encoding="utf-8")
+
+    report = validate_stations(path)
+    flag_issues = [i for i in report.naming_issues if "mutually exclusive" in i.reason]
+    assert len(flag_issues) == 1
+    assert flag_issues[0].name == "Wien Verwirrt"
+
+
+def test_naming_validation_flags_neither_vienna_nor_pendler(tmp_path: Path) -> None:
+    """A regular station with neither flag is invalid; only manual_foreign_city is exempt."""
+    stations = [
+        {
+            "bst_id": 600,
+            "bst_code": "Q2",
+            "name": "Niemandsland",
+            "aliases": ["Niemandsland"],
+            "latitude": 48.5,
+            "longitude": 16.7,
+            "source": "oebb",
+            "in_vienna": False,
+            "pendler": False,
+        },
+        {
+            "name": "Roma Termini",
+            "aliases": ["Roma Termini"],
+            "latitude": 41.901,
+            "longitude": 12.500,
+            "source": "manual",
+            "type": "manual_foreign_city",
+            "in_vienna": False,
+            "pendler": False,
+        },
+    ]
+    path = tmp_path / "stations.json"
+    path.write_text(json.dumps(stations), encoding="utf-8")
+
+    report = validate_stations(path)
+    issues = [i for i in report.naming_issues if "both false" in i.reason]
+    assert len(issues) == 1
+    assert issues[0].name == "Niemandsland", "manual_foreign_city must be exempt"
+
+
+def test_stations_json_has_mutually_exclusive_flags() -> None:
+    """Lock the live data: no entry has both flags or none (except foreign cities)."""
+    repo_root = Path(__file__).resolve().parent.parent
+    with (repo_root / "data" / "stations.json").open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    stations = data["stations"] if isinstance(data, dict) else data
+
+    both = [s for s in stations if s.get("in_vienna") and s.get("pendler")]
+    assert not both, (
+        "Stations with both in_vienna and pendler are invalid: "
+        + ", ".join(s.get("name", "<unnamed>") for s in both)
+    )
+    neither = [
+        s for s in stations
+        if not s.get("in_vienna") and not s.get("pendler") and s.get("type") != "manual_foreign_city"
+    ]
+    assert not neither, (
+        "Stations with neither flag (and not manual_foreign_city) are invalid: "
+        + ", ".join(s.get("name", "<unnamed>") for s in neither)
+    )

--- a/tests/test_stations_validation_unsafe.py
+++ b/tests/test_stations_validation_unsafe.py
@@ -61,7 +61,9 @@ def test_validation_passes_safe_chars(tmp_path: Path) -> None:
                 "aliases": ["Safe Station (Hbf)", "Safe / Alias", "St. Pölten", "900100"],
                 "latitude": 48.0,
                 "longitude": 16.0,
-                "source": "vor"
+                "source": "vor",
+                "in_vienna": True,
+                "pendler": False
             },
             {
                 "name": "Safe Station 2",
@@ -71,7 +73,9 @@ def test_validation_passes_safe_chars(tmp_path: Path) -> None:
                 "aliases": ["Safe Station 2", "900200"],
                 "latitude": 48.1,
                 "longitude": 16.1,
-                "source": "vor"
+                "source": "vor",
+                "in_vienna": True,
+                "pendler": False
             }
         ]
     }

--- a/tests/test_update_station_directory_flags.py
+++ b/tests/test_update_station_directory_flags.py
@@ -1,0 +1,80 @@
+"""Mutual-exclusivity guard for in_vienna and pendler flags.
+
+Verifies that ``_annotate_station_flags`` never produces an entry with
+both flags set, even if a Vienna station's bst_id is mistakenly listed
+in ``data/pendler_bst_ids.json``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from scripts import update_station_directory as usd
+
+
+def _make_station(name: str, bst_id: str = "1") -> usd.Station:
+    return usd.Station(bst_id=bst_id, bst_code="X", name=name, in_vienna=False, pendler=False)
+
+
+def _make_location(lat: float, lon: float, *, source: str = "oebb") -> usd.LocationInfo:
+    return usd.LocationInfo(latitude=lat, longitude=lon, sources={source})
+
+
+def test_in_vienna_wins_over_mistaken_pendler_whitelist_entry(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A station inside Vienna must keep pendler=False even when its
+    bst_id sneaks into pendler_bst_ids.json. The override logs a warning."""
+    station = _make_station("Wien Westbahnhof", bst_id="2511")
+    # Wien Westbahnhof's actual coordinates from data/stations.json
+    locations = {"wien westbahnhof": _make_location(48.196654, 16.337652)}
+    pendler_ids = {"2511"}  # mistakenly added Wien station
+
+    with caplog.at_level(logging.WARNING):
+        usd._annotate_station_flags([station], pendler_ids, locations)
+
+    assert station.in_vienna is True
+    assert station.pendler is False, "Vienna stations must never carry pendler=true"
+    assert any("inside Vienna" in record.getMessage() for record in caplog.records), (
+        "Expected a WARNING when a Vienna station is on the pendler whitelist"
+    )
+
+
+def test_outside_station_is_marked_pendler_only() -> None:
+    """A station outside Vienna with a pendler whitelist entry stays pendler-only."""
+    station = _make_station("Mödling", bst_id="1390")
+    locations = {"modling": _make_location(48.085628, 16.295474)}
+    pendler_ids = {"1390"}
+
+    usd._annotate_station_flags([station], pendler_ids, locations)
+
+    assert station.in_vienna is False
+    assert station.pendler is True
+
+
+def test_wl_outside_station_becomes_pendler() -> None:
+    """A WL-sourced station outside Vienna is auto-promoted to pendler=True
+    even without a whitelist entry — preserves legacy behaviour."""
+    station = _make_station("Eisenstadt Domplatz", bst_id="9999")
+    locations = {"eisenstadt domplatz": _make_location(47.846, 16.522, source="wl")}
+    pendler_ids: set[str] = set()
+
+    usd._annotate_station_flags([station], pendler_ids, locations)
+
+    assert station.in_vienna is False
+    assert station.pendler is True
+
+
+def test_wl_vienna_station_does_not_become_pendler() -> None:
+    """The WL-auto-promotion path must respect the in_vienna check.
+    A WL station inside Vienna stays pendler=False."""
+    station = _make_station("Wien Karlsplatz", bst_id="900101")
+    locations = {"wien karlsplatz": _make_location(48.200888, 16.368907, source="wl")}
+    pendler_ids: set[str] = set()
+
+    usd._annotate_station_flags([station], pendler_ids, locations)
+
+    assert station.in_vienna is True
+    assert station.pendler is False


### PR DESCRIPTION
## Summary

Antwort auf die Frage „Gibt es Stationen mit Wien- und Pendler-Markierung?": **aktuell 0**, aber strukturell war diese Invariante **bisher ungeschützt**. Drei Layer Schutz eingezogen:

### 1. Updater fix
`scripts/update_station_directory.py:_annotate_station_flags` korrigiert sich selbst, wenn eine Wien-Station versehentlich in `data/pendler_bst_ids.json` landet:
- `in_vienna=true` gewinnt
- `pendler` bleibt `false`
- Eine WARNING wird geloggt, damit der falsche Whitelist-Eintrag entfernt werden kann

### 2. Validator
`stations_validation.py:_find_naming_issues` bekommt zwei zusätzliche NamingIssue-Checks:

| Verstoß | Maßnahme |
|---|---|
| `in_vienna=true AND pendler=true` | Issue per Eintrag |
| `in_vienna=false AND pendler=false` | Issue per Eintrag, **außer** `type=manual_foreign_city` (München, Roma) |

### 3. JSON Schema
`docs/schema/stations.schema.json` bekommt zwei `allOf`-Constraints:
- `not`-Klausel: beide `true` lehnt ab
- Conditional `if/then`: beide `false` erfordert `type=manual_foreign_city`

Schema-Verhalten verifiziert: beide-true und beide-false-ohne-Exemption werden abgelehnt; manual_foreign_city wird akzeptiert.

### Tests
- `test_stations_json_has_mutually_exclusive_flags` pinnt die aktuelle Live-Datei (0 Verstöße)
- `test_update_station_directory_flags.py` mit 4 Cases (in_vienna gewinnt, pendler-only outside, WL-auto-promote, WL-Wien bleibt non-pendler)
- 2 zusätzliche Validator-Tests für Schema-NamingIssue-Triggers

**Aktuelle Datenlage:**
- `in_vienna=true AND pendler=true`: **0**
- `in_vienna=false AND pendler=false`: 2 (München Hauptbahnhof, Roma Termini, beide `manual_foreign_city`)

## Test plan
- [x] `pytest tests/` → 1037 passed, 1 skipped (1030 → 1037; +7 neue Tests)
- [x] `ruff check` clean
- [x] `mypy` clean
- [x] Schema-Roundtrip: stations.json → 0 Fehler, gegen synthetische Bad-Inputs → korrekt abgelehnt
- [x] Validator-Report regeneriert, 0 Naming-Issues

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_