### PR TITLE
fix(oebb): sentence boundaries, HTML residue, von/nach routes, transit-meta tokens

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -355,6 +355,13 @@ _ZWISCHEN_PLAIN_RE = re.compile(
     r"|[,;!?]"  # Plain sentence punctuation (period excluded — see above)
     r"|[—–]"  # German em-/en-dash often introduces a side remark
     r"|<"  # HTML tag start (defensive: we strip HTML, but stay safe)
+    # Period followed by a German sentence-starter word — typical ÖBB
+    # closers like "Mödling. Auch Auswirkung …" or "Mödling. Wir bitten
+    # …". Listed words cannot be the second part of a station name, so
+    # "St. Pölten" stays intact while sentence boundaries are recognised.
+    r"|\.\s+(?:Auch|Bitte|Wir|Es|Hier|Hinweis|Achtung|Wegen|Aufgrund|"
+    r"Heute|Morgen|Reisende|Details|Diese|Dieser|Bei|Im|Aus|Mit|"
+    r"Fahrgäste|Fahrgaeste|Beachten|ACHTUNG|HINWEIS)"
     r"|\.\s*$"  # Period only when it terminates the description
     r"|\s*$"
     r")",
@@ -413,6 +420,17 @@ def _normalize_endpoint_name(name: str) -> str:
     # — which is actually what we want for lookup).
     cleaned = re.sub(_BAHNHOF_TRAILING_RE.pattern + r"\s*$", "", cleaned, flags=re.IGNORECASE).strip()
     cleaned = re.sub(r"\s{2,}", " ", cleaned).strip()
+
+    # If the endpoint absorbed a sentence boundary ("Mödling. Auch ..."),
+    # truncate to the part before the period when *that* part resolves
+    # against the directory. Abbreviations like "St. Pölten" stay intact
+    # because "St" alone doesn't resolve.
+    if ". " in cleaned:
+        head, _, _tail = cleaned.partition(". ")
+        head_clean = head.strip()
+        if head_clean and station_info(head_clean) is not None:
+            cleaned = head_clean
+
     return cleaned
 
 

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -369,6 +369,33 @@ _ZWISCHEN_PLAIN_RE = re.compile(
 )
 
 
+# Alternative route-phrasing — "von X nach Y", "ab X bis Y" — used in
+# ÖBB descriptions when a relation is described directionally rather
+# than as a connection. Captures both endpoints so the strict route
+# check can reject Wien↔Distant variants (e.g. "ab Wien Hbf bis Graz
+# Hbf").
+_VON_NACH_PLAIN_RE = re.compile(
+    r"\b(?:von|ab)\s+(?P<a>.+?)\s+(?:nach|bis)\s+(?P<b>.+?)"
+    r"(?="
+    r"\s+(?:gesperrt|geschlossen|unterbrochen|eingestellt|"
+    r"betroffen|beeintr[äa]chtigt|gest[öo]rt|eingeschr[äa]nkt|"
+    r"auf|au[ßs]er\s+betrieb|nicht|kein|von|bis|am|im|in\s+der|"
+    r"f[üu]r|wegen|aufgrund|durch|infolge|"
+    r"ist|sind|war|waren|wird|werden|kann|k[öo]nnen|"
+    r"f[äa]hrt|fahren|kommt|fallen|halten|halten\s+nicht)\b"
+    r"|[,;!?]"
+    r"|[—–]"
+    r"|<"
+    r"|\.\s+(?:Auch|Bitte|Wir|Es|Hier|Hinweis|Achtung|Wegen|Aufgrund|"
+    r"Heute|Morgen|Reisende|Details|Diese|Dieser|Bei|Im|Aus|Mit|"
+    r"Fahrgäste|Fahrgaeste|Beachten|ACHTUNG|HINWEIS)"
+    r"|\.\s*$"
+    r"|\s*$"
+    r")",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
 # Alternative route-phrasing some descriptions use instead of "zwischen X und Y":
 # "Strecke X — Y", "Verbindung X-Y", "Linie X bis Y". The hyphen / en-dash /
 # em-dash separator is required to be surrounded by whitespace so we don't
@@ -466,7 +493,7 @@ def _extract_zwischen_routes(description: str) -> List[Tuple[str, str]]:
     routes: List[Tuple[str, str]] = []
     seen: set[Tuple[str, str]] = set()
 
-    for regex in (_ZWISCHEN_PLAIN_RE, _STRECKE_PLAIN_RE):
+    for regex in (_ZWISCHEN_PLAIN_RE, _STRECKE_PLAIN_RE, _VON_NACH_PLAIN_RE):
         for match in regex.finditer(plain):
             a_norm = _normalize_endpoint_name(match.group("a"))
             b_norm = _normalize_endpoint_name(match.group("b"))
@@ -729,6 +756,38 @@ _TITLE_NOISE_WORDS = frozenset({
     "b",
     "u",
     "s",
+    # Generic transit-meta words that shouldn't be misread as endpoints
+    "linie",
+    "linien",
+    "strecke",
+    "strecken",
+    "verbindung",
+    "verbindungen",
+    "abschnitt",
+    "abschnitte",
+    "bereich",
+    "bereiche",
+    "richtung",
+    "fahrtrichtung",
+    "haltestelle",
+    "haltestellen",
+    "station",
+    "stationen",
+    "betrieb",
+    "verkehr",
+    "fahrgäste",
+    "fahrgaeste",
+    "fahrt",
+    "fahrten",
+    "zug",
+    "zuege",
+    "züge",
+    "fernverkehr",
+    "fernverkehrszüge",
+    "fernverkehrszuege",
+    "nahverkehr",
+    "nahverkehrszüge",
+    "nahverkehrszuege",
 })
 
 
@@ -1010,8 +1069,16 @@ def _find_stations_in_text(blob: str) -> List[str]:
     Scans text for known station names using a sliding window.
     Returns a list of unique canonical station names found.
     """
+    if not blob:
+        return []
+    # Strip HTML tags and unescape entities — otherwise tokens like
+    # "Hbf<" (left over from "<b>Graz Hbf</b>") slip through the
+    # _GENERIC_STATION_TOKENS filter and canonicalise to flagship
+    # stations through their alias rules.
+    cleaned = re.sub(r"<[^>]+>", " ", blob)
+    cleaned = html.unescape(cleaned)
     # Use whitespace splitting to preserve punctuation like '.' in 'St. Pölten'
-    tokens = [t for t in re.split(r"[\s/]+", blob) if t]
+    tokens = [t for t in re.split(r"[\s/]+", cleaned) if t]
     if not tokens:
         return []
 

--- a/tests/test_html_residue_filter.py
+++ b/tests/test_html_residue_filter.py
@@ -1,0 +1,117 @@
+"""Audit-round-7 regression: HTML residue in _find_stations_in_text.
+
+Bug S surfaced from the live ÖBB cache. Items like
+``Bauarbeiten: Bruck/Mur Graz`` (Distant↔Distant route) used to slip
+into the feed because the description carried HTML-bolded station
+names::
+
+    nach <b>Graz Hbf</b> in der Nacht von …
+
+The single-station fall-through tokenises by whitespace + slash, so the
+``</b>`` tag attached to the next token: ``Hbf<``. That residue
+bypassed the ``_GENERIC_STATION_TOKENS`` filter (which only knew the
+clean ``hbf`` form) and ``canonical_name("Hbf<")`` cheerfully resolved
+to ``Wien Hauptbahnhof`` via the directory's alias normalisation.
+``has_relevant`` therefore turned True and the message was kept.
+
+The fix strips HTML tags and unescapes entities at the start of
+``_find_stations_in_text`` so tokens are never contaminated with
+markup.
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import _find_stations_in_text, _is_relevant
+
+
+class TestHtmlResidueDoesNotMatchWien:
+    def test_hbf_with_closing_tag_does_not_match(self) -> None:
+        text = "nach <b>Graz Hbf</b> in der Nacht"
+        assert _find_stations_in_text(text) == []
+
+    def test_bahnhof_with_closing_tag_does_not_match(self) -> None:
+        text = "von <b>Bruck/Mur Bahnhof</b> nach Graz"
+        assert _find_stations_in_text(text) == []
+
+    def test_html_entity_does_not_break_match(self) -> None:
+        text = "Wien&nbsp;Hauptbahnhof gesperrt"
+        # Entity decoded to non-breaking space, which still tokenises fine.
+        result = _find_stations_in_text(text)
+        assert "Wien Hauptbahnhof" in result
+
+
+class TestDistantDistantWithHtmlInDescription:
+    """Real cache items that previously slipped through."""
+
+    def test_bruck_mur_graz_dropped(self) -> None:
+        title = "Bauarbeiten: Bruck/Mur Graz"
+        desc = (
+            "14.02.2026 - 22.11.2026<br/><br/>Wegen Bauarbeiten kann<br>"
+            "von <b>Bruck/Mur Bahnhof</b> nach <b>Graz Hbf</b><br>"
+            "in der Nacht von <b>14.02.</b> auf <b>15.02.2026</b>."
+        )
+        assert _is_relevant(title, desc) is False
+
+    def test_voecklabruck_salzburg_dropped(self) -> None:
+        title = "Bauarbeiten: Vöcklabruck/Salzburg"
+        desc = (
+            "18.07.2026 - 26.07.2026<br/><br/>Wegen Bauarbeiten können<br>"
+            "in <b>Vöcklabruck Bahnhof</b><br>von <b>18.07.2026</b> bis "
+            "<b>19.07.2026 </b>einige Fernverkehrszüge nicht halten."
+        )
+        assert _is_relevant(title, desc) is False
+
+
+class TestVonNachAbBisRoutes:
+    """Bug T: 'von X nach Y' / 'ab X bis Y' is the alternative ÖBB
+    phrasing for a directional connection. Without recognising it the
+    single-station fall-through accepted Wien↔Distant routes whenever
+    the distant station was missing from the directory."""
+
+    def test_ab_bis_wien_distant_dropped(self) -> None:
+        assert (
+            _is_relevant(
+                "Bauarbeiten",
+                "Strecke ab Wien Hbf bis Graz Hbf gesperrt.",
+            )
+            is False
+        )
+
+    def test_von_nach_wien_pendler_kept(self) -> None:
+        assert (
+            _is_relevant(
+                "Bauarbeiten",
+                "Wegen Bauarbeiten kann von Wien Hbf nach Mödling "
+                "nicht gefahren werden.",
+            )
+            is True
+        )
+
+    def test_von_nach_distant_distant_dropped(self) -> None:
+        assert (
+            _is_relevant(
+                "Bauarbeiten",
+                "Von Bruck/Mur nach Graz nicht gefahren werden.",
+            )
+            is False
+        )
+
+    def test_lone_von_without_nach_kept(self) -> None:
+        # No second endpoint — falls through to single-station path.
+        assert _is_relevant("Bauarbeiten", "Verspätungen von Wien Hauptbahnhof") is True
+
+
+class TestLineNoiseTokens:
+    """Bug V: 'Linie 17', 'Linie S50' etc. should not be misread as
+    implicit second endpoints in the title-residual heuristic."""
+
+    def test_linie_token_in_title_kept(self) -> None:
+        assert (
+            _is_relevant("Bauarbeiten Wien Hbf — Linie 17", "Linie 17 ist betroffen.")
+            is True
+        )
+
+    def test_strecke_token_in_title_kept(self) -> None:
+        assert (
+            _is_relevant("Bauarbeiten Wien Hbf — Strecke betroffen", "x") is True
+        )

--- a/tests/test_sentence_boundary.py
+++ b/tests/test_sentence_boundary.py
@@ -1,0 +1,95 @@
+"""Audit-round-6 regression: sentence-boundary handling in description.
+
+Bug R surfaced when a description carried multiple sentences after the
+``zwischen X und Y`` route phrase:
+
+    Bauarbeiten zwischen Wien Hbf und Mödling. Auch Auswirkung auf
+    Reisende aus München.
+
+The non-greedy regex used to extend the ``b`` capture across the full
+sentence boundary, ending with
+``b="Mödling. Auch Auswirkung auf Reisende aus München"``. After the
+post-hoc Bahnhof normalisation that endpoint failed to resolve and the
+strict route check rejected an otherwise-valid Wien↔Pendler message.
+
+Two fixes work together:
+
+- ``_normalize_endpoint_name`` now truncates an endpoint at the first
+  ``". "`` when the part before the period resolves against the
+  directory. Abbreviations like "St. Pölten" stay intact because "St"
+  alone doesn't resolve.
+- ``_ZWISCHEN_PLAIN_RE`` accepts a sentence-starter list (``Auch``,
+  ``Bitte``, ``Wir``, ``Es``, …) as a period-terminated boundary so the
+  regex stops at the real sentence end and ``finditer`` continues into
+  the next ``zwischen`` clause.
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import _extract_routes, _is_relevant
+
+
+class TestSentenceBoundaryInDescription:
+    def test_period_followed_by_auch_terminates_endpoint(self) -> None:
+        routes = _extract_routes(
+            "Bauarbeiten Wien Hbf",
+            "Bauarbeiten zwischen Wien Hbf und Mödling. Auch Auswirkung auf "
+            "Reisende aus München.",
+        )
+        assert routes == [("Wien", "Mödling")]
+
+    def test_period_followed_by_wir_bitten_terminates(self) -> None:
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "zwischen Wien Hbf und Mödling. Wir bitten um Verständnis.",
+        )
+        assert routes == [("Wien", "Mödling")]
+
+    def test_period_followed_by_bitte_terminates(self) -> None:
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "zwischen Wien Hbf und Mödling. Bitte beachten Sie unsere Hinweise.",
+        )
+        assert routes == [("Wien", "Mödling")]
+
+    def test_st_poelten_abbreviation_stays_intact(self) -> None:
+        # Defence in depth: the "St." abbreviation period must not be
+        # treated as a sentence end.
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "zwischen Wien Hbf und St. Pölten ist der Verkehr eingestellt.",
+        )
+        assert routes == [("Wien", "St. Pölten")]
+
+    def test_two_sentences_two_routes_extracted(self) -> None:
+        # Two zwischen clauses in two sentences — both must surface.
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "Wegen Bauarbeiten zwischen Wien Hbf und München. Auch zwischen "
+            "Wien Hbf und Mödling.",
+        )
+        assert routes == [("Wien", "München"), ("Wien", "Mödling")]
+
+    def test_two_sentences_keeps_overall_message(self) -> None:
+        # Even if the first route is Wien↔Distant (München), the second
+        # route Wien↔Pendler (Mödling) should keep the message.
+        assert (
+            _is_relevant(
+                "Bauarbeiten",
+                "Wegen Bauarbeiten zwischen Wien Hbf und München. Auch "
+                "zwischen Wien Hbf und Mödling.",
+            )
+            is True
+        )
+
+    def test_single_route_followed_by_collateral_distant_kept(self) -> None:
+        # Single Wien↔Pendler route extracted, München is just collateral
+        # mention in the next sentence — message must keep.
+        assert (
+            _is_relevant(
+                "Bauarbeiten Wien Hbf",
+                "Bauarbeiten zwischen Wien Hbf und Mödling. Auch Auswirkung "
+                "auf Reisende aus München.",
+            )
+            is True
+        )


### PR DESCRIPTION
## Summary

Audit-Runden 6 + 7: Live-Cache von `origin/main` direkt geprüft. **Vier echte Bugs** entdeckt — alle waren live im Feed:

### Bug R (Runde 6): Sentence-Boundary verschluckte Folgesätze

```
zwischen Wien Hbf und Mödling. Auch Auswirkung auf Reisende aus München.
```

→ b extendete zu `"Mödling. Auch Auswirkung auf Reisende aus München"`. Endpoint-Lookup scheiterte → false drop.

**Fix:** `_normalize_endpoint_name` truncate am ersten `". "` wenn Teil davor im Verzeichnis. Lookahead akzeptiert `\.\s+(?:Auch|Bitte|Wir|Es|…)` als Sentence-Boundary.

### Bug S (Runde 7): HTML-Tag-Reste täuschen Wien-Match vor

ÖBB-Descriptions enthalten `<b>...</b>`. `_find_stations_in_text` tokenisierte nur per Whitespace/Slash, sodass `</b>` als Suffix am nächsten Token klebte: `"Hbf<"`. Dieser Token umging den `_GENERIC_STATION_TOKENS`-Filter (kennt nur „hbf"), und `canonical_name("Hbf<")` löste fälschlich zu „Wien Hauptbahnhof" auf.

**Live-Cache-Items, die deshalb durchrutschten:**
- `Bauarbeiten: Bruck/Mur Graz` (Distant↔Distant)
- `Bauarbeiten: Vöcklabruck/Salzburg` (Distant↔Distant)

**Fix:** HTML-Tags strippen + Entities dekodieren am Start von `_find_stations_in_text`.

### Bug T (Runde 7): „ab X bis Y" / „von X nach Y" wurde nicht als Route erkannt

Route-Extraktor kannte nur `zwischen X und Y` und `Strecke X — Y`. `Strecke ab Wien Hbf bis Graz Hbf` blieb unerkannt → strict route check sprang nicht an → Single-Station-Path keepte wegen Wien-Mention.

**Fix:** Neuer `_VON_NACH_PLAIN_RE` matched `(?:von|ab) X (?:nach|bis) Y` mit dem gleichen Boundary-Set wie die anderen Route-Regexes.

### Bug V (Runde 7): „Linie 17" als unbekannter Endpunkt missgedeutet

Die Title-Residual-Heuristik sah „Linie 17" nach Wien Hbf als impliziten zweiten Endpunkt. Generic Transit-Meta-Wörter waren nicht in `_TITLE_NOISE_WORDS`. Folge: legitime Wien-Items wurden gedroppt.

**Fix:** Transit-Meta-Vokabular (Linie/Strecke/Verbindung/Abschnitt/Bereich/Richtung/Haltestelle/Station/Betrieb/Verkehr/Zug/Züge/Fernverkehrszüge/Nahverkehrszüge) in `_TITLE_NOISE_WORDS`.

### Verifikation gegen Live-Cache

| Item | Vorher | Nachher |
|---|---|---|
| `Bauarbeiten: Bruck/Mur Graz` | KEEP ⚠️ | ✓ DROP |
| `Bauarbeiten: Vöcklabruck/Salzburg` | KEEP ⚠️ | ✓ DROP |
| `…Wien Hbf und Mödling. Auch …München.` | DROP ⚠️ | ✓ KEEP |
| `Strecke ab Wien Hbf bis Graz Hbf` | KEEP ⚠️ | ✓ DROP |
| `Bauarbeiten Wien Hbf — Linie 17` | DROP ⚠️ | ✓ KEEP |

## Tests

- `tests/test_sentence_boundary.py` — 7 Cases (Bug R)
- `tests/test_html_residue_filter.py` — 11 Cases (Bug S/T/V)

## Test plan

- [x] Volle Suite: **1120 passed, 1 skipped** (nur pre-existing test_feed_lint Fail)
- [x] `mypy --strict src/ tests/` clean
- [x] `ruff check src/ tests/` clean

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M