### PR TITLE
fix(filter): defence-in-depth post-filter + plural-form transit keywords

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -91,8 +91,38 @@ def read_cache_wl() -> List[Any]:
     return list(read_cache("wl") or [])
 
 
+def _post_filter_oebb(items: List[Any]) -> List[Any]:
+    """Re-apply the ÖBB relevance filter to cached items.
+
+    The cache is only refreshed by `update_oebb_cache.py`, so a filter
+    update doesn't reach the feed until the next cache refresh. Without
+    this defence-in-depth re-check the feed can carry items that the
+    *current* spec considers irrelevant (e.g. Wien↔Distant routes that
+    slipped through an older filter version).
+
+    Items without a title are passed through unchanged so test fixtures
+    and other generic dictionaries aren't accidentally dropped.
+    """
+    from .providers.oebb import _is_relevant  # local import: avoids circular at module load
+
+    out: List[Any] = []
+    for item in items:
+        if not isinstance(item, dict):
+            out.append(item)
+            continue
+        title = str(item.get("title") or "")
+        description = str(item.get("description") or "")
+        if not title and not description:
+            # Stub / metadata item — leave it alone.
+            out.append(item)
+            continue
+        if _is_relevant(title, description):
+            out.append(item)
+    return out
+
+
 def read_cache_oebb() -> List[Any]:
-    return list(read_cache("oebb") or [])
+    return _post_filter_oebb(list(read_cache("oebb") or []))
 
 
 def read_cache_vor() -> List[Any]:

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -102,11 +102,20 @@ _WEATHER_KEYWORD_RE = re.compile(
     re.IGNORECASE,
 )
 _TRANSIT_KEYWORD_RE = re.compile(
-    r"\b(bauarbeiten|störung|stoerung|verspätung|verspaetung|sperre|sperrung|"
-    r"umleitung|ersatzverkehr|haltausfall|zugausfall|streckenunterbrechung|"
-    r"unterbrechung|teilausfall|baustelle|baustellen|gleisbauarbeiten|"
-    r"schienenersatzverkehr|sev|fahrplanänderung|fahrplanaenderung|"
-    r"verkehrseinschränkung|verkehrseinschraenkung|einschränkung|einschraenkung)\b",
+    # Match common stems and accept trailing inflection (Verspätung →
+    # Verspätungen, Sperrung → Sperrungen, etc.). The trailing
+    # ``\w{0,4}`` keeps the regex bounded but covers German plural and
+    # genitive forms without enumerating every variant.
+    r"\b(bauarbeit\w{0,4}|störung\w{0,4}|stoerung\w{0,4}|"
+    r"verspätung\w{0,4}|verspaetung\w{0,4}|sperre\w{0,4}|sperrung\w{0,4}|"
+    r"gesperrt|geschlossen|unterbrochen|eingestellt|"
+    r"umleitung\w{0,4}|ersatzverkehr|haltausfall\w{0,4}|zugausfall\w{0,4}|"
+    r"streckenunterbrechung\w{0,4}|unterbrechung\w{0,4}|teilausfall\w{0,4}|"
+    r"baustelle\w{0,4}|gleisbauarbeit\w{0,4}|"
+    r"schienenersatzverkehr|sev|fahrplanänderung\w{0,4}|"
+    r"fahrplanaenderung\w{0,4}|"
+    r"verkehrseinschränkung\w{0,4}|verkehrseinschraenkung\w{0,4}|"
+    r"einschränkung\w{0,4}|einschraenkung\w{0,4})\b",
     re.IGNORECASE,
 )
 
