### PR TITLE
feat(stations): add OSM coordinates for 4 pendlers + WL-DIVA for 11 U-Bahn

### DIFF
--- a/data/stations.json
+++ b/data/stations.json
@@ -870,7 +870,16 @@
       "longitude": 16.36638,
       "name": "Herrengasse",
       "pendler": false,
-      "source": "google_places"
+      "source": "google_places",
+      "wl_diva": "60200506",
+      "wl_stops": [
+        {
+          "stop_id": "60200506",
+          "name": "Herrengasse",
+          "latitude": 48.209487,
+          "longitude": 16.365849
+        }
+      ]
     },
     {
       "aliases": [
@@ -888,7 +897,9 @@
       "in_vienna": false,
       "name": "Himberg",
       "pendler": true,
-      "source": "oebb"
+      "source": "oebb",
+      "latitude": 48.0828,
+      "longitude": 16.4392
     },
     {
       "aliases": [
@@ -978,7 +989,16 @@
       "longitude": 16.358950999999998,
       "name": "Kettenbrückengasse",
       "pendler": false,
-      "source": "google_places"
+      "source": "google_places",
+      "wl_diva": "60200670",
+      "wl_stops": [
+        {
+          "stop_id": "60200670",
+          "name": "Kettenbrückengasse",
+          "latitude": 48.1968178,
+          "longitude": 16.358995
+        }
+      ]
     },
     {
       "aliases": [
@@ -1263,7 +1283,9 @@
       "in_vienna": false,
       "name": "Laxenburg-Biedermannsdorf",
       "pendler": true,
-      "source": "oebb"
+      "source": "oebb",
+      "latitude": 47.9893,
+      "longitude": 16.364
     },
     {
       "aliases": [
@@ -1431,7 +1453,16 @@
       "longitude": 16.4037766,
       "name": "Messe - Prater",
       "pendler": false,
-      "source": "google_places"
+      "source": "google_places",
+      "wl_diva": "60201892",
+      "wl_stops": [
+        {
+          "stop_id": "60201892",
+          "name": "Messe-Prater",
+          "latitude": 48.217789,
+          "longitude": 16.405698
+        }
+      ]
     },
     {
       "aliases": [
@@ -1475,7 +1506,9 @@
       "in_vienna": false,
       "name": "Mistelbach Stadt",
       "pendler": true,
-      "source": "oebb"
+      "source": "oebb",
+      "latitude": 48.5754,
+      "longitude": 16.5821
     },
     {
       "aliases": [
@@ -1653,7 +1686,16 @@
       "longitude": 16.3520877,
       "name": "Neubaugasse",
       "pendler": false,
-      "source": "google_places"
+      "source": "google_places",
+      "wl_diva": "60200056",
+      "wl_stops": [
+        {
+          "stop_id": "60200056",
+          "name": "Neubaugasse",
+          "latitude": 48.1982908,
+          "longitude": 16.3502005
+        }
+      ]
     },
     {
       "aliases": [
@@ -1953,7 +1995,16 @@
       "longitude": 16.354467,
       "name": "Pilgramgasse",
       "pendler": false,
-      "source": "google_places"
+      "source": "google_places",
+      "wl_diva": "60201018",
+      "wl_stops": [
+        {
+          "stop_id": "60201018",
+          "name": "Pilgramgasse",
+          "latitude": 48.1926261,
+          "longitude": 16.3544765
+        }
+      ]
     },
     {
       "aliases": [
@@ -2182,7 +2233,16 @@
       "longitude": 16.3861494,
       "name": "Rennweg",
       "pendler": false,
-      "source": "google_places"
+      "source": "google_places",
+      "wl_diva": "60201091",
+      "wl_stops": [
+        {
+          "stop_id": "60201091",
+          "name": "Rennweg",
+          "latitude": 48.194764,
+          "longitude": 16.386277
+        }
+      ]
     },
     {
       "aliases": [
@@ -2291,7 +2351,16 @@
       "longitude": 16.37128,
       "name": "Schottenring",
       "pendler": false,
-      "source": "google_places"
+      "source": "google_places",
+      "wl_diva": "60201182",
+      "wl_stops": [
+        {
+          "stop_id": "60201182",
+          "name": "Schottenring",
+          "latitude": 48.216921,
+          "longitude": 16.371131
+        }
+      ]
     },
     {
       "aliases": [
@@ -2348,7 +2417,16 @@
       "longitude": 16.3780646,
       "name": "Schwedenplatz",
       "pendler": false,
-      "source": "google_places"
+      "source": "google_places",
+      "wl_diva": "60201198",
+      "wl_stops": [
+        {
+          "stop_id": "60201198",
+          "name": "Schwedenplatz",
+          "latitude": 48.21175,
+          "longitude": 16.377896
+        }
+      ]
     },
     {
       "aliases": [
@@ -2686,7 +2764,16 @@
       "longitude": 16.3790822,
       "name": "Stadtpark",
       "pendler": false,
-      "source": "google_places"
+      "source": "google_places",
+      "wl_diva": "60201305",
+      "wl_stops": [
+        {
+          "stop_id": "60201305",
+          "name": "Stadtpark",
+          "latitude": 48.202512,
+          "longitude": 16.3791083
+        }
+      ]
     },
     {
       "aliases": [
@@ -2755,7 +2842,16 @@
       "longitude": 16.3796274,
       "name": "Stubentor",
       "pendler": false,
-      "source": "google_places"
+      "source": "google_places",
+      "wl_diva": "60200245",
+      "wl_stops": [
+        {
+          "stop_id": "60200245",
+          "name": "Stubentor",
+          "latitude": 48.2070681,
+          "longitude": 16.3802761
+        }
+      ]
     },
     {
       "_google_place_id": "ChIJZ1D-htapbUcROoi_2Jg_fcg",
@@ -3087,7 +3183,16 @@
       "longitude": 16.3575922,
       "name": "Volkstheater",
       "pendler": false,
-      "source": "google_places"
+      "source": "google_places",
+      "wl_diva": "60201430",
+      "wl_stops": [
+        {
+          "stop_id": "60201430",
+          "name": "Volkstheater",
+          "latitude": 48.20514,
+          "longitude": 16.357971
+        }
+      ]
     },
     {
       "aliases": [
@@ -3125,7 +3230,9 @@
       "in_vienna": false,
       "name": "Weigelsdorf",
       "pendler": true,
-      "source": "oebb"
+      "source": "oebb",
+      "latitude": 47.9484,
+      "longitude": 16.4082
     },
     {
       "aliases": [


### PR DESCRIPTION
## Summary

User-flagged audit gaps from the latest review:
- 4 Pendler-Stationen ohne `latitude`/`longitude`
- 11 Wien-U-Bahn-Stationen ohne `wl_diva` / `wl_stops`

### 1. Koordinaten (4 Pendler)

Die 4 Stationen werden vom VOR-Resolver konsistent zurückgewiesen (nur Bus-Stop-Varianten kommen zurück, alle durch die Resolver-Filter blockiert). Ohne Koordinaten fehlen sie auf Kartendarstellungen und in geo-basierten Anfragen. Hand-kuratiert aus OpenStreetMap rail-station nodes (~10m Genauigkeit):

| Station | Latitude | Longitude | Linie |
|---|---|---|---|
| Himberg | 48.0828 | 16.4392 | Pottendorfer Linie |
| Laxenburg-Biedermannsdorf | 47.9893 | 16.3640 | R95 Aspangbahn |
| Mistelbach Stadt | 48.5754 | 16.5821 | Laaer Ostbahn (REX2) |
| Weigelsdorf | 47.9484 | 16.4082 | Pottendorfer Linie |

`_restore_existing_metadata` (in `update_station_directory.py`) sucht per `bst_id` und kopiert alle Nicht-Core-Felder (inkl. `latitude`/`longitude`) auf den frischen Excel-Eintrag — die 4 Einträge haben ÖBB-Excel-`bst_id`s, also überlebt die Koordinate künftige Cron-Läufe.

### 2. WL-DIVA + wl_stops (11 U-Bahn-Stationen)

Die 11 Wien-U-Bahn-Stationen kamen über Google Places ins Verzeichnis, aber bekamen nie Wiener-Linien-IDs. Lookup der Haltestelle-Level-DIVA aus `wienerlinien-ogd-haltestellen.csv`:

| Station | DIVA | Coords |
|---|---|---|
| Stadtpark | 60201305 | 48.2025, 16.3791 |
| Schwedenplatz | 60201198 | 48.2118, 16.3779 |
| Schottenring | 60201182 | 48.2169, 16.3711 |
| Stubentor | 60200245 | 48.2071, 16.3803 |
| Volkstheater | 60201430 | 48.2051, 16.3580 |
| Pilgramgasse | 60201018 | 48.1926, 16.3545 |
| Neubaugasse | 60200056 | 48.1983, 16.3502 |
| Kettenbrückengasse | 60200670 | 48.1968, 16.3590 |
| Herrengasse | 60200506 | 48.2095, 16.3658 |
| Rennweg (U3) | 60201091 | 48.1948, 16.3863 |
| Messe-Prater | 60201892 | 48.2178, 16.4057 |

Jede Station bekommt die Surface-Haltestelle-DIVA + eine `wl_stops`-Liste mit einem Einzeleintrag. Sobald die `haltepunkte.csv` (aktuell 404 bei data.wien.gv.at) wieder verfügbar ist, ergänzt der Cron platform-level Einträge.

**"Südtiroler Platz" bewusst nicht enthalten**: Wurde mit der Wien-Hbf-Eröffnung 2014 in "Hauptbahnhof" umbenannt — der existierende `Wien Hauptbahnhof`-Eintrag trägt die WL-Daten bereits.

## Test plan

- [x] Full test suite: 1136 passed, 1 skipped (unverändert)
- [x] `validate_stations`: **coordinate_issues 6 → 2** (verbleibend: München/Roma international, beabsichtigt)
- [x] All blocking gates remain 0/0/0/0/0 (provider/cross_station_id/naming/security/duplicates)
- [x] Manual verification: 4/4 Pendler haben coords, 11/11 U-Bahn haben wl_diva + wl_stops
- [x] Persistence-Pfad geprüft: `_restore_existing_metadata` kopiert `latitude`/`longitude` als extras → Coords überleben künftige Cron-Läufe

## Out of scope

- VOR-IDs für die 4 Pendler-Stationen: erfordert hand-kuratierte VOR-Lookups (der Resolver kann ihre korrekten IDs nicht zuverlässig finden); separater Folge-PR.
- Platform-level wl_stops: warten auf das Wiederverfügbarwerden der haltepunkte.csv bei data.wien.gv.at.

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_