### PR TITLE
fix(feed): tighten fuzzy dedup so different-station events don't merge

### DIFF
--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -7,7 +7,143 @@ from typing import Any, Dict, List, Set, Tuple, Union
 _LINE_PREFIX_RE = re.compile(r"^\s*([A-Za-z0-9]+\s*(?:/\s*[A-Za-z0-9]+){0,20})\s*:\s*")
 _LINE_TOKEN_RE = re.compile(r"^(?:\d{1,3}[A-Z]?|[A-Z]{1,4}\d{0,3})$")
 
-_STOP_WORDS = {"störung", "ausfall", "einschränkung", "betrieb", "info", "meldung", "hinweis"}
+# Tokens that must not by themselves drive a fuzzy merge. The baseline list
+# covers generic disruption verbs ("Störung", "Ausfall", …) that show up in
+# nearly every title; the extended list adds German articles, prepositions
+# and connector words ("im", "am", "bereich", …) so that two titles which
+# only share these fillers do NOT get merged.
+#
+# Why this matters: without prepositions in the stop list, "U1: Störung im
+# Bereich Praterstern" and "U1: Störung im Bereich Karlsplatz" share the
+# tokens {"störung", "im", "bereich"} and exceed the 0.4 overlap threshold
+# despite referring to two completely different stations.
+_STOP_WORDS = {
+    # Generic disruption nouns
+    "störung",
+    "stoerung",
+    "ausfall",
+    "ausfälle",
+    "ausfaelle",
+    "einschränkung",
+    "einschraenkung",
+    "betrieb",
+    "verkehr",
+    "verkehrsbehinderung",
+    "fahrtbehinderung",
+    "behinderung",
+    "verspätung",
+    "verspaetung",
+    "verspätungen",
+    "verspaetungen",
+    "info",
+    "information",
+    "meldung",
+    "hinweis",
+    "sperre",
+    "sperrung",
+    "gesperrt",
+    "umleitung",
+    "ersatzverkehr",
+    "kurzführung",
+    "kurzfuehrung",
+    "fahrt",
+    "fahrten",
+    "linie",
+    "linien",
+    "bauarbeiten",
+    # Equipment/state words that recur across unrelated incidents
+    "aufzug",
+    "aufzüge",
+    "aufzuege",
+    "aufzugsinfo",
+    "lift",
+    "fahrstuhl",
+    "fahrtreppe",
+    "fahrtreppen",
+    "fahrtreppeninfo",
+    "rolltreppe",
+    "rolltreppen",
+    "defekt",
+    "kaputt",
+    "gestört",
+    "gestoert",
+    "blockiert",
+    "weichenstörung",
+    "weichenstoerung",
+    "signalstörung",
+    "signalstoerung",
+    "polizeieinsatz",
+    "rettungseinsatz",
+    "feuerwehreinsatz",
+    "notarzteinsatz",
+    "personenschaden",
+    "fahrzeugschaden",
+    # German articles
+    "der",
+    "die",
+    "das",
+    "des",
+    "den",
+    "dem",
+    "ein",
+    "eine",
+    "einer",
+    "einem",
+    "eines",
+    # German prepositions
+    "in",
+    "im",
+    "an",
+    "am",
+    "auf",
+    "aus",
+    "bei",
+    "mit",
+    "von",
+    "vom",
+    "zu",
+    "zum",
+    "zur",
+    "nach",
+    "durch",
+    "für",
+    "fuer",
+    "gegen",
+    "ohne",
+    "um",
+    "unter",
+    "über",
+    "ueber",
+    "wegen",
+    "während",
+    "waehrend",
+    "zwischen",
+    "vor",
+    "hinter",
+    "neben",
+    "ab",
+    "bis",
+    # German conjunctions
+    "und",
+    "oder",
+    "aber",
+    "sowie",
+    "sondern",
+    # Generic place-fillers
+    "bereich",
+    "höhe",
+    "hoehe",
+    "richtung",
+    "fahrtrichtung",
+    "station",
+    "haltestelle",
+    "haltestellen",
+    "bahnhof",
+    "bahnhst",
+    "hbf",
+    "bf",
+    "bhf",
+}
 
 
 def _parse_title(title: str) -> Tuple[Set[str], str]:
@@ -55,29 +191,33 @@ def _has_significant_overlap(name1: str, name2: str) -> bool:
     t2 = _get_tokens(name2)
 
     # 1. Token Overlap
-    # Filter out very short tokens (e.g. "a", "of") if necessary?
-    # Prompt says: "ignoring numbers/years" (already done in normalize)
     intersection = t1 & t2
     union = t1 | t2
     if not union:
         return False
-    # Ignore matches that consist solely of generic stop-words
-    meaningful = intersection - _STOP_WORDS
-    if not meaningful and intersection:
-        # Wait, if both strings are literally ONLY stop words (e.g. "Störung" and "Störung"),
-        # they SHOULD merge because they are essentially the same generic event type!
-        # The bug "False-positive merge on single generic tokens" typically applies when
-        # matching "Störung" with "Störung am Schottentor" -> meaningful intersection is empty for intersection = {"störung"}.
-        # Let's fix this properly: only reject if the UNION contains meaningful words
-        # but the INTERSECTION doesn't.
-        # If the entire UNION is just stop words, it's perfectly fine to merge them!
-        meaningful_union = union - _STOP_WORDS
-        if meaningful_union:
-            return False
-        else:
-            return True
 
-    if len(intersection) / len(union) >= 0.4:
+    # Compare only meaningful (non-stop-word) tokens. The intent: two
+    # disruption titles must share something distinctive (typically a
+    # station/place token) — sharing only "Störung" or "im Bereich" is not
+    # enough.
+    meaningful_intersection = intersection - _STOP_WORDS
+    meaningful_union = union - _STOP_WORDS
+
+    if not meaningful_union:
+        # Both titles consist solely of stop words. Only merge if they are
+        # token-identical — otherwise different stop-word combinations like
+        # "Sperre wegen Bauarbeiten" and "Sperre wegen Polizeieinsatz"
+        # would be falsely lumped together.
+        return t1 == t2
+
+    if not meaningful_intersection:
+        # Distinguishing tokens exist somewhere, but none are shared. The
+        # titles describe different events at the same generic level.
+        return False
+
+    # Token overlap threshold — measured against the meaningful tokens so
+    # that sharing many fillers does not inflate the score.
+    if len(meaningful_intersection) / len(meaningful_union) >= 0.4:
         return True
 
     return False

--- a/tests/test_fuzzy_merge_stopwords.py
+++ b/tests/test_fuzzy_merge_stopwords.py
@@ -1,4 +1,4 @@
-from src.feed.merge import _has_significant_overlap
+from src.feed.merge import _has_significant_overlap, deduplicate_fuzzy
 
 def test_has_significant_overlap_stopwords() -> None:
     # Only stopwords in both, they SHOULD merge because there's nothing else to distinguish them.
@@ -24,3 +24,73 @@ def test_has_significant_overlap_stopwords() -> None:
 
     # Completely distinct
     assert not _has_significant_overlap("A", "B")
