### PR TITLE
fix(oebb): treat 'über'/'via' as route-endpoint boundaries

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -283,7 +283,10 @@ _ZWISCHEN_PLAIN_RE = re.compile(
     r"unterbrochen|gestört|gestoert|ausgefallen|verspätet|verspaetet|"
     r"verz[öo]gert|aufgehoben|freigegeben|"
     # Connectors that introduce a side clause
-    r"sowie|sondern|sowie\s+zwischen"
+    r"sowie|sondern|sowie\s+zwischen|"
+    # Intermediate-via marker — ends the captured endpoint at the via stop
+    # so "Mödling über Wiener Neudorf" yields b="Mödling".
+    r"[üu]ber|via"
     r")\b"
     r"|[,;!?]"  # Plain sentence punctuation (period excluded — see above)
     r"|[—–]"  # German em-/en-dash often introduces a side remark

--- a/tests/test_filter_audit_round2.py
+++ b/tests/test_filter_audit_round2.py
@@ -116,6 +116,49 @@ class TestStreckePattern:
         assert _is_relevant("", text) is True
 
 
+class TestUeberViaBoundary:
+    """Bug I: ``zwischen X und Y über Z`` extended Y into "Y über Z" because
+    the via marker was not in the lookahead. The actual disrupted route is
+    X↔Y; Z is just the intermediate stop on the line."""
+
+    def test_ueber_terminates_route_endpoint(self) -> None:
+        routes = _extract_routes(
+            "",
+            "Bauarbeiten zwischen Wien Hbf und Mödling über Wiener Neudorf",
+        )
+        assert routes == [("Wien", "Mödling")]
+
+    def test_ueber_keeps_wien_pendler_relevant(self) -> None:
+        # Without the fix this returned False because endpoint b was
+        # "Mödling über Wiener Neudorf", which fails station_info lookup.
+        assert (
+            _is_relevant(
+                "",
+                "Bauarbeiten zwischen Wien Hbf und Mödling über Wiener Neudorf",
+            )
+            is True
+        )
+
+    def test_ueber_still_drops_wien_distant(self) -> None:
+        # End-to-end: Wien-Salzburg via St. Pölten is still rejected as
+        # Wien-Distant — extracting the right Y just exposes the strict
+        # classification rule.
+        assert (
+            _is_relevant(
+                "",
+                "Bauarbeiten zwischen Wien Hbf und Salzburg über St. Pölten",
+            )
+            is False
+        )
+
+    def test_via_english_terminator_works(self) -> None:
+        routes = _extract_routes(
+            "",
+            "Bauarbeiten zwischen Wien Hbf und Mödling via Wiener Neudorf",
+        )
+        assert routes == [("Wien", "Mödling")]
+
+
 # ---------------- Bug H: pubDate case-sensitivity ----------------
 
 class TestPubDateMerge:


### PR DESCRIPTION
## Summary

Dritter Audit-Durchgang nach Bugs A–H. Ein zusätzlicher echter Bug entdeckt:

### Bug I: `über`/`via` (Wegpunkt) verschluckte den End-Endpunkt

`Bauarbeiten zwischen Wien Hbf und Mödling über Wiener Neudorf`
- Ohne Fix: extrahiertes Endpoint-Paar `("Wien", "Mödling über Wiener Neudorf")`
- `station_info("Mödling über Wiener Neudorf")` = None → Wien-Pendler-Route wird **fälschlich verworfen**

`über`/`via` markieren in ÖBB-Beschreibungen den Zwischenstopp auf der Linie. Die eigentliche Verbindung ist `X ↔ Y`; der via-Stopp ist nur Routing-Detail. Mit `[üu]ber|via` im Lookahead endet die Endpoint-Erfassung am via-Marker und die echte Strecke (Wien Hbf, Mödling) kommt sauber raus.

**Wichtige Sicherheitsprüfung:** Wien-Distant-Routen mit via (`Wien Hbf und Salzburg über St. Pölten`) werden weiterhin korrekt verworfen — der Fix legt nur den richtigen Endpunkt frei, die strenge Klassifizierungsregel rejected dann wie zuvor.

### Was beim Audit GEPRÜFT, aber NICHT als Bug bestätigt wurde

| Beobachtung | Bewertung |
|---|---|
| Multi-↔-Title (3+ Stationen) erzeugt redundantes „A ↔ B / B ↔ C" | Kosmetisch, kein Bug |
| HTML mit verschachtelten Tags `<b><i>X</i></b>` | Funktioniert (HTML wird gestrippt) |
| HTML-Entities in Stationsnamen (`M&ouml;dling`) | Funktioniert (entities werden dekodiert) |
| `&nbsp;` als Trenner | Funktioniert |
| Empty/None inputs | Korrekt False |
| Title-Pfeile `→`, `—`, `>>`, `->`, `-` | Funktioniert dank `_clean_title_keep_places`-Normalisierung |
| Identity-Wechsel zwischen Runs nach Cross-Provider-Merge | Bekanntes Designverhalten, kein neuer Bug |
| Baustellen-Provider | Eigener Pfad, keine Filter-Interaktion |

## Tests

4 neue Regressionstests in `tests/test_filter_audit_round2.py::TestUeberViaBoundary`:
- `über` terminiert Endpunkt korrekt
- Wien-Pendler-Route bleibt mit `über` erhalten
- Wien-Distant-Route mit `über` wird trotzdem verworfen
- `via` (Englisch) funktioniert ebenso

## Test plan

- [x] `pytest tests/test_filter_audit_round2.py` — 15/15 passed
- [x] Volle Suite: **1050 passed, 1 skipped** (pre-existing test_feed_lint Fail unverändert)
- [x] `mypy --strict src/ tests/` clean
- [x] `ruff check src/ tests/` clean

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_