### PR TITLE
feat(stations): name-based pendler whitelist for unknown bst_ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,11 +359,25 @@ bei jedem Befund mit einem Fehlercode ab. In CI läuft der Validator als Pflicht
 
 ### Pendler-Whitelist
 
-`data/pendler_bst_ids.json` listet Stationen außerhalb der Stadtgrenze,
-die als Pendler-Knoten im Verzeichnis verbleiben. Die Auswahl ist
-**redaktionell kuratiert** und priorisiert die für Wien-Pendler:innen
-relevantesten Bahnhöfe, nicht algorithmisch bestimmt. Änderungen wirken
-beim nächsten Lauf von `python -m src.cli stations update directory`.
+Zwei komplementäre Dateien legen fest, welche Bahnhöfe außerhalb der
+Stadtgrenze als Pendler-Knoten ins Verzeichnis aufgenommen werden:
+
+- **`data/pendler_bst_ids.json`** – Liste von ÖBB-`bst_id`-Werten.
+  Eintrag wirkt sofort: ist die ID im ÖBB-Excel-Verzeichnis vorhanden,
+  wird die Station mit `pendler=true` übernommen.
+- **`data/pendler_candidates.json`** – name-basierte Wishlist (siehe
+  [`docs/schema/pendler_candidates.schema.json`](docs/schema/pendler_candidates.schema.json)).
+  Sinnvoll, wenn der `bst_id` der gewünschten Station unbekannt ist —
+  der Updater matcht den Stationsnamen aus dem ÖBB-Excel gegen diese
+  Liste und ergänzt die fehlende ID automatisch.
+
+Die Auswahl ist in beiden Dateien **redaktionell kuratiert** und
+priorisiert die für Wien-Pendler:innen relevantesten Bahnhöfe.
+Änderungen wirken beim nächsten Lauf von
+`python -m src.cli stations update directory`. Die Mutual-Exclusivity
+zu `in_vienna` (Vienna-Station vs. Pendler) wird sowohl vom Updater als
+auch vom Validator und JSON-Schema erzwungen — Verstöße führen zu einer
+WARNING bzw. blockieren den Atomic-Write.
 
 ### Zusätzliche Datenquellen
 