+
+
+def test_no_merge_on_generic_filler_words() -> None:
+    """German fillers ("im", "Bereich", "am") must not bridge two titles
+    that otherwise reference different stations."""
+    # Different stations should never merge.
+    assert not _has_significant_overlap(
+        "Störung im Bereich Praterstern", "Störung im Bereich Karlsplatz"
+    )
+    assert not _has_significant_overlap(
+        "Aufzug defekt am Längenfeldgasse", "Aufzug defekt am Karlsplatz"
+    )
+    assert not _has_significant_overlap(
+        "Sperre wegen Bauarbeiten", "Sperre wegen Polizeieinsatz"
+    )
+    # Same station with related verbs: should still recognise as overlap.
+    assert _has_significant_overlap(
+        "Störung Karlsplatz", "Karlsplatz gesperrt"
+    )
+
+
+def test_dedupe_fuzzy_keeps_distinct_station_events() -> None:
+    """Regression: two U1 incidents at different stations must stay separate."""
+    items = [
+        {
+            "guid": "a",
+            "_identity": "a",
+            "source": "Wiener Linien",
+            "title": "U1: Störung im Bereich Praterstern",
+            "description": "Signalstörung im Bereich Praterstern.",
+        },
+        {
+            "guid": "b",
+            "_identity": "b",
+            "source": "Wiener Linien",
+            "title": "U1: Störung im Bereich Karlsplatz",
+            "description": "Signalstörung im Bereich Karlsplatz.",
+        },
+    ]
+    result = deduplicate_fuzzy(items)
+    assert len(result) == 2
+    titles = sorted(item["title"] for item in result)
+    assert titles == [
+        "U1: Störung im Bereich Karlsplatz",
+        "U1: Störung im Bereich Praterstern",
+    ]
+
+
+def test_dedupe_fuzzy_still_merges_same_topic() -> None:
+    """The fuzzy merge must still combine ÖBB+VOR for the same incident."""
+    items = [
+        {
+            "guid": "oebb-foo",
+            "_identity": "oebb|foo",
+            "source": "ÖBB",
+            "title": "U6: Signalstörung Spittelau",
+            "description": "Signalstörung im Bereich Spittelau",
+        },
+        {
+            "guid": "vor-bar",
+            "_identity": "vor|bar",
+            "source": "VOR/VAO",
+            "title": "U6: Signalstörung Spittelau",
+            "description": "Signalstörung U6 Spittelau, Auswirkung bis Längenfeldgasse",
+        },
+    ]
+    result = deduplicate_fuzzy(items)
+    assert len(result) == 1
+    # VOR record wins as master; ÖBB description appended only when substantive.
+    assert result[0].get("source") == "VOR/VAO"


### PR DESCRIPTION
## Summary

Behebt einen False-Positive in der `deduplicate_fuzzy`-Logik (`src/feed/merge.py`): zwei klar unterschiedliche Vorfälle an verschiedenen Stationen wurden zusammengeführt, weil sie nur generische Füllwörter teilten.

### Bug

Die Fuzzy-Merge-Heuristik nutzt Token-Überlappung um „gleiches Event von zwei Providern" zu erkennen. Die alte Stop-Word-Liste enthielt nur eine Handvoll Verben (`Störung`, `Ausfall`, …). Deutsche Präpositionen/Artikel wie `im`, `am`, `Bereich`, `wegen` galten als „bedeutungsvoll":

```
U1: Störung im Bereich Praterstern
U1: Störung im Bereich Karlsplatz
  → shared {störung, im, bereich} = 3/5 = 0.6 → fälschlich gemergt
```

Gleiches Problem für `Aufzug defekt am X` ↔ `Aufzug defekt am Y` und `Sperre wegen Bauarbeiten` ↔ `Sperre wegen Polizeieinsatz`.

### Fix

1. **Stop-Word-Liste massiv erweitert** um:
   - Deutsche Artikel/Präpositionen/Konjunktionen (`im`, `am`, `der`, `die`, `und`, `wegen`, …)
   - Wiederkehrende Equipment-/Status-Wörter (`aufzug`, `lift`, `defekt`, `signalstörung`, `polizeieinsatz`, …)
   - Generische Place-Filler (`bereich`, `höhe`, `richtung`, `linie`, `bahnhof`, `hbf`, …)
2. **Overlap-Score gegen *meaningful*-Tokens** statt gegen das gesamte Token-Set — lange Stop-Word-Vorspänne können kein Merge mehr erzwingen.
3. **„All-stop-words"-Fallback** mergt nur noch bei Token-Identität; `Sperre wegen Bauarbeiten` ≠ `Sperre wegen Polizeieinsatz` werden korrekt getrennt.

### Tests

- Neue Regressionstests in `tests/test_fuzzy_merge_stopwords.py`:
  - U1 Praterstern ≠ U1 Karlsplatz
  - Aufzug defekt unterschiedliche Stationen
  - Sperre wegen X/Y bleibt getrennt
  - Cross-Provider-Merge ÖBB ↔ VOR funktioniert weiter (kein Regress)

## Test plan

- [x] `pytest tests/test_fuzzy_merge_stopwords.py` — 4/4 passed
- [x] `pytest tests/` — 1023 passed (1 pre-existing failure in `test_feed_lint::test_feed_lint_ok_without_issues` ist unabhängig von diesem Fix — VOR-Cache-Fixture stale, schlug auch auf `main` schon fehl)
- [x] `mypy --strict src/ tests/` — clean
- [x] `ruff check src/ tests/` — clean

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_