### PR TITLE
fix(stations-update): three reasons the cron validation gate fired

### DIFF
--- a/scripts/fetch_vor_haltestellen.py
+++ b/scripts/fetch_vor_haltestellen.py
@@ -38,6 +38,7 @@ log = logging.getLogger("fetch_vor_haltestellen")
 class Station:
     name: str
     bst_id: str | None = None
+    is_pendler_candidate: bool = False
 
 
 @dataclass
@@ -315,15 +316,18 @@ def main(argv: Sequence[str] | None = None) -> int:
     # Augment with pendler-candidate names so the next update_all_stations
     # pass already has VOR IDs for the station names that aren't yet in
     # stations.json. The matcher dedupes by station name, so listing a
-    # candidate twice is a no-op.
+    # candidate twice is a no-op. Pendler candidates set is_pendler_candidate=True
+    # so the resolver doesn't skip them via the "no bst_id" filter below.
+    candidate_names_lookup: set[str] = set()
     if args.pendler_candidates and args.pendler_candidates.exists():
         existing_names = {s.name.casefold() for s in stations}
         candidate_names = load_pendler_candidate_names(args.pendler_candidates)
+        candidate_names_lookup = {n.casefold() for n in candidate_names}
         added = 0
         for name in candidate_names:
             if name.casefold() in existing_names:
                 continue
-            stations.append(Station(name=name, bst_id=None))
+            stations.append(Station(name=name, bst_id=None, is_pendler_candidate=True))
             existing_names.add(name.casefold())
             added += 1
         if added:
@@ -332,6 +336,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 added,
                 args.pendler_candidates.name,
             )
+
+    # Tag pre-existing stations.json entries that match a pendler candidate
+    # by name, so they bypass the "no bst_id" skip filter even if their
+    # bst_id is unknown (e.g. fresh entries from the previous Excel pull).
+    if candidate_names_lookup:
+        for station in stations:
+            if station.name.casefold() in candidate_names_lookup:
+                station.is_pendler_candidate = True
 
     resolved_unique: dict[str, VORCandidate] = {}
     resolved_pairs: list[tuple[Station, VORCandidate]] = []
@@ -345,6 +357,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 1
 
         for station in stations:
+            # Skip stations that have no ÖBB bst_id and aren't a pendler
+            # candidate. These are typically Google-Places-only U-Bahn stops
+            # (Stadtpark, Schwedenplatz) or manual_foreign_city entries
+            # (Roma Termini, München Hauptbahnhof). The HAFAS resolver
+            # accepts almost any input and produces wrong matches for them
+            # — e.g. "Roma Termini" → "Wels (OÖ) Hbf (Busterminal)" — which
+            # then pollute the merge step in update_vor_stations.py.
+            if station.bst_id is None and not station.is_pendler_candidate:
+                log.debug(
+                    "Skipping VOR resolution for %s (no bst_id, not a pendler candidate)",
+                    station.name,
+                )
+                continue
             candidate = resolve_station(session, DEFAULT_MGATE_URL, access_id, station, args.sleep)
             if not candidate:
                 continue

--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -214,6 +214,13 @@ class Station:
             if key in {"bst_id", "bst_code", "name", "in_vienna", "pendler", "vor_id", "_lat", "_lng", "_types", "_google_place_id"}:
                 continue
             payload[key] = value
+        # Tag every Excel-imported entry with source="oebb" if no other
+        # source has been merged in. Without this, the next run treats the
+        # entry as `manual` (see _load_existing_station_entries) and appends
+        # it on top of a fresh Excel import — producing the duplicate-name
+        # NamingIssues seen in the 2026-05 cron after PR #1201.
+        if "source" not in payload:
+            payload["source"] = "oebb"
         return payload
 
     def update_from_entry(self, entry: Mapping[str, object]) -> None:

