### PR TITLE
fix(filter): three more bugs (VOR Pendler, Strecke pattern, pubDate camelCase)

### DIFF
--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -390,7 +390,7 @@ def deduplicate_fuzzy(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                         elif desc2:
                             existing_copy["description"] = desc2
 
-                    for date_key in ("pubdate", "pub_date", "updated"):
+                    for date_key in ("pubDate", "pubdate", "pub_date", "updated"):
                         existing_date = existing_copy.get(date_key)
                         item_date = item.get(date_key)
                         if existing_date and item_date:

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -294,6 +294,28 @@ _ZWISCHEN_PLAIN_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
+
+# Alternative route-phrasing some descriptions use instead of "zwischen X und Y":
+# "Strecke X — Y", "Verbindung X-Y", "Linie X bis Y". The hyphen / en-dash /
+# em-dash separator is required to be surrounded by whitespace so we don't
+# split compound station names like "Wien Mitte-Landstraße".
+_STRECKE_PLAIN_RE = re.compile(
+    r"(?:strecke|verbindung|linie|abschnitt)\s+(?P<a>.+?)\s+[-—–]\s+(?P<b>.+?)"
+    r"(?="
+    r"\s+(?:gesperrt|geschlossen|unterbrochen|eingestellt|"
+    r"betroffen|beeintr[äa]chtigt|gest[öo]rt|eingeschr[äa]nkt|"
+    r"auf|au[ßs]er\s+betrieb|nicht|kein|von|bis|am|im|in\s+der|"
+    r"f[üu]r|wegen|aufgrund|durch|infolge|"
+    r"ist|sind|war|waren|wird|werden|kann|k[öo]nnen)\b"
+    r"|[,;!?]"
+    r"|[—–]"
+    r"|<"
+    r"|\.\s*$"
+    r"|\s*$"
+    r")",
+    re.IGNORECASE | re.DOTALL,
+)
+
 # Suffixes that should be stripped before looking up a station name.
 _BAHNHOF_TRAILING_RE = re.compile(
     r"\s*\b(?:Hauptbahnhof|Bahnhof|Bahnhst|Hbf|Bhf|Bf)\b\.?",
@@ -341,10 +363,12 @@ def _looks_like_station_name(text: str) -> bool:
 
 
 def _extract_zwischen_routes(description: str) -> List[Tuple[str, str]]:
-    """Find all 'zwischen X und Y' route mentions in *description*.
+    """Find all route mentions in *description*.
 
-    Returns a list of normalised ``(name_a, name_b)`` tuples. Names are
-    deduplicated regardless of order (so ``A ↔ B`` and ``B ↔ A`` count once).
+    Recognises both the dominant ``zwischen X und Y`` phrasing and the
+    alternative ``Strecke|Verbindung|Linie|Abschnitt X — Y`` form. Returns a
+    list of normalised ``(name_a, name_b)`` tuples, deduplicated regardless
+    of A/B order (so ``A ↔ B`` and ``B ↔ A`` count once).
     """
     if not description:
         return []
@@ -357,18 +381,19 @@ def _extract_zwischen_routes(description: str) -> List[Tuple[str, str]]:
     routes: List[Tuple[str, str]] = []
     seen: set[Tuple[str, str]] = set()
 
-    for match in _ZWISCHEN_PLAIN_RE.finditer(plain):
-        a_norm = _normalize_endpoint_name(match.group("a"))
-        b_norm = _normalize_endpoint_name(match.group("b"))
-        if not _looks_like_station_name(a_norm) or not _looks_like_station_name(b_norm):
-            continue
-        # Deduplicate regardless of A/B order
-        sorted_pair = sorted([a_norm.casefold(), b_norm.casefold()])
-        key: Tuple[str, str] = (sorted_pair[0], sorted_pair[1])
-        if key in seen:
-            continue
-        seen.add(key)
-        routes.append((a_norm, b_norm))
+    for regex in (_ZWISCHEN_PLAIN_RE, _STRECKE_PLAIN_RE):
+        for match in regex.finditer(plain):
+            a_norm = _normalize_endpoint_name(match.group("a"))
+            b_norm = _normalize_endpoint_name(match.group("b"))
+            if not _looks_like_station_name(a_norm) or not _looks_like_station_name(b_norm):
+                continue
+            # Deduplicate regardless of A/B order
+            sorted_pair = sorted([a_norm.casefold(), b_norm.casefold()])
+            key: Tuple[str, str] = (sorted_pair[0], sorted_pair[1])
+            if key in seen:
+                continue
+            seen.add(key)
+            routes.append((a_norm, b_norm))
 
     return routes
 

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -854,7 +854,20 @@ def _collect_from_board(station_id: str, root: Mapping[str, Any]) -> List[FeedIt
     """
     info = station_info(station_id)
     station_name = info.name if info else None
-    is_vienna_station = info.in_vienna if info else False
+    # Stations explicitly chosen for monitoring (Wien Hbf and Pendler nodes
+    # like Flughafen Wien) are inherently relevant — every disruption at
+    # the platform itself matters for Wien-Pendler. Only fall back to the
+    # text-based Wien check for stations that the directory classifies as
+    # neither in Vienna nor as a commuter hub. ``getattr`` keeps the check
+    # defensive against test fixtures that mock ``station_info`` with a
+    # narrower record type.
+    station_is_relevant = bool(
+        info
+        and (
+            getattr(info, "in_vienna", False)
+            or getattr(info, "pendler", False)
+        )
+    )
 
     items: List[FeedItem] = []
     for raw_msg in _iter_messages(root):
@@ -875,8 +888,13 @@ def _collect_from_board(station_id: str, root: Mapping[str, Any]) -> List[FeedIt
             )
             continue
 
-        # FILTER: Bei Pendlerbahnhöfen muss die konkrete Meldung Wien betreffen
-        if not is_vienna_station:
+        # FILTER: For stations not classified as in-Vienna or Pendler the
+        # message must explicitly mention a Wien station — otherwise we
+        # cannot tell whether a disruption at a randomly configured station
+        # affects Wien commuters. Whitelisted Pendler nodes (Flughafen Wien
+        # etc.) bypass this check; their disruptions are already considered
+        # relevant by the project specification.
+        if not station_is_relevant:
             full_text = f"{head} {text}"
             if not text_has_vienna_connection(full_text):
                 continue

--- a/tests/test_filter_audit_round2.py
+++ b/tests/test_filter_audit_round2.py
@@ -1,0 +1,175 @@
+"""Regression tests for the second-round audit (bugs F/G/H).
+
+- F: VOR's text-based Wien check used to drop legitimate Pendler-station
+  messages (Flughafen Wien) because it only short-circuited on
+  ``in_vienna``. Pendler nodes in the whitelist are now treated as
+  inherently relevant.
+- G: ``Strecke|Verbindung|Linie X — Y`` route phrasing was invisible to the
+  route extractor, so Pendler ↔ Pendler descriptions like
+  ``Strecke Mödling - Baden gesperrt`` slipped through the strict-route
+  filter via the single-station fallback.
+- H: ``deduplicate_fuzzy`` iterated date keys ``("pubdate", …)`` in lower
+  case, but the items carry ``pubDate`` (camelCase) — peer merges silently
+  kept the older timestamp.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.feed.merge import deduplicate_fuzzy
+from src.providers.oebb import _extract_routes, _is_relevant
+from src.providers.vor import _collect_from_board
+
+
+# ---------------- Bug F: VOR Pendler-Filter ----------------
+
+class TestVorPendlerFilter:
+    """The VOR provider must keep messages from explicitly chosen Pendler
+    stations even when the message text doesn't carry a Wien token."""
+
+    def _payload_with_message(self, head: str, text: str) -> dict[str, object]:
+        return {
+            "DepartureBoard": {"Departure": []},
+            "warnings": [
+                {
+                    "id": "msg1",
+                    "head": head,
+                    "text": text,
+                    "act": "true",
+                }
+            ],
+        }
+
+    def test_flughafen_wien_facility_message_kept(self) -> None:
+        # Real-world example: an elevator notice at the Pendler hub that
+        # never explicitly names "Wien" — used to be silently dropped.
+        items = _collect_from_board(
+            "430470800",  # Flughafen Wien VOR ID
+            self._payload_with_message(
+                "Aufzug defekt",
+                "Bahnsteig 3 Aufzug außer Betrieb.",
+            ),
+        )
+        assert len(items) == 1
+
+    def test_wien_hauptbahnhof_message_kept(self) -> None:
+        # Sanity: in_vienna stations always pass.
+        items = _collect_from_board(
+            "490134900",  # Wien Hauptbahnhof VOR ID
+            self._payload_with_message(
+                "Bauarbeiten",
+                "Gleis 12 gesperrt von 14:00 bis 18:00.",
+            ),
+        )
+        assert len(items) == 1
+
+    def test_unknown_station_still_requires_wien_text(self) -> None:
+        # Defence in depth: a non-whitelist, non-Pendler station keeps the
+        # text-based filter so a misconfigured VOR_STATION_NAMES entry
+        # cannot flood the feed with off-topic messages.
+        items = _collect_from_board(
+            "999999999",  # Unknown ID — not in directory
+            self._payload_with_message(
+                "Aufzug defekt",
+                "Bahnsteig 3 Aufzug außer Betrieb.",
+            ),
+        )
+        assert len(items) == 0
+
+
+# ---------------- Bug G: Strecke|Verbindung|Linie pattern ----------------
+
+class TestStreckePattern:
+    """``Strecke X — Y gesperrt`` and friends must feed the strict route
+    classifier so Pendler ↔ Pendler descriptions are dropped consistently."""
+
+    def test_strecke_pendler_pendler_dropped(self) -> None:
+        assert _is_relevant("", "Strecke Mödling - Baden gesperrt") is False
+        routes = _extract_routes("", "Strecke Mödling - Baden gesperrt")
+        assert routes == [("Mödling", "Baden")]
+
+    def test_verbindung_pendler_pendler_dropped(self) -> None:
+        assert (
+            _is_relevant("", "Verbindung Mödling - Baden unterbrochen") is False
+        )
+
+    def test_strecke_wien_pendler_kept(self) -> None:
+        assert _is_relevant("", "Strecke Wien Hbf - Mödling gesperrt") is True
+
+    def test_strecke_wien_distant_dropped(self) -> None:
+        assert (
+            _is_relevant("", "Strecke Wien Hbf - München Hbf gesperrt") is False
+        )
+
+    def test_abschnitt_keyword_supported(self) -> None:
+        assert (
+            _is_relevant("", "Abschnitt Wien Hbf - Mödling betroffen") is True
+        )
+
+    def test_hyphen_in_station_name_does_not_split(self) -> None:
+        # Defence in depth: real station names with hyphens
+        # ("Wien Mitte-Landstraße") must NOT be broken into "Wien Mitte"
+        # and "Landstraße" by the new pattern.
+        text = "Wien Mitte-Landstraße ist gesperrt"
+        assert _extract_routes("", text) == []
+        assert _is_relevant("", text) is True
+
+
+# ---------------- Bug H: pubDate case-sensitivity ----------------
+
+class TestPubDateMerge:
+    """Peer merges of two items for the same incident must surface the
+    later pubDate so feed clients see the freshest timestamp."""
+
+    def test_peer_merge_keeps_later_pubdate(self) -> None:
+        items = [
+            {
+                "guid": "wl-1",
+                "_identity": "wl|1",
+                "source": "Wiener Linien",
+                "title": "U6: Signalstörung Spittelau",
+                "description": "Erste Meldung",
+                "pubDate": datetime(2026, 5, 6, 10, 0, tzinfo=timezone.utc),
+            },
+            {
+                "guid": "wl-2",
+                "_identity": "wl|2",
+                "source": "Wiener Linien",
+                "title": "U6: Signalstörung Spittelau",
+                "description": "Spätere Meldung mit Updates",
+                "pubDate": datetime(2026, 5, 6, 11, 0, tzinfo=timezone.utc),
+            },
+        ]
+        result = deduplicate_fuzzy(items)
+        assert len(result) == 1
+        assert result[0]["pubDate"] == datetime(
+            2026, 5, 6, 11, 0, tzinfo=timezone.utc
+        )
+
+    def test_existing_pubdate_kept_when_newer(self) -> None:
+        # The reverse case: incoming item is older — keep the existing
+        # pubDate.
+        items = [
+            {
+                "guid": "wl-a",
+                "_identity": "wl|a",
+                "source": "Wiener Linien",
+                "title": "U6: Signalstörung Spittelau",
+                "description": "Aktuelle Meldung",
+                "pubDate": datetime(2026, 5, 6, 12, 0, tzinfo=timezone.utc),
+            },
+            {
+                "guid": "wl-b",
+                "_identity": "wl|b",
+                "source": "Wiener Linien",
+                "title": "U6: Signalstörung Spittelau",
+                "description": "Frühere Meldung",
+                "pubDate": datetime(2026, 5, 6, 10, 0, tzinfo=timezone.utc),
+            },
+        ]
+        result = deduplicate_fuzzy(items)
+        assert len(result) == 1
+        assert result[0]["pubDate"] == datetime(
+            2026, 5, 6, 12, 0, tzinfo=timezone.utc
+        )


### PR DESCRIPTION
## Summary

Zweiter Audit-Durchgang nach den Bugs A–E. Drei weitere echte Filter-/Merge-Bugs entdeckt und behoben:

### Bug F: VOR-Pendler-Filter dropt Flughafen-Wien-Meldungen

`src/providers/vor.py` nutzte nur `info.in_vienna` als Short-Circuit für den text-basierten Wien-Check. Flughafen Wien ist `pendler=True, in_vienna=False` — alle facility-spezifischen Meldungen ohne expliziten „Wien"-Token (z.B. „Aufzug defekt — Bahnsteig 3 außer Betrieb") wurden gedroppt.

Per Spec sind die in der Whitelist konfigurierten Pendler-Stationen genau die, deren Störungen relevant sind. Der Check akzeptiert jetzt `in_vienna OR pendler`. Nur unkonfigurierte, weder-Wien-noch-Pendler-Stationen brauchen weiterhin einen Wien-Text-Beweis.

### Bug G: „Strecke X — Y gesperrt" wurde nicht erfasst

Die Route-Extraktion kannte nur den dominanten `zwischen X und Y`-Pattern. ÖBB-Beschreibungen verwenden gelegentlich `Strecke|Verbindung|Linie|Abschnitt X — Y` stattdessen. Folge: Pendler-Pendler-Beschreibungen wie „Strecke Mödling - Baden gesperrt" überlebten den Single-Station-Fallback (beide Endpunkte sind valide Pendler).

Neuer `_STRECKE_PLAIN_RE` mit:
- Anchor auf Keyword (`Strecke`, `Verbindung`, `Linie`, `Abschnitt`)
- Whitespace um Hyphen/Em-Dash erforderlich → spaltet keine Stationsnamen mit internem Hyphen (`Wien Mitte-Landstraße`)
- Eigene Lookahead-Liste mit Status-Verben (`gesperrt`, `unterbrochen`, `betroffen`, `beeinträchtigt`, …)

### Bug H: `deduplicate_fuzzy` ignorierte `pubDate` (camelCase)

`src/feed/merge.py` iterierte Date-Keys `("pubdate", "pub_date", "updated")` in lowercase. Alle Provider emittieren das Feld als `pubDate`. Peer-Merges behielten den älteren Zeitstempel — Feed-Clients sahen veraltete „Letzte Aktualisierung". Loop prüft jetzt `pubDate` zuerst.

## Tests

11 neue Regressionstests in `tests/test_filter_audit_round2.py`:

- `TestVorPendlerFilter` (3): Flughafen Wien behält Facility-Meldungen, Wien Hbf weiterhin durchgehend, unbekannte Stationen brauchen weiterhin Wien-Text (Defence-in-Depth)
- `TestStreckePattern` (6): Strecke / Verbindung / Linie / Abschnitt Patterns droppen Pendler-Pendler und Wien-Distant, behalten Wien-Pendler; Stationsnamen mit Hyphen werden nicht gespalten
- `TestPubDateMerge` (2): Peer-Merge surface't den späteren `pubDate`

## Test plan

- [x] `pytest tests/test_filter_audit_round2.py` — 11/11 passed
- [x] Volle Suite: **1050 passed, 1 skipped** (vorher 1039). Pre-existing `test_feed_lint`-Fail (VOR-Cache-Fixture stale) bleibt unverändert.
- [x] `mypy --strict src/ tests/` clean
- [x] `ruff check src/ tests/` clean

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_