### PR TITLE
feat(vor): Heartbeat-Marker für VOR-Cache-Läufe

### DIFF
--- a/.github/workflows/update-vor-cache.yml
+++ b/.github/workflows/update-vor-cache.yml
@@ -86,4 +86,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: 'chore: update VOR cache [skip ci]'
-          file_pattern: 'cache/vor*/events.json data/vor_request_count.json'
+          file_pattern: 'cache/vor*/events.json cache/vor*/last_run.json data/vor_request_count.json'

--- a/scripts/update_vor_cache.py
+++ b/scripts/update_vor_cache.py
@@ -55,7 +55,7 @@ from src.providers.vor import (  # noqa: E402  (import after path setup)
     get_configured_stations,
     select_stations_for_run,
 )
-from src.utils.cache import write_cache  # noqa: E402
+from src.utils.cache import write_cache, write_status  # noqa: E402
 from src.utils.serialize import serialize_for_cache  # noqa: E402
 
 
@@ -93,6 +93,37 @@ def _limit_reached(now_local: datetime) -> bool:
     return False
 
 
+def _record_status(
+    *,
+    status: str,
+    stations_queried: int,
+    events_collected: int | None,
+    now_local: datetime,
+) -> None:
+    """Persist a heartbeat for the VOR cache run.
+
+    The marker is committed even when ``events.json`` would otherwise stay
+    byte-identical (e.g. a stretch of empty provider responses), so the most
+    recent successful run stays visible in git history.
+    """
+
+    todays_count = _todays_request_count(now_local)
+    payload: dict = {
+        "last_run_at": now_local.astimezone(timezone.utc).isoformat(),
+        "last_run_at_local": now_local.isoformat(),
+        "status": status,
+        "stations_queried": stations_queried,
+        "requests_used_today": todays_count,
+        "daily_limit": MAX_REQUESTS_PER_DAY,
+    }
+    if events_collected is not None:
+        payload["events_collected"] = events_collected
+    try:
+        write_status("vor", payload)
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("VOR: Status-Marker konnte nicht geschrieben werden.")
+
+
 def main() -> int:
     """Entry point for refreshing the VOR cache."""
 
@@ -126,6 +157,12 @@ def main() -> int:
 
     now_local = _now_local()
     if _limit_reached(now_local):
+        _record_status(
+            status="skipped_quota",
+            stations_queried=0,
+            events_collected=None,
+            now_local=now_local,
+        )
         return 0
 
     try:
@@ -136,16 +173,34 @@ def main() -> int:
             "VOR: API nicht erreichbar – behalte bestehenden Cache bei.",
             exc_info=True,
         )
+        _record_status(
+            status="api_unreachable",
+            stations_queried=STATIONS_COUNT,
+            events_collected=None,
+            now_local=now_local,
+        )
         return 0
     except Exception:  # pragma: no cover - defensive
         logger.exception(
             "VOR: Fehler beim Abrufen der Daten – behalte bestehenden Cache bei.",
+        )
+        _record_status(
+            status="error",
+            stations_queried=STATIONS_COUNT,
+            events_collected=None,
+            now_local=now_local,
         )
         return 1
 
     serialized_items = [serialize_for_cache(item) for item in items]
     write_cache("vor", serialized_items)
     logger.info("VOR: Cache mit %d Einträgen aktualisiert.", len(serialized_items))
+    _record_status(
+        status="ok",
+        stations_queried=STATIONS_COUNT,
+        events_collected=len(serialized_items),
+        now_local=now_local,
+    )
     return 0
 
 

--- a/scripts/update_vor_cache.py
+++ b/scripts/update_vor_cache.py
@@ -8,6 +8,7 @@ import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 from zoneinfo import ZoneInfo
 
 from requests.exceptions import RequestException
