### PR TITLE
fix(stations): close 155 alias_issues by pushing bst_code into aliases

### DIFF
--- a/data/stations.json
+++ b/data/stations.json
@@ -10,6 +10,7 @@
       "aliases": [
         "430482400",
         "St.Andrä-Wördern",
+        "Aw",
         "Bahnhof Sankt Andrae Woerdern",
         "Bahnhof Sankt Andrae-Woerdern",
         "Bahnhof Sankt Andrä Wördern",
@@ -114,6 +115,7 @@
         "bf Klosterneuburg Weidling",
         "Bf Klosterneuburg-Weidling",
         "bf Klosterneuburg-Weidling",
+        "Ken",
         "Klosterneuburg Weidling",
         "Klosterneuburg Weidling Bahnhof",
         "Klosterneuburg Weidling Bf",
@@ -142,6 +144,7 @@
         "bf Klosterneuburg Kierling",
         "Bf Klosterneuburg-Kierling",
         "bf Klosterneuburg-Kierling",
+        "Ken H1",
         "Klosterneuburg Kierling",
         "Klosterneuburg Kierling Bahnhof",
         "Klosterneuburg Kierling Bf",
@@ -167,6 +170,7 @@
         "Bahnhof Korneuburg",
         "Bf Korneuburg",
         "bf Korneuburg",
+        "Ko",
         "Korneuburg Bahnhof",
         "Korneuburg Bf",
         "Korneuburg bf"
@@ -188,6 +192,7 @@
         "Bahnhof Spillern",
         "Bf Spillern",
         "bf Spillern",
+        "Ko  H2",
         "Spillern Bahnhof",
         "Spillern Bf",
         "Spillern bf"
@@ -209,6 +214,7 @@
         "Bahnhof Krems a.d.Donau",
         "Bf Krems a.d.Donau",
         "bf Krems a.d.Donau",
+        "Kr",
         "Krems a.d.Donau Bahnhof",
         "Krems a.d.Donau Bf",
         "Krems a.d.Donau bf",
@@ -230,6 +236,7 @@
       "aliases": [
         "430300800",
         "Achau",
+        "Ach",
         "Achau Bahnhof",
         "Achau Bf",
         "Achau bf",
@@ -256,7 +263,8 @@
         "bf Kittsee",
         "Kittsee Bahnhof",
         "Kittsee Bf",
-        "Kittsee bf"
+        "Kittsee bf",
+        "Ktt"
       ],
       "latitude": 48.081322,
       "longitude": 17.071369,
@@ -277,7 +285,8 @@
         "bf Kritzendorf",
         "Kritzendorf Bahnhof",
         "Kritzendorf Bf",
-        "Kritzendorf bf"
+        "Kritzendorf bf",
+        "Kz"
       ],
       "latitude": 48.335906,
       "longitude": 16.299115,
@@ -296,6 +305,7 @@
         "Bahnhof Laa a.d.Thaya",
         "Bf Laa a.d.Thaya",
         "bf Laa a.d.Thaya",
+        "Laa",
         "Laa a.d.Thaya Bahnhof",
         "Laa a.d.Thaya Bf",
         "Laa a.d.Thaya bf",
@@ -324,6 +334,7 @@
         "Bahnhof Atzgersdorf",
         "Bf Atzgersdorf",
         "bf Atzgersdorf",
+        "Lga",
         "Wien Atzgersdorf Bahnhof",
         "Wien Atzgersdorf Bf",
         "Wien Atzgersdorf bf"
@@ -345,6 +356,7 @@
         "Bahnhof Leobersdorf",
         "Bf Leobersdorf",
         "bf Leobersdorf",
+        "Lb",
         "Leobersdorf Bahnhof",
         "Leobersdorf Bf",
         "Leobersdorf bf"
@@ -366,6 +378,7 @@
         "Bahnhof Liesing",
         "Bf Liesing",
         "bf Liesing",
+        "Lg",
         "Liesing",
         "Liesing Bahnhof",
         "Liesing Bf",
@@ -391,6 +404,7 @@
         "Bahnhof Perchtoldsdorf",
         "Bf Perchtoldsdorf",
         "bf Perchtoldsdorf",
+        "Lg  H1",
         "Perchtoldsdorf Bahnhof",
         "Perchtoldsdorf Bf",
         "Perchtoldsdorf bf"
@@ -412,6 +426,7 @@
         "Bahnhof Sollenau",
         "Bf Sollenau",
         "bf Sollenau",
+        "Lb  H1",
         "Sollenau Bahnhof",
         "Sollenau Bf",
         "Sollenau bf"
@@ -430,6 +445,7 @@
       "aliases": [
         "410447300",
         "Parndorf Ort",
+        "Apo H1",
         "Bahnhof Parndorf Ort",
         "Bf Parndorf Ort",
         "bf Parndorf Ort",
@@ -457,6 +473,7 @@
         "bf Sankt Marx",
         "Bf St. Marx",
         "bf St. Marx",
+        "Nw  H1H",
         "Sankt Marx",
         "Sankt Marx Bahnhof",
         "Sankt Marx Bf",
@@ -508,6 +525,7 @@
         "Geiselbergstrasse bf",
         "Geiselbergstraße Bf",
         "Geiselbergstraße bf",
+        "Sah H1",
         "Wien Geiselbergstr.",
         "Wien Geiselbergstr. Bahnhof",
         "Wien Geiselbergstr. Bf",
@@ -541,6 +559,7 @@
         "Leopoldau Bahnhof",
         "Leopoldau Bf",
         "Leopoldau bf",
+        "Lp",
         "Wien Leopoldau Bahnhof",
         "Wien Leopoldau Bf",
         "Wien Leopoldau bf"
@@ -569,7 +588,8 @@
         "Laxenburg Biedermannsdorf bf",
         "Laxenburg-Biedermannsdorf Bahnhof",
         "Laxenburg-Biedermannsdorf Bf",
-        "Laxenburg-Biedermannsdorf bf"
+        "Laxenburg-Biedermannsdorf bf",
+        "Lx"
       ],
       "source": "oebb",
       "latitude": 47.9893,
@@ -588,6 +608,7 @@
         "Bahnhof Marchegg",
         "Bf Marchegg",
         "bf Marchegg",
+        "Mac",
         "Marchegg Bahnhof",
         "Marchegg Bf",
         "Marchegg bf"
@@ -609,6 +630,7 @@
         "Bahnhof Maria Ellend",
         "Bf Maria Ellend",
         "bf Maria Ellend",
+        "Mae",
         "Maria Ellend an der Donau",
         "Maria Ellend Bahnhof",
         "Maria Ellend Bf",
