### PR TITLE
fix(stations-update): legacy entries without source field re-classified as ÖBB

### DIFF
--- a/data/stations.json
+++ b/data/stations.json
@@ -63,7 +63,8 @@
         "St.Andrä-Wördern Bahnhof",
         "St.Andrä-Wördern Bf",
         "St.Andrä-Wördern bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1019",
@@ -156,7 +157,8 @@
         "Spillern Bahnhof",
         "Spillern Bf",
         "Spillern bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "11",
@@ -172,7 +174,8 @@
         "Bahnhof Achau",
         "Bf Achau",
         "bf Achau"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1103",
@@ -209,7 +212,8 @@
         "Kritzendorf Bahnhof",
         "Kritzendorf Bf",
         "Kritzendorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "115",
@@ -317,7 +321,8 @@
         "Sollenau Bahnhof",
         "Sollenau Bf",
         "Sollenau bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1240762",
@@ -469,7 +474,8 @@
         "Laxenburg-Biedermannsdorf Bahnhof",
         "Laxenburg-Biedermannsdorf Bf",
         "Laxenburg-Biedermannsdorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1318",
@@ -506,7 +512,8 @@
         "Maria Lanzendorf Bahnhof",
         "Maria Lanzendorf Bf",
         "Maria Lanzendorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1348",
@@ -699,7 +706,8 @@
         "Gumpoldskirchen Bahnhof",
         "Gumpoldskirchen Bf",
         "Gumpoldskirchen bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1410",
@@ -740,7 +748,8 @@
         "Bahnhof Bad Deutsch Altenburg",
         "Bf Bad Deutsch Altenburg",
         "bf Bad Deutsch Altenburg"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "145",
@@ -756,7 +765,8 @@
         "Bernhardsthal bf",
         "Bf Bernhardsthal",
         "bf Bernhardsthal"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1469",
@@ -779,7 +789,8 @@
         "Münchendorf Bahnhof",
         "Münchendorf Bf",
         "Münchendorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "148",
@@ -802,7 +813,8 @@
         "Pfaffstätten Bahnhof",
         "Pfaffstätten Bf",
         "Pfaffstätten bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "149",
@@ -921,7 +933,8 @@
         "Hohenau Bahnhof",
         "Hohenau Bf",
         "Hohenau bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1558",
@@ -1292,7 +1305,8 @@
         "Petronell-Carnuntum Bahnhof",
         "Petronell-Carnuntum Bf",
         "Petronell-Carnuntum bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "17",
@@ -1315,7 +1329,8 @@
         "bf Absdorf Hippersdorf",
         "Bf Absdorf-Hippersdorf",
         "bf Absdorf-Hippersdorf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1718",
@@ -1408,7 +1423,8 @@
         "Payerbach-Reichenau Bahnhof",
         "Payerbach-Reichenau Bf",
         "Payerbach-Reichenau bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1762",
@@ -1424,7 +1440,8 @@
         "Pottenbrunn Bahnhof",
         "Pottenbrunn Bf",
         "Pottenbrunn bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1797",
@@ -1465,7 +1482,8 @@
         "Raasdorf Bahnhof",
         "Raasdorf Bf",
         "Raasdorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1813",
@@ -1481,7 +1499,8 @@
         "Glinzendorf Bahnhof",
         "Glinzendorf Bf",
         "Glinzendorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1832",
@@ -1497,7 +1516,8 @@
         "Regelsbrunn Bahnhof",
         "Regelsbrunn Bf",
         "Regelsbrunn bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1833",
@@ -1513,7 +1533,8 @@
         "Wildungsmauer Bahnhof",
         "Wildungsmauer Bf",
         "Wildungsmauer bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1904",
@@ -1529,7 +1550,8 @@
         "Rekawinkel Bahnhof",
         "Rekawinkel Bf",
         "Rekawinkel bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1905",
@@ -1573,7 +1595,8 @@
         "Mistelbach Stadt Bahnhof",
         "Mistelbach Stadt Bf",
         "Mistelbach Stadt bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1950",
@@ -1596,7 +1619,8 @@
         "Siebenbrunn-Leopoldsdorf Bahnhof",
         "Siebenbrunn-Leopoldsdorf Bf",
         "Siebenbrunn-Leopoldsdorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1952",
@@ -1612,7 +1636,8 @@
         "Untersiebenbrunn Bahnhof",
         "Untersiebenbrunn Bf",
         "Untersiebenbrunn bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1969",
@@ -1674,7 +1699,8 @@
         "Schönfeld-Lassee Bahnhof",
         "Schönfeld-Lassee Bf",
         "Schönfeld-Lassee bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "1998",
@@ -1954,7 +1980,8 @@
         "Tattendorf Bahnhof",
         "Tattendorf Bf",
         "Tattendorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "2208",
@@ -1970,7 +1997,8 @@
         "Teesdorf Bahnhof",
         "Teesdorf Bf",
         "Teesdorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "2218",