@@ -108,7 +109,7 @@ def _record_status(
     """
 
     todays_count = _todays_request_count(now_local)
-    payload: dict = {
+    payload: dict[str, Any] = {
         "last_run_at": now_local.astimezone(timezone.utc).isoformat(),
         "last_run_at_local": now_local.isoformat(),
         "status": status,

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -15,6 +15,7 @@ from .files import atomic_write, safe_path_join, sanitize_filename
 
 _CACHE_DIR = Path("cache")
 _CACHE_FILENAME = "events.json"
+_STATUS_FILENAME = "last_run.json"
 
 log = logging.getLogger(__name__)
 
@@ -69,6 +70,12 @@ def _cache_file(provider: str) -> Path:
     if not re.match(r"^[a-zA-Z0-9_-]+$", provider):
         raise ValueError(f"Invalid cache key format: {provider}")
     return safe_path_join(_CACHE_DIR, sanitize_filename(provider), _CACHE_FILENAME)
+
+
+def _status_file(provider: str) -> Path:
+    if not re.match(r"^[a-zA-Z0-9_-]+$", provider):
+        raise ValueError(f"Invalid cache key format: {provider}")
+    return safe_path_join(_CACHE_DIR, sanitize_filename(provider), _STATUS_FILENAME)
 
 
 def cache_modified_at(provider: str) -> Optional[datetime]:
@@ -276,3 +283,55 @@ def write_cache(provider: str, items: List[Any], *, pretty: Optional[bool] = Non
             cache_file,
         )
         raise
+
+
+def write_status(provider: str, status: dict) -> None:
+    """Persist a heartbeat record for ``provider`` next to its events cache.
+
+    The status file lives at ``cache/<sanitized provider>/last_run.json`` and
+    is intended to make workflow runs visible in git even when the events
+    payload is unchanged (e.g. an empty provider response collapsing into the
+    same ``[]`` cache file commit after commit).
+    """
+
+    if not isinstance(status, dict):
+        raise TypeError("status must be a dict")
+
+    status_file = _status_file(provider)
+
+    try:
+        with atomic_write(
+            status_file, mode="w", encoding="utf-8", permissions=0o600
+        ) as fh:
+            json.dump(status, fh, ensure_ascii=False, indent=2, sort_keys=True)
+            fh.write("\n")
+    except Exception:
+        log.exception(
+            "Failed to write status for provider '%s' to %s",
+            provider,
+            status_file,
+        )
+        raise
+
+
+def read_status(provider: str) -> Optional[dict]:
+    """Return the persisted heartbeat for ``provider`` or ``None``."""
+
+    status_file = _status_file(provider)
+    try:
+        with status_file.open("r", encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except FileNotFoundError:
+        return None
+    except (json.JSONDecodeError, OSError) as exc:
+        log.warning(
+            "Could not read status for provider '%s' at %s: %s",
+            provider,
+            status_file,
+            exc,
+        )
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+    return payload

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -285,7 +285,7 @@ def write_cache(provider: str, items: List[Any], *, pretty: Optional[bool] = Non
         raise
 
 
-def write_status(provider: str, status: dict) -> None:
+def write_status(provider: str, status: dict[str, Any]) -> None:
     """Persist a heartbeat record for ``provider`` next to its events cache.
 
     The status file lives at ``cache/<sanitized provider>/last_run.json`` and
@@ -314,7 +314,7 @@ def write_status(provider: str, status: dict) -> None:
         raise
 
 
-def read_status(provider: str) -> Optional[dict]:
+def read_status(provider: str) -> Optional[dict[str, Any]]:
     """Return the persisted heartbeat for ``provider`` or ``None``."""
 
     status_file = _status_file(provider)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -67,3 +67,62 @@ def test_write_cache_env_compact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
         [{"id": 2}], ensure_ascii=False, indent=None, separators=(",", ":")
     )
     assert cache_file.read_text(encoding="utf-8") == expected
+
+
+def test_write_status_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    base = tmp_path / "cache-root"
+    monkeypatch.setattr(cache, "_CACHE_DIR", base, raising=False)
+
+    payload = {
+        "last_run_at": "2026-05-05T17:30:00+00:00",
+        "status": "ok",
+        "events_collected": 0,
+        "stations_queried": 2,
+    }
+    cache.write_status("vor", payload)
+
+    status_path = base / sanitize_filename("vor") / "last_run.json"
+    assert status_path.exists()
+    assert json.loads(status_path.read_text(encoding="utf-8")) == payload
+    assert cache.read_status("vor") == payload
+
+
+def test_read_status_returns_none_when_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = tmp_path / "cache-root"
+    monkeypatch.setattr(cache, "_CACHE_DIR", base, raising=False)
+
+    assert cache.read_status("vor") is None
+
+
+def test_read_status_returns_none_on_invalid_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = tmp_path / "cache-root"
+    monkeypatch.setattr(cache, "_CACHE_DIR", base, raising=False)
+    target = base / sanitize_filename("vor")
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "last_run.json").write_text("{not json", encoding="utf-8")
+
+    assert cache.read_status("vor") is None
+
+
+def test_write_status_rejects_non_dict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = tmp_path / "cache-root"
+    monkeypatch.setattr(cache, "_CACHE_DIR", base, raising=False)
+
+    with pytest.raises(TypeError):
+        cache.write_status("vor", [1, 2, 3])  # type: ignore[arg-type]
+
+
+def test_write_status_rejects_invalid_provider_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    base = tmp_path / "cache-root"
+    monkeypatch.setattr(cache, "_CACHE_DIR", base, raising=False)
+
+    with pytest.raises(ValueError):
+        cache.write_status("../escape", {"status": "ok"})

