### PR TITLE
fix(oebb): drop facility-only and weather-only messages

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -87,6 +87,57 @@ MULTI_ARROW_RE  = re.compile(r"(?:\s*↔\s*){2,}")
 _MULTI_SLASH_RE = re.compile(r"\s*/{2,}\s*")
 _MULTI_COMMA_RE = re.compile(r"\s*,{2,}\s*")
 
+# Topics the user explicitly excludes from the feed: facility-only
+# notices (broken elevators, escalators) and standalone weather warnings.
+# A message is treated as such when its title carries one of these
+# keywords AND none of the "real" transit-disruption keywords below.
+_FACILITY_KEYWORD_RE = re.compile(
+    r"\b(aufzug|aufzüge|aufzuege|aufzugsinfo|lift|fahrstuhl|fahrtreppe|"
+    r"fahrtreppen|fahrtreppeninfo|rolltreppe|rolltreppen)\b",
+    re.IGNORECASE,
+)
+_WEATHER_KEYWORD_RE = re.compile(
+    r"\b(sturm|sturmwarnung|unwetter|gewitter|hochwasser|wetter|wetterlage|"
+    r"glatteis|schneefall|schneefälle|murenabgang|lawinengefahr)\b",
+    re.IGNORECASE,
+)
+_TRANSIT_KEYWORD_RE = re.compile(
+    r"\b(bauarbeiten|störung|stoerung|verspätung|verspaetung|sperre|sperrung|"
+    r"umleitung|ersatzverkehr|haltausfall|zugausfall|streckenunterbrechung|"
+    r"unterbrechung|teilausfall|baustelle|baustellen|gleisbauarbeiten|"
+    r"schienenersatzverkehr|sev|fahrplanänderung|fahrplanaenderung|"
+    r"verkehrseinschränkung|verkehrseinschraenkung|einschränkung|einschraenkung)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_facility_or_weather_only(title: str, description: str) -> bool:
+    """Decide whether the message's primary topic is facility/weather.
+
+    Per project spec elevator/escalator notices and standalone weather
+    warnings have nothing to do in the Wien-ÖPNV feed — they don't
+    describe a transit disruption that affects Wiener or Pendler-to-Wien
+    travellers. The heuristic flags those messages so the caller can
+    drop them before the relevance check.
+
+    A message is considered facility/weather-only when its title carries
+    one of the facility/weather keywords above AND no real
+    disruption keyword (Bauarbeiten, Störung, Verspätung, …). Mixed
+    messages like "Bauarbeiten zwischen Wien und Mödling — auch Aufzug
+    betroffen" therefore pass through and are evaluated normally.
+    """
+    if not title:
+        return False
+    title_low = title.lower()
+    has_facility = bool(_FACILITY_KEYWORD_RE.search(title_low))
+    has_weather = bool(_WEATHER_KEYWORD_RE.search(title_low))
+    if not (has_facility or has_weather):
+        return False
+    if _TRANSIT_KEYWORD_RE.search(title_low):
+        return False
+    return True
+
+
 NON_LOCATION_PREFIXES = {
     "bauarbeiten", "störung", "störungen", "ausfall", "ausfälle", "verspätung", "verspätungen", "sperre",
     "einschränkung", "verkehrsunfall", "feuerwehreinsatz", "rettungseinsatz",
@@ -756,7 +807,16 @@ def _is_relevant(title: str, description: str) -> bool:
           Pendler station. If only distant stations are mentioned, drop.
        c. As a final fall-back, use the generic Vienna-text heuristic for
           U-Bahn references and the like.
+
+    Before any of the above runs, messages whose primary topic is a
+    broken facility (Aufzug, Lift, Fahrtreppe, …) or a standalone weather
+    warning (Sturm, Wetterlage, …) are dropped: they are explicitly out
+    of scope per project spec. Mixed transit messages that merely mention
+    weather/facility as cause or side-effect still go through.
     """
+    if _is_facility_or_weather_only(title, description):
+        return False
+
     routes = _extract_routes(title, description)
 
     if routes:

--- a/tests/test_facility_weather_filter.py
+++ b/tests/test_facility_weather_filter.py
@@ -1,0 +1,88 @@
+"""User-spec: facility-only and weather-only messages have no place in
+the feed.
+
+> Defekte Aufzüge oder die Wetterlage hat im Feed nichts zu suchen.
+> Im Feed soll es um Störungen des ÖPNVs in Wien und deren Pendler gehen.
+
+The filter must therefore drop messages whose primary topic is a broken
+facility (Aufzug, Lift, Fahrtreppe, Rolltreppe) or a standalone weather
+warning (Sturm, Wetterlage, …) — even when a Wien station is mentioned.
+Mixed messages, where the title also carries a real transit keyword
+(Bauarbeiten, Störung, Verspätung, Sperre, …), still pass through so
+the route- and station-level checks can take over.
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import _is_facility_or_weather_only, _is_relevant
+
+
+class TestUserReportedFacilityWeatherDrops:
+    def test_aufzug_defekt_wien_hbf_dropped(self) -> None:
+        assert _is_relevant("Aufzug defekt: Wien Hauptbahnhof", "x") is False
+
+    def test_sturm_im_raum_wien_dropped(self) -> None:
+        assert (
+            _is_relevant("Sturm im Raum Wien", "Verzögerungen bei der S-Bahn Wien.")
+            is False
+        )
+
+    def test_wetterlage_dropped(self) -> None:
+        assert _is_relevant("Wetterlage Wien", "Hinweis") is False
+
+    def test_lift_outage_dropped(self) -> None:
+        assert _is_relevant("Lift außer Betrieb Wien Hbf", "x") is False
+
+    def test_fahrtreppe_dropped(self) -> None:
+        assert _is_relevant("Fahrtreppe defekt Wien Mitte", "x") is False
+
+
+class TestRealDisruptionsStillKept:
+    def test_bauarbeiten_wien_kept(self) -> None:
+        assert _is_relevant("Bauarbeiten Wien Hauptbahnhof", "x") is True
+
+    def test_stoerung_wien_kept(self) -> None:
+        assert _is_relevant("Störung Wien Hauptbahnhof", "x") is True
+
+    def test_route_message_kept(self) -> None:
+        assert _is_relevant(
+            "Bauarbeiten: Wien Hauptbahnhof ↔ Mödling", "x"
+        ) is True
+
+    def test_weather_caused_route_disruption_kept(self) -> None:
+        # Mixed: weather-caused but transit-described — keep.
+        assert (
+            _is_relevant(
+                "Sturmschaden: Strecke Wien - Mödling gesperrt",
+                "Wegen Sturm kein Verkehr zwischen Wien Hbf und Mödling.",
+            )
+            is True
+        )
+
+    def test_aufzug_betroffen_with_bauarbeiten_kept(self) -> None:
+        # Mixed: title primary subject is Bauarbeiten, Aufzug is collateral.
+        assert _is_relevant(
+            "Bauarbeiten Wien Hbf - Aufzug betroffen", "x"
+        ) is True
+
+
+class TestFacilityWeatherFunctionDirectly:
+    def test_pure_facility_title(self) -> None:
+        assert _is_facility_or_weather_only("Aufzug defekt: Wien Hauptbahnhof", "")
+
+    def test_pure_weather_title(self) -> None:
+        assert _is_facility_or_weather_only("Sturmwarnung im Raum Wien", "")
+
+    def test_mixed_with_bauarbeiten(self) -> None:
+        # "Bauarbeiten" is a real transit keyword → not facility-only.
+        assert not _is_facility_or_weather_only(
+            "Bauarbeiten Wien Hbf - Aufzug betroffen", ""
+        )
+
+    def test_no_facility_no_weather(self) -> None:
+        assert not _is_facility_or_weather_only(
+            "Bauarbeiten: Wien Hauptbahnhof ↔ Mödling", ""
+        )
+
+    def test_empty_title(self) -> None:
+        assert not _is_facility_or_weather_only("", "")

--- a/tests/test_filter_audit_round4.py
+++ b/tests/test_filter_audit_round4.py
@@ -55,10 +55,18 @@ class TestSingleStationDropsOnDistant:
         )
         assert _is_relevant(title, desc) is False
 
-    def test_wien_only_message_still_kept(self) -> None:
-        # Sanity: a real Wien-only facility notice must keep working.
+    def test_wien_only_facility_notice_dropped(self) -> None:
+        # Per project spec ("Defekte Aufzüge ... haben im Feed nichts
+        # zu suchen") a facility-only notice must drop even when it
+        # mentions a Wien station.
         title = "Aufzug defekt: Wien Hauptbahnhof"
         desc = "Aufzug am Bahnsteig 12 außer Betrieb."
+        assert _is_relevant(title, desc) is False
+
+    def test_wien_only_real_disruption_kept(self) -> None:
+        # A real transit disruption at a single Wien station still keeps.
+        title = "Bauarbeiten Wien Hauptbahnhof"
+        desc = "Wegen Bauarbeiten kein Verkehr."
         assert _is_relevant(title, desc) is True
 
     def test_wien_pendler_mention_kept(self) -> None:
@@ -104,8 +112,8 @@ class TestImplicitRouteToUnknown:
         assert _is_relevant("Bauarbeiten: Wien Hauptbahnhof Brixlegg", "x") is False
 
     def test_wien_only_kept(self) -> None:
-        # Sanity: a real Wien-only facility notice must keep working.
-        assert _is_relevant("Bauarbeiten: Wien Hauptbahnhof", "Aufzug defekt.") is True
+        # A real transit disruption at a single Wien station must keep.
+        assert _is_relevant("Bauarbeiten: Wien Hauptbahnhof", "Wegen Bauarbeiten gesperrt.") is True
 
     def test_wien_pendler_pair_kept(self) -> None:
         # Pendler is a known station — the residual check must not fire.
@@ -117,11 +125,16 @@ class TestImplicitRouteToUnknown:
         # ↔-titles are handled by _extract_routes, not by this heuristic.
         assert _is_relevant("Wien Hauptbahnhof ↔ Mödling", "") is True
 
-    def test_weather_word_before_wien_kept(self) -> None:
-        # Tokens that sit BEFORE the last known station (e.g. "Sturm im
-        # Raum Wien") are sentence preamble, not implicit endpoints.
+    def test_token_before_wien_does_not_imply_route(self) -> None:
+        # Position-Constraint: tokens BEFORE the last known station are
+        # sentence preamble, not implicit second endpoints. Use a
+        # transit-like preamble word so the new facility/weather filter
+        # doesn't intercept the message before this heuristic runs.
         assert (
-            _is_relevant("Sturm im Raum Wien", "Verzögerungen bei der S-Bahn Wien.")
+            _is_relevant(
+                "Bauarbeiten im Bereich Wien Hauptbahnhof",
+                "Verzögerungen bei der S-Bahn Wien.",
+            )
             is True
         )
 

--- a/tests/test_oebb_filter_audit.py
+++ b/tests/test_oebb_filter_audit.py
@@ -77,13 +77,16 @@ class TestFakeRouteFilter:
     """Bug D: a regex match between two non-station phrases must not block
     the single-station fall-through path."""
 
-    def test_aufzug_zwischen_bahnsteig_falls_through_to_station_match(self) -> None:
+    def test_zwischen_bahnsteig_falls_through_to_station_match(self) -> None:
         # The "zwischen Bahnsteig 1 und Bahnsteig 5" reads like a route
         # but actually describes a facility-internal segment. Both
         # endpoints fail to resolve, so the route is discarded and
         # the single-station path picks up "Wien Mitte" → relevant.
-        title = "Aufzug Wien Mitte"
-        desc = "Aufzug zwischen Bahnsteig 1 und Bahnsteig 5 in Wien Mitte defekt"
+        # NOTE: title is a Bauarbeiten notice (not facility-only) so the
+        # facility-or-weather filter doesn't intercept this case before
+        # the fake-route heuristic runs.
+        title = "Bauarbeiten Wien Mitte"
+        desc = "Bauarbeiten zwischen Bahnsteig 1 und Bahnsteig 5 in Wien Mitte"
         assert _extract_routes(title, desc) == []
         assert _is_relevant(title, desc) is True
 

--- a/tests/test_oebb_filtering.py
+++ b/tests/test_oebb_filtering.py
@@ -60,9 +60,13 @@ class TestOebbFiltering:
         ) is False
 
     def test_relevant_general_disruption_with_vienna(self) -> None:
-        # General disruption WITH Vienna reference -> Keep
+        # General disruption WITH Vienna reference -> Keep.
+        # NOTE: per project spec ("die Wetterlage hat im Feed nichts zu
+        # suchen") a pure weather warning is dropped — use a real
+        # disruption word as title primary subject so this test exercises
+        # the Vienna-context path rather than the facility/weather filter.
         assert _is_relevant(
-            "Sturm im Raum Wien",
+            "Verspätungen im Raum Wien",
             "Verzögerungen bei der S-Bahn Wien."
         ) is True
 

--- a/tests/test_payerbach_leak.py
+++ b/tests/test_payerbach_leak.py
@@ -108,13 +108,16 @@ class TestFacilityHeuristic:
     fake routes (platform/track references) while letting real station
     routes through to the strict classifier."""
 
-    def test_aufzug_between_platforms_drops_route_candidate(self) -> None:
-        # Bug D regression: the message must still pick up Wien Mitte
-        # via the single-station fall-through.
+    def test_facility_route_candidate_dropped(self) -> None:
+        # Bug D regression: the fake "zwischen Bahnsteig 1 und Bahnsteig
+        # 5" route must be dropped from the candidate list. The new
+        # facility/weather filter then drops the message itself because
+        # an "Aufzug"-titled notice without a transit keyword is
+        # facility-only per project spec.
         title = "Aufzug Wien Mitte"
         desc = "Aufzug zwischen Bahnsteig 1 und Bahnsteig 5 in Wien Mitte defekt"
         assert _extract_routes(title, desc) == []
-        assert _is_relevant(title, desc) is True
+        assert _is_relevant(title, desc) is False
 
     def test_facility_endpoint_detection(self) -> None:
         # Single-word and "<word> <number>" forms both classify as facility.


### PR DESCRIPTION
## Summary

User-Spec verfeinert: Defekte Aufzüge und reine Wetter-Meldungen haben im Feed nichts zu suchen. Beispiele:

```
Aufzug defekt: Wien Hauptbahnhof   → DROP
Sturm im Raum Wien                  → DROP
```

Beide nennen einen Wien-Bahnhof, aber das primäre Thema ist Facility/Wetter — keine ÖPNV-Störung. Der bisherige Single-Station-Fallback hat sie fälschlich gehalten.

### Implementierung

Neue Helper-Funktion `_is_facility_or_weather_only(title, description)`:

- **Facility-Keywords**: `aufzug`, `lift`, `fahrtreppe`, `rolltreppe`, `fahrstuhl` und Varianten
- **Wetter-Keywords**: `sturm`, `unwetter`, `gewitter`, `hochwasser`, `wetter`, `wetterlage`, `glatteis`, `schneefall`, `murenabgang`, `lawinengefahr`
- **Transit-Keywords (override)**: `bauarbeiten`, `störung`, `verspätung`, `sperre`, `umleitung`, `ersatzverkehr`, `haltausfall`, `zugausfall`, etc.

**Regel:** Drop nur wenn Facility/Wetter im Title UND kein Transit-Keyword im Title. Mixed-Messages wie `Bauarbeiten Wien Hbf - Aufzug betroffen` oder `Sturmschaden: Strecke Wien-Mödling gesperrt` bleiben.

Check läuft am Anfang von `_is_relevant`, bevor Routen-Extraktion oder Single-Station-Fallback greifen.

### Live-Cache Audit (origin/main)

| Metrik | Wert |
|---|---|
| Total ÖBB Items | 18 |
| KEEP | 12 |
| DROP | 6 |

**Drops aufgeschlüsselt:**
- 2 korrekt (Wiener Neustadt-Semmering, Wien/München Roma Termini)
- 4 false-negatives durch **Bug M (DATA)** — Felixdorf, Götzendorf, Gramatneusiedl, Traiskirchen Aspangbahn fehlen in `data/stations.json` als Pendler. Nur per Verzeichnis-Update lösbar.

### Tests

- **15 neue Regressionstests** in `tests/test_facility_weather_filter.py` (User-Beispiele droppen, Mixed-Disruptions bleiben, Helper-Direkttests)
- **5 bestehende Tests** angepasst die zuvor die alte Spec testeten (`Aufzug Wien Hbf` als KEEP) — jetzt entweder spec-aligned (DROP) oder auf `Bauarbeiten`-Titel umgepointet um den ursprünglichen Test-Intent (Bug D / Bug N / Position-Constraint) zu erhalten

## Test plan

- [x] `pytest tests/test_facility_weather_filter.py` — 15/15 passed
- [x] Volle Suite: **1074 passed, 1 skipped** (nur pre-existing test_feed_lint Fail)
- [x] `mypy --strict src/ tests/` clean
- [x] `ruff check src/ tests/` clean

### Empfehlung

Folge-Issue: `data/pendler_bst_ids.json` und `data/stations.json` mit den klassischen Pendler-Stationen ergänzen (Aspangbahn, R95, Marchegger-Strecke, Semmeringbahn, südliches NÖ, nördliches Burgenland), damit die durch Bug M verursachten false-negatives verschwinden.

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_