--- a/data/pendler_candidates.json
+++ b/data/pendler_candidates.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "../docs/schema/pendler_candidates.schema.json",
+  "description": "Name-based pendler whitelist for the station directory updater. Stations listed here are marked pendler=true on the next ÖBB Excel refresh, regardless of their bst_id. The complementary file data/pendler_bst_ids.json is the legacy bst_id-based whitelist; the updater honors both and the union is the effective pendler set.",
+  "candidates": [
+    {"name": "Pfaffstätten", "line": "S-Bahn Südbahn", "priority": 1, "added": "2026-05-05"},
+    {"name": "Gumpoldskirchen", "line": "S-Bahn Südbahn", "priority": 1, "added": "2026-05-05"},
+    {"name": "Guntramsdorf Südbahn", "line": "S-Bahn Südbahn", "priority": 1, "added": "2026-05-05"},
+    {"name": "Hennersdorf", "line": "S60-Verstärker Pottendorfer Linie", "priority": 1, "added": "2026-05-05"},
+    {"name": "Achau", "line": "S60-Verstärker Pottendorfer Linie", "priority": 1, "added": "2026-05-05"},
+    {"name": "Münchendorf", "line": "S60-Verstärker Pottendorfer Linie", "priority": 1, "added": "2026-05-05"},
+    {"name": "Gramatneusiedl", "line": "S60/REX6/REX64 Ostbahn", "priority": 1, "added": "2026-05-05"},
+    {"name": "Götzendorf an der Leitha", "line": "S60/REX6 Ostbahn", "priority": 1, "added": "2026-05-05"},
+    {"name": "Himberg bei Wien", "line": "S60/REX6 Ostbahn (gesperrt bis Ende 2026)", "priority": 1, "added": "2026-05-05"},
+    {"name": "Felixdorf", "line": "S3/S4/REX Südbahn-Aspangbahn-Verzweigung", "priority": 1, "added": "2026-05-05"},
+    {"name": "Sollenau", "line": "S-Bahn Südbahn / Aspangbahn-Verzweigung", "priority": 1, "added": "2026-05-05"},
+    {"name": "Traiskirchen Aspangbahn", "line": "R95 Innere Aspangbahn", "priority": 1, "added": "2026-05-05"},
+
+    {"name": "Kottingbrunn", "line": "S-Bahn Südbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Wiener Neustadt Nord", "line": "Südbahn (Stadtteilbahnhof)", "priority": 2, "added": "2026-05-05"},
+    {"name": "Neunkirchen NÖ", "line": "CJX9/REX1 Südbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Pottschach", "line": "CJX9 Südbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Gloggnitz", "line": "CJX9/REX Südbahn (Endpunkt vor Semmering)", "priority": 2, "added": "2026-05-05"},
+    {"name": "Payerbach-Reichenau", "line": "CJX9/REX/R Südbahn", "priority": 2, "added": "2026-05-05"},
+
+    {"name": "Weigelsdorf", "line": "R/REX Pottendorfer Linie", "priority": 2, "added": "2026-05-05"},
+    {"name": "Wampersdorf", "line": "R/REX Pottendorfer Linie (Abzweigung)", "priority": 2, "added": "2026-05-05"},
+    {"name": "Pottendorf-Landegg", "line": "R/REX Pottendorfer Linie (namensgebend)", "priority": 2, "added": "2026-05-05"},
+
+    {"name": "Maria Lanzendorf", "line": "R95 Innere Aspangbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Laxenburg-Biedermannsdorf", "line": "R95 Innere Aspangbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Guntramsdorf-Kaiserau", "line": "R95 Innere Aspangbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Möllersdorf Aspangbahn", "line": "R95 Innere Aspangbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Trumau", "line": "R95 Innere Aspangbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Oberwaltersdorf", "line": "R95 Innere Aspangbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Tattendorf", "line": "R95 Innere Aspangbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Teesdorf", "line": "R95 Innere Aspangbahn", "priority": 2, "added": "2026-05-05"},
+
+    {"name": "Lanzendorf-Rannersdorf", "line": "S60/REX Ostbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Trautmannsdorf an der Leitha", "line": "S60 Ostbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Wilfleinsdorf", "line": "S60 Ostbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Sarasdorf", "line": "S60 Ostbahn", "priority": 2, "added": "2026-05-05"},
+
+    {"name": "Mannswörth", "line": "S7 Pressburger Bahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Fischamend", "line": "S7 Pressburger Bahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Maria Ellend an der Donau", "line": "S7 Pressburger Bahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Haslau an der Donau", "line": "S7 Pressburger Bahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Regelsbrunn", "line": "S7 Pressburger Bahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Wildungsmauer", "line": "S7 Pressburger Bahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Petronell-Carnuntum", "line": "S7 Pressburger Bahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Bad Deutsch-Altenburg", "line": "S7 Pressburger Bahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Hainburg Kulturfabrik", "line": "S7 Pressburger Bahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Hainburg Ungartor", "line": "S7 Pressburger Bahn", "priority": 2, "added": "2026-05-05"},
+
+    {"name": "Raasdorf", "line": "S80/R81/REX8 Marchegger Ostbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Glinzendorf", "line": "R81/REX8 Marchegger Ostbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Siebenbrunn-Leopoldsdorf", "line": "R81/REX8 Marchegger Ostbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Untersiebenbrunn", "line": "R81/REX8 Marchegger Ostbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Schönfeld-Lassee", "line": "R81/REX8 Marchegger Ostbahn", "priority": 2, "added": "2026-05-05"},
+
+    {"name": "Helmahof", "line": "S1/REX2 Nordbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Bernhardsthal", "line": "REX Nordbahn (Inland-Endbahnhof)", "priority": 2, "added": "2026-05-05"},
+    {"name": "Hohenau", "line": "REX/R Nordbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Drösing", "line": "REX/R Nordbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Dürnkrut", "line": "R Nordbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Angern an der March", "line": "R Nordbahn", "priority": 2, "added": "2026-05-05"},
+
+    {"name": "Mistelbach Stadt", "line": "REX2 Laaer Ostbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Laa an der Thaya", "line": "REX2 Laaer Ostbahn (Endbahnhof)", "priority": 2, "added": "2026-05-05"},
+
+    {"name": "Langenzersdorf", "line": "S3/R3 Nordwestbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Bisamberg", "line": "S3/R3 Nordwestbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Spillern", "line": "S3/R3/REX3 Nordwestbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Absdorf-Hippersdorf", "line": "S5/REX41 (Knoten FJB/Stockerau)", "priority": 2, "added": "2026-05-05"},
+
+    {"name": "Kritzendorf", "line": "S40/R40 Franz-Josefs-Bahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "St. Andrä-Wördern", "line": "S40/R40 Franz-Josefs-Bahn (P&R)", "priority": 2, "added": "2026-05-05"},
+    {"name": "Tulln Stadt", "line": "S40 Franz-Josefs-Bahn (zentrumsnah)", "priority": 2, "added": "2026-05-05"},
+    {"name": "Krems an der Donau", "line": "REX4/R44 Franz-Josefs-Bahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Hadersdorf am Kamp", "line": "REX4/R44 Franz-Josefs-Bahn", "priority": 2, "added": "2026-05-05"},
+
+    {"name": "Rekawinkel", "line": "S50 Westbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Maria Anzbach", "line": "S50 Westbahn", "priority": 2, "added": "2026-05-05"},
+    {"name": "Neulengbach Stadt", "line": "S50 Westbahn (Stadtbahnhof)", "priority": 2, "added": "2026-05-05"},
+    {"name": "Pottenbrunn", "line": "REX51/R Westbahn (St. Pölten Vorort)", "priority": 2, "added": "2026-05-05"}
+  ],
+  "notes": [
+    "Excerpt from the 2026-05 stations-coverage research; see docs/archive/audits/stations_coverage_2026-05.md for the full picture and rationale.",
+    "Priority 1 = 'critical missing for Wien-pendler use case' (Top-12 of the research).",
+    "Priority 2 = 'important' (additional commuter stations identified in the same research).",
+    "Future planned stations (Wien Hietzinger Hauptstraße, Wien Stranzenbergbrücke, possible Wien Lobau reactivation) are intentionally not listed — they are documented in the audit file under 'Beobachten / nach Inbetriebnahme nachpflegen'."
+  ]
+}