@@ -631,6 +653,7 @@
         "Bahnhof Maria Lanzendorf",
         "Bf Maria Lanzendorf",
         "bf Maria Lanzendorf",
+        "Mar",
         "Maria Lanzendorf Bahnhof",
         "Maria Lanzendorf Bf",
         "Maria Lanzendorf bf"
@@ -652,6 +675,7 @@
         "Bahnhof Hetzendorf",
         "Bf Hetzendorf",
         "bf Hetzendorf",
+        "Het",
         "Hetzendorf",
         "Hetzendorf Bahnhof",
         "Hetzendorf Bf",
@@ -695,6 +719,7 @@
         "Matzleinsdorfer Platz Bahnhof",
         "Matzleinsdorfer Platz Bf",
         "Matzleinsdorfer Platz bf",
+        "Wbf H1S",
         "Wien Matzleinsdorfer Pl.",
         "Wien Matzleinsdorfer pl.",
         "Wien Matzleinsdorfer Pl. Bahnhof",
@@ -730,7 +755,8 @@
         "Quartier Belvedere bf",
         "Wien Quartier Belvedere Bahnhof",
         "Wien Quartier Belvedere Bf",
-        "Wien Quartier Belvedere bf"
+        "Wien Quartier Belvedere bf",
+        "Wwb"
       ],
       "latitude": 48.188024,
       "longitude": 16.381366,
@@ -746,6 +772,7 @@
       "aliases": [
         "490109100",
         "Wien Rennweg",
+        "Ren",
         "Wien Rennweg Bahnhof",
         "Wien Rennweg Bf",
         "Wien Rennweg bf"
@@ -767,6 +794,7 @@
         "Bahnhof Mistelbach",
         "Bf Mistelbach",
         "bf Mistelbach",
+        "Mb",
         "Mistelbach (NOe) Bahnhof",
         "Mistelbach (NOe) Bf",
         "Mistelbach (NOe) bf",
@@ -797,6 +825,7 @@
         "bf Moedling",
         "Bf Mödling",
         "bf Mödling",
+        "Md",
         "Moedling",
         "Moedling Bahnhof",
         "Moedling Bf",
@@ -824,7 +853,8 @@
         "bf Gumpoldskirchen",
         "Gumpoldskirchen Bahnhof",
         "Gumpoldskirchen Bf",
-        "Gumpoldskirchen bf"
+        "Gumpoldskirchen bf",
+        "Md  H2"
       ],
       "latitude": 48.041293,
       "longitude": 16.285389,
@@ -847,6 +877,7 @@
         "Meidling Bahnhof",
         "Meidling Bf",
         "Meidling bf",
+        "Mi",
         "Wien Meidling Bahnhof",
         "Wien Meidling Bf",
         "Wien Meidling bf"
@@ -875,6 +906,7 @@
         "Bad Deutsch-Altenburg/Donau",
         "Bahnhof Bad Deutsch Altenburg",
         "Bahnhof Bad Deutsch-Altenburg",
+        "Bde",
         "Bf Bad Deutsch Altenburg",
         "bf Bad Deutsch Altenburg",
         "Bf Bad Deutsch-Altenburg",
@@ -895,6 +927,7 @@
         "430316200",
         "Bernhardsthal",
         "Bahnhof Bernhardsthal",
+        "Beh",
         "Bernhardsthal Bahnhof",
         "Bernhardsthal Bf",
         "Bernhardsthal bf",
@@ -921,6 +954,7 @@
         "bf Muenchendorf",
         "Bf Münchendorf",
         "bf Münchendorf",
+        "Mue",
         "Muenchendorf",
         "Muenchendorf Bahnhof",
         "Muenchendorf Bf",
@@ -945,6 +979,7 @@
         "Pfaffstätten",
         "Bahnhof Pfaffstaetten",
         "Bahnhof Pfaffstätten",
+        "Bf",
         "Bf Pfaffstaetten",
         "bf Pfaffstaetten",
         "Bf Pfaffstätten",
@@ -976,6 +1011,7 @@
         "Baden Bf",
         "Baden bf",
         "Bahnhof Baden",
+        "Bf  H1",
         "Bf Baden",
         "bf Baden"
       ],
@@ -1006,6 +1042,7 @@
         "bf Wiener Neustadt Hbahnhof",
         "Bf Wiener Neustadt Hbf",
         "bf Wiener Neustadt Hbf",
+        "Nb",
         "Wiener Neustadt",
         "Wiener Neustadt Hauptbahnhof Bahnhof",
         "Wiener Neustadt Hauptbahnhof Bf",
@@ -1038,6 +1075,7 @@
       "aliases": [
         "430304600",
         "Angern",
+        "Ag",
         "Angern (March)",
         "Angern (March) Bahnhof",
         "Angern (March) Bf",
@@ -1074,6 +1112,7 @@
         "Bf Nußdorf",
         "bf Nussdorf",
         "bf Nußdorf",
+        "Nf",
         "Nussdorf",
         "Nußdorf",
         "Nussdorf Bahnhof",
@@ -1110,7 +1149,8 @@
         "Hohenau an der March Bahnhof",
         "Hohenau Bahnhof",
         "Hohenau Bf",
-        "Hohenau bf"
+        "Hohenau bf",
+        "Nh"
       ],
       "latitude": 48.598256,
       "longitude": 16.900853,
@@ -1131,7 +1171,8 @@
         "bf Neulengbach",
         "Neulengbach Bahnhof",
         "Neulengbach Bf",
-        "Neulengbach bf"
+        "Neulengbach bf",
+        "Nl"
       ],
       "latitude": 48.199504,
       "longitude": 15.892875,
@@ -1152,7 +1193,8 @@
         "bf Neusiedl am See",
         "Neusiedl am See Bahnhof",
         "Neusiedl am See Bf",
-        "Neusiedl am See bf"
+        "Neusiedl am See bf",
+        "Ns"
       ],
       "latitude": 47.955824,
       "longitude": 16.823788,
@@ -1171,6 +1213,7 @@
         "Bahnhof Praterstern",
         "Bf Praterstern",
         "bf Praterstern",
+        "Nw",
         "Praterstern",
         "Praterstern Bahnhof",
         "Praterstern Bf",
@@ -1208,6 +1251,7 @@
         "bf Traiseng.",
         "Bf Traisengasse",
         "bf Traisengasse",
+        "Nw  H1",
         "Traiseng.",
         "Traiseng. Bahnhof",
         "Traiseng. Bf",
@@ -1243,7 +1287,8 @@
         "bf Hollabrunn",
         "Hollabrunn Bahnhof",
         "Hollabrunn Bf",
-        "Hollabrunn bf"
+        "Hollabrunn bf",
+        "Oh"
       ],
       "latitude": 48.562964,
       "longitude": 16.07229,
