### PR TITLE
fix(stations): include allocated bst_id in STATIC entry aliases

### DIFF
--- a/data/stations.json
+++ b/data/stations.json
@@ -14,6 +14,10 @@
         "Bahnhof Sankt Andrae-Woerdern",
         "Bahnhof Sankt Andrä Wördern",
         "Bahnhof Sankt Andrä-Wördern",
+        "Bahnhof St Andrae-Woerdern",
+        "Bahnhof St Andrä-Wördern",
+        "Bahnhof St. Andrae-Woerdern",
+        "Bahnhof St. Andrä-Wördern",
         "Bahnhof St.Andrae Woerdern",
         "Bahnhof St.Andrae-Woerdern",
         "Bahnhof St.Andrä Wördern",
@@ -26,6 +30,14 @@
         "bf Sankt Andrä Wördern",
         "Bf Sankt Andrä-Wördern",
         "bf Sankt Andrä-Wördern",
+        "Bf St Andrae-Woerdern",
+        "bf St Andrae-Woerdern",
+        "Bf St Andrä-Wördern",
+        "bf St Andrä-Wördern",
+        "Bf St. Andrae-Woerdern",
+        "bf St. Andrae-Woerdern",
+        "Bf St. Andrä-Wördern",
+        "bf St. Andrä-Wördern",
         "Bf St.Andrae Woerdern",
         "bf St.Andrae Woerdern",
         "Bf St.Andrae-Woerdern",
@@ -50,7 +62,15 @@
         "Sankt Andrä-Wördern Bahnhof",
         "Sankt Andrä-Wördern Bf",
         "Sankt Andrä-Wördern bf",
+        "St Andrae-Woerdern",
+        "St Andrae-Woerdern Bahnhof",
+        "St Andrae-Woerdern Bf",
+        "St Andrae-Woerdern bf",
         "St Andrä-Wördern",
+        "St Andrä-Wördern Bahnhof",
+        "St Andrä-Wördern Bf",
+        "St Andrä-Wördern bf",
+        "St. Andrae-Woerdern",
         "St. Andrae-Woerdern Bahnhof",
         "St. Andrae-Woerdern Bf",
         "St. Andrae-Woerdern bf",
@@ -852,8 +872,11 @@
         "Bad Deutsch-Altenburg bf",
         "Bad Deutsch-Altenburg/Donau",
         "Bahnhof Bad Deutsch Altenburg",
+        "Bahnhof Bad Deutsch-Altenburg",
         "Bf Bad Deutsch Altenburg",
-        "bf Bad Deutsch Altenburg"
+        "bf Bad Deutsch Altenburg",
+        "Bf Bad Deutsch-Altenburg",
+        "bf Bad Deutsch-Altenburg"
       ],
       "source": "oebb",
       "latitude": 48.132489,
@@ -1026,8 +1049,11 @@
         "Angern bf",
         "Angern March",
         "Bahnhof Angern",
+        "Bahnhof Angern (March)",
         "Bf Angern",
