### PR TITLE
feat(stations-update): heartbeat, diff report, VOR refresh, expanded gate

### DIFF
--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/install-deps
 
+      - name: Refresh VOR stop list (best-effort)
+        run: |
+          python scripts/fetch_vor_haltestellen.py --verbose \
+            || echo "::warning::VOR refresh failed; using pinned data/vor-haltestellen.csv"
+        continue-on-error: true
+
       - name: Refresh station directory
         run: python scripts/update_all_stations.py --verbose
 

--- a/README.md
+++ b/README.md
@@ -341,8 +341,35 @@ damit kurze Stellencodes wie `Sue`/`Su` distinkt bleiben).
 
 
 Die GitHub Action `.github/workflows/update-stations.yml` aktualisiert
-`data/stations.json` monatlich automatisch und schreibt im selben Lauf
-den Validation-Report nach `docs/stations_validation_report.md`.
+`data/stations.json` monatlich automatisch (Cron `0 1 1 * *`). Pipeline-Schritte:
+
+1. **VOR-Stop-Liste auffrischen** – `scripts/fetch_vor_haltestellen.py`
+   holt die aktuelle Liste vom HAFAS-Endpoint `anachb.vor.at` und
+   überschreibt `data/vor-haltestellen.csv`. Best-effort: bei Netzwerk-
+   oder Rate-Limit-Fehler wird die gepinnte CSV weitergenutzt
+   (`continue-on-error: true`, mit GitHub-`::warning::`).
+2. **Sub-Skripte** (`scripts/update_all_stations.py`) – `update_station_directory.py` →
+   `update_vor_stations.py` → `update_wl_stations.py` → `enrich_station_aliases.py`,
+   alle gegen ein Temp-File. Erst nach erfolgreicher Validierung wird per
+   `atomic_write` ins Repo zurückkopiert.
+3. **Validation-Gate** – die Sub-Skript-Ausgabe wird vom selben Wrapper
+   validiert. Vier Kategorien blockieren den Commit (Working Tree bleibt
+   bytewise unverändert): `provider_issues`, `cross_station_id_issues`,
+   `naming_issues` (Mutual-Exclusivity, Source-Format, Namens-
+   Eindeutigkeit) und `security_issues`. Andere Kategorien
+   (`alias_issues`, `coordinate_issues` mit `manual_foreign_city`-
+   Exemption) sind tolerant.
+4. **Beobachtbarkeit** – nach erfolgreichem Atomic-Write schreibt der
+   Wrapper zwei Artefakte:
+   - `data/stations_last_run.json` – Heartbeat mit Timestamp,
+     Sub-Skript-Laufzeiten und Exit-Codes, Validation-Summary nach
+     Kategorie, Diff-Summary und aktuelle Polygon-Vertex-Zahl.
+   - `docs/stations_diff.md` – menschenlesbarer Diff (added / removed /
+     renamed / Koordinaten-Drift ≥ 100 m) gegen den Pre-Update-Snapshot.
+     Ein leerer Bericht bestätigt den No-Change-Lauf (Heartbeat-Funktion).
+5. **Validation-Report regenerieren** – `python -m src.cli stations validate
+   --output docs/stations_validation_report.md` schreibt die Markdown-
+   Variante des Validation-Reports (alle 8 Kategorien) für Review-Zwecke.
 
 #### Automatisierte Qualitätsberichte
 
@@ -351,9 +378,10 @@ acht Issue-Kategorien: **geographic duplicates**, **alias issues**,
 **coordinate anomalies**, **GTFS mismatches**, **security warnings**,
 **provider issues** (VOR-/OEBB-Konsistenz), **cross-station ID
 collisions** und **naming issues** (kanonische Namens-Eindeutigkeit +
-no-space-Source-Format). Über `--output docs/stations_validation_report.md`
-wird der Bericht persistiert; mit `--fail-on-issues` bricht die CLI
-bei jedem Befund mit einem Fehlercode ab. In CI läuft der Validator als Pflicht-Gate (siehe
+no-space-Source-Format + Vienna/Pendler Mutual-Exclusivity).
+Über `--output docs/stations_validation_report.md` wird der Bericht
+persistiert; mit `--fail-on-issues` bricht die CLI bei jedem Befund mit
+einem Fehlercode ab. In CI läuft der Validator als Pflicht-Gate (siehe
 `.github/workflows/test.yml`); zusätzlich regeneriert
 `update-stations.yml` den persistenten Report im monatlichen Daten-Refresh.
 

