### PR TITLE
feat(stations): add 'Wien &lt;Name&gt;' alias to 11 Wien U-Bahn-only stations

### DIFF
--- a/data/stations.json
+++ b/data/stations.json
@@ -4118,7 +4118,8 @@
         "Herreng. bf",
         "Herrengasse Bahnhof",
         "Herrengasse Bf",
-        "Herrengasse bf"
+        "Herrengasse bf",
+        "Wien Herrengasse"
       ],
       "in_vienna": true,
       "latitude": 48.2096482,
@@ -4164,7 +4165,8 @@
         "Kettenbrückeng. bf",
         "Kettenbrückengasse Bahnhof",
         "Kettenbrückengasse Bf",
-        "Kettenbrückengasse bf"
+        "Kettenbrückengasse bf",
+        "Wien Kettenbrückengasse"
       ],
       "in_vienna": true,
       "latitude": 48.19680150000001,
@@ -4196,7 +4198,9 @@
         "Messe Prater",
         "Messe Prater Bahnhof",
         "Messe Prater Bf",
-        "Messe Prater bf"
+        "Messe Prater bf",
+        "Wien Messe Prater",
+        "Wien Messe-Prater"
       ],
       "in_vienna": true,
       "latitude": 48.2177854,
@@ -4289,7 +4293,8 @@
         "Neubaug. bf",
         "Neubaugasse Bahnhof",
         "Neubaugasse Bf",
-        "Neubaugasse bf"
+        "Neubaugasse bf",
+        "Wien Neubaugasse"
       ],
       "in_vienna": true,
       "latitude": 48.199120199999996,
@@ -4321,7 +4326,8 @@
         "Pilgramg. bf",
         "Pilgramgasse Bahnhof",
         "Pilgramgasse Bf",
-        "Pilgramgasse bf"
+        "Pilgramgasse bf",
+        "Wien Pilgramgasse"
       ],
       "in_vienna": true,
       "latitude": 48.1926175,
@@ -4391,7 +4397,8 @@
         "bf Schottenring",
         "Schottenring Bahnhof",
         "Schottenring Bf",
-        "Schottenring bf"
+        "Schottenring bf",
+        "Wien Schottenring"
       ],
       "in_vienna": true,
       "latitude": 48.217113,
@@ -4423,7 +4430,8 @@
         "Schwedenpl. bf",
         "Schwedenplatz Bahnhof",
         "Schwedenplatz Bf",
-        "Schwedenplatz bf"
+        "Schwedenplatz bf",
+        "Wien Schwedenplatz"
       ],
       "in_vienna": true,
       "latitude": 48.2114745,
@@ -4448,7 +4456,8 @@
         "bf Stadtpark",
         "Stadtpark Bahnhof",
         "Stadtpark Bf",
-        "Stadtpark bf"
+        "Stadtpark bf",
+        "Wien Stadtpark"
       ],
       "in_vienna": true,
       "latitude": 48.2024486,
@@ -4473,7 +4482,8 @@
         "bf Stubentor",
         "Stubentor Bahnhof",
         "Stubentor Bf",
-        "Stubentor bf"
+        "Stubentor bf",
+        "Wien Stubentor"
       ],
       "in_vienna": true,
       "latitude": 48.2074954,
@@ -4533,7 +4543,8 @@
         "Südtiroler pl. bf",
         "Südtiroler Platz Bahnhof",
         "Südtiroler Platz Bf",
-        "Südtiroler Platz bf"
+        "Südtiroler Platz bf",
+        "Wien Südtiroler Platz"
       ],
       "in_vienna": true,
       "latitude": 48.186496999999996,
@@ -4558,7 +4569,8 @@
         "bf Volkstheater",
         "Volkstheater Bahnhof",
         "Volkstheater Bf",
-        "Volkstheater bf"
+        "Volkstheater bf",
+        "Wien Volkstheater"
       ],
       "in_vienna": true,
       "latitude": 48.2050705,

--- a/scripts/enrich_station_aliases.py
+++ b/scripts/enrich_station_aliases.py
@@ -488,6 +488,25 @@ def _alias_candidates(
         r"St. Pölten Hbf$": ["St. Pölten", "Sankt Pölten"],
         r"Wiener Neustadt Hbf$": ["Wr. Neustadt", "Wiener Neustadt"],
         r"Bratislava hl\.st\.$": ["Bratislava"],
+        # Wien U-Bahn stations from Google Places that lack the
+        # canonical "Wien " prefix. Adding the Wien-prefixed form as
+        # an alias (the bare form remains the canonical) makes them
+        # discoverable when feed text uses the full "Wien <Name>" form.
+        # "Rennweg" is intentionally omitted: a "Wien Rennweg" alias
+        # would collide with the separate S-Bahn station "Wien
+        # Rennweg" — the cross-station-collision filter blocks it
+        # anyway, so the omission keeps the missing_map intent clean.
+        r"^Herrengasse$": ["Wien Herrengasse"],
+        r"^Kettenbrückengasse$": ["Wien Kettenbrückengasse"],
+        r"^Messe - Prater$": ["Wien Messe-Prater", "Wien Messe Prater"],
+        r"^Neubaugasse$": ["Wien Neubaugasse"],
+        r"^Pilgramgasse$": ["Wien Pilgramgasse"],
+        r"^Schottenring$": ["Wien Schottenring"],
+        r"^Schwedenplatz$": ["Wien Schwedenplatz"],
+        r"^Stadtpark$": ["Wien Stadtpark"],
+        r"^Stubentor$": ["Wien Stubentor"],
+        r"^Südtiroler Platz$": ["Wien Südtiroler Platz"],
+        r"^Volkstheater$": ["Wien Volkstheater"],
     }
 
     for pattern, add_list in missing_map.items():