--- a/tests/test_update_vor_cache.py
+++ b/tests/test_update_vor_cache.py
@@ -12,7 +12,18 @@ from scripts import update_vor_cache
 from requests.exceptions import RequestException
 
 
-def test_cache_written_when_limit_reached(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture(autouse=True)
+def _mock_write_status(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    """Ensure no test in this module writes a real status file to the repo."""
+
+    write_status_mock = Mock()
+    monkeypatch.setattr(update_vor_cache, "write_status", write_status_mock)
+    return write_status_mock
+
+
+def test_cache_written_when_limit_reached(
+    monkeypatch: pytest.MonkeyPatch, _mock_write_status: Mock
+) -> None:
     """Ensure the cache is written even if the final request hits the limit."""
 
     now = datetime(2024, 1, 1, 12, tzinfo=ZoneInfo("Europe/Vienna"))
@@ -59,7 +70,9 @@ def test_cache_written_when_limit_reached(monkeypatch: pytest.MonkeyPatch) -> No
     save_request_count_mock.assert_not_called()
 
 
-def test_main_returns_success_when_fetch_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_main_returns_success_when_fetch_fails(
+    monkeypatch: pytest.MonkeyPatch, _mock_write_status: Mock
+) -> None:
     """Network failures must not cause a non-zero exit status."""
 
     # Mock safety check dependencies to ensure it passes
@@ -76,9 +89,15 @@ def test_main_returns_success_when_fetch_fails(monkeypatch: pytest.MonkeyPatch) 
     exit_code = update_vor_cache.main()
 
     assert exit_code == 0
+    assert _mock_write_status.call_count == 1
+    provider_arg, payload = _mock_write_status.call_args.args
+    assert provider_arg == "vor"
+    assert payload["status"] == "api_unreachable"
 
 
-def test_cache_written_when_empty_list_returned(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cache_written_when_empty_list_returned(
+    monkeypatch: pytest.MonkeyPatch, _mock_write_status: Mock
+) -> None:
     """Ensure an empty list is cached and returns success."""
 
     # Mock safety check dependencies to ensure it passes
@@ -98,3 +117,61 @@ def test_cache_written_when_empty_list_returned(monkeypatch: pytest.MonkeyPatch)
 
     assert exit_code == 0
     write_cache_mock.assert_called_once_with("vor", [])
+
+
+def test_status_marker_records_ok_run(
+    monkeypatch: pytest.MonkeyPatch, _mock_write_status: Mock
+) -> None:
+    """A successful run must leave a heartbeat with status=ok and event count."""
+
+    monkeypatch.setattr(update_vor_cache, "get_configured_stations", lambda: ["1", "2"])
+    monkeypatch.setattr(update_vor_cache, "select_stations_for_run", lambda stations: stations)
+    monkeypatch.setattr(update_vor_cache, "_limit_reached", lambda now: False)
+    monkeypatch.setattr(update_vor_cache, "_todays_request_count", lambda now: 14)
+    monkeypatch.setattr(
+        update_vor_cache, "fetch_events", lambda *args, **kwargs: [{"id": "x"}]
+    )
+    monkeypatch.setattr(update_vor_cache, "write_cache", Mock())
+    monkeypatch.setattr(update_vor_cache, "serialize_for_cache", lambda item: item)
+
+    exit_code = update_vor_cache.main()
+
+    assert exit_code == 0
+    assert _mock_write_status.call_count == 1
+    provider_arg, payload = _mock_write_status.call_args.args
+    assert provider_arg == "vor"
+    assert payload["status"] == "ok"
+    assert payload["events_collected"] == 1
+    assert payload["stations_queried"] == 2
+    assert payload["requests_used_today"] == 14
+    assert payload["daily_limit"] == update_vor_cache.MAX_REQUESTS_PER_DAY
+    assert "last_run_at" in payload
+    assert "last_run_at_local" in payload
+
+
+def test_status_marker_records_quota_skip(
+    monkeypatch: pytest.MonkeyPatch, _mock_write_status: Mock
+) -> None:
+    """When the daily quota is exhausted the heartbeat must reflect the skip."""
+
+    now = datetime(2024, 1, 1, 12, tzinfo=ZoneInfo("Europe/Vienna"))
+    monkeypatch.setattr(update_vor_cache, "get_configured_stations", lambda: ["1", "2"])
+    monkeypatch.setattr(update_vor_cache, "select_stations_for_run", lambda stations: stations)
+    monkeypatch.setattr(update_vor_cache, "_now_local", lambda: now)
+    monkeypatch.setattr(
+        update_vor_cache,
+        "_todays_request_count",
+        lambda _now: update_vor_cache.MAX_REQUESTS_PER_DAY,
+    )
+
+    fetch_mock = Mock()
+    monkeypatch.setattr(update_vor_cache, "fetch_events", fetch_mock)
+
+    exit_code = update_vor_cache.main()
+
+    assert exit_code == 0
+    fetch_mock.assert_not_called()
+    assert _mock_write_status.call_count == 1
+    _provider, payload = _mock_write_status.call_args.args
+    assert payload["status"] == "skipped_quota"
+    assert "events_collected" not in payload


### PR DESCRIPTION
## Hintergrund

Beim Audit der Datenquellen fiel auf, dass die VOR-Cache-Datei `cache/vor_929f1c/events.json` seit dem 21.02.2026 keinen Commit mehr bekommen hat — auf den ersten Blick wirkte das wie ein gebrochener Workflow.

Ein manueller Lauf des `update-vor-cache.yml`-Workflows hat bestätigt, dass die VOR-API einwandfrei funktioniert:

```
location.name -> HTTP 200
…
VOR Station 430470800: Keine Störungsmeldungen.
VOR Station 490134900: Keine Störungsmeldungen.
VOR-Abruf abgeschlossen: 2 Station(en) erfolgreich, 0 ohne Ergebnis, 0 Ereignis(se) gesammelt.
VOR: Cache mit 0 Einträgen aktualisiert.
```

Der Cache wird also korrekt mit `[]` überschrieben — `git-auto-commit-action` hat aber nichts zu committen, weil die Datei byte-identisch bleibt. Folge: Aus der Git-Historie lässt sich nicht mehr ablesen, ob der Workflow überhaupt noch läuft.

## Änderung

Nach jedem Lauf des Update-Skripts wird zusätzlich `cache/vor*/last_run.json` mit folgenden Feldern geschrieben:

```json
{
  "last_run_at": "2026-05-05T17:30:00+00:00",
  "last_run_at_local": "2026-05-05T19:30:00+02:00",
  "status": "ok",
  "stations_queried": 2,
  "events_collected": 0,
  "requests_used_today": 14,
  "daily_limit": 100
}
```

Der Status nimmt einen von vier Werten an: `ok`, `skipped_quota`, `api_unreachable`, `error`. Damit bleibt jeder Lauf sichtbar, ohne dass die zwei abgefragten Stationen oder das Tageskontingent (100 Req/Tag) angefasst werden müssen.

## Implementierung

- `src/utils/cache.py`: Neue Helper `write_status` / `read_status` (atomic write, `0600`, neben `events.json`).
- `scripts/update_vor_cache.py`: Schreibt den Heartbeat in jedem Pfad — Erfolg, Quota-Skip, `RequestException`, sonstige Exception.
- `.github/workflows/update-vor-cache.yml`: `file_pattern` ergänzt um `cache/vor*/last_run.json`.
- Tests: Round-Trip für `write_status`/`read_status`, drei neue `update_vor_cache`-Tests für Heartbeat-Pfade. Bestehende Tests mocken `write_status` jetzt automatisch via Fixture, damit keine echten Status-Dateien ins Repo wandern.

## Test plan

- [x] `pytest tests/test_cache.py tests/test_update_vor_cache.py` — 15 passed
- [x] Volle Suite — 1042 passed, 1 vorbestehend fehlschlagend (`test_feed_lint_ok_without_issues`, scheitert auch ohne diese Änderungen wegen Cache-Alter in der Sandbox-Umgebung — kein Regression)
- [ ] Nach Merge: ersten geplanten `Update VOR cache`-Lauf prüfen — sollte einen Commit mit `cache/vor*/last_run.json` erzeugen, auch wenn `events.json` unverändert bleibt.

## Nicht im Scope

Mehr Stationen abfragen wurde explizit verworfen, da das Tageskontingent eng ist (Standard: 2 Stationen × 24 Runs = 48/100 Req/Tag).

---
_Generated by [Claude Code](https://claude.ai/code/session_0178LWiUjPVDj5igjpDFiQNk)_