-        "bf Angern"
+        "bf Angern",
+        "Bf Angern (March)",
+        "bf Angern (March)"
       ]
     },
     {
@@ -5266,6 +5292,7 @@
       "aliases": [
         "430361600",
         "Guntramsdorf Bahnhof",
+        "900106",
         "Bahnhof Guntramsdorf",
         "Bf Guntramsdorf",
         "bf Guntramsdorf",
@@ -5288,6 +5315,7 @@
       "aliases": [
         "430361700",
         "Guntramsdorf-Kaiserau",
+        "900107",
         "Bahnhof Guntramsdorf Kaiserau",
         "Bahnhof Guntramsdorf-Kaiserau",
         "Bf Guntramsdorf Kaiserau",
@@ -5316,6 +5344,7 @@
       "aliases": [
         "430368100",
         "Hainburg Kulturfabrik",
+        "900108",
         "Bahnhof Hainburg Kulturfabrik",
         "Bf Hainburg Kulturfabrik",
         "bf Hainburg Kulturfabrik",
@@ -5339,6 +5368,7 @@
       "aliases": [
         "430367700",
         "Hainburg Ungartor",
+        "900109",
         "Bahnhof Hainburg Ungartor",
         "Bf Hainburg Ungartor",
         "bf Hainburg Ungartor",
@@ -5363,6 +5393,7 @@
       "aliases": [
         "430875800",
         "Neunkirchen NÖ",
+        "900110",
         "Bahnhof Neunkirchen",
         "Bahnhof Neunkirchen NOe",
         "Bahnhof Neunkirchen NÖ",
@@ -5397,6 +5428,7 @@
       "aliases": [
         "430442300",
         "Oberwaltersdorf",
+        "900111",
         "Bahnhof Oberwaltersdorf",
         "Bf Oberwaltersdorf",
         "bf Oberwaltersdorf",
@@ -5418,6 +5450,7 @@
       "aliases": [
         "430501300",
         "Trautmannsdorf an der Leitha",
+        "900112",
         "Bahnhof Trautmannsdorf",
         "Bahnhof Trautmannsdorf an der Leitha",
         "Bf Trautmannsdorf",

--- a/scripts/update_vor_stations.py
+++ b/scripts/update_vor_stations.py
@@ -897,6 +897,17 @@ def merge_into_stations(stations_path: Path, vor_entries: list[dict[str, object]
             new_entry["aliases"] = unique_aliases
         else:
             new_entry["aliases"] = []
+        # The validator's "missing required aliases" rule expects each
+        # station's bst_code (and bst_id) to be discoverable as an
+        # alias. For STATIC entries that omit explicit bst_id/bst_code
+        # (so the allocator picks the next free 900xxx), the values
+        # were only populated above — push them onto the alias list
+        # now so the validator's per-source code-as-alias check passes.
+        normalized_aliases = new_entry["aliases"]
+        if isinstance(normalized_aliases, list):
+            for synthetic_id in (bst_id, bst_code):
+                if synthetic_id and synthetic_id not in normalized_aliases:
+                    normalized_aliases.append(synthetic_id)
         new_entry.setdefault("source", "vor")
         return new_entry
 

--- a/tests/test_update_vor_stations_static_in_csv.py
+++ b/tests/test_update_vor_stations_static_in_csv.py
@@ -104,6 +104,62 @@ def test_static_entry_creates_new_directory_entry_when_csv_has_vor_id(
     assert "Guntramsdorf Südbahn" in guntramsdorf["aliases"]
 
 
+def test_static_entry_includes_allocated_bst_id_in_aliases(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The validator's "missing required aliases" rule expects each
+    station's bst_code to be present in its aliases list. STATIC
+    entries that omit explicit bst_id/bst_code rely on the synthetic
+    900xxx allocator — and the resulting bst_id must end up in the
+    aliases list, otherwise validate_stations reports an alias_issue.
+    Regression for the +7 alias_issues introduced by the original
+    PR #1213 add of seven new STATIC entries.
+    """
+    static_template = {
+        "vor_id": "430361600",
+        "name": "Guntramsdorf Bahnhof",
+        "in_vienna": False,
+        "pendler": True,
+        "latitude": 48.051964,
+        "longitude": 16.297551,
+        "aliases": ["Guntramsdorf Bahnhof", "430361600"],
+        "source": "vor",
+        # bst_id/bst_code intentionally omitted — allocator picks
+    }
+    monkeypatch.setattr(
+        update_vor_stations,
+        "STATIC_VOR_ENTRIES",
+        (static_template,),
+    )
+
+    stations_path = tmp_path / "stations.json"
+    stations_path.write_text(json.dumps({"stations": []}), encoding="utf-8")
+
+    update_vor_stations.merge_into_stations(
+        stations_path,
+        [
+            {
+                "vor_id": "430361600",
+                "name": "Guntramsdorf Bahnhof",
+                "latitude": 48.051964,
+                "longitude": 16.297551,
+                "aliases": ["Guntramsdorf Bahnhof"],
+            }
+        ],
+    )
+
+    payload = json.loads(stations_path.read_text(encoding="utf-8"))
+    entry = next(
+        e for e in payload["stations"] if e["name"] == "Guntramsdorf Bahnhof"
+    )
+    bst_id = entry["bst_id"]
+    assert bst_id, "allocator must populate bst_id"
+    assert bst_id in entry["aliases"], (
+        f"bst_id {bst_id!r} must be present as alias to satisfy the "
+        f"validator's per-source code-as-alias rule"
+    )
+
+
 def test_static_entry_merges_when_existing_station_matches_by_bst_id(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Audit follow-up to #1213. The 7 new `STATIC_VOR_ENTRIES` added in #1213 (Guntramsdorf Bahnhof + Kaiserau, Hainburg Kulturfabrik + Ungartor, Neunkirchen NÖ, Oberwaltersdorf, Trautmannsdorf an der Leitha) all listed their `vor_id` (430xxx) in aliases but not their auto-allocated `bst_code` (900xxx). The validator's "missing required aliases" rule expects each station's `bst_code` to be discoverable as an alias, so #1213 silently bumped `alias_issues` from **155 → 162**.

### Fix

In `_new_entry_from_static` — after the allocator populates `bst_id` and `bst_code` — push them onto the aliases list:

```python
normalized_aliases = new_entry["aliases"]
if isinstance(normalized_aliases, list):
    for synthetic_id in (bst_id, bst_code):
        if synthetic_id and synthetic_id not in normalized_aliases:
            normalized_aliases.append(synthetic_id)
```

Confined to the STATIC-fallback path. Existing entries that already include their identifiers as aliases (like `Wiener Neustadt Hauptbahnhof`'s `"900300"`) are unaffected because the push is guarded by an `"if not in aliases"` check.

## Test plan

- [x] 1 new test (`test_static_entry_includes_allocated_bst_id_in_aliases`) pinning the contract
- [x] Existing 2 STATIC-merge tests still pass
- [x] Full test suite: 1136 passed, 1 skipped (was 1135, +1 new)
- [x] `mypy` clean, `ruff check` clean
- [x] `validate_stations`: **alias_issues 162 → 155** (back to pre-#1213 baseline)
- [x] All blocking gates remain 0 (provider/cross_station_id/naming/security/duplicates)
- [x] Manual verification: each of the 7 new STATIC entries now has its `bst_id` (900106-900112) listed in aliases

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_