--- a/data/stations_last_run.json
+++ b/data/stations_last_run.json
@@ -1,0 +1,27 @@
+{
+  "diff": {
+    "added": 0,
+    "coord_shifted": 0,
+    "removed": 0,
+    "renamed": 0
+  },
+  "note": "initial baseline; first real run by update-stations.yml will overwrite",
+  "polygon_vertices": 5637,
+  "stations": {
+    "after": 107,
+    "before": 107,
+    "delta": 0
+  },
+  "sub_scripts": [],
+  "timestamp": "2026-05-05T19:48:08+00:00",
+  "validation": {
+    "alias_issues": 93,
+    "coordinate_issues": 2,
+    "cross_station_id_issues": 0,
+    "duplicates": 0,
+    "gtfs_issues": 0,
+    "naming_issues": 0,
+    "provider_issues": 0,
+    "security_issues": 0
+  }
+}

--- a/docs/stations_diff.md
+++ b/docs/stations_diff.md
@@ -1,0 +1,21 @@
+# stations.json Diff Report
+
+_Generated: 2026-05-05T19:48:08+00:00_
+
+**Stations: 107 → 107 (Δ +0)**
+
+## Added (0)
+
+_None._
+
+## Removed (0)
+
+_None._
+
+## Renamed (0)
+
+_None._
+
+## Coordinates shifted (≥ 100 m) (0)
+
+_None._

--- a/scripts/update_all_stations.py
+++ b/scripts/update_all_stations.py
@@ -1,15 +1,32 @@
 #!/usr/bin/env python3
-"""Convenience wrapper to refresh all station datasets."""
+"""Convenience wrapper to refresh all station datasets.
+
+Pipeline:
+  1. Copy the live ``data/stations.json`` into a temp directory so each
+     sub-script merges into the previous result without touching the repo.
+  2. Run every script in :data:`_SCRIPT_ORDER` against the temp file.
+  3. Validate the merged result. ``provider_issues``,
+     ``cross_station_id_issues``, ``naming_issues`` and ``security_issues``
+     are hard gates — the working tree is left untouched on any of them.
+  4. Compute the before/after diff (added/removed/renamed/coord-shifted)
+     and write ``data/stations_last_run.json`` (heartbeat) plus
+     ``docs/stations_diff.md`` (human-readable diff report).
+  5. Atomically copy the merged file back into ``data/stations.json``.
+"""
 from __future__ import annotations
 
 import argparse
+import json
 import logging
+import math
 import shutil
 import subprocess  # nosec B404 - utility script to run internal scripts
 import sys
 import tempfile
+import time
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Mapping, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -18,6 +35,7 @@ if str(REPO_ROOT) not in sys.path:
 from src.utils.files import atomic_write  # noqa: E402  (import after path setup)
 from src.utils.stations_validation import (  # noqa: E402
     StationValidationError,
+    ValidationReport,
     validate_stations,
 )
 
@@ -34,6 +52,11 @@ _SCRIPT_OUTPUT_FLAG = {
     "update_wl_stations.py": "--stations",
     "enrich_station_aliases.py": "--stations",
 }
