### PR TITLE
fix(stations): catch compound 'strasse' and 'schule' bus-suffixes

### DIFF
--- a/data/stations.json
+++ b/data/stations.json
@@ -2908,21 +2908,16 @@
       "name": "Weigelsdorf",
       "in_vienna": false,
       "pendler": true,
-      "vor_id": "430586500",
       "aliases": [
-        "430586500",
         "Weigelsdorf",
         "Bahnhof Weigelsdorf",
         "Bf Weigelsdorf",
         "bf Weigelsdorf",
         "Weigelsdorf Bahnhof",
         "Weigelsdorf Bf",
-        "Weigelsdorf bf",
-        "Weigelsdorf Volksschule"
+        "Weigelsdorf bf"
       ],
-      "source": "oebb",
-      "latitude": 47.948471,
-      "longitude": 16.405484
+      "source": "oebb"
     },
     {
       "bst_id": "325",
@@ -3764,21 +3759,16 @@
       "name": "Himberg",
       "in_vienna": false,
       "pendler": true,
-      "vor_id": "430373900",
       "source": "oebb",
       "aliases": [
-        "430373900",
         "Himberg",
         "Bahnhof Himberg",
         "Bf Himberg",
         "bf Himberg",
-        "Himberg (bei Wien) Hauptstraße",
         "Himberg Bahnhof",
         "Himberg Bf",
         "Himberg bf"
-      ],
-      "latitude": 48.086491,
-      "longitude": 16.43994
+      ]
     },
     {
       "bst_id": "850",

--- a/data/vor-haltestellen.mapping.json
+++ b/data/vor-haltestellen.mapping.json
@@ -808,14 +808,6 @@
     "longitude": 16.419319
   },
   {
-    "station_name": "Weigelsdorf",
-    "bst_id": "310",
-    "vor_id": "430586500",
-    "resolved_name": "Weigelsdorf Volksschule",
-    "latitude": 47.948471,
-    "longitude": 16.405484
-  },
-  {
     "station_name": "Ebenfurth",
     "bst_id": "325",
     "vor_id": "430331800",
@@ -1064,14 +1056,6 @@
     "longitude": 15.714879
   },
   {
-    "station_name": "Himberg",
-    "bst_id": "835",
-    "vor_id": "430373900",
-    "resolved_name": "Himberg (bei Wien) Hauptstraße",
-    "latitude": 48.086491,
-    "longitude": 16.43994
-  },
-  {
     "station_name": "Haslau an der Donau",
     "bst_id": "850",
     "vor_id": "430370600",
@@ -1246,14 +1230,6 @@
     "resolved_name": "Götzendorf/Leitha Bahnhof",
     "latitude": 48.025688,
     "longitude": 16.587561
-  },
-  {
-    "station_name": "Himberg bei Wien",
-    "bst_id": null,
-    "vor_id": "430373900",
-    "resolved_name": "Himberg (bei Wien) Hauptstraße",
-    "latitude": 48.086491,
-    "longitude": 16.43994
   },
   {
     "station_name": "Neunkirchen NÖ",

--- a/scripts/fetch_vor_haltestellen.py
+++ b/scripts/fetch_vor_haltestellen.py
@@ -200,14 +200,15 @@ _RAIL_TOKENS = frozenset({"bahnhof", "bahnhst", "bhf", "hbf", "bf"})
 # Common street-name fragments and village quarters that, when present in a
 # candidate *without* any of the rail tokens above, indicate a bus stop.
 # Both word-boundary and end-of-word matches: "Wehr" (separate word) and
-# "Judenweg"/"Gutenhof"/"Kienergasse"/"Hauptplatz" (compound) all trigger.
-# Compound "gasse"/"platz" need the end-of-word form because \bgasse\b would
-# not match inside "Kienergasse" (no word boundary between letters).
+# "Judenweg"/"Gutenhof"/"Kienergasse"/"Hauptplatz"/"Hauptstraße"/"Volksschule"
+# (compound) all trigger. Compound "strasse"/"schule"/"gasse"/"platz" need the
+# end-of-word form because \bstrasse\b would not match inside "Hauptstrasse"
+# (no word boundary between letters).
 _BUS_LIKE_SUFFIX_PATTERN = re.compile(
     r"(?:\b(?:strasse|str|gasse|platz|wehr|grenz|siedlung|kreuzung|"
     r"kreisverkehr|zentrum|abzw|abzweigung)\b"
-    r"|(?:weg|hof|markt|gasse|platz)$"
-    r"|\s(?:weg|hof|gasse|platz)$)",
+    r"|(?:weg|hof|markt|gasse|platz|strasse|schule)$"
+    r"|\s(?:weg|hof|gasse|platz|strasse|schule)$)",
     re.IGNORECASE,
 )
 

--- a/tests/test_fetch_vor_haltestellen_score.py
+++ b/tests/test_fetch_vor_haltestellen_score.py
@@ -52,6 +52,16 @@ from scripts.fetch_vor_haltestellen import (
         ("Himberg", "Himberg (bei Wien) Hauptplatz", "430373800"),
         ("Himberg bei Wien", "Himberg (bei Wien) Hauptplatz", "430373800"),
         ("Laxenburg-Biedermannsdorf", "BIEDERMANNSDORF", "900022021"),
+        # 2026-05-06 cron survivors: VOR returned a *different* bad
+        # candidate after the previous filter round closed. "Hauptstraße"
+        # uses the same compound problem as "Hauptplatz" but with
+        # 'strasse' (\bstrasse\b doesn't match inside "Hauptstrasse").
+        # "Volksschule" is a school stop — the existing _NON_RAIL_SUFFIXES
+        # entry "schule" only matches with a leading space (" schule"),
+        # not the compound "Volksschule".
+        ("Himberg", "Himberg (bei Wien) Hauptstraße", "430373900"),
+        ("Himberg bei Wien", "Himberg (bei Wien) Hauptstraße", "430373900"),
+        ("Weigelsdorf", "Weigelsdorf Volksschule", "430586500"),
     ],
     ids=[
         "laxenburg→hlw",
@@ -73,6 +83,9 @@ from scripts.fetch_vor_haltestellen import (
         "himberg→hauptplatz-compound",
         "himberg-bei-wien→hauptplatz-compound",
         "laxenburg→BIEDERMANNSDORF-9xx",
+        "himberg→hauptstrasse-compound",
+        "himberg-bei-wien→hauptstrasse-compound",
+        "weigelsdorf→volksschule-compound",
     ],
 )
 def test_score_rejects_bad_match(station: str, candidate: str, ext_id: str) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #1207. The 2026-05-06 cron run after that PR merged confirmed all the previously-fixed false positives are now correctly rejected (Laxenburg-Biedermannsdorf BIEDERMANNSDORF, Weigelsdorf Kienergasse, Himberg Hauptplatz), but VOR returned **two new** false candidates with the same compound-suffix shape:

| Station | Wrong VOR-Ziel | vor_id | Lücke |
|---|---|---|---|
| Himberg / Himberg bei Wien | `Himberg (bei Wien) Hauptstraße` | `430373900` | `\bstrasse\b` greift nicht im Compound `Hauptstrasse` |
| Weigelsdorf | `Weigelsdorf Volksschule` | `430586500` | `_NON_RAIL_SUFFIXES["schule"]` matcht nur ` schule` mit Leerzeichen, nicht Compound `Volksschule` |

This PR mechanically extends the same end-of-word fix from #1207: add `strasse` and `schule` to the end-of-word arm of `_BUS_LIKE_SUFFIX_PATTERN`. The same 0.85 ratio guard protects identity matches like `Wien Brünner Straße → Wien Brünner Straße` (ratio 1.0 → bus-suffix check skipped).

Plus closes the **Top-12 confirmation**: PR #1207's STATIC_VOR_ENTRIES + name-mapping for Guntramsdorf/Guntramsdorf-Kaiserau resolves correctly in the cron log:
- `Guntramsdorf Südbahn → Guntramsdorf Bahnhof (430361600)` ✓
- `Guntramsdorf-Kaiserau → Guntramsdorf Kaiserau Bf (430361700)` ✓

## Test plan

- [x] `tests/test_fetch_vor_haltestellen_score.py` extended with 3 new reject cases (Hauptstraße for both Himberg name variants, Volksschule for Weigelsdorf)
- [x] All 35 score-tests pass
- [x] Full test suite passes (1117 tests, 1 skipped)
- [x] `ruff check` clean
- [x] `validate_stations` blocking categories all 0 (provider/cross_station_id/naming/security)
- [x] Empirical re-check: `_score_candidate` now returns -100 for both Himberg variants and the Weigelsdorf case, and stays ≥ 50 for all 13 existing accept fixtures
- [ ] Next cron run produces 0 false-positive resolves for Himberg/Weigelsdorf

## Why this keeps coming back

VOR's HAFAS endpoint returns the closest stop name (geographic proximity + word similarity). When we filter out one bad candidate, the API returns the next-closest one — often another bus stop in the same town. The systematic fix is to make the bus-suffix filter recognise *compound* suffixes (any "...strasse$", "...schule$" etc.) rather than only space-separated suffix tokens.

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_