### PR TITLE
fix(oebb): drop messages that mention Wien together with a distant station

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -505,10 +505,19 @@ def _is_relevant(title: str, description: str) -> bool:
        message describes routes but none of them is Wien-relevant (e.g.
        Pendler ↔ Pendler, Wien ↔ Distant, or unknown endpoints), the message
        is dropped.
-    2. **Single-station / general messages** – if no route can be parsed, the
-       message must mention at least one Vienna or Pendler station. If only
-       distant stations are mentioned, drop. Otherwise fall back to the
-       generic Vienna-text heuristic for U-Bahn references.
+    2. **Single-station / general messages** – if no explicit route can be
+       parsed:
+
+       a. When at least one *known* distant station (in stations.json with
+          ``in_vienna=False`` and ``pendler=False``) is mentioned alongside
+          relevant stations, the message almost always describes a
+          Wien↔Distant or Pendler↔Distant route — drop it. Standalone
+          "Aufzug defekt am Wien Hbf" messages never drag in München names,
+          so this rule is safe in practice.
+       b. Otherwise, the message must mention at least one Vienna or
+          Pendler station. If only distant stations are mentioned, drop.
+       c. As a final fall-back, use the generic Vienna-text heuristic for
+          U-Bahn references and the like.
     """
     routes = _extract_routes(title, description)
 
@@ -533,10 +542,15 @@ def _is_relevant(title: str, description: str) -> bool:
         else:
             has_distant = True
 
-    if has_relevant:
-        return True
+    # Step 2a: a known-distant station mention together with anything else
+    # almost always implies a route into the distant station. Wien↔Distant,
+    # Pendler↔Distant and Distant↔Distant routes are all not relevant per
+    # spec, so drop the message even when a Wien station is co-mentioned.
     if has_distant:
         return False
+
+    if has_relevant:
+        return True
 
     # OEBB_ONLY_VIENNA narrows the fallback to text-detected Vienna references.
     if OEBB_ONLY_VIENNA:

--- a/tests/test_filter_audit_round4.py
+++ b/tests/test_filter_audit_round4.py
@@ -1,0 +1,80 @@
+"""Audit-Round-4 regression tests.
+
+Bug L: a Wien station mentioned alongside a known-distant station in the
+single-station fall-through used to KEEP the message even though the
+described route is almost certainly Wien↔Distant. The user reported
+
+    Bauarbeiten: Wien/München Roma Termini
+    Wegen Bauarbeiten werden … die NJ-Züge … via Salzburg/Kufstein … umgeleitet
+
+as an obvious leak: the actual disrupted route is Wien↔Rom, not a
+Wien-internal or Wien↔Pendler trip.
+
+The fix: in the single-station path, drop any message that mentions a
+known-distant station (``in_vienna=False`` and ``pendler=False`` in
+stations.json) — even if a Wien station is co-mentioned. Standalone Wien
+disruptions don't drag in München / Roma names; route-style messages
+do.
+
+Two further audit findings are *data* issues that this PR cannot fix in
+code:
+
+- **Bug M**: many real Wien commuter stations (Felixdorf, Traiskirchen
+  Aspangbahn, Gramatneusiedl, Götzendorf, Bruck/Leitha, Semmering,
+  Payerbach-Reichenau, Krems, Eisenstadt, Pamhagen, …) are absent from
+  ``data/stations.json``. Wien↔<missing-Pendler> routes are therefore
+  misclassified as Wien↔Unknown and dropped — a false negative the
+  filter cannot recover from without directory updates.
+
+- **Bug N**: when a title carries multiple proper-noun-shaped tokens but
+  only one resolves (because the others are missing from the directory,
+  see bug M), the single-station path keeps the message. Example:
+  ``Bauarbeiten: Wiener Neustadt Hauptbahnhof Semmering`` with no
+  zwischen pattern in the description — a Pendler↔Distant Fernverkehr
+  route stays in the feed because Semmering is unknown to the directory.
+  Resolving this generally requires more data (Bug M) or a stricter
+  text-based heuristic that risks false positives for legitimate
+  Pendler-only messages.
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import _is_relevant
+
+
+class TestSingleStationDropsOnDistant:
+    """Bug L: a known-distant mention next to a Wien mention drops."""
+
+    def test_wien_muenchen_rome_dropped(self) -> None:
+        # Exact failing payload from the live cache.
+        title = "Bauarbeiten: Wien/München Roma Termini"
+        desc = (
+            "Wegen Bauarbeiten werden von 22.08.2026 bis 20.09.2026 die "
+            "NJ-Züge 40233 und 40294 über Salzburg/Kufstein und die "
+            "NJ-Züge 294 und 295 über Brennero/Brenner umgeleitet."
+        )
+        assert _is_relevant(title, desc) is False
+
+    def test_wien_only_message_still_kept(self) -> None:
+        # Sanity: a real Wien-only facility notice must keep working.
+        title = "Aufzug defekt: Wien Hauptbahnhof"
+        desc = "Aufzug am Bahnsteig 12 außer Betrieb."
+        assert _is_relevant(title, desc) is True
+
+    def test_wien_pendler_mention_kept(self) -> None:
+        # Sanity: Wien + Pendler mentions (no distant) stay relevant.
+        title = "Verspätungen Wien Hauptbahnhof Mödling"
+        desc = "Wegen Sturm Verspätungen im Raum Wien und Mödling."
+        assert _is_relevant(title, desc) is True
+
+    def test_pendler_with_distant_dropped(self) -> None:
+        # Pendler + Distant mentions imply Pendler↔Distant route → drop.
+        title = "Sturm Mödling München"
+        desc = "Wegen Sturm einige Verspätungen."
+        assert _is_relevant(title, desc) is False
+
+    def test_distant_only_dropped(self) -> None:
+        # Sanity: a distant-only message stays rejected.
+        title = "Bauarbeiten München Hbf"
+        desc = "Im Raum München Verspätungen."
+        assert _is_relevant(title, desc) is False


