### PR TITLE
fix(ci): VOR-Workflow committet wieder – gitignored Pfad aus file_pattern entfernen

### DIFF
--- a/.github/workflows/update-vor-cache.yml
+++ b/.github/workflows/update-vor-cache.yml
@@ -86,4 +86,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: 'chore: update VOR cache [skip ci]'
-          file_pattern: 'cache/vor*/events.json cache/vor*/last_run.json data/vor_request_count.json'
+          file_pattern: 'cache/vor*/events.json cache/vor*/last_run.json'


### PR DESCRIPTION
## Problem

Der `Update VOR cache`-Workflow scheitert seit dem 03.05.2026 stumm im Commit-Step:

```
The following paths are ignored by one of your .gitignore files:
data/vor_request_count.json
hint: Use -f if you really want to add them.
Error: Invalid status code: 1
```

`stefanzweifel/git-auto-commit-action` ruft `git add` ohne `-f` auf — wenn auch nur eine Pattern-Datei via `.gitignore` blockiert ist, scheitert der ganze Add-Step und der Commit unterbleibt komplett. Der frische Cache wird also nicht in `main` gepusht, obwohl `update_vor_cache.py` sauber durchläuft.

## Root Cause

Am 03.05.2026 hat Merge `6c8b770` einen `.gitignore`-Eintrag für `data/vor_request_count.json` aufgenommen (Runtime-State, gehört nicht ins Repo). Der `file_pattern` der Action im `update-vor-cache.yml` zog die Datei aber weiter ein.

Folgen:
- Letzter `events.json`-Commit: 21.02.2026 (war zwar idempotent leer, aber ohne den Add-Fehler hätte zumindest die Existenz des Workflow-Laufs nichts kaputtgemacht).
- Letzter `vor_request_count.json`-Commit: 20.04.2026 (passt: kurz nach dem Merge wurde der Counter weiter inkrementiert, aber jeder `git-auto-commit`-Versuch warf seitdem den Add-Fehler).

Das war der eigentliche Grund, warum der Workflow lange "tot" wirkte — nicht die VOR-API.

## Fix

Eine Zeile: `data/vor_request_count.json` aus dem `file_pattern` entfernen. Die Datei darf laut `.gitignore` nicht im Repo liegen, und das `update_vor_cache.py`-Skript verträgt das problemlos (`load_request_count()` gibt `(None, 0)` zurück, wenn die Datei fehlt).

```diff
-          file_pattern: 'cache/vor*/events.json cache/vor*/last_run.json data/vor_request_count.json'
+          file_pattern: 'cache/vor*/events.json cache/vor*/last_run.json'
```

## Erwartung nach Merge

Beim nächsten geplanten Lauf (alle 60 Min., `:15`) wird der Commit-Step nicht mehr abbrechen, und die in #1193 eingeführte `cache/vor*/last_run.json` taucht im Repo auf — nachvollziehbares Lebenszeichen pro Stunde.

## Test plan

- [x] `git diff` lokal sauber, ein-Zeilen-Änderung
- [ ] Nach Merge: nächsten `Update VOR cache`-Run beobachten — der Commit-Step muss durchgehen, ohne `Error: Invalid status code: 1`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0178LWiUjPVDj5igjpDFiQNk)_