### PR TITLE
fix(filter): four bugs found in post-merge audit

### DIFF
--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -3,9 +3,25 @@ import hashlib
 import re
 from typing import Any, Dict, List, Set, Tuple, Union
 
-# Regex adapted from build_feed.py
-_LINE_PREFIX_RE = re.compile(r"^\s*([A-Za-z0-9]+\s*(?:/\s*[A-Za-z0-9]+){0,20})\s*:\s*")
-_LINE_TOKEN_RE = re.compile(r"^(?:\d{1,3}[A-Z]?|[A-Z]{1,4}\d{0,3})$")
+# Line-prefix grammar tolerant of two real-world spellings:
+#
+#   "U6: …", "1/2: …", "13A/14A: …"   (WL-style — no internal whitespace)
+#   "REX 7: …", "S 50: …", "REX 7/REX 8: …"  (ÖBB-style — letters and digits
+#   separated by whitespace)
+#
+# Without the optional inner space the ÖBB tokens silently fell through, so a
+# disruption surfaced once via VOR ("REX7") and once via ÖBB ("REX 7") — two
+# items in the feed for the exact same incident. Internal whitespace inside a
+# token is normalised away in :func:`_parse_title` before the line set is
+# compared.
+_LINE_PREFIX_RE = re.compile(
+    r"^\s*("
+    r"[A-Za-z]+\s*\d{1,3}[A-Za-z]?"  # ÖBB style: REX 7, S 50, RJX 12
+    r"(?:\s*/\s*[A-Za-z]+\s*\d{1,3}[A-Za-z]?)*"
+    r"|[A-Za-z0-9]+(?:\s*/\s*[A-Za-z0-9]+){0,20}"  # WL style: 1/2, U6, 13A
+    r")\s*:\s*"
+)
+_LINE_TOKEN_RE = re.compile(r"^(?:\d{1,3}[A-Z]?|[A-Z]{1,4}\d{0,3}[A-Z]?)$")
 
 # Tokens that must not by themselves drive a fuzzy merge. The baseline list
 # covers generic disruption verbs ("Störung", "Ausfall", …) that show up in
@@ -150,6 +166,8 @@ def _parse_title(title: str) -> Tuple[Set[str], str]:
     """
     Parses a title into a set of lines and the event name.
     Example: "1/2: Event Name" -> ({"1", "2"}, "Event Name")
+    Whitespace inside a token is collapsed so "REX 7" matches "REX7" across
+    providers.
     """
     m = _LINE_PREFIX_RE.match(title or "")
     if not m:
@@ -160,7 +178,8 @@ def _parse_title(title: str) -> Tuple[Set[str], str]:
 
     lines = set()
     for raw in lines_str.split("/"):
-        token = raw.strip().upper()
+        # Drop inner whitespace so "REX 7" and "REX7" become the same token.
+        token = re.sub(r"\s+", "", raw).upper()
         if _LINE_TOKEN_RE.match(token):
             lines.add(token)
 

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -254,10 +254,43 @@ def _strip_oebb_prefixes(text: str) -> str:
 # HTML-tolerant: a description usually contains entries like
 # "zwischen <b>Flughafen Wien Bahnhof</b> und <b>Wien Mitte-Landstraße Bahnhof</b>".
 # We strip HTML before matching so we only need a single plain-text pattern.