@@ -659,6 +668,30 @@ _TITLE_NOISE_WORDS = frozenset({
     "wochenenden",
     "feiertag",
     "feiertage",
+    # Weather words (Sturm/Wetter etc.) — not station names; mentioning
+    # them after a known Vienna station shouldn't drag the message into
+    # the implicit-route heuristic.
+    "sturm",
+    "sturmschaden",
+    "sturmwarnung",
+    "unwetter",
+    "gewitter",
+    "hochwasser",
+    "wetter",
+    "wetterlage",
+    "wettersituation",
+    "glatteis",
+    "schnee",
+    "schneefall",
+    "schneefälle",
+    "schneefaelle",
+    "regen",
+    "wind",
+    "hagel",
+    "frost",
+    "murenabgang",
+    "lawinengefahr",
+    "lawine",
     # Facility / generic location words (already in _NON_STATION_FIRST_WORDS
     # but we list them here too for the title-residual check)
     "aufzug",

--- a/tests/test_facility_weather_filter.py
+++ b/tests/test_facility_weather_filter.py
@@ -95,3 +95,41 @@ class TestFacilityWeatherFunctionDirectly:
 
     def test_empty_title(self) -> None:
         assert not _is_facility_or_weather_only("", "")
+
+
+class TestPluralFormsAndWeatherCause:
+    """Bug Q: the transit-keyword regex used \\b...\\b which missed German
+    plural / inflected forms (Verspätung → Verspätungen, Sperrung →
+    Sperrungen, …). Combined with the title-residual heuristic that
+    treated the German weather noun "Sturm" as an unknown second
+    endpoint, weather-caused real disruptions were dropped.
+    """
+
+    def test_verspaetungen_plural_keeps_with_weather_cause(self) -> None:
+        assert _is_relevant("Verspätungen Wien Hbf wegen Sturm", "x") is True
+
+    def test_sperrungen_plural_keeps(self) -> None:
+        assert (
+            _is_relevant(
+                "Sperrungen zwischen Wien Hbf und Mödling am Wochenende",
+                "Wegen Sturm.",
+            )
+            is True
+        )
+
+    def test_stoerungen_plural_keeps(self) -> None:
+        assert _is_relevant("Störungen wegen Sturm in Wien Hbf", "x") is True
+
+    def test_gesperrt_keeps(self) -> None:
+        assert (
+            _is_relevant(
+                "Sturmschaden zwischen Wien und Mödling — Strecke gesperrt",
+                "Wegen Sturm gesperrt zwischen Wien Hbf und Mödling.",
+            )
+            is True
+        )
+
+    def test_weather_only_still_drops(self) -> None:
+        # Sanity: pure weather (no transit keyword) still drops.
+        assert _is_relevant("Sturm im Raum Wien", "x") is False
+        assert _is_relevant("Wetterlage Wien", "x") is False

--- a/tests/test_post_filter_oebb.py
+++ b/tests/test_post_filter_oebb.py
@@ -1,0 +1,71 @@
+"""Defence-in-depth: re-apply the ÖBB relevance filter to cache items.
+
+Audit-round-5 finding (bug P). The ÖBB cache is only refreshed by the
+`update-oebb-cache.yml` workflow, so a filter improvement does not reach
+the feed until the next cache refresh — meanwhile the live feed can
+carry items that the *current* spec considers irrelevant. The post-
+filter in `build_feed.read_cache_oebb` re-runs `_is_relevant` against
+each cached item so the feed always reflects the latest filter state.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from src.build_feed import _post_filter_oebb
+
+
+class TestPostFilterDropsStaleCacheItems:
+    def test_passes_real_wien_pendler_route(self) -> None:
+        items: List[Any] = [
+            {
+                "title": "Wien Hauptbahnhof ↔ Mödling",
+                "description": "Bauarbeiten zwischen Wien Hbf und Mödling.",
+            }
+        ]
+        result = _post_filter_oebb(items)
+        assert len(result) == 1
+
+    def test_drops_wien_distant_routes(self) -> None:
+        items: List[Any] = [
+            {
+                "title": "Bauarbeiten: Wien/München Roma Termini",
+                "description": "NJ-Züge umgeleitet via Salzburg.",
+            }
+        ]
+        assert _post_filter_oebb(items) == []
+
+    def test_drops_pendler_distant_route(self) -> None:
+        items: List[Any] = [
+            {
+                "title": "Bauarbeiten: Wiener Neustadt Hauptbahnhof Semmering",
+                "description": "Wegen Bauarbeiten werden Fernverkehrszüge umgeleitet.",
+            }
+        ]
+        assert _post_filter_oebb(items) == []
+
+    def test_drops_facility_only_with_wien_mention(self) -> None:
+        items: List[Any] = [
+            {"title": "Aufzug defekt: Wien Hauptbahnhof", "description": "x"}
+        ]
+        assert _post_filter_oebb(items) == []
+
+    def test_drops_weather_only_with_wien_mention(self) -> None:
+        items: List[Any] = [
+            {
+                "title": "Sturm im Raum Wien",
+                "description": "Verzögerungen bei der S-Bahn Wien.",
+            }
+        ]
+        assert _post_filter_oebb(items) == []
+
+
+class TestPostFilterPreservesGenericItems:
+    def test_passes_through_items_without_title(self) -> None:
+        # Test fixtures and metadata items shouldn't be dropped.
+        items: List[Any] = [{"provider": "oebb"}, {"foo": "bar"}]
+        assert _post_filter_oebb(items) == items
+
+    def test_passes_through_non_dict_items(self) -> None:
+        items: List[Any] = ["not-a-dict", 42]
+        assert _post_filter_oebb(items) == items


### PR DESCRIPTION
## Summary

Audit-Runde 5: Live-Feed direkt geprüft. Zwei echte Bugs entdeckt — einer Architektur, einer Regex-Linguistik.

### Bug P (Architektur): Cache-Filter-Drift

`_is_relevant` läuft NUR in `update_oebb_cache.py` (beim Cache-Refresh). `build_feed` liest den Cache as-is. Folge: Filter-Änderungen erreichen den Live-Feed erst beim nächsten externen Cache-Refresh — meanwhile bleiben veraltete Items im Feed.

**Konkret im aktuellen Live-Feed:** 6 Items im ÖBB-Cache, die der aktuelle Filter dropping würde — aber sie sind im Feed weil der Build sie nicht re-prüft:

```
Wien Hauptbahnhof ↔ Felixdorf
Wien Hauptbahnhof ↔ Götzendorf / … ↔ Gramatneusiedl
Wien Hauptbahnhof ↔ Traiskirchen Aspangbahn
Wien Hauptbahnhof ↔ Gramatneusiedl
Bauarbeiten: Wiener Neustadt Hauptbahnhof Semmering
Bauarbeiten: Wien/München Roma Termini
```

**Fix:** Defense-in-Depth `_post_filter_oebb` in `build_feed.read_cache_oebb` läuft `_is_relevant` nochmal über jedes gecachte Item bevor es in den Feed geht. Stub-Items ohne Title werden unverändert durchgelassen, damit Test-Fixtures nicht brechen.

### Bug Q (Regex): Plural- und Partizip-Formen

`_TRANSIT_KEYWORD_RE` hat `\b...\b`-Boundaries — matcht „Verspätung" aber nicht „Verspätungen". Kombiniert mit dem Title-Heuristik die das Wetter-Substantiv „Sturm" als unbekannten zweiten Endpunkt erkannt hat → echte wetter-verursachte Disruptions wurden gedroppt:

| Title | Vorher | Nachher |
|---|---|---|
| `Verspätungen Wien Hbf wegen Sturm` | DROP ⚠️ | ✓ KEEP |
| `Sperrungen zwischen Wien Hbf und Mödling` | DROP ⚠️ | ✓ KEEP |
| `Sturm im Raum Wien` | DROP | DROP (sanity) |

**Fix:**
1. Transit-Stems erlauben Suffixe (`bauarbeit\w{0,4}`, `verspätung\w{0,4}`, …) und explizite Partizipien (`gesperrt`, `geschlossen`, `unterbrochen`, `eingestellt`)
2. `_TITLE_NOISE_WORDS` um Wetter-Substantive (Sturm, Wetter, Gewitter, Regen, …) erweitert, damit sie nicht als Routen-Endpunkt missinterpretiert werden

### Tests

- **7 neue Tests** in `tests/test_post_filter_oebb.py` für Cache-Drift-Schutz
- **5 neue Tests** in `TestPluralFormsAndWeatherCause` für Plural-Formen und Sturm-Cause-Keep

## Test plan

- [x] Volle Suite: **1102 passed, 1 skipped** (nur pre-existing test_feed_lint Fail)
- [x] `mypy --strict src/ tests/` clean
- [x] `ruff check src/ tests/` clean

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_