--- a/tests/test_enrich_station_aliases_filters.py
+++ b/tests/test_enrich_station_aliases_filters.py
@@ -145,6 +145,34 @@ def test_cross_station_collision_drops_mistelbach_phantom() -> None:
     assert "Mistelbach Stadt" in aliases
 
 
+def test_missing_map_adds_wien_prefix_to_ubahn_stations() -> None:
+    """The 12 bare-named Wien U-Bahn stations from Google Places get a
+    "Wien <Name>" alias added via missing_map so feed-text matching
+    against the colloquial "Wien Stadtpark" form still resolves."""
+    station = {"name": "Stadtpark", "aliases": ["Stadtpark"]}
+    aliases = _alias_candidates(station, vor_names={}, vor_mapping={}, gtfs_index={})
+    assert "Wien Stadtpark" in aliases
+    assert "Stadtpark" in aliases  # canonical preserved
+
+
+def test_missing_map_does_not_collide_with_wien_rennweg_sbahn() -> None:
+    """The U3 station "Rennweg" must NOT pick up "Wien Rennweg" as an
+    alias because that's the canonical name of the separate S-Bahn
+    station. The cross-station-collision filter enforces this even
+    if a missing_map entry tried to add it."""
+    rennweg_u3 = {"name": "Rennweg", "aliases": ["Rennweg"]}
+    other_keys = frozenset({"wien rennweg"})  # canonical of the S-Bahn station
+    aliases = _alias_candidates(
+        rennweg_u3,
+        vor_names={},
+        vor_mapping={},
+        gtfs_index={},
+        other_canonical_keys=other_keys,
+    )
+    assert "Wien Rennweg" not in aliases
+    assert "Rennweg" in aliases
+
+
 def test_cross_station_collision_does_not_drop_own_canonical() -> None:
     """The station's own canonical name normalizes to a key that is in
     other_canonical_keys (passed in as the full canonical-name set);


### PR DESCRIPTION
## Summary

Final item from the 2026-05 alias audit (#7). 12 Wien-U-Bahn stations sourced from Google Places lack the canonical `Wien ` prefix that the rest of the directory uses, making them invisible to feed-text matching that uses the conventional `Wien Stadtpark` form.

| Station | New alias |
|---|---|
| Stadtpark | `Wien Stadtpark` |
| Schwedenplatz | `Wien Schwedenplatz` |
| Schottenring | `Wien Schottenring` |
| Stubentor | `Wien Stubentor` |
| Volkstheater | `Wien Volkstheater` |
| Pilgramgasse | `Wien Pilgramgasse` |
| Neubaugasse | `Wien Neubaugasse` |
| Kettenbrückengasse | `Wien Kettenbrückengasse` |
| Südtiroler Platz | `Wien Südtiroler Platz` |
| Messe - Prater | `Wien Messe-Prater`, `Wien Messe Prater` |
| Herrengasse | `Wien Herrengasse` |
| Rennweg | _intentionally omitted_ — see below |

### Rename vs. Alias

I considered renaming the canonical name from `<Name>` → `Wien <Name>`, but rejected it. The Wiener-Linien update (`scripts/update_wl_stations.py`) merges by exact normalized name match against its canonical `Wien <Name> (WL)` form (`_lookup_candidates` does plain `index.get()`, no fuzzy fallback). The next time the WL haltepunkte URL works (currently 404), a renamed `Wien Stadtpark` would NOT match `Wien Stadtpark (WL)` and a parallel entry would be created.

The additive alias approach via `missing_map` is risk-free:
- Canonical name stays `Stadtpark` → no collision when WL re-runs
- New `Wien Stadtpark` alias makes the entry discoverable from feed text
- The cross-station-collision filter (PR #1210) already prevents accidental clashes

### Rennweg omitted

A `Wien Rennweg` alias on the U3 station `Rennweg` would collide with the canonical name of the separate S-Bahn station `Wien Rennweg`. The cross-station-collision filter introduced in PR #1210 already blocks this, so listing it in `missing_map` would be a no-op and confuse the intent.

### Out of scope

The 12 stations still lack `vor_id`. Solving that requires either WL haltepunkte data (currently 404) or a hand-curated VOR id list — neither is a small change. The main pain point of the audit (feed-text matching) is addressed by the alias addition.

## Test plan

- [x] 2 new tests (`test_missing_map_adds_wien_prefix_to_ubahn_stations`, `test_missing_map_does_not_collide_with_wien_rennweg_sbahn`)
- [x] Full test suite: 1130 passed, 1 skipped (was 1128, +2 new)
- [x] `mypy` clean, `ruff check` clean
- [x] `validate_stations`: provider/cross_station_id/naming/security all 0
- [x] `enrich_station_aliases.py` updated 11 stations on-disk
- [x] Manual verification: each of 11 stations has the corresponding `Wien <Name>` alias in `data/stations.json`

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_