@@ -1262,6 +1307,7 @@
         "Bahnhof Ottakring",
         "Bf Ottakring",
         "bf Ottakring",
+        "Ok",
         "Ottakring",
         "Ottakring Bahnhof",
         "Ottakring Bf",
@@ -1291,6 +1337,7 @@
         "Breitensee Bahnhof",
         "Breitensee Bf",
         "Breitensee bf",
+        "Ok  H1",
         "Wien Breitensee Bahnhof",
         "Wien Breitensee Bf",
         "Wien Breitensee bf"
@@ -1312,6 +1359,7 @@
         "Bahnhof Parndorf",
         "Bf Parndorf",
         "bf Parndorf",
+        "Par",
         "Parndorf Bahnhof",
         "Parndorf Bf",
         "Parndorf bf"
@@ -1384,6 +1432,7 @@
         "bf St.Pölten Hbahnhof",
         "Bf St.Pölten Hbf",
         "bf St.Pölten Hbf",
+        "Pb",
         "Sankt Poelten Hauptbahnhof",
         "Sankt Poelten Hauptbahnhof Bahnhof",
         "Sankt Poelten Hauptbahnhof Bf",
@@ -1480,6 +1529,7 @@
         "bf Petronell Carnuntum",
         "Bf Petronell-Carnuntum",
         "bf Petronell-Carnuntum",
+        "Pet",
         "Petronell Carnuntum",
         "Petronell Carnuntum Bahnhof",
         "Petronell Carnuntum Bf",
@@ -1509,6 +1559,7 @@
         "Absdorf-Hippersdorf Bahnhof",
         "Absdorf-Hippersdorf Bf",
         "Absdorf-Hippersdorf bf",
+        "Ah",
         "Bahnhof Absdorf Hippersdorf",
         "Bahnhof Absdorf-Hippersdorf",
         "Bf Absdorf Hippersdorf",
@@ -1536,6 +1587,7 @@
         "bf Tullnerbach Pressbaum",
         "Bf Tullnerbach-Pressbaum",
         "bf Tullnerbach-Pressbaum",
+        "Pm",
         "Tullnerbach Pressbaum",
         "Tullnerbach Pressbaum Bahnhof",
         "Tullnerbach Pressbaum Bf",
@@ -1561,6 +1613,7 @@
         "Bahnhof Pressbaum",
         "Bf Pressbaum",
         "bf Pressbaum",
+        "Pm  H1",
         "Pressbaum Bahnhof",
         "Pressbaum Bf",
         "Pressbaum bf"
@@ -1582,6 +1635,7 @@
         "Bahnhof Bruck an der Leitha",
         "Bf Bruck an der Leitha",
         "bf Bruck an der Leitha",
+        "Bl",
         "Bruck an der Leitha Bahnhof",
         "Bruck an der Leitha Bf",
         "Bruck an der Leitha bf"
@@ -1612,7 +1666,8 @@
         "Payerbach Reichenau bf",
         "Payerbach-Reichenau Bahnhof",
         "Payerbach-Reichenau Bf",
-        "Payerbach-Reichenau bf"
+        "Payerbach-Reichenau bf",
+        "Pr"
       ],
       "latitude": 47.696063,
       "longitude": 15.86321,
@@ -1633,7 +1688,8 @@
         "bf Pottenbrunn",
         "Pottenbrunn Bahnhof",
         "Pottenbrunn Bf",
-        "Pottenbrunn bf"
+        "Pottenbrunn bf",
+        "Wgm"
       ],
       "latitude": 48.223658,
       "longitude": 15.701908,
@@ -1656,6 +1712,7 @@
         "Penzing Bahnhof",
         "Penzing Bf",
         "Penzing bf",
+        "Pz",
         "Wien Penzing Bahnhof",
         "Wien Penzing Bf",
         "Wien Penzing bf"
@@ -1685,7 +1742,8 @@
         "Raasdorf (NÖ) bf",
         "Raasdorf Bahnhof",
         "Raasdorf Bf",
-        "Raasdorf bf"
+        "Raasdorf bf",
+        "Raf"
       ],
       "latitude": 48.238984,
       "longitude": 16.582078,
@@ -1706,7 +1764,8 @@
         "bf Glinzendorf",
         "Glinzendorf Bahnhof",
         "Glinzendorf Bf",
-        "Glinzendorf bf"
+        "Glinzendorf bf",
+        "Raf H1"
       ],
       "latitude": 48.24231,
       "longitude": 16.640094,
@@ -1725,6 +1784,7 @@
         "Bahnhof Regelsbrunn",
         "Bf Regelsbrunn",
         "bf Regelsbrunn",
+        "Reg",
         "Regelsbrunn Bahnhof",
         "Regelsbrunn Bf",
         "Regelsbrunn bf"
@@ -1746,6 +1806,7 @@
         "Bahnhof Wildungsmauer",
         "Bf Wildungsmauer",
         "bf Wildungsmauer",
+        "Reg H1",
         "Wildungsmauer Bahnhof",
         "Wildungsmauer Bf",
         "Wildungsmauer bf"
@@ -1769,7 +1830,8 @@
         "bf Rekawinkel",
         "Rekawinkel Bahnhof",
         "Rekawinkel Bf",
-        "Rekawinkel bf"
+        "Rekawinkel bf",
+        "Rw"
       ],
       "latitude": 48.17979,
       "longitude": 16.031111,
@@ -1797,7 +1859,8 @@
         "Eichgraben Altlengbach bf",
         "Eichgraben-Altlengbach Bahnhof",
         "Eichgraben-Altlengbach Bf",
-        "Eichgraben-Altlengbach bf"
+        "Eichgraben-Altlengbach bf",
+        "Rw  H1"
       ],
       "latitude": 48.17348,
       "longitude": 15.981544,
@@ -1814,6 +1877,7 @@
         "Bahnhof Mistelbach Stadt",
         "Bf Mistelbach Stadt",
         "bf Mistelbach Stadt",
+        "Mb  H1H",
         "Mistelbach Stadt Bahnhof",
         "Mistelbach Stadt Bf",
         "Mistelbach Stadt bf"
@@ -1838,6 +1902,7 @@
         "bf Siebenbrunn Leopoldsdorf",
         "Bf Siebenbrunn-Leopoldsdorf",
         "bf Siebenbrunn-Leopoldsdorf",
+        "Sbl",
         "Siebenbrunn Leopoldsdorf",
         "Siebenbrunn Leopoldsdorf Bahnhof",
         "Siebenbrunn Leopoldsdorf Bf",
@@ -1863,6 +1928,7 @@
         "Bahnhof Untersiebenbrunn",
         "Bf Untersiebenbrunn",
         "bf Untersiebenbrunn",
