### PR TITLE
fix(stations): accept type='manual_distant_at' + widen coord bounds

### DIFF
--- a/docs/schema/stations.schema.json
+++ b/docs/schema/stations.schema.json
@@ -43,14 +43,14 @@
         "latitude": {
           "type": "number",
           "minimum": 41.0,
-          "maximum": 50.0,
-          "description": "WGS84 Breitengrad."
+          "maximum": 55.0,
+          "description": "WGS84 Breitengrad. Hauptbereich Wien/NÖ (~47.7-48.6°); obere Grenze 55° lässt manuell gepflegte Knoten Richtung Berlin (52.5°) und Hamburg zu (manual_foreign_city)."
         },
         "longitude": {
           "type": "number",
           "minimum": 9.0,
-          "maximum": 18.0,
-          "description": "WGS84 Längengrad."
+          "maximum": 20.0,
+          "description": "WGS84 Längengrad. Reicht von Bregenz (9.7°) bis Budapest-Ost (19.1°)."
         },
         "source": {
           "type": "string",
@@ -96,12 +96,12 @@
               "latitude": {
                 "type": ["number", "null"],
                 "minimum": 41.0,
-                "maximum": 50.0
+                "maximum": 55.0
               },
               "longitude": {
                 "type": ["number", "null"],
                 "minimum": 9.0,
-                "maximum": 18.0
+                "maximum": 20.0
               }
             },
             "additionalProperties": false