### PR DESCRIPTION
## Summary

Audit-Runde 4: Live-Cache komplett gegen Filter klassifiziert. Ein Code-Bug + zwei Data-Issues identifiziert.

### Bug L (CODE — gefixt): Wien + Distant Mention durchgelassen

Live-Cache-Item: `Bauarbeiten: Wien/München Roma Termini` mit Description „NJ-Züge umgeleitet via Salzburg/Kufstein und Brennero/Brenner".

- Beschreibt Wien↔Rom (Wien↔Distant)
- Keine `zwischen X und Y`-Pattern → Single-Station-Fallback
- Bare „Wien" Mention reicht aktuell aus → KEEP (falsch)

**Fix:** Im Single-Station-Fallback wird die Nachricht verworfen, sobald **eine** im Verzeichnis bekannte Distant-Station genannt wird — auch wenn Wien co-erwähnt ist. Echte Wien-interne Facility-Meldungen ziehen niemals München/Roma-Namen herein, daher in der Praxis sicher.

### Bug M (DATA — dokumentiert): Pendlerstationen fehlen im Verzeichnis

`data/stations.json` fehlen viele klassische Wien-Pendler-Stationen:

```
Felixdorf, Traiskirchen Aspangbahn, Gramatneusiedl, Götzendorf,
Bruck/Leitha, Semmering, Payerbach-Reichenau, Krems, Eisenstadt, Pamhagen
```

Folge: Wien↔Felixdorf wird als Wien↔Unknown klassifiziert → falsch DROP. Das ist ein Data-Issue, kein Code-Issue — der Filter kann das ohne Verzeichnis-Update nicht reparieren.

### Bug N (CODE-LIMITATION — dokumentiert): Pendler+Distant ohne `zwischen`

`Bauarbeiten: Wiener Neustadt Hauptbahnhof Semmering` (Pendler + Distant). Description ohne `zwischen`-Pattern. Single-Station findet nur Wiener Neustadt (Pendler), Semmering ist unbekannt → KEEP. Korrekt wäre DROP (Pendler↔Distant).

Lösung primär via Bug M (Semmering ins Verzeichnis), oder strengere Heuristik die false-positives bei legitim Pendler-only-Meldungen riskiert.

### Live-Cache nach Fix

| Item | Vorher | Nachher |
|---|---|---|
| `Wien/München Roma Termini` | KEEP ⚠️ | ✓ DROP |
| `Wien Hbf ↔ Felixdorf` | DROP ⚠️ (Bug M) | DROP |
| `Wiener Neustadt Hauptbahnhof Semmering` | KEEP ⚠️ (Bug N) | KEEP |

## Tests

5 neue Regressionstests in `tests/test_filter_audit_round4.py`:
- Failing-Payload-Test (Wien/München Roma Termini → DROP)
- Wien-only Facility-Notice → KEEP (Sanity)
- Wien + Pendler Mention → KEEP (Sanity)
- Pendler + Distant → DROP
- Distant-only → DROP

## Test plan

- [x] `pytest tests/test_filter_audit_round4.py` — 5/5 passed
- [x] Volle Suite: **1066 passed, 1 skipped** (pre-existing test_feed_lint Fail unverändert)
- [x] `mypy --strict` clean
- [x] `ruff check` clean

## Empfehlung für Bug M / N

Folge-Issue: `data/pendler_bst_ids.json` und `data/stations.json` mit klassischen Wien-Pendler-Stationen erweitern, insbesondere die Aspangbahn, R95, Semmeringbahn und Marchegger-Strecke.

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_