### PR TITLE
fix(stations): catch compound bus-suffixes, 9xx synthetic ext_ids, add Guntramsdorf

### DIFF
--- a/data/stations.json
+++ b/data/stations.json
@@ -529,9 +529,7 @@
       "name": "Laxenburg-Biedermannsdorf",
       "in_vienna": false,
       "pendler": true,
-      "vor_id": "900022021",
       "aliases": [
-        "900022021",
         "Laxenburg-Biedermannsdorf",
         "Bahnhof Laxenburg Biedermannsdorf",
         "Bahnhof Laxenburg-Biedermannsdorf",
@@ -539,8 +537,6 @@
         "bf Laxenburg Biedermannsdorf",
         "Bf Laxenburg-Biedermannsdorf",
         "bf Laxenburg-Biedermannsdorf",
-        "BIEDERMANNSDORF",
-        "Biedermannsdorf HLW",
         "Laxenburg Biedermannsdorf",
         "Laxenburg Biedermannsdorf Bahnhof",
         "Laxenburg Biedermannsdorf Bf",
@@ -549,9 +545,7 @@
         "Laxenburg-Biedermannsdorf Bf",
         "Laxenburg-Biedermannsdorf bf"
       ],
-      "source": "oebb",
-      "latitude": 48.083381,
-      "longitude": 16.345643
+      "source": "oebb"
     },
     {
       "bst_id": "1318",
@@ -2914,22 +2908,16 @@
       "name": "Weigelsdorf",
       "in_vienna": false,
       "pendler": true,
-      "vor_id": "430518500",
       "aliases": [
-        "430518500",
         "Weigelsdorf",
         "Bahnhof Weigelsdorf",
         "Bf Weigelsdorf",
         "bf Weigelsdorf",
         "Weigelsdorf Bahnhof",
         "Weigelsdorf Bf",
-        "Weigelsdorf bf",
-        "Weigelsdorf Grenzweg",
-        "Weigelsdorf Kienergasse"
+        "Weigelsdorf bf"
       ],
-      "source": "oebb",
-      "latitude": 47.948776,
-      "longitude": 16.408406
+      "source": "oebb"
     },
     {
       "bst_id": "325",
@@ -3771,21 +3759,16 @@
       "name": "Himberg",
       "in_vienna": false,
       "pendler": true,
-      "vor_id": "430373800",
       "source": "oebb",
       "aliases": [
-        "430373800",
         "Himberg",
         "Bahnhof Himberg",
         "Bf Himberg",
         "bf Himberg",
-        "Himberg (bei Wien) Hauptplatz",
         "Himberg Bahnhof",
         "Himberg Bf",
         "Himberg bf"
-      ],
-      "latitude": 48.081979,
-      "longitude": 16.440255
+      ]
     },
     {
       "bst_id": "850",

--- a/data/vor-haltestellen.mapping.json
+++ b/data/vor-haltestellen.mapping.json
@@ -136,14 +136,6 @@
     "longitude": 16.450691
   },
   {
-    "station_name": "Laxenburg-Biedermannsdorf",
-    "bst_id": "1290",
-    "vor_id": "900022021",
-    "resolved_name": "BIEDERMANNSDORF",
-    "latitude": 48.083381,
-    "longitude": 16.345643
-  },
-  {
     "station_name": "Marchegg",
     "bst_id": "1318",
     "vor_id": "430413200",
@@ -784,14 +776,6 @@
     "longitude": 16.419319
   },
   {
-    "station_name": "Weigelsdorf",
-    "bst_id": "310",
-    "vor_id": "430518500",
-    "resolved_name": "Weigelsdorf Kienergasse",
-    "latitude": 47.948776,
-    "longitude": 16.408406
-  },
-  {
     "station_name": "Ebenfurth",
     "bst_id": "325",
     "vor_id": "430331800",
@@ -1040,14 +1024,6 @@
     "longitude": 15.714879
   },
   {
-    "station_name": "Himberg",
-    "bst_id": "835",
-    "vor_id": "430373800",
-    "resolved_name": "Himberg (bei Wien) Hauptplatz",
-    "latitude": 48.081979,
-    "longitude": 16.440255
-  },
-  {
     "station_name": "Haslau an der Donau",
     "bst_id": "850",
     "vor_id": "430370600",
@@ -1222,14 +1198,6 @@
     "resolved_name": "Götzendorf/Leitha Bahnhof",
     "latitude": 48.025688,
     "longitude": 16.587561
-  },
-  {
-    "station_name": "Himberg bei Wien",
-    "bst_id": null,
-    "vor_id": "430373800",
-    "resolved_name": "Himberg (bei Wien) Hauptplatz",
-    "latitude": 48.081979,
-    "longitude": 16.440255
   },
   {
     "station_name": "Neunkirchen NÖ",

--- a/scripts/fetch_vor_haltestellen.py
+++ b/scripts/fetch_vor_haltestellen.py
@@ -200,12 +200,14 @@ _RAIL_TOKENS = frozenset({"bahnhof", "bahnhst", "bhf", "hbf", "bf"})
 # Common street-name fragments and village quarters that, when present in a
 # candidate *without* any of the rail tokens above, indicate a bus stop.
 # Both word-boundary and end-of-word matches: "Wehr" (separate word) and
-# "Judenweg"/"Gutenhof" (compound) all trigger.
+# "Judenweg"/"Gutenhof"/"Kienergasse"/"Hauptplatz" (compound) all trigger.
+# Compound "gasse"/"platz" need the end-of-word form because \bgasse\b would
+# not match inside "Kienergasse" (no word boundary between letters).
 _BUS_LIKE_SUFFIX_PATTERN = re.compile(
     r"(?:\b(?:strasse|str|gasse|platz|wehr|grenz|siedlung|kreuzung|"
     r"kreisverkehr|zentrum|abzw|abzweigung)\b"
-    r"|(?:weg|hof|markt)$"
-    r"|\s(?:weg|hof)$)",
+    r"|(?:weg|hof|markt|gasse|platz)$"
+    r"|\s(?:weg|hof|gasse|platz)$)",
     re.IGNORECASE,
 )
 
@@ -275,12 +277,26 @@ def _score_candidate(station_name: str, candidate_name: str, ext_id: str | None)
     # "Weigelsdorf Judenweg" (a footpath)
     # "Laxenburg Guntramsdorfer Straße" (a street)
     # "Himberg (bei Wien) Gutenhof" (a village quarter)
+    # "Weigelsdorf Kienergasse" (compound 'gasse')
+    # "Himberg (bei Wien) Hauptplatz" (compound 'platz')
     candidate_tokens = set(candidate_norm.split())
     if (
         ratio < 0.85
         and not (_RAIL_TOKENS & candidate_tokens)
         and _BUS_LIKE_SUFFIX_PATTERN.search(candidate_norm)
     ):
+        return -100.0
+
+    # Synthetic ext_id range: VOR ids starting with "9" are typically
+    # park-and-ride / transfer-point pseudo-stops with no real platform.
+    # Hand-curated 9xx entries (STATIC_VOR_ENTRIES) carry an explicit
+    # rail token like "Hauptbahnhof" and pass through; bare names like
+    # "BIEDERMANNSDORF" (ext_id 900022021) without any rail context are
+    # rejected. The ext_id 9xx penalty above (-20) is no longer enough
+    # for high-ratio cases, since the substring-escape-hatch in the
+    # first-word check lets candidates like "BIEDERMANNSDORF" survive
+    # with a score around 55 (just over the 50 acceptance floor).
+    if ext_id_str.startswith("9") and not (_RAIL_TOKENS & candidate_tokens):
         return -100.0
 
     # First-word-mismatch: the input "Tulln an der Donau" must not match

--- a/scripts/update_vor_stations.py
+++ b/scripts/update_vor_stations.py
@@ -55,6 +55,31 @@ STATIC_VOR_ENTRIES: tuple[dict[str, object], ...] = (
         "bst_code": "900300",
         "source": "vor",
     },
+    # Guntramsdorf Bahnhof — Südbahn S-Bahn pendler stop. Closes the
+    # Top-12 priority-1 gap from the 2026-05 stations-coverage research:
+    # the ÖBB Excel "Verzeichnis der Verkehrsstationen" has no row for
+    # Guntramsdorf, so the name-based pendler whitelist alone cannot
+    # produce an entry — only the synthetic VOR pathway does.
+    {
+        "vor_id": "430361600",
+        "name": "Guntramsdorf Bahnhof",
+        "in_vienna": False,
+        "pendler": True,
+        "latitude": 48.051964,
+        "longitude": 16.297551,
+        "aliases": [
+            "Guntramsdorf Bahnhof",
+            "Guntramsdorf Bf",
+            "Guntramsdorf",
+            "Guntramsdorf Südbahn",
+            "Bahnhof Guntramsdorf",
+            "Bf Guntramsdorf",
+            "430361600",
+        ],
+        "bst_id": "430361600",
+        "bst_code": "430361600",
+        "source": "vor",
+    },
 )
 
 