+        "Sbl H1",
         "Untersiebenbrunn Bahnhof",
         "Untersiebenbrunn Bf",
         "Untersiebenbrunn bf"
@@ -1884,6 +1950,7 @@
         "Bahnhof Strebersdorf",
         "Bf Strebersdorf",
         "bf Strebersdorf",
+        "Sdf",
         "Strebersdorf",
         "Strebersdorf Bahnhof",
         "Strebersdorf Bf",
@@ -1932,7 +1999,8 @@
         "Schönfeld Lassee bf",
         "Schönfeld-Lassee Bahnhof",
         "Schönfeld-Lassee Bf",
-        "Schönfeld-Lassee bf"
+        "Schönfeld-Lassee bf",
+        "Sfl"
       ],
       "latitude": 48.251129,
       "longitude": 16.807284,
@@ -1962,6 +2030,7 @@
         "Grillgasse Bahnhof",
         "Grillgasse Bf",
         "Grillgasse bf",
+        "Sg",
         "Wien Grillg.",
         "Wien Grillg. Bahnhof",
         "Wien Grillg. Bf",
@@ -2068,6 +2137,7 @@
         "Erzherzog-Karl-Strasse bf",
         "Erzherzog-Karl-Straße Bf",
         "Erzherzog-Karl-Straße bf",
+        "Stk",
         "Wien Erzherzog Karl Str.",
         "Wien Erzherzog Karl str.",
         "Wien Erzherzog Karl Str. Bahnhof",
@@ -2137,6 +2207,7 @@
         "Hirschstetten Bahnhof",
         "Hirschstetten Bf",
         "Hirschstetten bf",
+        "Stc",
         "Wien Hirschstetten Bahnhof",
         "Wien Hirschstetten Bf",
         "Wien Hirschstetten bf"
@@ -2160,7 +2231,8 @@
         "bf Stockerau",
         "Stockerau Bahnhof",
         "Stockerau Bf",
-        "Stockerau bf"
+        "Stockerau bf",
+        "Su"
       ],
       "latitude": 48.382308,
       "longitude": 16.213016,
@@ -2182,6 +2254,7 @@
         "bf Suessenbrunn",
         "Bf Süßenbrunn",
         "bf Süßenbrunn",
+        "Sue",
         "Suessenbrunn",
         "Suessenbrunn Bahnhof",
         "Suessenbrunn Bf",
@@ -2215,6 +2288,7 @@
         "Bahnhof Tattendorf",
         "Bf Tattendorf",
         "bf Tattendorf",
+        "Tat",
         "Tattendorf Bahnhof",
         "Tattendorf Bf",
         "Tattendorf bf"
@@ -2236,6 +2310,7 @@
         "Bahnhof Teesdorf",
         "Bf Teesdorf",
         "bf Teesdorf",
+        "Tat H1",
         "Teesdorf Bahnhof",
         "Teesdorf Bf",
         "Teesdorf bf"
@@ -2257,6 +2332,7 @@
         "Bahnhof Traiskirchen Aspangbahn",
         "Bf Traiskirchen Aspangbahn",
         "bf Traiskirchen Aspangbahn",
+        "Ti",
         "Traiskirchen Aspangbahn Bahnhof",
         "Traiskirchen Aspangbahn Bf",
         "Traiskirchen Aspangbahn bf"
@@ -2278,6 +2354,7 @@
         "Bahnhof Trumau",
         "Bf Trumau",
         "bf Trumau",
+        "Ti  K1",
         "Trumau Bahnhof",
         "Trumau Bf",
         "Trumau bf"
@@ -2301,7 +2378,8 @@
         "bf Ternitz",
         "Ternitz Bahnhof",
         "Ternitz Bf",
-        "Ternitz bf"
+        "Ternitz bf",
+        "Tn"
       ],
       "latitude": 47.713753,
       "longitude": 16.033385,
@@ -2322,7 +2400,8 @@
         "bf Pottschach",
         "Pottschach Bahnhof",
         "Pottschach Bf",
-        "Pottschach bf"
+        "Pottschach bf",
+        "Tn  H1"
       ],
       "latitude": 47.696899,
       "longitude": 16.005968,
@@ -2341,6 +2420,7 @@
         "Bahnhof Tulln an der Donau",
         "Bf Tulln an der Donau",
         "bf Tulln an der Donau",
+        "Tu",
         "Tulln an der Donau Bahnhof",
         "Tulln an der Donau Bf",
         "Tulln an der Donau bf",
@@ -2365,7 +2445,8 @@
         "bf Tulln Stadt",
         "Tulln Stadt Bahnhof",
         "Tulln Stadt Bf",
-        "Tulln Stadt bf"
+        "Tulln Stadt bf",
+        "Tus"
       ],
       "latitude": 48.328436,
       "longitude": 16.053997,
@@ -2387,7 +2468,8 @@
         "Purkersdorf bei Wien Zentrum Bahnhof",
         "Purkersdorf Zentrum Bahnhof",
         "Purkersdorf Zentrum Bf",
-        "Purkersdorf Zentrum bf"
+        "Purkersdorf Zentrum bf",
+        "Upz"
       ],
       "latitude": 48.206138,
       "longitude": 16.175774,
@@ -2424,6 +2506,7 @@
         "Haidestrasse bf",
         "Haidestraße Bf",
         "Haidestraße bf",
+        "Wbf H2",
         "Wien Haidestr.",
         "Wien Haidestr. Bahnhof",
         "Wien Haidestr. Bf",
@@ -2456,6 +2539,7 @@
         "Franz-Josefs-Bahnhof",
         "Franz-Josefs-Bf",
         "Franz-Josefs-bf",
+        "Wf",
         "Wien Franz Josefs Bahnhof",
         "Wien Franz Josefs Bf",
         "Wien Franz Josefs bf",
@@ -2483,6 +2567,7 @@
         "Spittelau Bahnhof",
         "Spittelau Bf",
         "Spittelau bf",
+        "Wf  H1",
         "Wien Spittelau Bahnhof",
         "Wien Spittelau Bf",
         "Wien Spittelau bf"
@@ -2509,7 +2594,8 @@
         "Deutsch Wagram bf",
         "Deutsch-Wagram Bahnhof",
         "Deutsch-Wagram Bf",
-        "Deutsch-Wagram bf"
+        "Deutsch-Wagram bf",
+        "Wg"
       ],
       "latitude": 48.303014,
       "longitude": 16.563982,
@@ -2530,7 +2616,8 @@
         "bf Helmahof",
         "Helmahof Bahnhof",
         "Helmahof Bf",
-        "Helmahof bf"
+        "Helmahof bf",
+        "Wg  H1"
       ],
       "latitude": 48.310323,
       "longitude": 16.596973,