--- a/docs/archive/audits/INDEX.md
+++ b/docs/archive/audits/INDEX.md
@@ -9,6 +9,7 @@ Chronologische Übersicht aller archivierten Audits dieses Projekts.
 | 2026-05-05 | [Erst-Audit](stations_data_audit_2026-05-05.md) | [#1188](https://github.com/Origamihase/wien-oepnv/pull/1188) | Koordinaten-Fixes (9 Stationen), kanonische Namen, source-Format, Rennweg-Doublette, NamingIssue-Validator |
 | 2026-05-05 | [Follow-up](stations_data_audit_2026-05-05_followup.md) | [#1189](https://github.com/Origamihase/wien-oepnv/pull/1189) | 31-Vertex-Polygon (vorher 8-Vertex-Konvex-Hülle), Liesing-VOR-Coords, Sue↔Su-Token-Fix, WL-OGD-Auto-Download |
 | 2026-05-05 | [Offizielles Polygon](stations_data_audit_2026-05-05_official_polygon.md) | [#1190](https://github.com/Origamihase/wien-oepnv/pull/1190) | Hand-kuratiertes Polygon ersetzt durch offizielle `LANDESGRENZEOGD`-Quelle der MA 41 (5.637 Vertices, ~1–2 m Genauigkeit) |
+| 2026-05 | [Vollständigkeit / Pendler-Coverage](stations_coverage_2026-05.md) | (offen) | 12 kritische + 57 wichtige Pendlerstationen identifiziert; name-basierte Wishlist `data/pendler_candidates.json` + Updater-Erweiterung statt manuelle ID-Raterei |
 
 ## Code & System
 

--- a/docs/archive/audits/stations_coverage_2026-05.md
+++ b/docs/archive/audits/stations_coverage_2026-05.md
@@ -1,0 +1,141 @@
+# Stationsverzeichnis – Vollständigkeits-Audit 2026-05
+
+Vollständigkeits-Vergleich der `data/stations.json` gegen das ÖBB-/VOR-
+Bahnhofsverzeichnis (Stand Mai 2026, alle aktiven S-Bahn-/REX-/R-Halte
+des VOR-Kerngebiets) und resultierende Anpassungen am Updater.
+
+## Zusammenfassung der Recherche-Befunde
+
+| Kennzahl | Wert | Bewertung |
+|---|---|---|
+| Wien-Stationen (`in_vienna: true`) im Verzeichnis | 48 | vollständig (siehe unten) |
+| NÖ/Bgld-Pendlerstationen im Verzeichnis | 41 | systematische Lücken |
+| Recherche-Behauptung „Wien Mitte fehlt" | falsch | Eintrag existiert als `Wien Mitte-Landstraße` (bst_id 900102) mit Aliasen `Wien Mitte`, `Mitte`, … |
+| Tatsächlich kritisch fehlende Pendlerstationen | **12** | siehe Tabelle |
+| Wichtige Pendlerstationen 2. Priorität | **57** | siehe `data/pendler_candidates.json` |
+
+## Verifikation der Recherche-Behauptung „Wien Mitte fehlt"
+
+Falsch. `data/stations.json` enthält den Eintrag:
+
+```json
+{
+  "name": "Wien Mitte-Landstraße",
+  "vor_id": "490074300",
+  "bst_id": "900102",
+  "aliases": ["Wien Mitte", "Mitte", "Mitte-Landstraße", … (~100 weitere)]
+}
+```
+
+Lookup-Tests bestätigen: `station_info("Wien Mitte")` → `Wien Mitte-Landstraße`.
+Die Recherche hat den kanonischen Namen übersehen — **kein Datenfehler**.
+
+## Wirklich fehlende Pendlerstationen (Top-12)
+
+Verifiziert per Cross-Check gegen Existing-Aliase:
+
+| Station | Linie | Begründung |
+|---|---|---|
+| Pfaffstätten | S-Bahn Südbahn | starkes Pendleraufkommen Bezirk Baden |
+| Gumpoldskirchen | S-Bahn Südbahn | starkes Pendleraufkommen |
+| Guntramsdorf Südbahn | S-Bahn Südbahn | Pendlerbahnhof zwischen Mödling und Baden |
+| Hennersdorf | S60-Verstärker Pottendorfer Linie | erster Halt nach Wien Blumental |
+| Achau | S60-Verstärker Pottendorfer Linie | modernisiert 2019 |
+| Münchendorf | S60-Verstärker Pottendorfer Linie | modernisiert 2019 |
+| Gramatneusiedl | S60/REX6/REX64 Ostbahn | wichtiger Knoten Industrieviertel |
+| Götzendorf an der Leitha | S60/REX6 Ostbahn | Pendlerknoten Bruck/Leitha |
+| Himberg bei Wien | S60/REX6 Ostbahn | sehr starker Pendlerbahnhof (z.Z. baulich gesperrt bis Ende 2026) |
+| Felixdorf | S3/S4/REX | Verzweigung Süd-/Aspangbahn |
+| Sollenau | S-Bahn Südbahn / Aspangbahn | Knoten |
+| Traiskirchen Aspangbahn | R95 Innere Aspangbahn | Hauptbahnhof Bezirk Baden |
+
+Hinzu kommen ~57 weitere wichtige Pendlerstationen aus den Linien Südbahn,
+Pottendorfer, Innere Aspangbahn, Pressburger Bahn, Marchegger Ostbahn,
+Nordbahn, Laaer Ostbahn, Nordwestbahn, Franz-Josefs-Bahn und Westbahn.
+
+## Maßnahme dieses Audits
+
+Die `bst_id`-Werte der fehlenden Stationen sind nicht aus den lokalen
+GTFS-/VOR-CSV-Dateien ableitbar (diese decken nur die bereits ergänzten
+Stationen ab — 97 / 93 Zeilen). Sie liegen ausschließlich im
+ÖBB-Excel-Verzeichnis „Verkehrsstation", das beim monatlichen Lauf von
+`update-stations.yml` von `data.oebb.at` heruntergeladen wird.
+
+Statt die Stationen heute manuell mit (potenziell falschen) Provisorisch-
+IDs zu ergänzen, führt dieser PR eine **name-basierte Pendler-Whitelist**
+ein:
+
+### Neue Datei `data/pendler_candidates.json`
+
+```json
+{
+  "candidates": [
+    {"name": "Pfaffstätten", "line": "S-Bahn Südbahn", "priority": 1},
+    {"name": "Gumpoldskirchen", "line": "S-Bahn Südbahn", "priority": 1},
+    …
+    {"name": "Pottenbrunn", "line": "REX51/R Westbahn", "priority": 2}
+  ]
+}
+```
+
+69 normalisierte Name-Keys (12 Top-Priorität + 57 weitere). JSON-Schema:
+[`docs/schema/pendler_candidates.schema.json`](../../schema/pendler_candidates.schema.json).
+
+### Updater-Erweiterung in `scripts/update_station_directory.py`
+
+`_annotate_station_flags` bekommt einen optionalen Parameter
+`pendler_name_candidates: set[str]`. Beim Verarbeiten jedes ÖBB-Excel-
+Eintrags wird zusätzlich zur `bst_id`-Whitelist (`pendler_bst_ids.json`)
+auch der normalisierte Stationsname gegen die Kandidaten-Liste geprüft.
+
+```python
+pendler_candidate = station.bst_id in pendler_ids
+if not pendler_candidate and name_candidates:
+    for key in _normalize_location_keys(station.name):
+        if key and key in name_candidates:
+            pendler_candidate = True
+            break
+```
+
+Die mutual-exclusivity-Garantie aus PR #1192 bleibt unangetastet:
+`in_vienna=true` schlägt jeden Pendler-Marker (sowohl bst_id- als auch
+namensbasiert) und loggt eine WARNING.
+
+## Auswirkung auf den nächsten Workflow-Lauf
+
+Beim nächsten monatlichen `update-stations.yml`-Cron (`0 1 1 * *`):
+
+1. `update_station_directory.py` lädt das ÖBB-Excel von `data.oebb.at`.
+2. Für jeden Excel-Eintrag wird geprüft:
+   - bst_id ∈ `pendler_bst_ids.json`? (alt)
+   - normalisierter Name ∈ `pendler_candidates.json`? (neu)
+3. Trifft beides oder eines davon zu, wird der Eintrag mit
+   `pendler=true` ins Verzeichnis übernommen.
+4. Ihre echten `bst_id`/`bst_code`/`vor_id`-Werte kommen direkt aus der
+   ÖBB-Quelle — keine ID-Raterei, keine manuellen Korrekturen nötig.
+5. Der Heartbeat (`data/stations_last_run.json`, eingeführt in PR #1200)
+   meldet die neuen Einträge in `diff.added`; `docs/stations_diff.md`
+   listet sie namentlich.
+
+Stationen, die im Excel nicht auftauchen (z.B. weil ÖBB sie
+zwischenzeitlich umbenannt hat), bleiben in `pendler_candidates.json`
+stehen, ohne den Lauf zu blockieren.
+
+## Nicht in diesem Audit
+
+- **Perchtoldsdorf**: laut Recherche kein aktiver ÖBB-Personenverkehr (Kalten­
+  leutgebener Bahn seit 1951 ohne Personenverkehr). Der Eintrag wird
+  vorerst behalten, weil die VOR-ID `430450000` für die Bus-Haltestelle
+  „Perchtoldsdorf Bahnhof" der WLB Badner Bahn weiter relevant ist.
+  Reklassifizierung erfordert Schema-Erweiterung um `transport_modes`
+  oder `note` und ist außerhalb dieses PRs.
+- **Geplante Stationen** (Wien Hietzinger Hauptstraße, Wien Stranzenberg-
+  brücke aus dem ÖBB-Projekt „Attraktivierung Verbindungsbahn",
+  ev. Reaktivierung Wien Lobau): noch nicht in Betrieb — werden bei
+  Inbetriebnahme nachgepflegt.
+- **VOR-Kernzone-Flag** (`kernzone_wien: true` für Stationen wie Gerasdorf,
+  Schwechat, Purkersdorf Sanatorium, Kledering): Schema-Erweiterung mit
+  Auswirkung auf den Feed-Code; eigener Folge-PR.
+- **Hauptbahnhof S-Bahn-Bahnsteige** als sekundäre VOR-ID: erfordert
+  Schema-Anpassung zu `vor_ids: list[string]` statt `vor_id: string`;
+  invasiv und außerhalb dieses Scopes.

--- a/docs/schema/pendler_candidates.schema.json
+++ b/docs/schema/pendler_candidates.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://origamihase.github.io/wien-oepnv/schema/pendler_candidates.schema.json",
+  "title": "Wien ÖPNV Pendler Candidates",
+  "description": "Name-based pendler whitelist consumed by scripts/update_station_directory.py. Stations whose ÖBB Excel-Verzeichnis name matches a candidate here are marked pendler=true on the next refresh, regardless of whether their bst_id is in data/pendler_bst_ids.json. Use this file when the station's bst_id is unknown — common for new commuter stations not yet in the editor's local cache.",
+  "type": "object",
+  "required": ["candidates"],
+  "additionalProperties": true,
+  "properties": {
+    "$schema": {"type": "string"},
+    "description": {"type": "string"},
+    "notes": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "candidates": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/Candidate"}
+    }
+  },
+  "$defs": {
+    "Candidate": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Station name as it appears in the ÖBB Excel-Verzeichnis 'Verkehrsstation' column. Whitespace is harmonized in the matcher; case-insensitive comparison."
+        },
+        "line": {
+          "type": "string",
+          "description": "Free-text annotation: which S-Bahn/REX/R lines serve this stop. Documentation only — does not influence matching."
+        },
+        "priority": {
+          "type": "integer",
+          "enum": [1, 2, 3],
+          "description": "1 = critical, 2 = important, 3 = nice-to-have. Used by the audit report to sort/group; not relevant for the matcher."
+        },
+        "added": {
+          "type": "string",
+          "format": "date",
+          "description": "When this candidate was first added — useful for tracking how long an entry has been waiting for ÖBB-Excel coverage."
+        }
+      }
+    }
+  }
+}

