### PR TITLE
fix(stations): general 1-token-station rule + brucke compound

### DIFF
--- a/data/stations.json
+++ b/data/stations.json
@@ -2908,21 +2908,16 @@
       "name": "Weigelsdorf",
       "in_vienna": false,
       "pendler": true,
-      "vor_id": "430543200",
       "aliases": [
-        "430543200",
         "Weigelsdorf",
         "Bahnhof Weigelsdorf",
         "Bf Weigelsdorf",
         "bf Weigelsdorf",
-        "Weigelsdorf B60/Boschansiedlung",
         "Weigelsdorf Bahnhof",
         "Weigelsdorf Bf",
         "Weigelsdorf bf"
       ],
-      "source": "oebb",
-      "latitude": 47.940533,
-      "longitude": 16.400693
+      "source": "oebb"
     },
     {
       "bst_id": "325",

--- a/data/vor-haltestellen.mapping.json
+++ b/data/vor-haltestellen.mapping.json
@@ -808,14 +808,6 @@
     "longitude": 16.419319
   },
   {
-    "station_name": "Weigelsdorf",
-    "bst_id": "310",
-    "vor_id": "430543200",
-    "resolved_name": "Weigelsdorf B60/Boschansiedlung",
-    "latitude": 47.940533,
-    "longitude": 16.400693
-  },
-  {
     "station_name": "Ebenfurth",
     "bst_id": "325",
     "vor_id": "430331800",
@@ -1238,14 +1230,6 @@
     "resolved_name": "Götzendorf/Leitha Bahnhof",
     "latitude": 48.025688,
     "longitude": 16.587561
-  },
-  {
-    "station_name": "Himberg bei Wien",
-    "bst_id": null,
-    "vor_id": "430374100",
-    "resolved_name": "Himberg (bei Wien) Neubachbrücke",
-    "latitude": 48.087714,
-    "longitude": 16.431922
   },
   {
     "station_name": "Neunkirchen NÖ",

--- a/scripts/fetch_vor_haltestellen.py
+++ b/scripts/fetch_vor_haltestellen.py
@@ -201,14 +201,14 @@ _RAIL_TOKENS = frozenset({"bahnhof", "bahnhst", "bhf", "hbf", "bf"})
 # candidate *without* any of the rail tokens above, indicate a bus stop.
 # Both word-boundary and end-of-word matches: "Wehr" (separate word) and
 # "Judenweg"/"Gutenhof"/"Kienergasse"/"Hauptplatz"/"Hauptstraße"/"Volksschule"
-# (compound) all trigger. Compound "strasse"/"schule"/"gasse"/"platz" need the
-# end-of-word form because \bstrasse\b would not match inside "Hauptstrasse"
-# (no word boundary between letters).
+# /"Neubachbrücke" (compound) all trigger. Compound "strasse"/"schule"/
+# "gasse"/"platz"/"brucke" need the end-of-word form because \bstrasse\b
+# would not match inside "Hauptstrasse" (no word boundary between letters).
 _BUS_LIKE_SUFFIX_PATTERN = re.compile(
     r"(?:\b(?:strasse|str|gasse|platz|wehr|grenz|siedlung|kreuzung|"
     r"kreisverkehr|zentrum|abzw|abzweigung)\b"
-    r"|(?:weg|hof|markt|gasse|platz|strasse|schule)$"
-    r"|\s(?:weg|hof|gasse|platz|strasse|schule)$)",
+    r"|(?:weg|hof|markt|gasse|platz|strasse|schule|brucke)$"
+    r"|\s(?:weg|hof|gasse|platz|strasse|schule|brucke)$)",
     re.IGNORECASE,
 )
 
@@ -298,6 +298,31 @@ def _score_candidate(station_name: str, candidate_name: str, ext_id: str | None)
     # first-word check lets candidates like "BIEDERMANNSDORF" survive
     # with a score around 55 (just over the 50 acceptance floor).
     if ext_id_str.startswith("9") and not (_RAIL_TOKENS & candidate_tokens):
+        return -100.0
+
+    # General rule for single-token pendler stops: when the canonical
+    # name is a single word ("Weigelsdorf", "Himberg") and VOR returns
+    # a multi-token candidate without any rail token, the candidate is
+    # almost always a different stop in the same town (a bus stop, a
+    # bridge, a residential quarter etc.). The 0.85 ratio guard keeps
+    # identity-ish matches working; the rail-token check keeps the
+    # legit "<station> Bahnhof" suffixes; the station-token-in-candidate
+    # check makes sure we only reject when the candidate is plausibly
+    # in the same town (not a different station that just happens to
+    # be 2-token). Subsumes the _BUS_LIKE_SUFFIX_PATTERN end-of-word
+    # whack-a-mole rounds for "gasse"/"platz"/"strasse"/"schule" /
+    # "siedlung"/"brucke" — VOR keeps returning new compound suffixes
+    # (Weigelsdorf B60/Boschansiedlung, Himberg Neubachbrücke etc.)
+    # that the hand-coded list can't keep up with.
+    station_tokens_list = station_norm.split()
+    candidate_tokens_list = candidate_norm.split()
+    if (
+        len(station_tokens_list) == 1
+        and len(candidate_tokens_list) >= 2
+        and station_tokens_list[0] in candidate_tokens
+        and not (_RAIL_TOKENS & candidate_tokens)
+        and ratio < 0.85
+    ):
         return -100.0
 
     # First-word-mismatch: the input "Tulln an der Donau" must not match

--- a/tests/test_fetch_vor_haltestellen_score.py
+++ b/tests/test_fetch_vor_haltestellen_score.py
@@ -62,6 +62,22 @@ from scripts.fetch_vor_haltestellen import (
         ("Himberg", "Himberg (bei Wien) Hauptstraße", "430373900"),
         ("Himberg bei Wien", "Himberg (bei Wien) Hauptstraße", "430373900"),
         ("Weigelsdorf", "Weigelsdorf Volksschule", "430586500"),
+        # 2026-05-06 second-cron survivors: after the strasse/schule
+        # filter, VOR returned yet another bad pair. The single-token
+        # case ("Weigelsdorf B60/Boschansiedlung") is now caught by
+        # the general single-token-station rule (1-token station + 2+
+        # token candidate without rail token + ratio < 0.85). The
+        # multi-token case ("Himberg (bei Wien) Neubachbrücke") needs
+        # the new 'brucke' end-of-word entry in _BUS_LIKE_SUFFIX_PATTERN.
+        ("Weigelsdorf", "Weigelsdorf B60/Boschansiedlung", "430543200"),
+        ("Himberg bei Wien", "Himberg (bei Wien) Neubachbrücke", "430374100"),
+        ("Himberg", "Himberg (bei Wien) Neubachbrücke", "430374100"),
+        # Defensive: the single-token rule must reject any added
+        # non-rail descriptor, even when the bus-suffix pattern
+        # doesn't recognize the suffix word. This locks in the rule
+        # itself against future VOR-returned compounds we haven't
+        # seen yet (e.g. "Weigelsdorf Stadion", "Achau Friedhofweg").
+        ("Achau", "Achau Stadtsaal", "430000000"),
     ],
     ids=[
         "laxenburg→hlw",
@@ -86,6 +102,10 @@ from scripts.fetch_vor_haltestellen import (
         "himberg→hauptstrasse-compound",
         "himberg-bei-wien→hauptstrasse-compound",
         "weigelsdorf→volksschule-compound",
+        "weigelsdorf→boschansiedlung-1token-rule",
+        "himberg-bei-wien→neubachbruecke-compound",
+        "himberg→neubachbruecke-1token-rule",
+        "achau→stadtsaal-1token-rule-defensive",
     ],
 )
 def test_score_rejects_bad_match(station: str, candidate: str, ext_id: str) -> None:


### PR DESCRIPTION
## Summary

Third follow-up after PR #1208. The next cron run produced two more false-positive resolves with **new** compound suffixes that the hand-coded `_BUS_LIKE_SUFFIX_PATTERN` list didn't cover:

| Station | Wrong VOR-Ziel | vor_id | Lücke |
|---|---|---|---|
| Weigelsdorf | `Weigelsdorf B60/Boschansiedlung` | `430543200` | `siedlung` als Compound (in `Boschansiedlung`) |
| Himberg bei Wien | `Himberg (bei Wien) Neubachbrücke` | `430374100` | `brucke` fehlte komplett |

Three rounds of "add the next bad suffix" (`gasse|platz` → `strasse|schule` → now `siedlung|brucke`) is whack-a-mole. This PR introduces a **general rule** that subsumes every single-token-pendler-stop case:

```
if station has 1 token AND candidate has ≥2 tokens
   AND no rail token in {bahnhof, hbf, bhf, bf, bahnhst}
   AND station-name in candidate-tokens
   AND ratio < 0.85
→ reject
```

Plus a targeted `brucke` addition to `_BUS_LIKE_SUFFIX_PATTERN`'s end-of-word arm for the 3-token case ("Himberg bei Wien"), since the general rule only applies to 1-token station names.

## Critical regression guards (verified)

The new general rule must NOT break the S7 Hainburg stops, which look like bus-stop names but are real rail stations opened 2017:

| Test | Ratio | Why it survives |
|---|---|---|
| `Hainburg Ungartor` → `Hainburg/Donau Ungartor/B9` | 0.791 | Station has 2 tokens — new rule only applies to 1-token stations |
| `Hainburg Kulturfabrik` → `Hainburg/Donau Kulturfabrik` | 0.875 | Above 0.85 ratio guard |
| `Wien Karlsplatz` → `Wien Karlsplatz` | 1.000 | Identity match |

## Test plan

- [x] 4 new reject tests (Boschansiedlung 1-token-rule, Neubachbrücke compound + 1-token-rule, defensive Achau Stadtsaal)
- [x] All 39 score-tests pass (was 35; +4 new)
- [x] Full test suite: 1121 passed, 1 skipped
- [x] `ruff check` clean
- [x] `validate_stations`: provider/cross_station_id/naming/security all 0
- [x] `_score_candidate('Hainburg Ungartor', 'Hainburg/Donau Ungartor/B9', '430367700') = 119.1` (preserved — critical guard)
- [ ] Next cron produces 0 false-positive resolves for Weigelsdorf/Himberg

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_