### PR TITLE
fix(ci): update_all_stations.py – Repo-Root in sys.path bootstrappen

### DIFF
--- a/scripts/update_all_stations.py
+++ b/scripts/update_all_stations.py
@@ -11,8 +11,12 @@ import tempfile
 from pathlib import Path
 from typing import Sequence
 
-from src.utils.files import atomic_write
-from src.utils.stations_validation import (
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.utils.files import atomic_write  # noqa: E402  (import after path setup)
+from src.utils.stations_validation import (  # noqa: E402
     StationValidationError,
     validate_stations,
 )


### PR DESCRIPTION
## Problem

Der Workflow `Update station directory` (`update-stations.yml`) bricht in seinem Hauptschritt mit:

```
File "/home/runner/work/wien-oepnv/wien-oepnv/scripts/update_all_stations.py", line 14, in <module>
    from src.utils.files import atomic_write
ModuleNotFoundError: No module named 'src'
```

## Root Cause

Der Workflow setzt `env: PYTHONPATH: src` für alle Steps. Damit ist das **Verzeichnis `src/`** der Import-Root — `src` ist als Package-Name dann nicht mehr auflösbar (Python sieht direkt `utils/`, `providers/`, … auf der obersten Ebene).

Das Skript `scripts/update_all_stations.py` importiert jedoch:

```python
from src.utils.files import atomic_write
from src.utils.stations_validation import (...)
```

Vier andere Skripte (`update_vor_cache.py`, `update_oebb_cache.py`, `update_wl_cache.py`, `generate_sitemap.py`) lösen genau das, indem sie zu Beginn den **Repo-Root** in `sys.path` einfügen — egal was der Workflow als `PYTHONPATH` mitgibt:

```python
REPO_ROOT = Path(__file__).resolve().parents[1]
if str(REPO_ROOT) not in sys.path:
    sys.path.insert(0, str(REPO_ROOT))
```

`update_all_stations.py` macht das nicht — daher der Fehler. Im lokalen Dev-Setup fällt das nicht auf, weil dort meist beide Pfade im `PYTHONPATH` landen.

## Fix

Sechs Zeilen: gleiche `sys.path`-Bootstrap-Idiom wie in den anderen Update-Skripten, plus `# noqa: E402` für die nachfolgenden absoluten Imports.

## Verifikation

- `PYTHONPATH=src python scripts/update_all_stations.py …` importiert jetzt sauber (lokal reproduziert mit `importlib.util` ohne sys.path-Manipulation).
- `mypy --strict scripts/update_all_stations.py` → success
- `ruff check scripts/update_all_stations.py` → all checks passed

## Test plan

- [x] Lokal: Import unter `PYTHONPATH=src` reproduziert + bestätigt
- [x] mypy + ruff sauber
- [ ] Nach Merge: nächsten `Update station directory`-Run (Cron monatlich, oder manuell via `workflow_dispatch`) überprüfen — Import-Fehler darf nicht mehr auftreten.

---
_Generated by [Claude Code](https://claude.ai/code/session_0178LWiUjPVDj5igjpDFiQNk)_