+#
+# The lookahead is the tricky part. Two real-world failure modes drove the
+# current shape:
+#
+# 1. A bare "." in the boundary class truncated abbreviated station names:
+#    "und St. Pölten ist …" was captured as endpoint "St". The fix accepts
+#    a period as a boundary only when it ends a sentence (end-of-string,
+#    closing tag, or followed by whitespace + a lowercase German word) —
+#    not when it sits inside an abbreviation like "St.".
+# 2. Several common follow-up words ("aufgrund", "wegen", em-dash, …) were
+#    not in the boundary list, so the regex over-extended into them
+#    ("Mödling aufgrund Sturm" became the second endpoint). The list below
+#    covers the recurring ÖBB phrasings.
 _ZWISCHEN_PLAIN_RE = re.compile(
     r"zwischen\s+(?P<a>.+?)\s+und\s+(?P<b>.+?)"
-    r"(?=\s+(?:von|bis|am|im|in\s+der|jeweils|nicht|der\s+Zug|halten|fahren|"
-    r"kommt|f[äa]hrt|fallen|k[öo]nnen|sowie|werden|ab|seit|um|gegen)\b|[,;.!?]|\s*$)",
+    r"(?="
+    r"\s+(?:"
+    # Time/date prepositions
+    r"von|bis|am|im|in\s+der|jeweils|ab|seit|um|gegen|nach|vor|"
+    # Causal/circumstantial
+    r"aufgrund|wegen|durch|f[üu]r|infolge|trotz|während|waehrend|"
+    # Verbs typical for the predicate that follows the route phrase
+    r"nicht|der\s+Zug|halten|fahren|kommt|f[äa]hrt|fallen|k[öo]nnen|"
+    r"werden|wird|kann|d[üu]rfen|sollen|soll|m[üu]ssen|"
+    # State / past-participle endings of the sentence
+    r"ist|sind|war|waren|gesperrt|geschlossen|blockiert|eingestellt|"
+    r"unterbrochen|gestört|gestoert|ausgefallen|verspätet|verspaetet|"
+    r"verz[öo]gert|aufgehoben|freigegeben|"
+    # Connectors that introduce a side clause
+    r"sowie|sondern|sowie\s+zwischen"
+    r")\b"
+    r"|[,;!?]"  # Plain sentence punctuation (period excluded — see above)
+    r"|[—–]"  # German em-/en-dash often introduces a side remark
+    r"|<"  # HTML tag start (defensive: we strip HTML, but stay safe)
+    r"|\.\s*$"  # Period only when it terminates the description
+    r"|\s*$"
+    r")",
     re.IGNORECASE | re.DOTALL,
 )
 
@@ -345,9 +378,13 @@ def _extract_routes(title: str, description: str) -> List[Tuple[str, str]]:
 
     Pure category words like "Bauarbeiten ↔ Umleitung" are filtered out so
     they don't drag a real station-mention message into the strict-route path