@@ -2552,7 +2639,8 @@
         "Strasshof (Nordbahn) Bahnhof",
         "Strasshof an der Nordbahn Bahnhof",
         "Strasshof an der Nordbahn Bf",
-        "Strasshof an der Nordbahn bf"
+        "Strasshof an der Nordbahn bf",
+        "Wg  H2"
       ],
       "latitude": 48.318476,
       "longitude": 16.6339,
@@ -2571,6 +2659,7 @@
         "Bahnhof Wolfsthal",
         "Bf Wolfsthal",
         "bf Wolfsthal",
+        "Wof",
         "Wolfsthal Bahnhof",
         "Wolfsthal Bf",
         "Wolfsthal bf"
@@ -2592,6 +2681,7 @@
         "Bahnhof Wolkersdorf",
         "Bf Wolkersdorf",
         "bf Wolkersdorf",
+        "Wol",
         "Wolkersdorf Bahnhof",
         "Wolkersdorf Bf",
         "Wolkersdorf bf"
@@ -2615,7 +2705,8 @@
         "bf Wampersdorf",
         "Wampersdorf Bahnhof",
         "Wampersdorf Bf",
-        "Wampersdorf bf"
+        "Wampersdorf bf",
+        "Wp"
       ],
       "latitude": 47.931535,
       "longitude": 16.417305,
@@ -2643,7 +2734,8 @@
         "Pottendorf Landegg bf",
         "Pottendorf-Landegg Bahnhof",
         "Pottendorf-Landegg Bf",
-        "Pottendorf-Landegg bf"
+        "Pottendorf-Landegg bf",
+        "Wp  H1"
       ],
       "latitude": 47.904954,
       "longitude": 16.395596,
@@ -2679,7 +2771,8 @@
         "Wien Westbf",
         "Wien Westbf Bahnhof",
         "Wien Westbf Bf",
-        "Wien Westbf bf"
+        "Wien Westbf bf",
+        "Ws"
       ],
       "latitude": 48.196654,
       "longitude": 16.337652,
@@ -2700,7 +2793,8 @@
         "bf Brunn am Gebirge",
         "Brunn am Gebirge Bahnhof",
         "Brunn am Gebirge Bf",
-        "Brunn am Gebirge bf"
+        "Brunn am Gebirge bf",
+        "Bu"
       ],
       "latitude": 48.10509,
       "longitude": 16.288094,
@@ -2728,7 +2822,8 @@
         "Bf Bad Voeslau",
         "bf Bad Voeslau",
         "Bf Bad Vöslau",
-        "bf Bad Vöslau"
+        "bf Bad Vöslau",
+        "Bvs"
       ],
       "latitude": 47.969533,
       "longitude": 16.223929,
@@ -2747,6 +2842,7 @@
         "Bahnhof Kottingbrunn",
         "Bf Kottingbrunn",
         "bf Kottingbrunn",
+        "Bvs H1",
         "Kottingbrunn Bahnhof",
         "Kottingbrunn Bf",
         "Kottingbrunn bf"
@@ -2773,7 +2869,8 @@
         "Kledering Bf",
         "Kledering bf",
         "Kledering Bf (VOR)",
-        "Kledering bf (VOR)"
+        "Kledering bf (VOR)",
+        "Za"
       ],
       "latitude": 48.132453,
       "longitude": 16.439724,
@@ -2801,7 +2898,8 @@
         "Lanzendorf Rannersdorf bf",
         "Lanzendorf-Rannersdorf Bahnhof",
         "Lanzendorf-Rannersdorf Bf",
-        "Lanzendorf-Rannersdorf bf"
+        "Lanzendorf-Rannersdorf bf",
+        "Zs"
       ],
       "latitude": 48.113486,
       "longitude": 16.447482,
@@ -2820,6 +2918,7 @@
         "Bahnhof Zentralfriedhof",
         "Bf Zentralfriedhof",
         "bf Zentralfriedhof",
+        "Cf",
         "Wien Zentralfriedhof Bahnhof",
         "Wien Zentralfriedhof Bf",
         "Wien Zentralfriedhof bf",
@@ -2845,6 +2944,7 @@
         "Bahnhof Wolf in der Au",
         "Bf Wolf in der Au",
         "bf Wolf in der Au",
+        "Hf  H1",
         "Wien Wolf in der Au Bahnhof",
         "Wien Wolf in der Au Bf",
         "Wien Wolf in der Au bf",
@@ -2873,6 +2973,7 @@
         "bf Droesing",
         "Bf Drösing",
         "bf Drösing",
+        "Drg",
         "Droesing",
         "Droesing Bahnhof",
         "Droesing Bf",
@@ -2901,6 +3002,7 @@
         "bf Duernkrut",
         "Bf Dürnkrut",
         "bf Dürnkrut",
+        "Due",
         "Duernkrut",
         "Duernkrut Bahnhof",
         "Duernkrut Bf",
@@ -2926,6 +3028,7 @@
         "Bahnhof Ebreichsdorf",
         "Bf Ebreichsdorf",
         "bf Ebreichsdorf",
+        "Ebr",
         "Ebreichsdorf Bahnhof",
         "Ebreichsdorf Bf",
         "Ebreichsdorf bf"
@@ -2945,6 +3048,7 @@
         "Bahnhof Weigelsdorf",
         "Bf Weigelsdorf",
         "bf Weigelsdorf",
+        "Ebr H1",
         "Weigelsdorf Bahnhof",
         "Weigelsdorf Bf",
         "Weigelsdorf bf"
@@ -2968,7 +3072,8 @@
         "bf Ebenfurth",
         "Ebenfurth Bahnhof",
         "Ebenfurth Bf",
-        "Ebenfurth bf"
+        "Ebenfurth bf",
+        "Ef"
       ],
       "latitude": 47.877573,
       "longitude": 16.361851,
@@ -2987,6 +3092,7 @@
         "Bahnhof Praterkai",
         "Bf Praterkai",
         "bf Praterkai",
+        "El  H1",
         "Praterkai",
         "Praterkai Bahnhof",
         "Praterkai Bf",
@@ -3012,6 +3118,7 @@
         "Bahnhof Floridsdorf",
         "Bf Floridsdorf",
         "bf Floridsdorf",
+        "F",
         "Floridsdorf",
         "Floridsdorf Bahnhof",
         "Floridsdorf Bf",
@@ -3043,6 +3150,7 @@
         "Bf Siemensstraße",
         "bf Siemensstrasse",
         "bf Siemensstraße",
+        "F   H1",
         "Siemensstr.",
         "Siemensstr. Bahnhof",
         "Siemensstr. Bf",
