### PR TITLE
fix(oebb): plug Payerbach-Mürzzuschlag leak (bugs J + K)

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -406,11 +406,15 @@ def _extract_routes(title: str, description: str) -> List[Tuple[str, str]]:
 
     Pure category words like "Bauarbeiten ↔ Umleitung" are filtered out so
     they don't drag a real station-mention message into the strict-route path
-    incorrectly. Likewise "fake routes" where both endpoints fail to resolve
-    against the station directory (e.g. "Aufzug zwischen Bahnsteig 1 und
-    Bahnsteig 5 in Wien Mitte defekt") are dropped — they describe internal
-    layout, not transit connections, and would otherwise mask the real
-    Wien-Mitte station mention from the fall-through filter.
+    incorrectly. Likewise candidates whose endpoints are obviously
+    non-station references (``Bahnsteig 1`` / ``Bahnsteig 5``, ``Gleis 3``,
+    ``Aufzug``-etc.) are discarded so the single-station fall-through can
+    pick up the real station mention.
+
+    Real distant routes between two unknown stations (e.g. ``Mürzzuschlag
+    ↔ Payerbach-Reichenau``) are *kept* — they look like real station
+    names, and the strict route classifier in :func:`_route_is_wien_relevant`
+    is then responsible for rejecting them.
     """
     candidates: List[Tuple[str, str]] = []
     seen: set[Tuple[str, str]] = set()
@@ -443,13 +447,13 @@ def _extract_routes(title: str, description: str) -> List[Tuple[str, str]]:
         seen.add(desc_key)
         candidates.append((raw_a, raw_b))
 
-    # 3. Drop candidates where both endpoints are unresolvable. These are
-    #    almost always false positives from regex over-extraction (platform
-    #    numbers, generic phrases) — keeping them would force the strict
-    #    route path to reject otherwise-relevant single-station messages.
+    # 3. Drop candidates that describe a station-internal element rather
+    #    than a transit connection. This is what allows "Aufzug zwischen
+    #    Bahnsteig 1 und Bahnsteig 5 in Wien Mitte defekt" to fall through
+    #    to the single-station path and pick up the Wien-Mitte mention.
     routes: List[Tuple[str, str]] = []
     for a, b in candidates:
-        if station_info(a) is None and station_info(b) is None:
+        if _looks_like_facility_endpoint(a) or _looks_like_facility_endpoint(b):
             continue
         routes.append((a, b))
 
@@ -579,7 +583,49 @@ _GENERIC_STATION_TOKENS = frozenset({
     "nordbahnhof",
     "nordbf",
     "station",
+    # German preposition that aliases to "Wien Hauptbahnhof" via several
+    # "(VOR)"-suffixed entries in stations.json. Without skipping it, words
+    # like "vor Reiseantritt" inside an ÖBB description silently classify
+    # the message as Wien-relevant.
+    "vor",
 })
+
+
+# Endpoint candidates whose first word matches one of these never describe
+# a real transit connection — they're typical inside-station references
+# ("Bahnsteig 1 und Bahnsteig 5", "Gleis 3 und Gleis 7"). Routes built from
+# such candidates are dropped so the message can fall through to the
+# single-station path and pick up the real station mention.
+_NON_STATION_FIRST_WORDS = frozenset({
+    "bahnsteig",
+    "gleis",
+    "steig",
+    "wagen",
+    "waggon",
+    "abteil",
+    "ausgang",
+    "eingang",
+    "tor",
+    "tür",
+    "tuer",
+    "sektor",
+    "zone",
+    "halle",
+    "platz",
+    "lift",
+    "aufzug",
+    "rolltreppe",
+    "fahrtreppe",
+})
+
+
+def _looks_like_facility_endpoint(name: str) -> bool:
+    """Return True if *name* describes a non-station element (platform,
+    track, exit, …) rather than a transit station."""
+    if not name:
+        return False
+    first = name.strip().split(maxsplit=1)[0].casefold().rstrip(".:,;")
+    return first in _NON_STATION_FIRST_WORDS
 
 
 def _find_stations_in_text(blob: str) -> List[str]:

--- a/tests/test_payerbach_leak.py
+++ b/tests/test_payerbach_leak.py
@@ -10,11 +10,14 @@ on the Pendler whitelist) and must NOT appear in the feed.
 
 Two bugs combined to let the first variant slip through:
 
-J. ``canonical_name("vor")`` returned ``Wien Hauptbahnhof`` because several
-   ``Hbf (VOR)``-style aliases in stations.json normalize down to a key
-   of just ``"vor"``. The German preposition ``vor`` (e.g. "vor
-   Reiseantritt") in a description then aliased to a flagship Wien
-   station and tripped the single-station fall-through path.
+J. ``canonical_name("vor")`` returned ``Wien Hauptbahnhof`` because
+   ``Hbf (VOR)``-style aliases in stations.json normalised down to a
+   single ``"vor"`` key. The German preposition ``vor`` (e.g. "vor
+   Reiseantritt") therefore aliased to a flagship Wien station and
+   tripped the single-station fall-through path. The directory side has
+   since been cleaned up upstream, but ``vor`` is still on the
+   single-token skip list as defence in depth in case the alias
+   re-enters via a future regeneration run.
 
 K. The previous Bug-D fix discarded a route candidate whenever both
    endpoints failed station_info lookup. The ``Aufzug zwischen Bahnsteig
@@ -38,7 +41,6 @@ from src.providers.oebb import (
     _is_relevant,
     _looks_like_facility_endpoint,
 )
-from src.utils.stations import canonical_name
 
 
 class TestVorAliasFalsePositive:
@@ -125,9 +127,9 @@ class TestFacilityHeuristic:
         assert not _looks_like_facility_endpoint("Mürzzuschlag")
         assert not _looks_like_facility_endpoint("Payerbach-Reichenau an der Rax")
 
-    def test_canonical_name_for_vor_token_still_returns_wien(self) -> None:
-        # Documents the upstream directory state — the fix is the
-        # single-token skip in _find_stations_in_text, NOT removing the
-        # alias. If a future stations.json cleanup removes the alias the
-        # test here can be updated; until then we lock the behaviour in.
-        assert canonical_name("vor") == "Wien Hauptbahnhof"
+    def test_vor_token_skipped_by_find_stations(self) -> None:
+        # Defence in depth: even if a future stations.json regeneration
+        # re-introduces an "Hbf (VOR)" alias that normalises to "vor",
+        # _find_stations_in_text must NOT surface a Wien station for the
+        # bare preposition "vor".
+        assert _find_stations_in_text("Wir empfehlen, sich vor der Reise zu informieren.") == []

--- a/tests/test_payerbach_leak.py
+++ b/tests/test_payerbach_leak.py
@@ -1,0 +1,133 @@
+"""Regression tests for the user-reported Payerbach-Mürzzuschlag leak.
+
+The live ÖBB cache contained:
+
+    Bauarbeiten: Mürzzuschlag Payerbach-Reichenau an der Rax
+    Bauarbeiten: Payerbach-Reichenau an der Rax Mürzzuschlag
+
+Both describe a Distant ↔ Distant route (neither station is in Vienna or
+on the Pendler whitelist) and must NOT appear in the feed.
+
+Two bugs combined to let the first variant slip through:
+
+J. ``canonical_name("vor")`` returned ``Wien Hauptbahnhof`` because several
+   ``Hbf (VOR)``-style aliases in stations.json normalize down to a key
+   of just ``"vor"``. The German preposition ``vor`` (e.g. "vor
+   Reiseantritt") in a description then aliased to a flagship Wien
+   station and tripped the single-station fall-through path.
+
+K. The previous Bug-D fix discarded a route candidate whenever both
+   endpoints failed station_info lookup. The ``Aufzug zwischen Bahnsteig
+   1 und Bahnsteig 5 in Wien Mitte`` case really is a fake route, but a
+   real Distant ↔ Distant connection like ``Mürzzuschlag ↔
+   Payerbach-Reichenau`` is also "both unknown" — and dropping it
+   forced the message into the fall-through path where bug J kicked in.
+
+The fix replaces the both-unknown heuristic with a more precise
+"non-station first word" check (``Bahnsteig``, ``Gleis``, ``Wagen``,
+``Aufzug``, …) so real distant routes stay in the route list and get
+rejected by the strict classifier, while facility-internal references
+still fall through.
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import (
+    _extract_routes,
+    _find_stations_in_text,
+    _is_relevant,
+    _looks_like_facility_endpoint,
+)
+from src.utils.stations import canonical_name
+
+
+class TestVorAliasFalsePositive:
+    """Bug J: the German preposition 'vor' must not alias-match a Wien
+    station via the directory's '(VOR)'-suffixed aliases."""
+
+    def test_vor_token_not_in_find_stations(self) -> None:
+        # Standalone 'vor' inside a real ÖBB sentence used to surface
+        # 'Wien Hauptbahnhof'.
+        text = (
+            "Wir empfehlen Reisenden, sich vor Reiseantritt mit dem "
+            "Kundenservice in Verbindung zu setzen."
+        )
+        assert "Wien Hauptbahnhof" not in _find_stations_in_text(text)
+
+    def test_vor_in_non_route_message_does_not_force_relevance(self) -> None:
+        # Distant-only message that contains the German preposition 'vor'
+        # — the message must stay rejected.
+        title = "Bauarbeiten: Mürzzuschlag Payerbach-Reichenau"
+        desc = (
+            "Wegen Bauarbeiten zwischen Mürzzuschlag Bahnhof und "
+            "Payerbach-Reichenau Bahnhof. Wir empfehlen Reisenden, sich "
+            "vor Reiseantritt mit dem Kundenservice in Verbindung zu "
+            "setzen."
+        )
+        assert _is_relevant(title, desc) is False
+
+
+class TestDistantRouteRejection:
+    """Bug K: real Distant ↔ Distant routes must be rejected by the
+    strict route classifier rather than slipping into the fall-through."""
+
+    def test_muerzzuschlag_payerbach_rejected(self) -> None:
+        title = "Bauarbeiten: Payerbach-Reichenau an der Rax Mürzzuschlag"
+        desc = (
+            "Wegen Bauarbeiten können zwischen Payerbach-Reichenau an "
+            "der Rax Bahnhof und Mürzzuschlag Bahnhof von 04.10.2026 "
+            "(01:00 Uhr) bis 29.11.2026 (05:00 Uhr) einige "
+            "Nahverkehrszüge nicht fahren."
+        )
+        # Route is recognised — it just isn't Wien-relevant.
+        routes = _extract_routes(title, desc)
+        assert routes
+        assert _is_relevant(title, desc) is False
+
+    def test_muerzzuschlag_payerbach_full_payload_rejected(self) -> None:
+        # The exact failing description from the live ÖBB cache.
+        title = "Bauarbeiten: Mürzzuschlag Payerbach-Reichenau an der Rax"
+        desc = (
+            "04.10.2026 - 29.11.2026<br/><br/>Wegen Bauarbeiten können<br>"
+            "zwischen <b>Mürzzuschlag Bahnhof</b> und "
+            "<b>Payerbach-Reichenau an der Rax Bahnhof</b><br>am "
+            "<span><b>04.10.2026</b> (01:00 Uhr - 05:00 Uhr),<br>am "
+            "<b>08.11.2026</b> (01:00 Uhr - 05:00 Uhr) und<br>am "
+            "<b>29.11.2026</b> (01:00 Uhr - 05:00 Uhr)</span> einige "
+            "Nahverkehrszüge nicht fahren. Wir empfehlen Reisenden, sich "
+            "vor Reiseantritt mit dem Kundenservice in Verbindung zu "
+            "setzen."
+        )
+        assert _is_relevant(title, desc) is False
+
+
+class TestFacilityHeuristic:
+    """The replacement for the both-unknown filter must keep working for
+    fake routes (platform/track references) while letting real station
+    routes through to the strict classifier."""
+
+    def test_aufzug_between_platforms_drops_route_candidate(self) -> None:
+        # Bug D regression: the message must still pick up Wien Mitte
+        # via the single-station fall-through.
+        title = "Aufzug Wien Mitte"
+        desc = "Aufzug zwischen Bahnsteig 1 und Bahnsteig 5 in Wien Mitte defekt"
+        assert _extract_routes(title, desc) == []
+        assert _is_relevant(title, desc) is True
+
+    def test_facility_endpoint_detection(self) -> None:
+        # Single-word and "<word> <number>" forms both classify as facility.
+        assert _looks_like_facility_endpoint("Bahnsteig 5")
+        assert _looks_like_facility_endpoint("Gleis 12")
+        assert _looks_like_facility_endpoint("Aufzug")
+        assert _looks_like_facility_endpoint("Wagen 3")
+        # Real station-shaped names must NOT trip the heuristic.
+        assert not _looks_like_facility_endpoint("Wien Mitte")
+        assert not _looks_like_facility_endpoint("Mürzzuschlag")
+        assert not _looks_like_facility_endpoint("Payerbach-Reichenau an der Rax")
+
+    def test_canonical_name_for_vor_token_still_returns_wien(self) -> None:
+        # Documents the upstream directory state — the fix is the
+        # single-token skip in _find_stations_in_text, NOT removing the
+        # alias. If a future stations.json cleanup removes the alias the
+        # test here can be updated; until then we lock the behaviour in.
+        assert canonical_name("vor") == "Wien Hauptbahnhof"


### PR DESCRIPTION
## Summary

User-reported Leak: zwei Mürzzuschlag-Payerbach-Reichenau-Einträge im Live-Feed (Distant ↔ Distant-Route, gehört nicht rein). Zwei kombinierte Bugs identifiziert und gefixt:

### Bug J: `canonical_name("vor")` aliasiert zu „Wien Hauptbahnhof"

`stations.json` hat zahlreiche `Hbf (VOR)`-Aliase für Wien Hauptbahnhof. Nach Token-Normalisierung kollabieren mehrere zu einem Schlüssel `"vor"`. Die deutsche Präposition „vor" (z.B. in „vor Reiseantritt") matchte daher fälschlich auf Wien Hauptbahnhof — `_find_stations_in_text` lieferte einen False-Positive für jede ÖBB-Description mit dem Wort.

**Fix:** `"vor"` in die `_GENERIC_STATION_TOKENS`-Skip-Liste aufgenommen. Single-Token-Chunks `"vor"` werden im Sliding-Window nicht mehr canonisiert.

### Bug K: Both-unknown-Filter verwarf echte Distant ↔ Distant-Routen

Mein früherer Bug-D-Fix verwarf Routen-Kandidaten sobald beide Endpunkte ungelöst waren. Das war für Fake-Routen wie „Bahnsteig 1 ↔ Bahnsteig 5" sinnvoll — aber für **echte** Distant ↔ Distant-Verbindungen wie Mürzzuschlag ↔ Payerbach-Reichenau ebenfalls. Der strikte Routen-Classifier sah die Route nie, die Nachricht fiel in den Single-Station-Pfad und Bug J kippte sie auf „relevant".

**Fix:** Heuristik präziser gemacht. Ein Kandidat wird nur verworfen, wenn mindestens ein Endpunkt mit einem Non-Station-Wort (`Bahnsteig`, `Gleis`, `Wagen`, `Aufzug`, …) anfängt. Echte Distant-Routen bleiben in der Routenliste und werden vom strict classifier korrekt verworfen.

### User-Beispiele (Live-Feed Cache)

| Item | Vorher | Nachher |
|---|---|---|
| `Bauarbeiten: Mürzzuschlag Payerbach-Reichenau an der Rax` | im Feed | ✓ gefiltert |
| `Bauarbeiten: Payerbach-Reichenau an der Rax Mürzzuschlag` | im Feed | ✓ gefiltert |

## Tests

7 neue Regressionstests in `tests/test_payerbach_leak.py`:

- **TestVorAliasFalsePositive** (2): `"vor"` löst nicht mehr Wien Hauptbahnhof aus, Distant-Description mit „vor Reiseantritt" wird abgewiesen
- **TestDistantRouteRejection** (2): Mürzzuschlag-Payerbach in beiden Varianten + die exakte Cache-Payload werden abgewiesen
- **TestFacilityHeuristic** (3): Bug-D-Regression bleibt grün, Facility-Klassifikation erkennt Bahnsteig/Gleis/Aufzug, station-shaped Namen werden nicht fälschlich als Facility eingestuft

## Test plan

- [x] `pytest tests/test_payerbach_leak.py` — 7/7 passed
- [x] Volle Suite: **1061 passed, 1 skipped** (pre-existing test_feed_lint Fail unverändert)
- [x] `mypy --strict src/ tests/` clean
- [x] `ruff check src/ tests/` clean

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_