@@ -109,8 +109,8 @@
         },
         "type": {
           "type": "string",
-          "enum": ["manual_foreign_city"],
-          "description": "Sondertyp für manuell gepflegte Auslandsknoten (München Hauptbahnhof, Roma Termini). Diese Einträge haben kein bst_id/vor_id und werden im Coordinate-Validator als out-of-bounds toleriert."
+          "enum": ["manual_foreign_city", "manual_distant_at"],
+          "description": "Sondertyp für manuell gepflegte Knotenpunkte außerhalb des Wien/NÖ-Pendlergürtels. 'manual_foreign_city' für Auslandsknoten (München Hauptbahnhof, Roma Termini, Bratislava hl.st.); 'manual_distant_at' für distante österreichische Hauptbahnhöfe außerhalb der Pendler-Reichweite (Salzburg, Graz, Linz, Innsbruck etc.). Beide haben kein bst_id/vor_id und werden im Coordinate-Validator als out-of-bounds toleriert."
         },
         "_google_place_id": {
           "type": "string",
@@ -150,7 +150,7 @@
           }
         },
         {
-          "description": "Mindestens eines von in_vienna oder pendler muss true sein, außer bei manuell gepflegten Auslandsknoten (type: manual_foreign_city).",
+          "description": "Mindestens eines von in_vienna oder pendler muss true sein, außer bei manuell gepflegten Knotenpunkten außerhalb des Pendlergürtels (type: manual_foreign_city ODER manual_distant_at).",
           "if": {
             "properties": {
               "in_vienna": {"const": false},
@@ -159,7 +159,9 @@
             "required": ["in_vienna", "pendler"]
           },
           "then": {
-            "properties": {"type": {"const": "manual_foreign_city"}},
+            "properties": {
+              "type": {"enum": ["manual_foreign_city", "manual_distant_at"]}
+            },
             "required": ["type"]
           }
         }

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -604,8 +604,9 @@ def _find_naming_issues(
        lookup branches and signals an unnormalized write path.
     3. **Vienna/pendler mutual exclusivity** – ``in_vienna`` and ``pendler``
        partition the directory: every entry is *either* inside the city
-       limits *or* a commuter-belt station outside, never both. The single
-       exception is ``type: manual_foreign_city`` (München, Roma) where
+       limits *or* a commuter-belt station outside, never both. The
+       exceptions are ``type: manual_foreign_city`` (München, Roma) and
+       ``type: manual_distant_at`` (Salzburg, Graz, Linz etc.) where
        both flags may legitimately be ``false``.
     """
     name_to_identifiers: dict[str, list[str]] = defaultdict(list)
@@ -664,14 +665,19 @@ def _find_naming_issues(
                     "commuter-belt station)"
                 ),
             )
-        elif not in_vienna and not pendler and entry_type != "manual_foreign_city":
+        elif (
+            not in_vienna
+            and not pendler
+            and entry_type not in ("manual_foreign_city", "manual_distant_at")
+        ):
             yield NamingIssue(
                 identifier=identifier,
                 name=name,
                 reason=(
                     "in_vienna and pendler are both false — entry should "
                     "either be classified as a Vienna station, a commuter "
-                    "station, or marked with type='manual_foreign_city'"
+                    "station, or marked with type='manual_foreign_city' "
+                    "or type='manual_distant_at'"
                 ),
             )
 

--- a/tests/test_station_validation.py
+++ b/tests/test_station_validation.py
@@ -350,6 +350,35 @@ def test_naming_validation_flags_neither_vienna_nor_pendler(tmp_path: Path) -> N
     assert issues[0].name == "Niemandsland", "manual_foreign_city must be exempt"
 
 
+def test_naming_validation_exempts_manual_distant_at(tmp_path: Path) -> None:
+    """Distant Austrian Hauptbahnhöfe (Salzburg, Graz, Linz etc.) carry
+    type='manual_distant_at' for the same reason München/Roma carry
+    type='manual_foreign_city' — they're outside Vienna and not commuter
+    stations, but they're legitimate manual entries for cross-country
+    routing references. Both type values must exempt from the strict
+    "in_vienna xor pendler" rule."""
+    stations = [
+        {
+            "name": "Salzburg Hbf",
+            "aliases": ["Salzburg Hbf"],
+            "latitude": 47.81,
+            "longitude": 13.04,
+            "source": "manual",
+            "type": "manual_distant_at",
+            "in_vienna": False,
+            "pendler": False,
+        },
+    ]
+    path = tmp_path / "stations.json"
+    path.write_text(json.dumps(stations), encoding="utf-8")
+
+    report = validate_stations(path)
+    flag_issues = [i for i in report.naming_issues if "both false" in i.reason]
+    assert flag_issues == [], (
+        "manual_distant_at must be exempt from the in_vienna/pendler rule"
+    )
+
+
 def test_stations_json_has_mutually_exclusive_flags() -> None:
     """Lock the live data: no entry has both flags or none (except foreign cities)."""
     repo_root = Path(__file__).resolve().parent.parent


### PR DESCRIPTION
## Summary

Der Cron-Lauf schlug fehl, weil die Daten 14 distante österreichische Hauptbahnhöfe (Salzburg, Graz, Linz, Innsbruck, Klagenfurt etc.) mit `type: "manual_distant_at"` enthielten — der Validator und das JSON-Schema kannten aber nur den älteren Exception-Wert `"manual_foreign_city"`. Die Test-Suite hatte bereits beide Werte aufgenommen (`test_stations_json_has_mutually_exclusive_flags`), aber Validator und Schema hingen hinterher.

```
naming issue: Bischofshofen (source:manual): in_vienna and pendler are
both false — entry should either be classified as a Vienna station, a
commuter station, or marked with type='manual_foreign_city'
[…14× repeated…]
Validation failed on the new stations data. Working tree left unmodified.
```

## Drei koordinierte Fixes

### 1. Validator (`src/utils/stations_validation.py`)
Die `in_vienna ⊕ pendler`-Mutual-Exclusivity-Regel akzeptiert jetzt beide Exception-Types:
```python
elif (
    not in_vienna and not pendler
    and entry_type not in ("manual_foreign_city", "manual_distant_at")
):
```

### 2. JSON Schema (`docs/schema/stations.schema.json`)
- `type`-enum erweitert: `["manual_foreign_city", "manual_distant_at"]`
- `latitude.maximum`: **50.0 → 55.0** (Berlin Hbf bei 52.525 war out-of-bounds)
- `longitude.maximum`: **18.0 → 20.0** (Budapest-Keleti bei 19.08 war out-of-bounds)
- `allOf`-Neither-Flag-Conditional: `const: "manual_foreign_city"` → `enum: ["manual_foreign_city", "manual_distant_at"]`

### 3. Test (`tests/test_station_validation.py`)
Neuer `test_naming_validation_exempts_manual_distant_at` pinnt das neue Verhalten.

## Test plan

- [x] Full test suite: 1289 passed, 1 skipped (was 1220, +69 from main)
- [x] `validate_stations` exit 0 auf `data/stations.json` (196 Stations, 14 davon distant_at)
- [x] `tests/test_stations_schema.py::test_stations_json_matches_schema` PASSED
- [x] `naming_issues: 0` (vorher 14)
- [x] Andere Validation-Gates bleiben 0 (provider/cross_station_id/security/duplicates/alias_issues)
- [ ] Nächster Cron-Lauf endet erfolgreich

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_