@@ -3123,6 +3231,7 @@
         "Brünner Straße Bahnhof",
         "Brünner Straße Bf",
         "Brünner Straße bf",
+        "Bse",
         "Wien Bruenner Str.",
         "Wien Bruenner str.",
         "Wien Bruenner Str. Bahnhof",
@@ -3164,6 +3273,7 @@
         "Bahnhof Fischamend",
         "Bf Fischamend",
         "bf Fischamend",
+        "Fam",
         "Fischamend Bahnhof",
         "Fischamend Bf",
         "Fischamend bf"
@@ -3185,6 +3295,7 @@
         "Bahnhof Tullnerfeld",
         "Bf Tullnerfeld",
         "bf Tullnerfeld",
+        "Tfd",
         "Tullnerfeld Bahnhof",
         "Tullnerfeld Bf",
         "Tullnerfeld bf"
@@ -3206,6 +3317,7 @@
         "Bahnhof Stadlau",
         "Bf Stadlau",
         "bf Stadlau",
+        "El  H3",
         "Stadlau",
         "Stadlau Bahnhof",
         "Stadlau Bf",
@@ -3233,7 +3345,8 @@
         "bf Felixdorf",
         "Felixdorf Bahnhof",
         "Felixdorf Bf",
-        "Felixdorf bf"
+        "Felixdorf bf",
+        "Fld"
       ],
       "latitude": 47.886832,
       "longitude": 16.248146,
@@ -3252,6 +3365,7 @@
         "Bahnhof Wiener Neustadt Nord",
         "Bf Wiener Neustadt Nord",
         "bf Wiener Neustadt Nord",
+        "Fld H2",
         "Wiener Neustadt Nord Bahnhof",
         "Wiener Neustadt Nord Bf",
         "Wiener Neustadt Nord bf"
@@ -3277,6 +3391,7 @@
         "Simmering Bahnhof",
         "Simmering Bf",
         "Simmering bf",
+        "Wbf H1",
         "Wien Simmering Bahnhof",
         "Wien Simmering Bf",
         "Wien Simmering bf"
@@ -3302,6 +3417,7 @@
         "Bahnhof Aspern Nord",
         "Bf Aspern Nord",
         "bf Aspern Nord",
+        "Sty",
         "Wien Aspern Nord Bahnhof",
         "Wien Aspern Nord Bf",
         "Wien Aspern Nord bf"
@@ -3326,6 +3442,7 @@
         "Flughafen Wien Bahnhof",
         "Flughafen Wien Bf",
         "Flughafen Wien bf",
+        "Fws",
         "Schwechat Flughafen Wien Bahnhof",
         "Vienna Airport"
       ],
@@ -3349,6 +3466,7 @@
         "bf Gaenserndorf",
         "Bf Gänserndorf",
         "bf Gänserndorf",
+        "Gae",
         "Gaenserndorf",
         "Gaenserndorf Bahnhof",
         "Gaenserndorf Bf",
@@ -3374,6 +3492,7 @@
         "Bahnhof Gerasdorf",
         "Bf Gerasdorf",
         "bf Gerasdorf",
+        "Gef",
         "Gerasdorf Bahnhof",
         "Gerasdorf bei Wien Bahnhof",
         "Gerasdorf bei Wien Bahnhof (VOR)",
@@ -3397,6 +3516,7 @@
         "Bahnhof Gloggnitz",
         "Bf Gloggnitz",
         "bf Gloggnitz",
+        "Glo",
         "Gloggnitz Bahnhof",
         "Gloggnitz Bf",
         "Gloggnitz bf"
@@ -3418,6 +3538,7 @@
         "Bahnhof Gramatneusiedl",
         "Bf Gramatneusiedl",
         "bf Gramatneusiedl",
+        "Gn",
         "Gramatneusiedl Bahnhof",
         "Gramatneusiedl Bf",
         "Gramatneusiedl bf"
@@ -3442,6 +3563,7 @@
         "bf Goetzendorf",
         "Bf Götzendorf",
         "bf Götzendorf",
+        "Goe",
         "Goetzendorf",
         "Goetzendorf Bahnhof",
         "Goetzendorf Bf",
@@ -3469,6 +3591,7 @@
         "Bahnhof Sarasdorf",
         "Bf Sarasdorf",
         "bf Sarasdorf",
+        "Goe H1",
         "Sarasdorf Bahnhof",
         "Sarasdorf Bf",
         "Sarasdorf bf"
@@ -3490,6 +3613,7 @@
         "Bahnhof Wilfleinsdorf",
         "Bf Wilfleinsdorf",
         "bf Wilfleinsdorf",
+        "Goe H2",
         "Wilfleinsdorf Bahnhof",
         "Wilfleinsdorf Bf",
         "Wilfleinsdorf bf"
@@ -3511,6 +3635,7 @@
         "Bahnhof Schwechat",
         "Bf Schwechat",
         "bf Schwechat",
+        "Gs",
         "Schwechat Bahnhof",
         "Schwechat Bahnhof (VOR)",
         "Schwechat Bf",
@@ -3544,7 +3669,8 @@
         "Mannswoerth bf",
         "Mannswörth Bahnhof",
         "Mannswörth Bf",
-        "Mannswörth bf"
+        "Mannswörth bf",
+        "Msw"
       ],
       "latitude": 48.136678,
       "longitude": 16.506928,
@@ -3566,6 +3692,7 @@
         "bf Moellersdorf Aspangbahn",
         "Bf Möllersdorf Aspangbahn",
         "bf Möllersdorf Aspangbahn",
+        "Guk H2",
         "Moellersdorf Aspangbahn",
         "Moellersdorf Aspangbahn Bahnhof",
         "Moellersdorf Aspangbahn Bf",
@@ -3594,6 +3721,7 @@
         "bf Hainburg an der Donau Personenbahnhof",
         "Bf Hainburg an der Donau Personenbf",
         "bf Hainburg an der Donau Personenbf",
+        "Hai H1",
         "Hainburg an der Donau Personenbahnhof Bahnhof",
         "Hainburg an der Donau Personenbahnhof Bf",
         "Hainburg an der Donau Personenbahnhof bf",
@@ -3620,6 +3748,7 @@
         "Bahnhof Handelskai",
         "Bf Handelskai",
         "bf Handelskai",
+        "Hak",
         "Handelskai",
         "Handelskai Bahnhof",
         "Handelskai Bf",
@@ -3648,6 +3777,7 @@
         "bf Huetteldorf",
         "Bf Hütteldorf",
         "bf Hütteldorf",
+        "Hf",
         "Huetteldorf",
         "Huetteldorf Bahnhof",
         "Huetteldorf Bf",
@@ -3685,6 +3815,7 @@
         "Hadersdorf Bahnhof",
         "Hadersdorf Bf",
         "Hadersdorf bf",