-    incorrectly.
+    incorrectly. Likewise "fake routes" where both endpoints fail to resolve
+    against the station directory (e.g. "Aufzug zwischen Bahnsteig 1 und
+    Bahnsteig 5 in Wien Mitte defekt") are dropped — they describe internal
+    layout, not transit connections, and would otherwise mask the real
+    Wien-Mitte station mention from the fall-through filter.
     """
-    routes: List[Tuple[str, str]] = []
+    candidates: List[Tuple[str, str]] = []
     seen: set[Tuple[str, str]] = set()
 
     # 1. Parse title — split on ↔
@@ -367,7 +404,7 @@ def _extract_routes(title: str, description: str) -> List[Tuple[str, str]]:
             if key in seen:
                 continue
             seen.add(key)
-            routes.append((a_norm, b_norm))
+            candidates.append((a_norm, b_norm))
 
     # 2. Parse description — "zwischen X und Y" patterns
     for raw_a, raw_b in _extract_zwischen_routes(description):
@@ -376,7 +413,17 @@ def _extract_routes(title: str, description: str) -> List[Tuple[str, str]]:
         if desc_key in seen:
             continue
         seen.add(desc_key)
-        routes.append((raw_a, raw_b))
+        candidates.append((raw_a, raw_b))
+
+    # 3. Drop candidates where both endpoints are unresolvable. These are
+    #    almost always false positives from regex over-extraction (platform
+    #    numbers, generic phrases) — keeping them would force the strict
+    #    route path to reject otherwise-relevant single-station messages.
+    routes: List[Tuple[str, str]] = []
+    for a, b in candidates:
+        if station_info(a) is None and station_info(b) is None:
+            continue
+        routes.append((a, b))
 
     return routes
 
@@ -517,15 +564,33 @@ def _find_stations_in_text(blob: str) -> List[str]:
     if not tokens:
         return []
 
+    # Drop tokens that can never be part of a station name. The arrow
+    # characters appear in route titles ("A ↔ B"), and including them in
+    # sliding-window chunks let canonical_name silently expand "Hbf ↔"
+    # into "Wien Hauptbahnhof" via the directory's alias-expansion rules.
+    _NOISE_TOKEN_RE = re.compile(r"^[↔→←↗↘↙↖<>=–—\-«»‹›]+$")
+    tokens = [t for t in tokens if not _NOISE_TOKEN_RE.match(t)]
+    if not tokens:
+        return []
+
     found = set()
     window = min(_MAX_STATION_WINDOW, len(tokens))
     for size in range(window, 0, -1):
         for idx in range(len(tokens) - size + 1):
-            chunk = " ".join(tokens[idx : idx + size])
-            # Skip generic single-token aliases ("Hbf", "Bahnhof", …) that
-            # would otherwise spuriously canonicalise to a flagship station.
-            if size == 1 and chunk.casefold().rstrip(".:,;") in _GENERIC_STATION_TOKENS:
-                continue
+            chunk_tokens = tokens[idx : idx + size]
+            chunk = " ".join(chunk_tokens)
+            chunk_alpha = re.sub(r"[^A-Za-zÄÖÜäöüß]", "", chunk)
+            if size == 1:
+                # Skip single-token chunks that are either generic
+                # aliases ("Hbf", "Bahnhof", …) or two-letter
+                # abbreviations like "SG"/"NÖ" — these falsely match
+                # flagship stations through the directory's alias
+                # expansions.
+                token_norm = chunk.casefold().rstrip(".:,;")
+                if token_norm in _GENERIC_STATION_TOKENS:
+                    continue
+                if len(chunk_alpha) < 3:
+                    continue
             canon = canonical_name(chunk)
             if canon:
                 found.add(canon)

--- a/tests/test_oebb_filter_audit.py
+++ b/tests/test_oebb_filter_audit.py
@@ -1,0 +1,175 @@
+"""Regression tests for filter bugs found during the post-merge audit.
+
+Each section describes the exact failure mode that the fix addresses so a
+future regression has a chance to show up under the right test name.
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import (
+    _extract_routes,
+    _find_stations_in_text,
+    _is_relevant,
+)
+from src.feed.merge import _parse_title, deduplicate_fuzzy
+
+
+class TestStPoeltenPeriodTruncation:
+    """Bug B: a bare period in the lookahead truncated abbreviated names.
+
+    "und St. Pölten ist …" used to capture endpoint "St" because the
+    boundary class included ".". The fix accepts a period as a boundary
+    only at the end of the description.
+    """
+
+    def test_st_poelten_kept_intact_before_ist(self) -> None:
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "zwischen Wien Hbf und St. Pölten ist der Verkehr eingestellt.",
+        )
+        assert routes == [("Wien", "St. Pölten")]
+        assert _is_relevant(
+            "Bauarbeiten",
+            "zwischen Wien Hbf und St. Pölten ist der Verkehr eingestellt.",
+        ) is True
+
+    def test_st_poelten_kept_intact_before_gesperrt(self) -> None:
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "Strecke zwischen Wien Hbf und St. Pölten Hbf gesperrt",
+        )
+        assert routes
+        assert routes[0][0] == "Wien"
+        assert routes[0][1].startswith("St. Pölten")
+
+
+class TestRouteBoundaryWords:
+    """Bug C: missing boundary words in the lookahead let the regex
+    extend the second endpoint into surrounding prose."""
+
+    def test_aufgrund_terminates_route(self) -> None:
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "zwischen Wien Hbf und Mödling aufgrund Sturm",
+        )
+        assert routes == [("Wien", "Mödling")]
+
+    def test_wegen_terminates_route(self) -> None:
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "zwischen Wien Hbf und Mödling wegen Bauarbeiten",
+        )
+        assert routes == [("Wien", "Mödling")]
+
+    def test_em_dash_terminates_route(self) -> None:
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "zwischen Wien und Mödling — bitte umsteigen",
+        )
+        assert routes == [("Wien", "Mödling")]
+
+    def test_period_at_end_terminates_route(self) -> None:
+        routes = _extract_routes("Bauarbeiten", "zwischen Wien Hbf und Mödling.")
+        assert routes == [("Wien", "Mödling")]
+
+
+class TestFakeRouteFilter:
+    """Bug D: a regex match between two non-station phrases must not block
+    the single-station fall-through path."""
+
+    def test_aufzug_zwischen_bahnsteig_falls_through_to_station_match(self) -> None:
+        # The "zwischen Bahnsteig 1 und Bahnsteig 5" reads like a route
+        # but actually describes a facility-internal segment. Both
+        # endpoints fail to resolve, so the route is discarded and
+        # the single-station path picks up "Wien Mitte" → relevant.
+        title = "Aufzug Wien Mitte"
+        desc = "Aufzug zwischen Bahnsteig 1 und Bahnsteig 5 in Wien Mitte defekt"
+        assert _extract_routes(title, desc) == []
+        assert _is_relevant(title, desc) is True
+
+    def test_unknown_unknown_route_in_arrow_title_still_drops(self) -> None:
+        # "Innsbruck Hbf ↔ Salzburg Hbf" — both endpoints unknown but
+        # plausibly station-shaped. The candidate is dropped from the
+        # route list, and the single-station path finds nothing in the
+        # directory, so the message is correctly rejected.
+        assert (
+            _is_relevant("Innsbruck Hbf ↔ Salzburg Hbf", "Verspätung.") is False
+        )
+
+    def test_lindau_st_margrethen_sg_dropped(self) -> None:
+        # Both endpoints unknown. Falls through, but the abbreviation
+        # "SG" must NOT alias-match Wien Grillgasse anymore (the
+        # ≥3-alpha-char filter in _find_stations_in_text guards this).
+        assert (
+            _is_relevant(
+                "Lindau (Bodensee) Reutin ↔ ST. MARGRETHEN SG",
+                "Wegen Bauarbeiten der Deutschen Bahn (DB) können zwischen "
+                "Lindau (Bodensee) Reutin Bahnhof und ST. MARGRETHEN SG…",
+            )
+            is False
+        )
+
+
+class TestNoiseTokenFilter:
+    """The arrow character "↔" used to combine with adjacent generic
+    aliases ("Hbf ↔") and silently produce "Wien Hauptbahnhof" through
+    the station directory's expansion rules."""
+
+    def test_arrow_token_does_not_create_phantom_wien_hauptbahnhof(self) -> None:
+        # No real Vienna mention → must return no Wien station.
+        found = _find_stations_in_text("Innsbruck Hbf ↔ Salzburg Hbf Verspätung.")
+        assert "Wien Hauptbahnhof" not in found
+
+    def test_two_letter_abbreviation_does_not_match_short_alias(self) -> None:
+        # "SG" alone used to alias to Wien Grillgasse via the directory.
+        found = _find_stations_in_text("ST. MARGRETHEN SG")
+        assert all(not name.startswith("Wien") for name in found)
+
+
+class TestLinePrefixWithSpace:
+    """Bug A: cross-provider merge silently failed for ÖBB-style line
+    prefixes like "REX 7:" because _LINE_PREFIX_RE didn't allow internal
+    whitespace, so the line-overlap check yielded an empty set."""
+
+    def test_rex_7_with_space_parsed_as_single_line(self) -> None:
+        lines, name = _parse_title("REX 7: Bauarbeiten")
+        assert lines == {"REX7"}
+        assert name == "Bauarbeiten"
+
+    def test_rex_7_and_rex7_normalise_to_same_token(self) -> None:
+        spaced, _ = _parse_title("REX 7: Bauarbeiten Wien Hbf")
+        compact, _ = _parse_title("REX7: Bauarbeiten Wien Hbf")
+        assert spaced == compact == {"REX7"}
+
+    def test_s_50_with_space_parsed(self) -> None:
+        lines, name = _parse_title("S 50: Wien Westbahnhof")
+        assert lines == {"S50"}
+        assert name == "Wien Westbahnhof"
+
+    def test_multi_segment_oebb_lines(self) -> None:
+        lines, _ = _parse_title("REX 7/REX 8: Bauarbeiten")
+        assert lines == {"REX7", "REX8"}
+
+    def test_cross_provider_merge_works_with_space_prefix(self) -> None:
+        # Same incident reported by both providers. ÖBB uses "REX 7:",
+        # VOR uses "REX7:" — without the fix they would not merge.
+        items = [
+            {
+                "guid": "oebb-1",
+                "_identity": "oebb|1",
+                "source": "ÖBB",
+                "title": "REX 7: Bauarbeiten Wien Hauptbahnhof",
+                "description": "Strecke gesperrt",
+            },
+            {
+                "guid": "vor-1",
+                "_identity": "vor|1",
+                "source": "VOR/VAO",
+                "title": "REX7: Bauarbeiten Wien Hauptbahnhof",
+                "description": "Echtzeit Strecke",
+            },
+        ]
+        result = deduplicate_fuzzy(items)
+        assert len(result) == 1
+        # VOR wins as master per provider priority logic.
+        assert result[0]["source"] == "VOR/VAO"