--- a/scripts/update_vor_stations.py
+++ b/scripts/update_vor_stations.py
@@ -775,19 +775,21 @@ def merge_into_stations(stations_path: Path, vor_entries: list[dict[str, object]
                 target["vor_id"] = vor_id
             continue
 
-        new_entry = dict(vor_entry)
-        bst_id = _normalize_id(new_entry.get("bst_id"))
-        if not bst_id:
-            bst_id = _allocate_identifier()
-        new_entry["bst_id"] = bst_id
-        used_bst_ids.add(bst_id)
-        bst_code = _normalize_id(new_entry.get("bst_code"))
-        if not bst_code:
-            bst_code = bst_id
-        new_entry["bst_code"] = bst_code
-        used_bst_codes.add(bst_code)
-        new_entry["source"] = "vor"
-        new_vor_entries.append(new_entry)
+        # A VOR-stop that did not merge into an existing entry is most often
+        # a "lost in translation" mismatch produced by fetch_vor_haltestellen
+        # (e.g. "Roma Termini" → "Wels Hbf", "Rennweg" → "Rennweg am Katschberg")
+        # or a Pendler-Bahnhof outside the Wien-relevant scope. Either way,
+        # creating a synthetic entry is harmful: it pollutes the directory
+        # with false-positive matches and trips the in_vienna/pendler
+        # mutual-exclusivity gate (#1192). We log and skip; the static
+        # `STATIC_VOR_ENTRIES` block below still creates entries for the
+        # explicitly curated VOR-only stations (e.g. Wiener Neustadt Hbf).
+        log.info(
+            "Skipping VOR-only stop %s (%s): no ÖBB merge target — keeping out of stations.json",
+            vor_entry.get("name") or "<unnamed>",
+            vor_id,
+        )
+        continue
 
     for vor_id, static_entry in static_map.items():
         if vor_id in handled_static:

--- a/scripts/update_vor_stations.py
+++ b/scripts/update_vor_stations.py
@@ -733,6 +733,7 @@ def merge_into_stations(stations_path: Path, vor_entries: list[dict[str, object]
 
     new_vor_entries: list[dict[str, object]] = []
     seen_vor_ids: set[str] = set()
+    skipped_unmerged_count = 0
 
     for vor_entry in vor_entries:
         vor_id = _normalize_id(vor_entry.get("vor_id"))
@@ -781,14 +782,14 @@ def merge_into_stations(stations_path: Path, vor_entries: list[dict[str, object]
         # or a Pendler-Bahnhof outside the Wien-relevant scope. Either way,
         # creating a synthetic entry is harmful: it pollutes the directory
         # with false-positive matches and trips the in_vienna/pendler
-        # mutual-exclusivity gate (#1192). We log and skip; the static
+        # mutual-exclusivity gate (#1192). Count and skip; the static
         # `STATIC_VOR_ENTRIES` block below still creates entries for the
         # explicitly curated VOR-only stations (e.g. Wiener Neustadt Hbf).
-        log.info(
-            "Skipping VOR-only stop %s (%s): no ÖBB merge target — keeping out of stations.json",
-            vor_entry.get("name") or "<unnamed>",
-            vor_id,
-        )
+        # We aggregate to a single count instead of per-entry logging so
+        # untrusted VOR payload fields (name, vor_id) never reach the log
+        # stream — keeps CodeQL "clear-text logging of sensitive
+        # information" rules happy and avoids leaking provider-side data.
+        skipped_unmerged_count += 1
         continue
 
     for vor_id, static_entry in static_map.items():
@@ -827,6 +828,11 @@ def merge_into_stations(stations_path: Path, vor_entries: list[dict[str, object]
         output = {"stations": merged_entries}
         json.dump(output, handle, ensure_ascii=False, indent=2)
         handle.write("\n")
+    if skipped_unmerged_count:
+        log.info(
+            "Skipped %d VOR stops without ÖBB merge target (kept out of stations.json)",
+            skipped_unmerged_count,
+        )
     log.info(
         "Wrote %d total stations (%d merged, %d added VOR entries)",
         len(merged_entries),


### PR DESCRIPTION
## Diagnose des Cron-Laufs

`update-stations.yml` lief nach #1202 durch und der Validation-Gate hat zu Recht abgebrochen. Drei unabhängige Wurzeln, alle adressiert.

### 1. Duplikate `St.Andrä-Wördern (code:Aw): … (also used by )` (~30×)

`Station.as_dict()` gab Einträge ohne `source`-Feld zurück. Beim nächsten Lauf klassifiziert `_load_existing_station_entries` sie als `manual` und parkt sie. Danach erzeugt der Excel-Pull denselben Eintrag nochmal → zwei Einträge, identische Identität → NamingIssues mit leerem `(also used by )`.

**Fix:** `as_dict()` defaultet `source = "oebb"` wenn nicht bereits gesetzt.

### 2. VOR-Synthetic-Einträge mit `in_vienna=false AND pendler=false` (21×)

`update_vor_stations.py` legte für jeden nicht-merge-baren VOR-Stop einen synthetischen `source: "vor"`-Eintrag an — inklusive Müll wie `Wels (OÖ) Hbf (Busterminal)` (gematched gegen Roma Termini). Diese Einträge tripten die PR-#1192-Mutual-Exclusivity-Gate.

**Fix:** Synthetic-Einträge ohne Merge-Target werden gedroppt; nur `STATIC_VOR_ENTRIES` (Wiener Neustadt Hbf etc.) bleibt aktiv.

### 3. `fetch_vor_haltestellen` löste Garbage auf

Manual-Foreign (Roma Termini, München Hbf) und Google-Places-only U-Bahn-Stops haben keine VOR-Repräsentation. Der HAFAS-Resolver akzeptiert trotzdem den nächst-besten Match — `Roma Termini → Wels Hbf`, `Rennweg → Rennweg am Katschberg`.

**Fix:** `Station.is_pendler_candidate`-Flag. Stationen ohne bst_id UND nicht auf der Pendler-Wishlist werden vom Resolver übersprungen.

## Erwartung beim nächsten Cron

- `validation.naming_issues` → 0 (Duplikate weg, in_vienna/pendler-false-Einträge weg)
- `vor-haltestellen.csv` wächst weiter mit legitimen Pendler-Resolutions, aber keine Roma-Termini-→-Wels-Mismatches mehr
- **Die 56 Pendler aus #1201 bekommen endlich Coordinates** — VOR-CSV (jetzt korrekt befüllt) → `_build_location_index` (#1202) → Match via Name

## Test plan
- [x] `pytest tests/` → 1074 passed, 1 skipped (unchanged)
- [x] `mypy --strict` → 308 source files no issues
- [x] `ruff`, `bandit`, `pip-audit` clean
- [x] Diagnose im Commit-Body dokumentiert die Belege im Cron-Log

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_