+        "Hf  H2",
         "Wien Hadersdorf Bahnhof",
         "Wien Hadersdorf Bf",
         "Wien Hadersdorf bf"
@@ -3706,6 +3837,7 @@
         "Bahnhof Speising",
         "Bf Speising",
         "bf Speising",
+        "Hf  H1A",
         "Speising",
         "Speising Bahnhof",
         "Speising Bf",
@@ -3731,6 +3863,7 @@
         "Bahnhof Weidlingau",
         "Bf Weidlingau",
         "bf Weidlingau",
+        "Hf  H3",
         "Weidlingau",
         "Weidlingau Bahnhof",
         "Weidlingau Bf",
@@ -3757,6 +3890,7 @@
         "Bahnhof Purkersdorf Sanatorium",
         "Bf Purkersdorf Sanatorium",
         "bf Purkersdorf Sanatorium",
+        "Hf  H4",
         "Purkersdorf bei Wien Bahnhof",
         "Purkersdorf Sanatorium Bahnhof",
         "Purkersdorf Sanatorium Bf",
@@ -3781,7 +3915,8 @@
         "bf Hadersdorf am Kamp",
         "Hadersdorf am Kamp Bahnhof",
         "Hadersdorf am Kamp Bf",
-        "Hadersdorf am Kamp bf"
+        "Hadersdorf am Kamp bf",
+        "Hfa"
       ],
       "latitude": 48.446572,
       "longitude": 15.714879,
@@ -3798,6 +3933,7 @@
         "Bahnhof Himberg",
         "Bf Himberg",
         "bf Himberg",
+        "Him",
         "Himberg Bahnhof",
         "Himberg bei Wien",
         "Himberg Bf",
@@ -3824,7 +3960,8 @@
         "Haslau (Donau) Bahnhof",
         "Haslau an der Donau Bahnhof",
         "Haslau an der Donau Bf",
-        "Haslau an der Donau bf"
+        "Haslau an der Donau bf",
+        "Hlu"
       ],
       "latitude": 48.109683,
       "longitude": 16.710192,
@@ -3846,7 +3983,8 @@
         "Hennersdorf Bahnhof",
         "Hennersdorf bei Wien Bahnhof",
         "Hennersdorf Bf",
-        "Hennersdorf bf"
+        "Hennersdorf bf",
+        "Hnd"
       ],
       "latitude": 48.112344,
       "longitude": 16.358201,
@@ -3869,6 +4007,7 @@
         "Hernals Bahnhof",
         "Hernals Bf",
         "Hernals bf",
+        "Hns",
         "Wien Hernals Bahnhof",
         "Wien Hernals Bf",
         "Wien Hernals bf"
@@ -3894,6 +4033,7 @@
         "Heiligenstadt Bahnhof",
         "Heiligenstadt Bf",
         "Heiligenstadt bf",
+        "Ht",
         "Wien Heiligenstadt Bahnhof",
         "Wien Heiligenstadt Bf",
         "Wien Heiligenstadt bf"
@@ -3918,6 +4058,7 @@
         "bf Oberdoebling",
         "Bf Oberdöbling",
         "bf Oberdöbling",
+        "Ht  H1",
         "Oberdoebling",
         "Oberdoebling Bahnhof",
         "Oberdoebling Bf",
@@ -3957,6 +4098,7 @@
         "Bf Krottenbachstraße",
         "bf Krottenbachstrasse",
         "bf Krottenbachstraße",
+        "Ht  H2",
         "Krottenbachstr.",
         "Krottenbachstr. Bahnhof",
         "Krottenbachstr. Bf",
@@ -4002,6 +4144,7 @@
         "Gersthof Bahnhof",
         "Gersthof Bf",
         "Gersthof bf",
+        "Ht  H3",
         "Wien Gersthof Bahnhof",
         "Wien Gersthof Bf",
         "Wien Gersthof bf"
@@ -4023,6 +4166,7 @@
         "Bahnhof Maria Anzbach",
         "Bf Maria Anzbach",
         "bf Maria Anzbach",
+        "Hu  H2",
         "Maria Anzbach Bahnhof",
         "Maria Anzbach Bf",
         "Maria Anzbach bf"
@@ -4044,6 +4188,7 @@
         "Bahnhof Neulengbach Stadt",
         "Bf Neulengbach Stadt",
         "bf Neulengbach Stadt",
+        "Hu  H4",
         "Neulengbach Stadt Bahnhof",
         "Neulengbach Stadt Bf",
         "Neulengbach Stadt bf"
@@ -4069,6 +4214,7 @@
         "Blumental Bahnhof",
         "Blumental Bf",
         "Blumental bf",
+        "Id",
         "Wien Blumental Bahnhof",
         "Wien Blumental Bf",
         "Wien Blumental bf"
@@ -4090,6 +4236,7 @@
         "Bahnhof Jedlersdorf",
         "Bf Jedlersdorf",
         "bf Jedlersdorf",
+        "J",
         "Jedlersdorf",
         "Jedlersdorf Bahnhof",
         "Jedlersdorf Bf",
@@ -4115,6 +4262,7 @@
         "Bahnhof Langenzersdorf",
         "Bf Langenzersdorf",
         "bf Langenzersdorf",
+        "F   H2S",
         "Langenzersdorf Bahnhof",
         "Langenzersdorf Bf",
         "Langenzersdorf bf"
@@ -4138,7 +4286,8 @@
         "bf Bisamberg",
         "Bisamberg Bahnhof",
         "Bisamberg Bf",
-        "Bisamberg bf"
+        "Bisamberg bf",
+        "F   H3S"
       ],
       "latitude": 48.31639,
       "longitude": 16.347252,