@@ -1986,7 +2014,8 @@
         "Traiskirchen Aspangbahn Bahnhof",
         "Traiskirchen Aspangbahn Bf",
         "Traiskirchen Aspangbahn bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "2220",
@@ -2002,7 +2031,8 @@
         "Trumau Bahnhof",
         "Trumau Bf",
         "Trumau bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "2232",
@@ -2039,7 +2069,8 @@
         "Pottschach Bahnhof",
         "Pottschach Bf",
         "Pottschach bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "2262",
@@ -2077,7 +2108,8 @@
         "Tulln Stadt Bahnhof",
         "Tulln Stadt Bf",
         "Tulln Stadt bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "2290",
@@ -2237,7 +2269,8 @@
         "Helmahof Bahnhof",
         "Helmahof Bf",
         "Helmahof bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "2449",
@@ -2317,7 +2350,8 @@
         "Wampersdorf Bahnhof",
         "Wampersdorf Bf",
         "Wampersdorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "2501",
@@ -2340,7 +2374,8 @@
         "Pottendorf-Landegg Bahnhof",
         "Pottendorf-Landegg Bf",
         "Pottendorf-Landegg bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "2511",
@@ -2441,7 +2476,8 @@
         "Kottingbrunn Bahnhof",
         "Kottingbrunn Bf",
         "Kottingbrunn bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "2548",
@@ -2488,7 +2524,8 @@
         "Lanzendorf-Rannersdorf Bahnhof",
         "Lanzendorf-Rannersdorf Bf",
         "Lanzendorf-Rannersdorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "263",
@@ -2561,7 +2598,8 @@
         "Drösing Bahnhof",
         "Drösing Bf",
         "Drösing bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "301",
@@ -2584,7 +2622,8 @@
         "Dürnkrut Bahnhof",
         "Dürnkrut Bf",
         "Dürnkrut bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "309",
@@ -2621,7 +2660,8 @@
         "Weigelsdorf Bahnhof",
         "Weigelsdorf Bf",
         "Weigelsdorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "325",
@@ -2835,7 +2875,8 @@
         "Fischamend Bahnhof",
         "Fischamend Bf",
         "Fischamend bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "4384321",
@@ -2897,7 +2938,8 @@
         "Felixdorf Bahnhof",
         "Felixdorf Bf",
         "Felixdorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "468",
@@ -2913,7 +2955,8 @@
         "Wiener Neustadt Nord Bahnhof",
         "Wiener Neustadt Nord Bf",
         "Wiener Neustadt Nord bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "4741048",
@@ -3054,7 +3097,8 @@
         "Gloggnitz Bahnhof",
         "Gloggnitz Bf",
         "Gloggnitz bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "642",
@@ -3070,7 +3114,8 @@
         "Gramatneusiedl Bahnhof",
         "Gramatneusiedl Bf",
         "Gramatneusiedl bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "655",
@@ -3086,7 +3131,8 @@
         "Sarasdorf Bahnhof",
         "Sarasdorf Bf",
         "Sarasdorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "656",
@@ -3102,7 +3148,8 @@
         "Wilfleinsdorf Bahnhof",
         "Wilfleinsdorf Bf",
         "Wilfleinsdorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "711",
@@ -3149,7 +3196,8 @@
         "Mannswörth Bahnhof",
         "Mannswörth Bf",
         "Mannswörth bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "741",
@@ -3172,7 +3220,8 @@
         "Möllersdorf Aspangbahn Bahnhof",
         "Möllersdorf Aspangbahn Bf",
         "Möllersdorf Aspangbahn bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "777",
@@ -3376,7 +3425,8 @@
         "Hadersdorf am Kamp Bahnhof",
         "Hadersdorf am Kamp Bf",
         "Hadersdorf am Kamp bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "850",
@@ -3392,7 +3442,8 @@
         "Haslau an der Donau Bahnhof",
         "Haslau an der Donau Bf",
         "Haslau an der Donau bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "856",
@@ -3408,7 +3459,8 @@
         "Hennersdorf Bahnhof",
         "Hennersdorf Bf",
         "Hennersdorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "857",
@@ -3582,7 +3634,8 @@
         "Maria Anzbach Bahnhof",
         "Maria Anzbach Bf",
         "Maria Anzbach bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "914",
@@ -3598,7 +3651,8 @@
         "Neulengbach Stadt Bahnhof",
         "Neulengbach Stadt Bf",
         "Neulengbach Stadt bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "934",
@@ -3664,7 +3718,8 @@
         "Langenzersdorf Bahnhof",
         "Langenzersdorf Bf",
         "Langenzersdorf bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "bst_id": "960",
@@ -3680,7 +3735,8 @@
         "Bisamberg Bahnhof",
         "Bisamberg Bf",
         "Bisamberg bf"