### PR DESCRIPTION
## Summary

Behebt vier weitere Filter-Bugs, die beim Post-Merge-Audit der Filterlogik aufgedeckt wurden:

### Bug A: Cross-Provider-Merge schlug bei ÖBB-Linienpräfixen mit Leerzeichen fehl

`_LINE_PREFIX_RE` in `src/feed/merge.py` akzeptierte nur kontinuierliche Tokens (`U6`, `1/2`, `13A`). ÖBB-Titel im Format `REX 7:` / `S 50:` wurden zu einem leeren Linien-Set geparst — die Fuzzy-Stufe überspringt Items ohne Linien sofort. Folge: derselbe Vorfall lieferte einen ÖBB- und einen VOR-Eintrag im Feed.

Die Grammatik akzeptiert jetzt zusätzlich `<Buchstaben> <Ziffern>`-Tokens, und `_parse_title` strippt internes Whitespace vor dem Vergleich, sodass `REX 7` und `REX7` denselben Token ergeben.

### Bug B: „St. Pölten" wurde auf „St" verstümmelt

`_ZWISCHEN_PLAIN_RE` in `src/providers/oebb.py` nutzte `[,;.!?]` als Boundary-Charclass. Der nackte `.` matchte den Abkürzungspunkt in „St. Pölten" und beendete die Erfassung nach „St". Der Boundary-Punkt wird jetzt nur noch akzeptiert, wenn er die Description abschließt (`\.\s*$`).

