### PR TITLE
feat(stations): restore Google Places metadata on merged knots + 4 VOR-IDs

### DIFF
--- a/data/stations.json
+++ b/data/stations.json
@@ -575,6 +575,7 @@
       "in_vienna": false,
       "pendler": true,
       "aliases": [
+        "430406200",
         "Laxenburg-Biedermannsdorf",
         "Bahnhof Laxenburg Biedermannsdorf",
         "Bahnhof Laxenburg-Biedermannsdorf",
@@ -593,7 +594,8 @@
       ],
       "source": "oebb",
       "latitude": 47.9893,
-      "longitude": 16.364
+      "longitude": 16.364,
+      "vor_id": "430406200"
     },
     {
       "bst_id": "1318",
@@ -786,7 +788,7 @@
       ],
       "latitude": 48.194766,
       "longitude": 16.386274,
-      "source": "oebb",
+      "source": "oebb,google_places",
       "wl_diva": "60201091",
       "wl_stops": [
         {
@@ -795,6 +797,14 @@
           "latitude": 48.194764,
           "longitude": 16.386277
         }
+      ],
+      "_google_place_id": "ChIJGZJ3hXsHbUcRoSEOdidtTe8",
+      "_types": [
+        "train_station",
+        "transit_station",
+        "transportation_service",
+        "point_of_interest",
+        "establishment"
       ]
     },
     {
@@ -1889,6 +1899,7 @@
       "in_vienna": false,
       "pendler": true,
       "aliases": [
+        "430420400",
         "Mistelbach Stadt",
         "Bahnhof Mistelbach Stadt",
         "Bf Mistelbach Stadt",
@@ -1900,7 +1911,8 @@
       ],
       "source": "oebb",
       "latitude": 48.5754,
-      "longitude": 16.5821
+      "longitude": 16.5821,
+      "vor_id": "430420400"
     },
     {
       "bst_id": "1950",
@@ -3087,6 +3099,7 @@
       "in_vienna": false,
       "pendler": true,
       "aliases": [
+        "430515600",
         "Weigelsdorf",
         "Bahnhof Weigelsdorf",
         "Bf Weigelsdorf",
@@ -3098,7 +3111,8 @@
       ],
       "source": "oebb",
       "latitude": 47.9484,
-      "longitude": 16.4082
+      "longitude": 16.4082,
+      "vor_id": "430515600"
     },
     {
       "bst_id": "325",
@@ -3972,6 +3986,7 @@
       "in_vienna": false,
       "pendler": true,
       "aliases": [
+        "430374600",
         "Himberg",
         "Bahnhof Himberg",
         "Bf Himberg",
@@ -3984,7 +3999,8 @@
       ],
       "source": "oebb",
       "latitude": 48.0828,
-      "longitude": 16.4392
+      "longitude": 16.4392,
+      "vor_id": "430374600"
     },
     {
       "bst_id": "850",
@@ -5124,7 +5140,7 @@
       "longitude": 16.376413,
       "name": "Wien Hauptbahnhof",
       "pendler": false,
-      "source": "vor",
+      "source": "vor,google_places",
       "vor_id": "490134900",
       "wl_diva": "60201349",
       "wl_stops": [
@@ -5134,6 +5150,14 @@
           "latitude": 48.185188,
           "longitude": 16.376413
         }
+      ],
+      "_google_place_id": "ChIJZ1D-htapbUcROoi_2Jg_fcg",
+      "_types": [
+        "subway_station",
+        "transit_station",
+        "transportation_service",
+        "point_of_interest",
+        "establishment"
       ]
     },
     {


### PR DESCRIPTION
## Summary

External-audit-Follow-up #3 schließt die zwei verbleibenden Punkte aus dem Reporter-Feedback:

### 1. Google Places-Metadaten auf merged Knoten wiederhergestellt

PR #1227 hat die standalone-Einträge `Rennweg` und `Südtiroler Platz` mit ihren neuen Hauptzeilen gemergt, dabei aber `_google_place_id`, `_types` und das `google_places`-Source-Token verloren. Wiederherstellt:

| Station | Restored | Source |
|---|---|---|
| Wien Rennweg | `ChIJGZJ3hXsHbUcRoSEOdidtTe8` + types | `oebb` → `oebb,google_places` |
| Wien Hauptbahnhof | `ChIJZ1D-htapbUcROoi_2Jg_fcg` + types | `vor` → `vor,google_places` |

### 2. Hand-kuratierte VOR-IDs für 4 unauflösbare Pendler-Stationen

Quelle: externer AI-Report (2026-05-06). Die VOR-Resolver-Pipeline konnte für diese 4 Stationen nie konfidente Treffer liefern (nur Bus-Stops kamen zurück), entsprechend war `vor_id` leer.

| Station | VOR-ID | Plausibilitäts-Check |
|---|---|---|
| Himberg | `430374600` | Zwischen Himberg-Bus-Stops 430373xxx-430374xxx |
| Laxenburg-Biedermannsdorf | `430406200` | Aspangbahn-Cluster |
| Mistelbach Stadt | `430420400` | Direkt neben Mistelbach Hbf 430420200 |
| Weigelsdorf | `430515600` | Nahe Weigelsdorf-Bus-Cluster 430518xxx |

⚠️ **Diese IDs sind NICHT gegen die Live-VOR-API verifiziert.** Keine taucht in der gecachten `vor-haltestellen.csv` auf — die API hat sie nie als Top-Treffer geliefert. Sie sind plausibel im 4xx-Range und durch Nachbarschaft zur Geographie stimmig, aber sollten bei nächster Gelegenheit gegen die VOR-API gegen-validiert werden. Falls der Resolver bei einem Cron-Run einen abweichenden ID liefert, soll der resolver-derived Wert gewinnen.

## Verifizierung der Reporter-Behauptungen

| Reporter-Punkt | Befund |
|---|---|
| "Duplikate nicht gemergt" | **FALSCH** — bereits in PR #1227 entfernt; 0 standalone "Rennweg"/"Südtiroler Platz" Einträge |
| "Google Places-Metadaten verloren" | **RICHTIG** — durch diesen PR behoben |
| "VOR-IDs fehlen" | **RICHTIG** — durch diesen PR (mit Caveat) behoben |

## Test plan

- [x] Full test suite: 1220 passed, 1 skipped
- [x] `validate_stations`: 0 in allen Blocking-Gates + alias_issues
- [x] Manual lookup smoke tests:
  - `station_info("Himberg").vor_id` = "430374600" ✓
  - `station_info("Wien Rennweg").source` = "oebb,google_places" ✓
  - `station_info("Wien Hauptbahnhof").source` = "vor,google_places" ✓
- [x] Persistenz-Pfad: vor_id wird in `_restore_existing_metadata` preserviert (nicht überschrieben), Google-Places-Felder ebenso

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_