### PR TITLE
fix(oebb): drop ANY facility-keyword title (incl. Bauarbeiten + Aufzug)

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -112,30 +112,34 @@ _TRANSIT_KEYWORD_RE = re.compile(
 
 
 def _is_facility_or_weather_only(title: str, description: str) -> bool:
-    """Decide whether the message's primary topic is facility/weather.
+    """Decide whether the message has no place in the Wien-ÖPNV feed.
 
-    Per project spec elevator/escalator notices and standalone weather
-    warnings have nothing to do in the Wien-ÖPNV feed — they don't
-    describe a transit disruption that affects Wiener or Pendler-to-Wien
-    travellers. The heuristic flags those messages so the caller can
-    drop them before the relevance check.
+    Per project spec elevator/escalator notices have nothing to do in
+    the feed — including titles that combine "Bauarbeiten" with
+    "Aufzug betroffen", because the actual subject is still the broken
+    elevator and not a service-affecting track disruption. Any mention
+    of a facility keyword in the title therefore drops the message.
 
-    A message is considered facility/weather-only when its title carries
-    one of the facility/weather keywords above AND no real
-    disruption keyword (Bauarbeiten, Störung, Verspätung, …). Mixed
-    messages like "Bauarbeiten zwischen Wien und Mödling — auch Aufzug
-    betroffen" therefore pass through and are evaluated normally.
+    Weather titles are dropped only when the title doesn't also carry a
+    real disruption keyword: ``Sturmschaden: Strecke Wien-Mödling
+    gesperrt`` describes a genuine transit interruption (cause: Sturm)
+    and stays in the feed, while ``Sturm im Raum Wien`` / ``Wetterlage
+    Wien`` are pure weather warnings and drop.
     """
     if not title:
         return False
     title_low = title.lower()
     has_facility = bool(_FACILITY_KEYWORD_RE.search(title_low))
+    if has_facility:
+        # Strict: any facility-keyword title drops, with or without an
+        # accompanying transit keyword. Side-mentions of "Aufzug" should
+        # never reach the feed per user spec.
+        return True
     has_weather = bool(_WEATHER_KEYWORD_RE.search(title_low))
-    if not (has_facility or has_weather):
+    if not has_weather:
         return False
-    if _TRANSIT_KEYWORD_RE.search(title_low):
-        return False
-    return True
+    # Weather: drop only when the title has no real disruption signal.
+    return not _TRANSIT_KEYWORD_RE.search(title_low)
 
 
 NON_LOCATION_PREFIXES = {

--- a/tests/test_facility_weather_filter.py
+++ b/tests/test_facility_weather_filter.py
@@ -59,11 +59,13 @@ class TestRealDisruptionsStillKept:
             is True
         )
 
-    def test_aufzug_betroffen_with_bauarbeiten_kept(self) -> None:
-        # Mixed: title primary subject is Bauarbeiten, Aufzug is collateral.
+    def test_aufzug_betroffen_with_bauarbeiten_dropped(self) -> None:
+        # Per spec the ANY mention of a facility keyword in the title
+        # drops the message — even when "Bauarbeiten" is also present,
+        # because the affected facility is still the actual subject.
         assert _is_relevant(
             "Bauarbeiten Wien Hbf - Aufzug betroffen", "x"
-        ) is True
+        ) is False
 
 
 class TestFacilityWeatherFunctionDirectly:
@@ -73,10 +75,17 @@ class TestFacilityWeatherFunctionDirectly:
     def test_pure_weather_title(self) -> None:
         assert _is_facility_or_weather_only("Sturmwarnung im Raum Wien", "")
 
-    def test_mixed_with_bauarbeiten(self) -> None:
-        # "Bauarbeiten" is a real transit keyword → not facility-only.
-        assert not _is_facility_or_weather_only(
+    def test_mixed_facility_with_bauarbeiten_still_drops(self) -> None:
+        # Strict facility rule: any title mention of "Aufzug" drops.
+        assert _is_facility_or_weather_only(
             "Bauarbeiten Wien Hbf - Aufzug betroffen", ""
+        )
+
+    def test_mixed_weather_with_bauarbeiten_kept(self) -> None:
+        # Weather is more lenient: a transit keyword in the title
+        # rescues a Sturm-caused service disruption.
+        assert not _is_facility_or_weather_only(
+            "Sturmschaden: Strecke Wien-Mödling gesperrt", ""
         )
 
     def test_no_facility_no_weather(self) -> None:


### PR DESCRIPTION
## Summary

User-Spec verschärft:

> Bauarbeiten Wien Hbf - Aufzug betroffen
> sollte ein Drop sein

Die bisherige Heuristik ließ Mixed-Messages passieren wenn Title sowohl Facility-Keyword (Aufzug) als auch Transit-Keyword (Bauarbeiten) enthielt. Per User ist das immer noch eine Facility-Meldung — das eigentliche Thema ist der Aufzug, nicht eine Strecken-Disruption.

### Verschärfung

**Facility (strict):** JEDE Title-Erwähnung von `aufzug`/`lift`/`fahrtreppe`/`rolltreppe`/`fahrstuhl` → DROP, unabhängig von begleitenden Transit-Keywords.

**Weather (asymmetrisch beibehalten):** Drop nur wenn KEIN Transit-Keyword im Title. `Sturmschaden: Strecke Wien-Mödling gesperrt` ist eine echte Strecken-Disruption (Ursache: Sturm) und bleibt; `Sturm im Raum Wien` / `Wetterlage Wien` sind reine Wetterwarnungen und droppen.

### Verifikation

| Title | Vorher | Nachher |
|---|---|---|
| `Bauarbeiten Wien Hbf - Aufzug betroffen` | KEEP ⚠️ | ✓ DROP |
| `Aufzug defekt: Wien Hauptbahnhof` | DROP | DROP |
| `Sturm im Raum Wien` | DROP | DROP |
| `Sturmschaden: Strecke Wien-Mödling gesperrt` | KEEP | KEEP |
| `Bauarbeiten Wien Hauptbahnhof` | KEEP | KEEP |
| `Bauarbeiten: Wien Hbf ↔ Mödling` | KEEP | KEEP |

### Tests aktualisiert

- `test_aufzug_betroffen_with_bauarbeiten_kept` invertiert zu `..._dropped` (assert False)
- `test_mixed_with_bauarbeiten` zu `test_mixed_facility_with_bauarbeiten_still_drops`
- Neuer `test_mixed_weather_with_bauarbeiten_kept` für asymmetrisches Weather-Verhalten

## Test plan

- [x] Volle Suite: 1075 passed, 1 skipped (nur pre-existing test_feed_lint Fail)
- [x] `mypy --strict src/ tests/` clean
- [x] `ruff check src/ tests/` clean

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_