-      ]
+      ],
+      "source": "oebb"
     },
     {
       "_google_place_id": "ChIJBa9sJZgHbUcRrekncb64g2M",

--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -499,6 +499,16 @@ def _load_existing_station_entries(
                     is_manual = False
                 elif isinstance(source, list) and "oebb" in source:
                     is_manual = False
+                elif not source:
+                    # Backward-compat: entries written before the
+                    # `as_dict` source-default fix lack a source field
+                    # entirely. If they carry the typical ÖBB Excel
+                    # fields (bst_id + bst_code), treat them as ÖBB —
+                    # otherwise the next Excel pull would create a
+                    # duplicate and trip the canonical-name uniqueness
+                    # gate (see PR #1203 cron failure post-mortem).
+                    bst_code = entry.get("bst_code")
+                    is_manual = not (isinstance(bst_code, str) and bst_code.strip())
                 else:
                     is_manual = True
 

--- a/tests/test_update_station_directory_flags.py
+++ b/tests/test_update_station_directory_flags.py
@@ -8,6 +8,7 @@ in ``data/pendler_bst_ids.json``.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 
 import pytest
 
@@ -78,3 +79,43 @@ def test_wl_vienna_station_does_not_become_pendler() -> None:
 
     assert station.in_vienna is True
     assert station.pendler is False
+
+
+def test_load_existing_treats_legacy_bst_id_entry_without_source_as_oebb(
+    tmp_path: Path,
+) -> None:
+    """Entries written before PR #1203's source-default fix lack a source
+    field entirely. The loader must treat them as ÖBB (not as manual)
+    when bst_id + bst_code are present, otherwise the next Excel pull
+    creates a duplicate and trips the naming-uniqueness gate."""
+    import json
+
+    legacy_payload = [
+        {
+            "bst_id": "100",
+            "bst_code": "Aw",
+            "name": "St.Andrä-Wördern",
+            "in_vienna": False,
+            "pendler": True,
+            "aliases": ["St.Andrä-Wördern"],
+            # No `source` field — characteristic of pre-#1203 entries
+        },
+        {
+            # A genuinely manual entry — no bst_code → still manual
+            "name": "Roma Termini",
+            "in_vienna": False,
+            "pendler": False,
+            "aliases": ["Roma Termini"],
+            "type": "manual_foreign_city",
+        },
+    ]
+    path = tmp_path / "stations.json"
+    path.write_text(json.dumps(legacy_payload), encoding="utf-8")
+
+    by_bst, manual = usd._load_existing_station_entries(path)
+    assert "100" in by_bst, (
+        "legacy ÖBB entry without source must be loaded by bst_id, not parked as manual"
+    )
+    assert {entry.get("name") for entry in manual} == {"Roma Termini"}, (
+        "true manual entries (no bst_code) stay parked as manual"
+    )


### PR DESCRIPTION
## Diagnose

PR #1203 hat den Source-Default für **neue** Excel-Imports gefixt — aber `data/stations.json` auf main enthält 56 Pendler-Einträge aus dem PR #1201-Lauf **ohne** `source`-Feld. Der Cron-Lauf produzierte daher weiterhin 60+ NamingIssue-Duplikate:

```
naming issue: St.Andrä-Wördern (code:Aw / source:oebb): canonical name 'St.Andrä-Wördern' is not unique (also used by code:Aw)
naming issue: St.Andrä-Wördern (code:Aw): canonical name 'St.Andrä-Wördern' is not unique (also used by code:Aw / source:oebb)
```

Wurzel: `_load_existing_station_entries` klassifiziert Einträge ohne `source` als `manual` und parkt sie. Der frische Excel-Pull legt sie mit `source: "oebb"` neu an → Duplikat.

## Zwei-Schritt-Fix

### 1. Loader-Heuristik
Wenn `source` fehlt UND `bst_id` + `bst_code` vorhanden sind → als ÖBB behandeln (nicht als manual). Echte manuelle Einträge (Roma Termini, ohne bst_code) bleiben weiterhin geparkt.

```python
elif not source:
    bst_code = entry.get("bst_code")
    is_manual = not (isinstance(bst_code, str) and bst_code.strip())
```

### 2. Daten-Migration
Die 56 Legacy-Einträge in `data/stations.json` bekommen `"source": "oebb"`. Technisch redundant nach dem Loader-Fix, aber hält das JSON sauber und schema-konform.

**Verifikation lokal:**
```
Naming: 0, Provider: 0, Cross: 0, Security: 0
```

## Erwartung beim nächsten Cron

- `validation.naming_issues` → 0 (Duplikate weg)
- Die 56 Pendler bekommen jetzt endlich Coordinates über `_build_location_index` (VOR-CSV-Source aus #1202 + erweiterte VOR-CSV aus #1201's fetch)

## Test plan
- [x] `pytest tests/` → 1075 passed, 1 skipped (+1 neuer Test: `test_load_existing_treats_legacy_bst_id_entry_without_source_as_oebb`)
- [x] `mypy --strict src tests` → 308 source files no issues
- [x] `ruff`, `bandit`, `pip-audit` clean
- [x] Validator gegen migrierte stations.json: 0 in allen blocking-Kategorien

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_