### Bug C: Lookahead fehlten gängige Folgewörter

„zwischen Wien Hbf und Mödling aufgrund Sturm" extendierte den zweiten Endpunkt zu „Mödling aufgrund Sturm". Lookahead um `aufgrund`, `wegen`, `infolge`, em-/en-dash, Status-Verben (`gesperrt`, `eingestellt`, `unterbrochen`, …) erweitert.

### Bug D: Fake-Routen blockierten den Single-Station-Fallback

„Aufzug zwischen Bahnsteig 1 und Bahnsteig 5 in Wien Mitte defekt" wurde fälschlich verworfen, weil die Regex `(Bahnsteig 1, Bahnsteig 5 in Wien Mitte defekt)` als „Route" matchte und beide Endpunkte unbekannt waren. Routen mit beiden Endpunkten unbekannt werden jetzt als Fake-Routen verworfen, sodass der Fallback das echte „Wien Mitte" findet.

Zwei Folge-Issues entdeckt und gefixt:
- `canonical_name("Hbf ↔")` expandierte über die Alias-Tabelle zu „Wien Hauptbahnhof". `_find_stations_in_text` strippt jetzt Pfeil-/Strich-Tokens vor dem Chunk-Bau.
- `canonical_name("SG")` aliasierte auf „Wien Grillgasse" über eine 2-Buchstaben-Alias-Regel. Single-Token-Chunks unter 3 alphabetischen Zeichen werden jetzt übersprungen.

## Tests

- 16 neue Tests in `tests/test_oebb_filter_audit.py` — jeder Bug einzeln dokumentiert
- Cross-Provider-Merge-Test belegt: ÖBB+VOR mit „REX 7:" / „REX7:" werden zu einem Item zusammengeführt
- Volle Suite: **1039 passed, 1 skipped** (vorher 1023). Der eine bestehende Fail in `test_feed_lint::test_feed_lint_ok_without_issues` ist unabhängig (Cache-Fixture stale, schlug auch auf `main` schon fehl).
- `mypy --strict src/ tests/` clean
- `ruff check src/ tests/` clean

## Test plan

- [x] `pytest tests/test_oebb_filter_audit.py` — 16/16 passed
- [x] `pytest tests/test_oebb_filtering.py tests/test_oebb_route_filter.py tests/test_oebb_user_examples.py` — alle bestehenden Filter-Tests grün
- [x] `pytest tests/test_fuzzy_merge_stopwords.py` — 4/4 passed
- [x] Volle Suite, mypy, ruff clean (außer pre-existing test_feed_lint)

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_