--- a/tests/test_fetch_vor_haltestellen_score.py
+++ b/tests/test_fetch_vor_haltestellen_score.py
@@ -43,6 +43,15 @@ from scripts.fetch_vor_haltestellen import (
         ("Laxenburg-Biedermannsdorf", "Laxenburg Guntramsdorfer Straße", "430615800"),
         ("Himberg", "Himberg (bei Wien) Gutenhof", "430361800"),
         ("Himberg bei Wien", "Himberg (bei Wien) Gutenhof", "430361800"),
+        # 2026-05-05 cron survivors: compound 'gasse'/'platz' suffix and
+        # 9xx synthetic ext_id without rail token. Without the extended
+        # bus-suffix end-anchor and the new 9xx-no-rail check these
+        # candidates land in stations.json with a wrong vor_id (the cron
+        # of 2026-05-05 22:07 published exactly these three).
+        ("Weigelsdorf", "Weigelsdorf Kienergasse", "430518500"),
+        ("Himberg", "Himberg (bei Wien) Hauptplatz", "430373800"),
+        ("Himberg bei Wien", "Himberg (bei Wien) Hauptplatz", "430373800"),
+        ("Laxenburg-Biedermannsdorf", "BIEDERMANNSDORF", "900022021"),
     ],
     ids=[
         "laxenburg→hlw",
@@ -60,6 +69,10 @@ from scripts.fetch_vor_haltestellen import (
         "laxenburg→guntramsdorfer-straße",
         "himberg→gutenhof",
         "himberg-bei-wien→gutenhof",
+        "weigelsdorf→kienergasse-compound",
+        "himberg→hauptplatz-compound",
+        "himberg-bei-wien→hauptplatz-compound",
+        "laxenburg→BIEDERMANNSDORF-9xx",
     ],
 )
 def test_score_rejects_bad_match(station: str, candidate: str, ext_id: str) -> None:
@@ -92,6 +105,18 @@ def test_score_rejects_bad_match(station: str, candidate: str, ext_id: str) -> N
         ("Wien Krottenbachstraße", "Wien Krottenbachstraße", "490072300"),
         ("Wien Geiselbergstraße", "Wien Geiselbergstraße", "490048400"),
         ("Wien Erzherzog Karl-Straße", "Wien Erzherzog-Karl-Straße", "490028800"),
+        # Closes the Top-12 priority-1 gap: Guntramsdorf Bahnhof must
+        # remain a high-confidence match (4xx ext_id, "Bahnhof" rail
+        # token, candidate is canonical name + suffix). Regression guard
+        # for the new 9xx-no-rail-token reject — Guntramsdorf is 4xx,
+        # so the new rule must not apply.
+        ("Guntramsdorf Südbahn", "Guntramsdorf Bahnhof", "430361600"),
+        # The Karlsplatz identity match also exercises the extended
+        # end-of-word "platz" rule: with the old pattern "platz" only
+        # matched as a standalone token (\bplatz\b) and never on
+        # "Karlsplatz". The new pattern matches it but the 0.85 ratio
+        # guard saves identity matches like this one.
+        ("Wien Stephansplatz", "Wien Stephansplatz", "490085600"),
     ],
     ids=[
         "karlsplatz",
@@ -105,6 +130,8 @@ def test_score_rejects_bad_match(station: str, candidate: str, ext_id: str) -> N
         "wien-krottenbachstraße",
         "wien-geiselbergstraße",
         "wien-erzherzog-karl-straße",
+        "guntramsdorf-südbahn→bahnhof",
+        "wien-stephansplatz-identity",
     ],
 )
 def test_score_accepts_good_match(station: str, candidate: str, ext_id: str) -> None:


### PR DESCRIPTION
## Summary

The 2026-05-05 22:07 cron run was successful (165 → 169 stations, 0 blocking issues), but persisted three false-positive VOR resolves into `data/stations.json` that the existing filter chain didn't catch — and one Top-12 priority-1 pendler stop (Guntramsdorf Südbahn) remained missing because the ÖBB Verkehrsstationen Excel has no row for it.

This PR closes both gaps and cleans up the directory:

- **Compound `gasse`/`platz` bus-suffix**: `_BUS_LIKE_SUFFIX_PATTERN` only matched `gasse`/`platz` as standalone tokens (`\bgasse\b`), never inside compounds like `Kienergasse`/`Hauptplatz`. Extended the end-of-word arm to include `gasse|platz` alongside the existing `weg|hof|markt`. The 0.85 ratio guard already protects identity matches like "Wien Karlsplatz" → "Wien Karlsplatz".
- **9xx synthetic ext_id without rail token**: the existing −20 score penalty for ext_ids starting with `9` wasn't enough — the substring escape hatch in the first-word check let "BIEDERMANNSDORF" (ext_id `900022021`, score 55) through. Added a hard reject for ext_id 9xx without any of `{bahnhof,hbf,bf,bhf,bahnhst}` in the candidate. Hand-curated 9xx STATIC_VOR_ENTRIES (e.g. Wr. Neustadt Hauptbahnhof) always carry "Hauptbahnhof" and pass through.
- **STATIC_VOR_ENTRIES**: added "Guntramsdorf Bahnhof" (vor_id `430361600`, S-Bahn Südbahn) analogous to Wr. Neustadt Hauptbahnhof — closes the last priority-1 gap from the 2026-05 stations-coverage research.
- **Cleanup**: stripped the three bad `vor_id`s + bad `aliases` + bad `latitude`/`longitude` from `data/stations.json` (Himberg, Weigelsdorf, Laxenburg-Biedermannsdorf) and the corresponding entries from `data/vor-haltestellen.mapping.json`. The next cron will repopulate via the corrected resolver.

| Station | Wrong VOR-Ziel | vor_id | Filter-Lücke |
|---|---|---|---|
| Laxenburg-Biedermannsdorf | BIEDERMANNSDORF | `900022021` | ext_id 9xx ohne Rail-Token (Score 55, knapp über 50) |
| Weigelsdorf | Weigelsdorf Kienergasse | `430518500` | Compound "gasse" (Wortinneres) wurde nicht erkannt |
| Himberg | Himberg (bei Wien) Hauptplatz | `430373800` | Compound "platz" (Wortinneres) wurde nicht erkannt |

## Test plan

- [x] `tests/test_fetch_vor_haltestellen_score.py` extended with 4 new reject cases (the three above plus the `Himberg bei Wien` alternative-name variant) and 2 new accept cases (Guntramsdorf Südbahn → Bahnhof, Wien Stephansplatz identity match for the new platz-end-suffix rule)
- [x] All 32 score-tests pass
- [x] Full test suite passes (1114 tests, 1 skipped)
- [x] `mypy --strict` clean on changed scripts
- [x] `ruff check` clean on changed files
- [x] `validate_stations` blocking categories all 0 (provider/cross_station_id/naming/security)
- [ ] Next cron run produces 0 false-positive resolves for these three stations
- [ ] Guntramsdorf Bahnhof appears in `data/stations.json` after next cron with `pendler=true`, vor_id `430361600`, coords `(48.051964, 16.297551)`

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_