### PR TITLE
fix(oebb): reject date/time fragments as route endpoints

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -462,13 +462,31 @@ def _normalize_endpoint_name(name: str) -> str:
 
 
 def _looks_like_station_name(text: str) -> bool:
-    """Reject pure dates/numbers; require at least one alphabetic character."""
+    """Reject pure dates/numbers and date/time fragments.
+
+    Real station names start with a letter (typically capitalised) and
+    contain at least three consecutive alphabetic characters. Dates,
+    times and number-prefixed phrases like ``03.10.2026 (23:15 Uhr)``
+    are rejected up-front so the route extractor never treats them as
+    endpoints.
+    """
     if not text:
+        return False
+    text = text.strip()
+    if not text:
+        return False
+    # Reject if starts with a digit — almost always a date/time fragment
+    # ("03.10.2026 (23:15 Uhr) einige …").
+    if text[0].isdigit():
         return False
     if not re.search(r"[A-Za-zÄÖÜäöüß]", text):
         return False
-    # Reject things like "13.04.2026" (pure date) — they have no letters anyway,
-    # but this guard is here for defence in depth.
+    # Reject if no run of three or more alphabetic characters survives
+    # — guards against "Hbf (U)" residue after stripping.
+    if not re.search(r"[A-Za-zÄÖÜäöüß]{3,}", text):
+        return False
+    # Defence in depth: reject if the entire string is dates / numbers
+    # interleaved with punctuation.
     if re.fullmatch(r"[\d.\-/\s]+", text):
         return False
     return True

--- a/tests/test_date_pattern_filter.py
+++ b/tests/test_date_pattern_filter.py
@@ -1,0 +1,82 @@
+"""Regression tests for Bug W (date/time fragments mis-extracted as route
+endpoints).
+
+Real ÖBB descriptions sometimes carry sentences like::
+
+    Wegen Bauarbeiten können von 03.10.2026 (23:15 Uhr) bis
+    05.10.2026 (04:40 Uhr) keine Züge fahren.
+
+The new ``_VON_NACH_PLAIN_RE`` pattern would otherwise match the
+``von DATUM bis DATUM`` clause and produce a "route" candidate with
+two date strings as endpoints. The unknown-unknown classification kept
+the message classification right today, but a future change could
+expose the misclassification.
+
+The fix tightens ``_looks_like_station_name`` to reject:
+
+- strings starting with a digit (date/time fragment),
+- strings with no run of 3+ alphabetic characters (residue of token
+  cleanup).
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import _extract_routes, _is_relevant, _looks_like_station_name
+
+
+class TestDatePatternRejection:
+    def test_pure_date_range_yields_no_route(self) -> None:
+        # "von 03.10.2026 bis 05.10.2026" is just a date range, not a route.
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "Wegen Bauarbeiten von 03.10.2026 bis 05.10.2026 keine Züge.",
+        )
+        assert routes == []
+
+    def test_time_range_yields_no_route(self) -> None:
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "Verspätungen von 14:00 bis 18:00.",
+        )
+        assert routes == []
+
+    def test_real_route_still_works_around_date_range(self) -> None:
+        # Real Wien-Pendler description with a date range elsewhere.
+        title = "Wien Hbf ↔ Gramatneusiedl"
+        desc = (
+            "Wegen Bauarbeiten können zwischen Wien Hbf (U) und "
+            "Gramatneusiedl Bahnhof von 03.10.2026 (23:15 Uhr) bis "
+            "05.10.2026 (04:40 Uhr) keine Züge fahren."
+        )
+        routes = _extract_routes(title, desc)
+        # Only the real route is extracted, not the date range.
+        assert routes == [("Wien", "Gramatneusiedl")]
+        assert _is_relevant(title, desc) is True
+
+
+class TestLooksLikeStationName:
+    def test_real_station_names(self) -> None:
+        assert _looks_like_station_name("Mödling")
+        assert _looks_like_station_name("Wien Hbf")
+        assert _looks_like_station_name("St. Pölten")
+        assert _looks_like_station_name("Wien 10.: Favoriten")
+        assert _looks_like_station_name("Wien Mitte-Landstraße")
+
+    def test_date_and_time_fragments_rejected(self) -> None:
+        assert not _looks_like_station_name("03.10.2026")
+        assert not _looks_like_station_name("03 .10.2026 (23:15 Uhr)")
+        assert not _looks_like_station_name("14:00")
+        assert not _looks_like_station_name("13.04.2026")
+        assert not _looks_like_station_name("23:15")
+        # "23:15 Uhr" starts with a digit → reject
+        assert not _looks_like_station_name("23:15 Uhr")
+
+    def test_too_short_alpha_rejected(self) -> None:
+        # "Hb (U)" has only "Hb" + "U" — no 3+ alpha run.
+        assert not _looks_like_station_name("Hb (U)")
+        assert not _looks_like_station_name("U")
+        assert not _looks_like_station_name("a b")
+
+    def test_empty_rejected(self) -> None:
+        assert not _looks_like_station_name("")
+        assert not _looks_like_station_name("   ")


### PR DESCRIPTION
## Summary

Audit-Runde 8: Live-Cache mit Bug-Reproduktion analysiert. **Ein neuer latent harmloser, aber defense-in-depth-relevanter Bug** entdeckt:

### Bug W: Datum/Zeit-Fragmente als Route extrahiert

Reale ÖBB-Description enthält:

```
Wegen Bauarbeiten können von 03.10.2026 (23:15 Uhr) bis
05.10.2026 (04:40 Uhr) keine Züge fahren.
```

Mein in Bug T eingeführter `_VON_NACH_PLAIN_RE` matcht diese Datums-Range als „Route" mit zwei Datums-Strings als Endpoints. **Aktuell harmlos** (unknown-unknown → reject), aber wenn sich die Heuristik ändert, könnte das exploded werden.

### Fix

`_looks_like_station_name` strikter:
- Strings die mit Ziffer beginnen → reject (Datums-/Zeit-Fragment)
- Mindestens ein Run von 3+ aufeinanderfolgenden alphabetischen Zeichen → reject "Hb (U)"-Reste

### Verifikation

| Pattern | Vorher | Nachher |
|---|---|---|
| `von 03.10.2026 bis 05.10.2026` | extrahiert (harmlos verworfen) | ✓ nicht extrahiert |
| `von 14:00 bis 18:00` | extrahiert | ✓ nicht extrahiert |
| `zwischen Wien Hbf und Gramatneusiedl von DATUM bis DATUM` | echte Route + Datums-„Route" | ✓ nur echte Route |
| `Mödling`, `Wien Hbf`, `St. Pölten` | passt | ✓ passt (Sanity) |

## Tests

7 neue Tests in `tests/test_date_pattern_filter.py`:
- `von DATUM bis DATUM` / `von HH:MM bis HH:MM` ergeben keine Routen
- Real Wien↔Pendler + Datums-Range → nur echte Route
- Real Stationsnamen passen weiter (Mödling, Wien Hbf, St. Pölten, „Wien 10.: Favoriten")
- Datum/Zeit/zu-kurz/leer-Inputs werden abgewiesen

## Test plan

- [x] `pytest tests/test_date_pattern_filter.py` — 7/7 passed
- [x] Volle Suite: **1285 passed, 3 skipped** (nur pre-existing test_feed_lint Fail)
- [x] `mypy --strict src/ tests/` clean
- [x] `ruff check src/ tests/` clean

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_