--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -79,6 +79,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when installed as pac
 
 DEFAULT_OUTPUT_PATH = _ROOT / "data" / "stations.json"
 DEFAULT_PENDLER_PATH = _ROOT / "data" / "pendler_bst_ids.json"
+DEFAULT_PENDLER_CANDIDATES_PATH = _ROOT / "data" / "pendler_candidates.json"
 DEFAULT_GTFS_STOPS_PATH = _ROOT / "data" / "gtfs" / "stops.txt"
 DEFAULT_WL_HALTEPUNKTE_PATH = _ROOT / "data" / "wienerlinien-ogd-haltepunkte.csv"
 DEFAULT_VOR_STOPS_PATH = _ROOT / "data" / "vor-haltestellen.csv"
@@ -912,6 +913,17 @@ def parse_args() -> argparse.Namespace:
         help="Path to the JSON file containing pendler station IDs",
     )
     parser.add_argument(
+        "--pendler-candidates",
+        type=Path,
+        metavar="PATH",
+        default=DEFAULT_PENDLER_CANDIDATES_PATH,
+        help=(
+            "Path to the name-based pendler whitelist "
+            "(default: data/pendler_candidates.json). Stations whose ÖBB name "
+            "matches a candidate here are also marked pendler=true."
+        ),
+    )
+    parser.add_argument(
         "--vor-stops",
         type=Path,
         metavar="PATH",
@@ -1069,6 +1081,7 @@ def _annotate_station_flags(
     stations: list[Station],
     pendler_ids: set[str],
     locations: Mapping[str, LocationInfo],
+    pendler_name_candidates: set[str] | None = None,
 ) -> None:
     """Set ``in_vienna`` and ``pendler`` mutually exclusively.
 
@@ -1077,7 +1090,15 @@ def _annotate_station_flags(
     listed in ``data/pendler_bst_ids.json``, the ``in_vienna`` flag wins and
     the pendler flag stays ``False`` — a warning is logged so the entry can
     be removed from the whitelist.
+
+    Pendler classification sources (any of them is sufficient):
+      1. ``bst_id in pendler_ids`` — legacy bst_id whitelist (`data/pendler_bst_ids.json`).
+      2. ``normalized name in pendler_name_candidates`` — name-based wishlist
+         (`data/pendler_candidates.json`). Lets the user nominate stations
+         without knowing the bst_id; the next ÖBB Excel pull resolves it.
+      3. WL-sourced location outside Vienna — auto-promoted (legacy heuristic).
     """
+    name_candidates = pendler_name_candidates or set()
     for station in stations:
         info: LocationInfo | None = None
         for key in _normalize_location_keys(station.name):
@@ -1089,12 +1110,18 @@ def _annotate_station_flags(
         else:
             station.in_vienna = _is_vienna_station(station.name)
         pendler_candidate = station.bst_id in pendler_ids
+        if not pendler_candidate and name_candidates:
+            for key in _normalize_location_keys(station.name):
+                if key and key in name_candidates:
+                    pendler_candidate = True
+                    break
         if info and not station.in_vienna and "wl" in info.sources:
             pendler_candidate = True
         if station.in_vienna and pendler_candidate:
             logger.warning(
                 "Station %s (bst_id=%s) is inside Vienna; ignoring pendler "
-                "marker — remove the entry from data/pendler_bst_ids.json",
+                "marker — remove the entry from data/pendler_bst_ids.json "
+                "or data/pendler_candidates.json",
                 station.name,
                 station.bst_id,
             )
@@ -1143,6 +1170,56 @@ def load_pendler_station_ids(path: Path) -> set[str]:
     return pendler_ids
 
 
+def load_pendler_name_candidates(path: Path) -> set[str]:
+    """Load the name-based pendler whitelist (`data/pendler_candidates.json`).
+
+    Returns a set of normalized name keys (via :func:`_normalize_location_keys`)
+    so the caller can do an O(1) ``key in candidates`` check while iterating
+    the ÖBB Excel rows. A missing or malformed file degrades to an empty set
+    with a warning — the bst_id-based whitelist remains the primary path.
+    """
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError:
+        logger.info(
+            "Pendler candidates file not found: %s (using bst_id whitelist only)",
+            path,
+        )
+        return set()
+    except json.JSONDecodeError as exc:
+        logger.warning("Invalid JSON in pendler candidates file %s: %s", path, exc)
+        return set()
+
+    if not isinstance(data, dict):
+        logger.warning("Pendler candidates file %s must be a JSON object", path)
+        return set()
+
+    raw = data.get("candidates", [])
+    if not isinstance(raw, list):
+        logger.warning(
+            "Pendler candidates file %s: 'candidates' must be a list", path
+        )
+        return set()
+
+    keys: set[str] = set()
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        for key in _normalize_location_keys(name):
+            if key:
+                keys.add(key)
+    logger.info(
+        "Loaded %d pendler name-keys from %d candidates",
+        len(keys),
+        len(raw),
+    )
+    return keys
+
+
 def write_json(stations_list: list[dict[str, object]], output_path: Path) -> None:
     payload = {"stations": stations_list}
     # Use atomic_write to prevent partial writes and reduce race conditions.
@@ -1162,10 +1239,18 @@ def main() -> None:
     _harmonize_station_names(stations, existing_entries)
     _restore_existing_metadata(stations, existing_entries)
     pendler_ids = load_pendler_station_ids(path=args.pendler)
+    pendler_name_candidates = load_pendler_name_candidates(
+        path=args.pendler_candidates
+    )
     location_index = _build_location_index(args.gtfs_stops, args.wl_haltepunkte)
     if not location_index:
         logger.warning("No coordinate data available; falling back to name heuristic")
-    _annotate_station_flags(stations, pendler_ids, location_index)
+    _annotate_station_flags(
+        stations,
+        pendler_ids,
+        location_index,
+        pendler_name_candidates=pendler_name_candidates,
+    )
     vor_stops = load_vor_stops(args.vor_stops) if args.vor_stops else []
     if vor_stops:
         _assign_vor_ids(stations, vor_stops)

--- a/tests/test_update_station_directory_pendler_candidates.py
+++ b/tests/test_update_station_directory_pendler_candidates.py
@@ -1,0 +1,151 @@
+"""Tests for the name-based pendler whitelist (data/pendler_candidates.json).
+
+These tests cover the loader (`load_pendler_name_candidates`) and the
+integration with `_annotate_station_flags`. The bst_id-based whitelist
+remains the primary source; the name-based candidate list complements it
+for stations whose bst_id is not yet known to the editor.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import update_station_directory as usd
+
+
+def _make_station(name: str, *, bst_id: str = "999") -> usd.Station:
+    return usd.Station(bst_id=bst_id, bst_code="X", name=name, in_vienna=False, pendler=False)
+
+
+def test_load_pendler_name_candidates_returns_normalized_keys(tmp_path: Path) -> None:
+    path = tmp_path / "pendler_candidates.json"
+    path.write_text(
+        json.dumps(
+            {
+                "candidates": [
+                    {"name": "Pfaffstätten", "line": "S-Bahn Südbahn"},
+                    {"name": "Münchendorf", "priority": 1},
+                    {"name": "  Spillern  "},  # whitespace tolerated
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    keys = usd.load_pendler_name_candidates(path)
+    assert "pfaffstatten" in keys
+    assert "munchendorf" in keys
+    assert "spillern" in keys
+
+
+def test_load_pendler_name_candidates_handles_missing_file(tmp_path: Path) -> None:
+    """Absent file degrades to an empty set; bst_id whitelist remains primary."""
+    keys = usd.load_pendler_name_candidates(tmp_path / "absent.json")
+    assert keys == set()
+
+
+def test_load_pendler_name_candidates_handles_malformed_json(tmp_path: Path) -> None:
+    path = tmp_path / "broken.json"
+    path.write_text("not json at all", encoding="utf-8")
+    assert usd.load_pendler_name_candidates(path) == set()
+
+
+def test_load_pendler_name_candidates_skips_non_dict_entries(tmp_path: Path) -> None:
+    path = tmp_path / "mixed.json"
+    path.write_text(
+        json.dumps(
+            {"candidates": ["bare string", {"name": "Achau"}, {"no_name": True}]}
+        ),
+        encoding="utf-8",
+    )
+    keys = usd.load_pendler_name_candidates(path)
+    assert keys == {"achau"}
+
+
+def test_annotate_marks_name_candidate_as_pendler() -> None:
+    """A station NOT in the bst_id whitelist but matching a name candidate
+    gets pendler=True on the next refresh — the whole point of the file."""
+    station = _make_station("Pfaffstätten", bst_id="9999")
+    locations: dict[str, usd.LocationInfo] = {}
+    usd._annotate_station_flags(
+        [station],
+        pendler_ids=set(),
+        locations=locations,
+        pendler_name_candidates={"pfaffstatten"},
+    )
+    assert station.in_vienna is False
+    assert station.pendler is True
+
+
+def test_annotate_falls_back_to_bst_id_when_name_not_in_candidates() -> None:
+    """Backward compat: a bst_id-whitelist hit alone still marks pendler=true."""
+    station = _make_station("Mödling", bst_id="1377")
+    usd._annotate_station_flags(
+        [station],
+        pendler_ids={"1377"},
+        locations={},
+        pendler_name_candidates=set(),
+    )
+    assert station.pendler is True
+
+
+def test_annotate_in_vienna_wins_over_name_candidate() -> None:
+    """Vienna stations always win — the mutual-exclusivity invariant from
+    PR #1192 must hold even when the name accidentally hits a candidate."""
+    station = _make_station("Wien Westbahnhof", bst_id="2511")
+    locations = {
+        "wien westbahnhof": usd.LocationInfo(
+            latitude=48.196654, longitude=16.337652, sources={"oebb"}
+        )
+    }
+    usd._annotate_station_flags(
+        [station],
+        pendler_ids=set(),
+        locations=locations,
+        pendler_name_candidates={"wien westbahnhof"},  # mistakenly added
+    )
+    assert station.in_vienna is True
+    assert station.pendler is False, (
+        "in_vienna must win over both bst_id and name-based pendler markers"
+    )
+
+
+def test_pendler_candidates_file_validates_against_schema() -> None:
+    """Lock the on-disk candidate file against its JSON Schema."""
+    jsonschema = pytest.importorskip("jsonschema")
+    repo_root = Path(__file__).resolve().parent.parent
+    schema_path = repo_root / "docs" / "schema" / "pendler_candidates.schema.json"
+    candidates_path = repo_root / "data" / "pendler_candidates.json"
+
+    with schema_path.open(encoding="utf-8") as handle:
+        schema = json.load(handle)
+    with candidates_path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda exc: exc.path)
+    assert not errors, "\n".join(
+        f"{'.'.join(str(p) for p in err.absolute_path)}: {err.message}"
+        for err in errors
+    )
+
+
+def test_pendler_candidates_top_12_present() -> None:
+    """Live-data pin: the 12 critical pendler stations from the
+    2026-05 stations-coverage research must be on the candidate list."""
+    repo_root = Path(__file__).resolve().parent.parent
+    candidates_path = repo_root / "data" / "pendler_candidates.json"
+    with candidates_path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    names = {c["name"] for c in data["candidates"]}
+
+    top_12 = {
+        "Pfaffstätten", "Gumpoldskirchen", "Guntramsdorf Südbahn",
+        "Hennersdorf", "Achau", "Münchendorf",
+        "Gramatneusiedl", "Götzendorf an der Leitha", "Himberg bei Wien",
+        "Felixdorf", "Sollenau", "Traiskirchen Aspangbahn",
+    }
+    missing = top_12 - names
+    assert not missing, f"Top-12 pendler stations missing from candidates: {missing}"


### PR DESCRIPTION
## Summary

Coverage-Audit auf Basis der ÖBB-/VOR-Recherche (Stand Mai 2026):
das Verzeichnis hat **12 kritische** + **57 wichtige** Pendler-Lücken
(Südbahn, Pottendorfer, Innere Aspangbahn, Pressburger, Marchegger
Ostbahn, Nordbahn, Laaer Ostbahn, Nordwestbahn, FJB, Westbahn).

### Verifikation der Recherche-Behauptung „Wien Mitte fehlt"
**Falsch.** Existiert als `Wien Mitte-Landstraße` (bst_id 900102) mit Aliasen `Wien Mitte`, `Mitte` u.v.m. Lookup-getestet.

### Strategie: name-basierte Wishlist statt manuelle ID-Raterei
Die `bst_id`s der fehlenden Stationen liegen ausschließlich im ÖBB-Excel-Verzeichnis — die lokalen GTFS/VOR-CSVs decken nur die bereits ingestierten 93 Halte ab. Manuelle ID-Vergabe wäre rateraierisch.

Lösung: **`data/pendler_candidates.json`** mit 12 Priority-1 + 57 Priority-2 Stations-Namen. Beim nächsten monatlichen `update-stations.yml`-Lauf matcht der Updater den ÖBB-Excel-Namen gegen die Liste und löst die `bst_id` automatisch auf.

### Änderungen

| Datei | Funktion |
|---|---|
| `data/pendler_candidates.json` | 69 Pendler-Namen (12 P1 + 57 P2), je `{name, line, priority, added}` |
| `docs/schema/pendler_candidates.schema.json` | Formales JSON Schema |
| `scripts/update_station_directory.py` | `_annotate_station_flags` um `pendler_name_candidates` erweitert + `load_pendler_name_candidates()` Helper + neuer `--pendler-candidates` CLI-Flag |
| `tests/test_update_station_directory_pendler_candidates.py` | 8 neue Tests (Loader, Schema-Pin, Top-12-Pin, in_vienna-wins-Guard) |
| `README.md` | Pendler-Whitelist-Sektion: beide Dateien dokumentiert |
| `docs/archive/audits/stations_coverage_2026-05.md` | Vollständigkeits-Audit |

### Was passiert beim nächsten Workflow-Lauf?
1. Excel-Pull von `data.oebb.at` (in CI mit Network-Zugang)
2. Pro Excel-Eintrag: bst_id ∈ Whitelist? **ODER** name ∈ Candidates?
3. Bei Match: `pendler=true`, echte ID/Coords aus ÖBB übernommen
4. Heartbeat (`stations_last_run.json` aus PR #1200 — wenn gemergt): meldet Neuzugänge in `diff.added`
5. Diff-Report (`docs/stations_diff.md`): listet sie namentlich

PR #1192-Garantie (in_vienna ⊕ pendler) bleibt unangetastet — Vienna-Stations werden auch bei Name-Match zwangsläufig als `pendler=false` gehalten, mit WARNING.

### Nicht in diesem PR (dokumentiert im Audit)
- **Perchtoldsdorf**-Reklassifizierung (kein ÖBB-Personenverkehr, nur WLB-Bus)
- **Geplante Stationen** (Hietzinger Hauptstraße, Stranzenbergbrücke)
- **VOR-Kernzone-Flag** für Gerasdorf/Schwechat/Kledering
- **Hauptbahnhof S-Bahn-Bahnsteige** als sekundäre VOR-ID

## Test plan
- [x] `pytest tests/` → 1061 passed, 1 skipped (+8 neue Tests)
- [x] `ruff check` clean
- [x] `mypy --strict src tests` → 307 source files, no issues
- [x] `bandit` clean, `pip-audit` clean
- [x] Schema-Validierung der `pendler_candidates.json` → 0 Fehler
- [x] Loader normalisiert 69 Name-Keys aus 69 Kandidaten
- [x] Top-12 als Pin-Test verankert

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_