@@ -4916,6 +5065,7 @@
       "aliases": [
         "490134900",
         "Wien Hauptbahnhof",
+        "900100",
         "Bahnhof Hauptbf",
         "Bahnhof Hauptbf (VOR)",
         "Bahnhof Hbahnhof",
@@ -4990,6 +5140,7 @@
       "aliases": [
         "490178000",
         "Wien Kaiserebersdorf",
+        "900105",
         "Bahnhof Kaiserebersdorf",
         "Bf Kaiserebersdorf",
         "bf Kaiserebersdorf",
@@ -5025,6 +5176,7 @@
         "Wien Karlsplatz",
         "60201076",
         "60201077",
+        "900101",
         "Bahnhof Karlspl.",
         "Bahnhof Karlspl. (VOR)",
         "Bahnhof Karlspl. (WL)",
@@ -5193,6 +5345,7 @@
       "aliases": [
         "490074300",
         "Wien Mitte-Landstraße",
+        "900102",
         "Bahnhof Mitte Landstr.",
         "Bahnhof Mitte Landstrasse",
         "Bahnhof Mitte Landstraße",
@@ -5317,6 +5470,7 @@
         "Wien Schottentor",
         "60201002",
         "60201003",
+        "900103",
         "Bahnhof Schottentor",
         "Bahnhof Schottentor (VOR)",
         "Bahnhof Schottentor (WL)",
@@ -5425,6 +5579,7 @@
         "490132000",
         "Wien Stephansplatz",
         "60201001",
+        "900104",
         "Bahnhof Stephanspl.",
         "Bahnhof Stephanspl. (VOR)",
         "Bahnhof Stephanspl. (WL)",

--- a/scripts/enrich_station_aliases.py
+++ b/scripts/enrich_station_aliases.py
@@ -422,6 +422,17 @@ def _alias_candidates(
     push(str(name_value) if isinstance(name_value, str) else None)
     vor_id_value = station.get("vor_id")
     push(str(vor_id_value) if vor_id_value is not None else None)
+    # Push bst_code so the JSON aliases array carries the ÖBB Stellencode
+    # explicitly. The runtime lookup in src/utils/stations.py already
+    # treats bst_code as IDENTITY-class via _iter_aliases_with_strength,
+    # but the validator's "missing required aliases" rule expects the
+    # code to also appear in the persisted aliases list. Closes the
+    # 155-entry alias_issues backlog inherited from the legacy ÖBB-Excel
+    # import flow that wrote bst_code to its own field but never to
+    # aliases. STATIC_VOR_ENTRIES already include their bst_code in
+    # aliases (via PR #1214's _new_entry_from_static helper).
+    bst_code_value = station.get("bst_code")
+    push(str(bst_code_value) if bst_code_value is not None else None)
 
     name = str(name_value if isinstance(name_value, str) else "").strip()
     no_paren = re.sub(r"\s*\([^)]*\)\s*", " ", name)
@@ -641,6 +652,17 @@ def _alias_candidates(
             continue
 
         safe_aliases.append(a)
+
+    # The station's own bst_code is its operational identity (ÖBB
+    # Stellencode like "Aw", "Ken H1") and must not be filtered by
+    # the generic-blocklist or any other rule. Pfaffstätten happens
+    # to have bst_code "Bf" — the blocklist correctly suppresses
+    # "Bf" coming from arbitrary alias generation, but the validator
+    # and runtime lookup expect the *own* bst_code to be present.
+    # Append unconditionally (deduplicated).
+    own_bst_code = str(station.get("bst_code") or "").strip()
+    if own_bst_code and own_bst_code not in safe_aliases:
+        safe_aliases.append(own_bst_code)
 
     return safe_aliases
 

--- a/tests/test_enrich_station_aliases_filters.py
+++ b/tests/test_enrich_station_aliases_filters.py
@@ -277,3 +277,42 @@ def test_pendler_alt_names_skipped_if_dict_is_empty_or_none() -> None:
         station, vor_names={}, vor_mapping={}, gtfs_index={}, pendler_alt_names=None
     )
     assert "Angern an der March" not in aliases
+
+
+def test_bst_code_pushed_into_aliases() -> None:
+    """The validator's "missing required aliases" rule expects the
+    station's own bst_code (ÖBB Stellencode) to be present in the
+    aliases array. Closes the legacy 155-entry alias_issues backlog
+    where the ÖBB-Excel import flow wrote bst_code to its own field
+    but never to aliases."""
+    station = {
+        "name": "St.Andrä-Wördern",
+        "bst_id": "100",
+        "bst_code": "Aw",
+        "aliases": ["St.Andrä-Wördern"],
+    }
+    aliases = _alias_candidates(
+        station, vor_names={}, vor_mapping={}, gtfs_index={}
+    )
+    assert "Aw" in aliases
+
+
+def test_bst_code_bypasses_generic_blocklist() -> None:
+    """Pfaffstätten's bst_code happens to be "Bf" — the generic-
+    blocklist suppresses "Bf" coming from arbitrary alias generation,
+    but the *own* bst_code must always survive. Otherwise the
+    validator's missing-alias check fires for a code the station
+    actually has."""
+    station = {
+        "name": "Pfaffstätten",
+        "bst_id": "148",
+        "bst_code": "Bf",
+        "aliases": ["Pfaffstätten"],
+    }
+    aliases = _alias_candidates(
+        station, vor_names={}, vor_mapping={}, gtfs_index={}
+    )
+    assert "Bf" in aliases, (
+        "the station's own bst_code must bypass the generic-blocklist "
+        "so the JSON aliases stay aligned with the bst_code field"
+    )


### PR DESCRIPTION
## Summary

Closes the 155-entry `alias_issues` backlog that has been carried in the validation report since the original ÖBB-Excel import flow.

The validator expects every ÖBB-sourced station's `bst_code` (the operational Stellencode like `Aw`, `Ken H1`, `Lx`) to appear in the persisted `aliases` array. The legacy import wrote `bst_code` to its own field only — never to `aliases` — so the validator complained for every Excel-derived station.

The runtime lookup in `src/utils/stations.py` already treated `bst_code` as IDENTITY-class via `_iter_aliases_with_strength`, so this is purely a JSON-format consistency fix. The persisted aliases array now matches what the runtime already sees.

### Two-line fix in `_alias_candidates`

1. `push(str(station.get("bst_code")))` — same identity-class treatment that `vor_id` already gets. Goes through the normal `safe_aliases` filter chain, so generic-blocklist and cross-station-collision still apply.
2. After the filter chain, append the *own* `bst_code` unconditionally if it isn't already in the result. Pfaffstätten happens to have `bst_code = "Bf"` — the generic-blocklist correctly suppresses `"Bf"` coming from arbitrary alias generation, but the station's *own identity field* must always survive.

| Metric | Before | After |
|---|---|---|
| alias_issues | 155 | **0** |
| provider_issues | 0 | 0 |
| cross_station_id_issues | 0 | 0 |
| naming_issues | 0 | 0 |
| security_issues | 0 | 0 |
| duplicates | 0 | 0 |
| coordinate_issues | 2 | 2 |

## Test plan

- [x] 2 new tests (`test_bst_code_pushed_into_aliases`, `test_bst_code_bypasses_generic_blocklist`)
- [x] All 14 alias-filter tests pass
- [x] Full test suite: 1218 passed, 1 skipped
- [x] `ruff check` clean
- [x] `validate_stations`: **alias_issues 155 → 0** (other gates remain 0)
- [x] Manual verification: `data/stations.json` after enrich-script run has 154 stations updated with their bst_code in aliases (the 155th is Pfaffstätten which gets the unconditional-append because its `Bf` is generic-blocked)

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_