+
+_DEFAULT_HEARTBEAT_PATH = REPO_ROOT / "data" / "stations_last_run.json"
+_DEFAULT_DIFF_REPORT_PATH = REPO_ROOT / "docs" / "stations_diff.md"
+_DEFAULT_POLYGON_PATH = REPO_ROOT / "data" / "LANDESGRENZEOGD.json"
+_COORD_SHIFT_THRESHOLD_M = 100.0
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -68,6 +91,217 @@ def run_script(python: str, script_path: Path, verbose: bool, output_flag: str, 
     subprocess.run(cmd, check=True, shell=False, timeout=600)  # nosec B603
 
 
+def _load_stations(path: Path) -> list[Mapping[str, Any]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if isinstance(data, dict):
+        entries = data.get("stations", [])
+    elif isinstance(data, list):
+        entries = data
+    else:
+        return []
+    return [e for e in entries if isinstance(e, Mapping)]
+
+
+def _station_key(entry: Mapping[str, Any]) -> str:
+    """Stable identity key for diff matching: bst_id if present, else name."""
+    bst_id = entry.get("bst_id")
+    if bst_id is not None and str(bst_id).strip():
+        return f"bst:{str(bst_id).strip()}"
+    name = str(entry.get("name") or "<unnamed>").strip()
+    return f"name:{name}"
+
+
+def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    radius = 6_371_000.0
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dp = math.radians(lat2 - lat1)
+    dl = math.radians(lon2 - lon1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return 2 * radius * math.asin(math.sqrt(a))
+
+
+def _compute_diff(
+    before: list[Mapping[str, Any]],
+    after: list[Mapping[str, Any]],
+) -> dict[str, list[Any]]:
+    """Compute additions/removals/renames/coord-shifts between two snapshots."""
+    by_key_before = {_station_key(s): s for s in before}
+    by_key_after = {_station_key(s): s for s in after}
+
+    added_keys = sorted(set(by_key_after) - set(by_key_before))
+    removed_keys = sorted(set(by_key_before) - set(by_key_after))
+
+    renamed: list[tuple[str, str, str]] = []
+    coord_shifted: list[tuple[str, str, int]] = []
+
+    for key in sorted(set(by_key_before) & set(by_key_after)):
+        before_entry = by_key_before[key]
+        after_entry = by_key_after[key]
+
+        before_name = str(before_entry.get("name") or "")
+        after_name = str(after_entry.get("name") or "")
+        if before_name != after_name:
+            renamed.append((key, before_name, after_name))
+
+        before_lat = before_entry.get("latitude")
+        before_lon = before_entry.get("longitude")
+        after_lat = after_entry.get("latitude")
+        after_lon = after_entry.get("longitude")
+        if all(isinstance(v, (int, float)) for v in (before_lat, before_lon, after_lat, after_lon)):
+            try:
+                distance = _haversine_m(
+                    float(before_lat), float(before_lon),
+                    float(after_lat), float(after_lon),
+                )
+            except (TypeError, ValueError):
+                continue
+            if distance >= _COORD_SHIFT_THRESHOLD_M:
+                coord_shifted.append((key, after_name or before_name, round(distance)))
+
+    return {
+        "added": [(k, str(by_key_after[k].get("name") or "")) for k in added_keys],
+        "removed": [(k, str(by_key_before[k].get("name") or "")) for k in removed_keys],
+        "renamed": renamed,
+        "coord_shifted": coord_shifted,
+    }
+
+
+def _render_diff_markdown(
+    diff: Mapping[str, list[Any]],
+    before_count: int,
+    after_count: int,
+    timestamp: str,
+) -> str:
+    lines = [
+        "# stations.json Diff Report",
+        "",
+        f"_Generated: {timestamp}_",
+        "",
+        f"**Stations: {before_count} → {after_count} (Δ {after_count - before_count:+d})**",
+        "",
+    ]
+
+    def section(title: str, items: list[Any], formatter: Any) -> None:
+        lines.append(f"## {title} ({len(items)})")
+        lines.append("")
+        if items:
+            for item in items:
+                lines.append(formatter(item))
+        else:
+            lines.append("_None._")
+        lines.append("")
+
+    section("Added", diff["added"], lambda it: f"- `{it[0]}` — {it[1]}")
+    section("Removed", diff["removed"], lambda it: f"- `{it[0]}` — {it[1]}")
+    section(
+        "Renamed",
+        diff["renamed"],
+        lambda it: f'- `{it[0]}`: "{it[1]}" → "{it[2]}"',
+    )
+    section(
+        f"Coordinates shifted (≥ {int(_COORD_SHIFT_THRESHOLD_M)} m)",
+        diff["coord_shifted"],
+        lambda it: f"- `{it[0]}` — {it[1]} ({it[2]} m)",
+    )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _count_polygon_vertices(path: Path) -> int | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    features = data.get("features") if isinstance(data, dict) else None
+    if not isinstance(features, list):
+        return None
+    total = 0
+    for feature in features:
+        if not isinstance(feature, dict):
+            continue
+        geometry = feature.get("geometry")
+        if not isinstance(geometry, dict):
+            continue
+        coords = geometry.get("coordinates")
+        if geometry.get("type") == "Polygon" and isinstance(coords, list):
+            for ring in coords:
+                if isinstance(ring, list):
+                    total += len(ring)
+        elif geometry.get("type") == "MultiPolygon" and isinstance(coords, list):
+            for polygon in coords:
+                if not isinstance(polygon, list):
+                    continue
+                for ring in polygon:
+                    if isinstance(ring, list):
+                        total += len(ring)
+    return total or None
+
+
+def _build_heartbeat(
+    report: ValidationReport,
+    diff: Mapping[str, list[Any]],
+    sub_scripts: list[Mapping[str, Any]],
+    before_count: int,
+    after_count: int,
+    polygon_vertices: int | None,
+    timestamp: str,
+) -> dict[str, Any]:
+    return {
+        "timestamp": timestamp,
+        "sub_scripts": list(sub_scripts),
+        "stations": {
+            "before": before_count,
+            "after": after_count,
+            "delta": after_count - before_count,
+        },
+        "validation": {
+            "duplicates": len(report.duplicates),
+            "alias_issues": len(report.alias_issues),
+            "coordinate_issues": len(report.coordinate_issues),
+            "gtfs_issues": len(report.gtfs_issues),
+            "security_issues": len(report.security_issues),
+            "cross_station_id_issues": len(report.cross_station_id_issues),
+            "provider_issues": len(report.provider_issues),
+            "naming_issues": len(report.naming_issues),
+        },
+        "diff": {
+            "added": len(diff["added"]),
+            "removed": len(diff["removed"]),
+            "renamed": len(diff["renamed"]),
+            "coord_shifted": len(diff["coord_shifted"]),
+        },
+        "polygon_vertices": polygon_vertices,
+    }
+
+
+def _collect_blocking_issues(report: ValidationReport) -> list[tuple[str, str]]:
+    """Return (category, message) tuples for issues that must block the commit."""
+    blocking: list[tuple[str, str]] = []
+    for issue in report.provider_issues:
+        blocking.append(("provider", issue.reason))
+    for issue in report.cross_station_id_issues:
+        blocking.append((
+            "cross-station",
+            f"alias '{issue.alias}' in '{issue.name}' ({issue.identifier}) "
+            f"collides with {issue.colliding_field} of "
+            f"'{issue.colliding_name}' ({issue.colliding_identifier})",
+        ))
+    for issue in report.naming_issues:
+        blocking.append((
+            "naming",
+            f"{issue.name} ({issue.identifier}): {issue.reason}",
+        ))
+    for issue in report.security_issues:
+        blocking.append((
+            "security",
+            f"{issue.name} ({issue.identifier}): {issue.reason}",
+        ))
+    return blocking
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     configure_logging(args.verbose)
@@ -75,11 +309,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     script_dir = Path(__file__).resolve().parent
     target_stations_json = Path("data/stations.json").resolve()
 
+    sub_script_results: list[dict[str, Any]] = []
+
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_stations_path = Path(tmp_dir) / "stations.json"
+        before_snapshot: list[Mapping[str, Any]] = []
 
         if target_stations_json.exists():
             shutil.copy2(target_stations_json, tmp_stations_path)
+            before_snapshot = _load_stations(tmp_stations_path)
 
         for script_name in _SCRIPT_ORDER:
             script_path = script_dir / script_name
@@ -92,13 +330,26 @@ def main(argv: Sequence[str] | None = None) -> int:
                 logging.error("No output flag mapping found for %s", script_name)
                 return 1
 
+            start = time.monotonic()
             try:
                 run_script(args.python, script_path, args.verbose, output_flag, tmp_stations_path)
             except subprocess.CalledProcessError as exc:  # pragma: no cover - thin wrapper
+                duration = time.monotonic() - start
+                sub_script_results.append({
+                    "name": script_name,
+                    "exit_code": exc.returncode or 1,
+                    "duration_s": round(duration, 2),
+                })
                 logging.error(
                     "Script %s failed with exit code %s", script_path.name, exc.returncode
                 )
                 return exc.returncode or 1
+            duration = time.monotonic() - start
+            sub_script_results.append({
+                "name": script_name,
+                "exit_code": 0,
+                "duration_s": round(duration, 2),
+            })
 
         # Run validation
         logging.info("Validating merged %s", tmp_stations_path)
@@ -111,24 +362,30 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 1
 
-        if report.provider_issues or report.cross_station_id_issues:
-            for p_issue in report.provider_issues:
-                logging.error("Provider issue: %s", p_issue.reason)
-            for c_issue in report.cross_station_id_issues:
-                logging.error(
-                    "Cross-station alias conflict: alias '%s' in '%s' (%s) "
-                    "collides with %s of '%s' (%s)",
-                    c_issue.alias,
-                    c_issue.name,
-                    c_issue.identifier,
-                    c_issue.colliding_field,
-                    c_issue.colliding_name,
-                    c_issue.colliding_identifier,
-                )
+        blocking = _collect_blocking_issues(report)
+        if blocking:
+            for category, message in blocking:
+                logging.error("%s issue: %s", category, message)
             logging.error(
                 "Validation failed on the new stations data. Working tree left unmodified."
             )
             return 1
+
+        # Compute the diff between the pre-update snapshot and the merged file
+        # before atomic copy-back so the heartbeat reflects what is about to land.
+        after_snapshot = _load_stations(tmp_stations_path)
+        diff = _compute_diff(before_snapshot, after_snapshot)
+        timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        polygon_vertices = _count_polygon_vertices(_DEFAULT_POLYGON_PATH)
+        heartbeat = _build_heartbeat(
+            report=report,
+            diff=diff,
+            sub_scripts=sub_script_results,
+            before_count=len(before_snapshot),
+            after_count=len(after_snapshot),
+            polygon_vertices=polygon_vertices,
+            timestamp=timestamp,
+        )
 
         # Atomic copy-back: atomic_write writes a temp file inside
         # target_stations_json.parent (same filesystem as the target —
@@ -140,6 +397,27 @@ def main(argv: Sequence[str] | None = None) -> int:
         ) as dst:
             shutil.copyfileobj(src, dst)
         logging.info("stations.json successfully updated and validated.")
+
+        # Persist the heartbeat and diff report next to the data they describe.
+        # Both files are atomic-written so a partial run never produces
+        # half-written observability artefacts.
+        _DEFAULT_HEARTBEAT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with atomic_write(_DEFAULT_HEARTBEAT_PATH, mode="w", encoding="utf-8") as handle:
+            json.dump(heartbeat, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+        _DEFAULT_DIFF_REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with atomic_write(_DEFAULT_DIFF_REPORT_PATH, mode="w", encoding="utf-8") as handle:
+            handle.write(_render_diff_markdown(
+                diff,
+                before_count=len(before_snapshot),
+                after_count=len(after_snapshot),
+                timestamp=timestamp,
+            ))
+        logging.info(
+            "Wrote heartbeat (%s) and diff report (%s)",
+            _DEFAULT_HEARTBEAT_PATH.name,
+            _DEFAULT_DIFF_REPORT_PATH.name,
+        )
 
     logging.info("All station update scripts completed successfully.")
     return 0

--- a/scripts/update_all_stations.py
+++ b/scripts/update_all_stations.py
@@ -26,7 +26,7 @@ import tempfile
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Sequence, TypedDict
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -123,10 +123,25 @@ def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     return 2 * radius * math.asin(math.sqrt(a))
 
 
+class _DiffResult(TypedDict):
+    added: list[tuple[str, str]]
+    removed: list[tuple[str, str]]
+    renamed: list[tuple[str, str, str]]
+    coord_shifted: list[tuple[str, str, int]]
+
+
+def _coerce_coord(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
 def _compute_diff(
-    before: list[Mapping[str, Any]],
-    after: list[Mapping[str, Any]],
-) -> dict[str, list[Any]]:
+    before: Sequence[Mapping[str, Any]],
+    after: Sequence[Mapping[str, Any]],
+) -> _DiffResult:
     """Compute additions/removals/renames/coord-shifts between two snapshots."""
     by_key_before = {_station_key(s): s for s in before}
     by_key_after = {_station_key(s): s for s in after}
@@ -146,31 +161,34 @@ def _compute_diff(
         if before_name != after_name:
             renamed.append((key, before_name, after_name))
 
-        before_lat = before_entry.get("latitude")
-        before_lon = before_entry.get("longitude")
-        after_lat = after_entry.get("latitude")
-        after_lon = after_entry.get("longitude")
-        if all(isinstance(v, (int, float)) for v in (before_lat, before_lon, after_lat, after_lon)):
-            try:
-                distance = _haversine_m(
-                    float(before_lat), float(before_lon),
-                    float(after_lat), float(after_lon),
-                )
-            except (TypeError, ValueError):
-                continue
-            if distance >= _COORD_SHIFT_THRESHOLD_M:
-                coord_shifted.append((key, after_name or before_name, round(distance)))
+        before_lat = _coerce_coord(before_entry.get("latitude"))
+        before_lon = _coerce_coord(before_entry.get("longitude"))
+        after_lat = _coerce_coord(after_entry.get("latitude"))
+        after_lon = _coerce_coord(after_entry.get("longitude"))
+        if (
+            before_lat is None
+            or before_lon is None
+            or after_lat is None
+            or after_lon is None
+        ):
+            continue
+        try:
+            distance = _haversine_m(before_lat, before_lon, after_lat, after_lon)
+        except (TypeError, ValueError):
+            continue
+        if distance >= _COORD_SHIFT_THRESHOLD_M:
+            coord_shifted.append((key, after_name or before_name, round(distance)))
 
-    return {
-        "added": [(k, str(by_key_after[k].get("name") or "")) for k in added_keys],
-        "removed": [(k, str(by_key_before[k].get("name") or "")) for k in removed_keys],
-        "renamed": renamed,
-        "coord_shifted": coord_shifted,
-    }
+    return _DiffResult(
+        added=[(k, str(by_key_after[k].get("name") or "")) for k in added_keys],
+        removed=[(k, str(by_key_before[k].get("name") or "")) for k in removed_keys],
+        renamed=renamed,
+        coord_shifted=coord_shifted,
+    )
 
 
 def _render_diff_markdown(
-    diff: Mapping[str, list[Any]],
+    diff: _DiffResult,
     before_count: int,
     after_count: int,
     timestamp: str,
@@ -242,8 +260,8 @@ def _count_polygon_vertices(path: Path) -> int | None:
 
 def _build_heartbeat(
     report: ValidationReport,
-    diff: Mapping[str, list[Any]],
-    sub_scripts: list[Mapping[str, Any]],
+    diff: _DiffResult,
+    sub_scripts: Sequence[Mapping[str, Any]],
     before_count: int,
     after_count: int,
     polygon_vertices: int | None,
@@ -280,24 +298,24 @@ def _build_heartbeat(
 def _collect_blocking_issues(report: ValidationReport) -> list[tuple[str, str]]:
     """Return (category, message) tuples for issues that must block the commit."""
     blocking: list[tuple[str, str]] = []
-    for issue in report.provider_issues:
-        blocking.append(("provider", issue.reason))
-    for issue in report.cross_station_id_issues:
+    for provider in report.provider_issues:
+        blocking.append(("provider", provider.reason))
+    for cross in report.cross_station_id_issues:
         blocking.append((
             "cross-station",
-            f"alias '{issue.alias}' in '{issue.name}' ({issue.identifier}) "
-            f"collides with {issue.colliding_field} of "
-            f"'{issue.colliding_name}' ({issue.colliding_identifier})",
+            f"alias '{cross.alias}' in '{cross.name}' ({cross.identifier}) "
+            f"collides with {cross.colliding_field} of "
+            f"'{cross.colliding_name}' ({cross.colliding_identifier})",
         ))
-    for issue in report.naming_issues:
+    for naming in report.naming_issues:
         blocking.append((
             "naming",
-            f"{issue.name} ({issue.identifier}): {issue.reason}",
+            f"{naming.name} ({naming.identifier}): {naming.reason}",
         ))
-    for issue in report.security_issues:
+    for security in report.security_issues:
         blocking.append((
             "security",
-            f"{issue.name} ({issue.identifier}): {issue.reason}",
+            f"{security.name} ({security.identifier}): {security.reason}",
         ))
     return blocking
 

--- a/tests/test_update_all_stations_diff_heartbeat.py
+++ b/tests/test_update_all_stations_diff_heartbeat.py
@@ -1,0 +1,183 @@
+"""Tests for the diff/heartbeat observability layer in update_all_stations."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts import update_all_stations as wrapper
+
+
+def _entry(
+    bst_id: str | None = None,
+    name: str = "X",
+    lat: float = 48.2,
+    lon: float = 16.4,
+) -> dict[str, Any]:
+    e: dict[str, Any] = {"name": name, "latitude": lat, "longitude": lon}
+    if bst_id is not None:
+        e["bst_id"] = bst_id
+    return e
+
+
+def test_compute_diff_detects_added_and_removed() -> None:
+    before = [_entry(bst_id="1", name="Alpha"), _entry(bst_id="2", name="Beta")]
+    after = [_entry(bst_id="1", name="Alpha"), _entry(bst_id="3", name="Gamma")]
+
+    diff = wrapper._compute_diff(before, after)
+
+    assert [k for k, _ in diff["added"]] == ["bst:3"]
+    assert [k for k, _ in diff["removed"]] == ["bst:2"]
+    assert diff["renamed"] == []
+    assert diff["coord_shifted"] == []
+
+
+def test_compute_diff_detects_renames() -> None:
+    before = [_entry(bst_id="1", name="Wien Westbf")]
+    after = [_entry(bst_id="1", name="Wien Westbahnhof")]
+
+    diff = wrapper._compute_diff(before, after)
+
+    assert diff["renamed"] == [("bst:1", "Wien Westbf", "Wien Westbahnhof")]
+    assert diff["added"] == []
+    assert diff["removed"] == []
+
+
+def test_compute_diff_detects_coord_shift_above_threshold() -> None:
+    # Wien Aspern Nord coordinates: old GTFS value vs corrected VOR value (~1.16 km drift)
+    before = [_entry(bst_id="4773541", name="Wien Aspern Nord", lat=48.234567, lon=16.520123)]
+    after = [_entry(bst_id="4773541", name="Wien Aspern Nord", lat=48.234669, lon=16.504456)]
+
+    diff = wrapper._compute_diff(before, after)
+
+    assert len(diff["coord_shifted"]) == 1
+    key, name, distance_m = diff["coord_shifted"][0]
+    assert key == "bst:4773541"
+    assert name == "Wien Aspern Nord"
+    assert 1100 < distance_m < 1200  # ~1160 m
+
+
+def test_compute_diff_ignores_sub_threshold_coord_shift() -> None:
+    """A 50m drift must not be reported (signal-to-noise floor)."""
+    before = [_entry(bst_id="1", name="X", lat=48.2000, lon=16.4000)]
+    after = [_entry(bst_id="1", name="X", lat=48.2003, lon=16.4003)]  # ~40m
+
+    diff = wrapper._compute_diff(before, after)
+    assert diff["coord_shifted"] == []
+
+
+def test_compute_diff_handles_no_bst_id_via_name_key() -> None:
+    """Google-Places-only entries lack bst_id; they fall back to a name key."""
+    before = [_entry(name="Stadtpark", lat=48.2024, lon=16.3791)]
+    after = [_entry(name="Stadtpark", lat=48.2024, lon=16.3791)]
+    after.append(_entry(name="Schwedenplatz", lat=48.2115, lon=16.378))
+
+    diff = wrapper._compute_diff(before, after)
+    assert [k for k, _ in diff["added"]] == ["name:Schwedenplatz"]
+    assert diff["removed"] == []
+
+
+def test_render_diff_markdown_clean_run_signals_no_change() -> None:
+    """An empty diff should still produce a non-empty report — that's the heartbeat."""
+    diff = {"added": [], "removed": [], "renamed": [], "coord_shifted": []}
+    rendered = wrapper._render_diff_markdown(diff, before_count=107, after_count=107, timestamp="2026-05-05T18:00:00+00:00")
+
+    assert "stations.json Diff Report" in rendered
+    assert "107 → 107 (Δ +0)" in rendered
+    assert "_None._" in rendered  # each empty section emits the placeholder
+    assert rendered.count("_None._") == 4  # all four sections empty
+
+
+def test_render_diff_markdown_lists_renames() -> None:
+    diff = {
+        "added": [],
+        "removed": [],
+        "renamed": [("bst:2511", "Wien Westbf", "Wien Westbahnhof")],
+        "coord_shifted": [],
+    }
+    rendered = wrapper._render_diff_markdown(diff, 107, 107, "2026-05-05T00:00:00+00:00")
+    assert '"Wien Westbf" → "Wien Westbahnhof"' in rendered
+
+
+def test_load_stations_handles_wrapped_and_bare_lists(tmp_path: Path) -> None:
+    """Both ``{"stations": [...]}`` and bare ``[...]`` are accepted (legacy tests)."""
+    wrapped = tmp_path / "wrapped.json"
+    wrapped.write_text(json.dumps({"stations": [{"name": "A"}]}))
+    bare = tmp_path / "bare.json"
+    bare.write_text(json.dumps([{"name": "B"}]))
+    missing = tmp_path / "missing.json"  # never created
+
+    assert wrapper._load_stations(wrapped) == [{"name": "A"}]
+    assert wrapper._load_stations(bare) == [{"name": "B"}]
+    assert wrapper._load_stations(missing) == []
+
+
+def test_collect_blocking_issues_includes_naming_and_security() -> None:
+    """Beyond the original provider/cross-station gates, naming + security
+    issues now also block the commit (added in this PR)."""
+    from src.utils.stations_validation import (
+        NamingIssue,
+        ProviderIssue,
+        SecurityIssue,
+        ValidationReport,
+    )
+
+    report = ValidationReport(
+        total_stations=2,
+        duplicates=(),
+        alias_issues=(),
+        coordinate_issues=(),
+        gtfs_issues=(),
+        security_issues=(SecurityIssue(identifier="bst:1", name="X", reason="unsafe char"),),
+        cross_station_id_issues=(),
+        provider_issues=(ProviderIssue(identifier="bst:2", name="Y", reason="bad"),),
+        naming_issues=(NamingIssue(identifier="bst:3", name="Z", reason="not unique"),),
+        gtfs_stop_count=0,
+    )
+    blocking = wrapper._collect_blocking_issues(report)
+    categories = {cat for cat, _ in blocking}
+    assert categories == {"provider", "naming", "security"}
+
+
+def test_wrapper_writes_heartbeat_and_diff_on_success(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A successful run produces both observability artefacts."""
+    from src.utils.stations_validation import ValidationReport
+
+    monkeypatch.setattr(
+        "scripts.update_all_stations.subprocess.run", lambda *a, **kw: None
+    )
+    clean_report = ValidationReport(
+        total_stations=0,
+        duplicates=(),
+        alias_issues=(),
+        coordinate_issues=(),
+        gtfs_issues=(),
+        security_issues=(),
+        cross_station_id_issues=(),
+        provider_issues=(),
+        naming_issues=(),
+        gtfs_stop_count=0,
+    )
+    monkeypatch.setattr(wrapper, "validate_stations", lambda *a, **kw: clean_report)
+
+    # Redirect heartbeat + diff to tmp_path so the live files stay untouched
+    monkeypatch.setattr(wrapper, "_DEFAULT_HEARTBEAT_PATH", tmp_path / "heartbeat.json")
+    monkeypatch.setattr(wrapper, "_DEFAULT_DIFF_REPORT_PATH", tmp_path / "diff.md")
+
+    exit_code = wrapper.main([])
+    assert exit_code == 0
+
+    heartbeat_path = tmp_path / "heartbeat.json"
+    assert heartbeat_path.exists()
+    payload = json.loads(heartbeat_path.read_text(encoding="utf-8"))
+    assert "timestamp" in payload
+    assert payload["validation"]["naming_issues"] == 0
+    assert payload["sub_scripts"], "expected per-script timing entries"
+
+    diff_path = tmp_path / "diff.md"
+    assert diff_path.exists()
+    assert "stations.json Diff Report" in diff_path.read_text(encoding="utf-8")

--- a/tests/test_update_all_stations_diff_heartbeat.py
+++ b/tests/test_update_all_stations_diff_heartbeat.py
@@ -81,7 +81,7 @@ def test_compute_diff_handles_no_bst_id_via_name_key() -> None:
 
 def test_render_diff_markdown_clean_run_signals_no_change() -> None:
     """An empty diff should still produce a non-empty report — that's the heartbeat."""
-    diff = {"added": [], "removed": [], "renamed": [], "coord_shifted": []}
+    diff: wrapper._DiffResult = {"added": [], "removed": [], "renamed": [], "coord_shifted": []}
     rendered = wrapper._render_diff_markdown(diff, before_count=107, after_count=107, timestamp="2026-05-05T18:00:00+00:00")
 
     assert "stations.json Diff Report" in rendered
@@ -91,7 +91,7 @@ def test_render_diff_markdown_clean_run_signals_no_change() -> None:
 
 
 def test_render_diff_markdown_lists_renames() -> None:
-    diff = {
+    diff: wrapper._DiffResult = {
         "added": [],
         "removed": [],
         "renamed": [("bst:2511", "Wien Westbf", "Wien Westbahnhof")],


### PR DESCRIPTION
## Summary

Drei Optimierungen für die `update-stations.yml`-Pipeline aus dem Post-#1192-Audit, in einem PR gebündelt.

### 1. Heartbeat + Diff-Report (Sichtbarkeit) 🆕
- **`data/stations_last_run.json`** — Heartbeat: timestamp, sub-script-Laufzeiten/exit-codes, Validation-Summary nach Kategorie, Diff-Summary, aktuelle Polygon-Vertex-Zahl
- **`docs/stations_diff.md`** — menschenlesbarer Diff: added / removed / renamed / Koordinaten-Drift ≥100 m gegen Pre-Update-Snapshot

Ohne diese Artefakte würde z.B. ein 100-Stationen-Massenrename (HAFAS-Schemawechsel) im Standard-`chore(data)`-Commit untergehen. Der leere Diff ist das Heartbeat-Signal: „Lauf erfolgreich, nichts geändert".

### 2. `fetch_vor_haltestellen.py` als Workflow-Step 🆕
```yaml
- name: Refresh VOR stop list (best-effort)
  run: |
    python scripts/fetch_vor_haltestellen.py --verbose \
      || echo "::warning::VOR refresh failed; using pinned data/vor-haltestellen.csv"
  continue-on-error: true
```

Schließt die Drift-Lücke: aktuell läuft `update_vor_stations.py` auf einem ggf. monatealten Snapshot. Der neue Step holt vorab die aktuelle CSV vom HAFAS-Endpoint. **Kein Repo-Secret nötig** — der Script holt seinen `access_id` selbst aus `hafas_webapp_config.js`.

### 3. Wrapper-Gate erweitert
`_collect_blocking_issues` (neuer Helper) blockiert den Atomic-Write jetzt bei vier statt zwei Kategorien:

| Kategorie | Vorher | Nachher |
|---|---|---|
| `provider_issues` | ✅ Block | ✅ Block |
| `cross_station_id_issues` | ✅ Block | ✅ Block |
| `naming_issues` (Mutual-Exclusivity, Source-Format, Name-Uniqueness) | ⚠️ tolerant | ✅ Block |
| `security_issues` (XSS in Aliasen) | ⚠️ tolerant | ✅ Block |
| `alias_issues` (93 pre-existing bst_code-not-in-aliases) | ⚠️ tolerant | ⚠️ tolerant |
| `coordinate_issues` (München/Roma sind by design out-of-bounds) | ⚠️ tolerant | ⚠️ tolerant |

## Erläuterung zum Vorschlag #4 (`STATIC_VOR_ENTRIES` extrahieren)
Bewusst **nicht in diesem PR**: aktuell nur 1 Eintrag (Wiener Neustadt Hauptbahnhof). Refactor lohnt sich erst ab dem 3. Eintrag.

## Test plan
- [x] `pytest tests/` → 1062 passed, 1 skipped (+10 neue Tests in `test_update_all_stations_diff_heartbeat.py`: diff-Fälle, Threshold, Heartbeat-Content, Gate-Kategorien)
- [x] `ruff check` clean
- [x] `mypy` clean
- [x] Wrapper-Tests aus #1192 weiter grün (atomic-failure, validation-failure-preserves-original)
- [x] Baseline `stations_last_run.json` + `stations_diff.md` committed; erste echte CI-Lauf-Iteration überschreibt sie

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_