### PR TITLE
fix(oebb): split multi-route descriptions joined by 'und zwischen'

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -346,8 +346,8 @@ _ZWISCHEN_PLAIN_RE = re.compile(
     r"ist|sind|war|waren|gesperrt|geschlossen|blockiert|eingestellt|"
     r"unterbrochen|gestört|gestoert|ausgefallen|verspätet|verspaetet|"
     r"verz[öo]gert|aufgehoben|freigegeben|"
-    # Connectors that introduce a side clause
-    r"sowie|sondern|sowie\s+zwischen|"
+    # Connectors that introduce a side clause / next "zwischen X und Y"
+    r"sowie|sondern|sowie\s+zwischen|und\s+zwischen|,\s*und|"
     # Intermediate-via marker — ends the captured endpoint at the via stop
     # so "Mödling über Wiener Neudorf" yields b="Mödling".
     r"[üu]ber|via"

--- a/tests/test_multi_zwischen.py
+++ b/tests/test_multi_zwischen.py
@@ -1,0 +1,90 @@
+"""Regression tests for Bug Y (multi-route with "und zwischen").
+
+ÖBB descriptions sometimes carry several ``zwischen X und Y`` clauses
+joined by plain "und zwischen" or "und," — for example::
+
+    Wegen Bauarbeiten zwischen Wien Hbf und Götzendorf, und zwischen
+    Wien Hbf und Gramatneusiedl.
+
+The previous lookahead listed only ``sowie\\s+zwischen`` as a
+multi-clause boundary. Plain "und zwischen" let the non-greedy ``b``
+capture span the whole sentence, so finditer surfaced just the first
+route and the rest of the message slipped through unchecked.
+
+The fix adds ``und\\s+zwischen`` and ``,\\s*und`` to the boundary
+list so both real-world phrasings split correctly.
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import _extract_routes, _is_relevant
+
+
+class TestMultiRouteUndZwischen:
+    def test_und_zwischen_separator_splits_correctly(self) -> None:
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "Wegen Bauarbeiten zwischen Wien Hbf und Wien Meidling und "
+            "zwischen Wien Hbf und Wien Praterstern.",
+        )
+        assert routes == [("Wien", "Wien Meidling"), ("Wien", "Wien Praterstern")]
+
+    def test_komma_und_zwischen_separator_splits_correctly(self) -> None:
+        # Real cache pattern: comma + und + zwischen.
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "Wegen Bauarbeiten zwischen Wien Hbf und Götzendorf, und "
+            "zwischen Wien Hbf und Gramatneusiedl.",
+        )
+        assert routes == [("Wien", "Götzendorf"), ("Wien", "Gramatneusiedl")]
+
+    def test_sowie_zwischen_still_works(self) -> None:
+        # Defence in depth: the original sowie-separator must keep working.
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "Wegen Bauarbeiten zwischen Wien Hbf und Mödling sowie "
+            "zwischen Wien Hbf und Baden.",
+        )
+        assert routes == [("Wien", "Mödling"), ("Wien", "Baden")]
+
+    def test_single_route_with_trailing_und(self) -> None:
+        # The "und" alone (without "zwischen" right after) must NOT be a
+        # boundary — otherwise endpoints get truncated.
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "zwischen Wien Hbf und Mödling sind Verspätungen zu erwarten.",
+        )
+        assert routes == [("Wien", "Mödling")]
+
+    def test_three_zwischen_clauses(self) -> None:
+        routes = _extract_routes(
+            "Bauarbeiten",
+            "zwischen Wien Hbf und Wien Meidling, und zwischen Wien Hbf "
+            "und Wien Floridsdorf, und zwischen Wien Hbf und Wien Praterstern.",
+        )
+        assert len(routes) == 3
+        assert ("Wien", "Wien Meidling") in routes
+        assert ("Wien", "Wien Floridsdorf") in routes
+        assert ("Wien", "Wien Praterstern") in routes
+
+    def test_relevant_message_with_multi_pendler_routes(self) -> None:
+        # All three routes are Wien↔Pendler; message must keep.
+        assert (
+            _is_relevant(
+                "Bauarbeiten",
+                "Wegen Bauarbeiten zwischen Wien Hbf und Mödling sowie "
+                "zwischen Wien Hbf und Baden.",
+            )
+            is True
+        )
+
+    def test_drop_when_all_multi_routes_are_pendler_pendler(self) -> None:
+        # All three are Pendler-Pendler — message must drop.
+        assert (
+            _is_relevant(
+                "Bauarbeiten",
+                "Wegen Bauarbeiten zwischen Mödling und Baden sowie "
+                "zwischen Mödling und Wiener Neustadt.",
+            )
+            is False
+        )


### PR DESCRIPTION
## Summary

Audit-Runde 9: Edge-Cases für Multi-Routen mit verschiedenen Konnektoren systematisch durchgespielt. **Ein neuer Bug** entdeckt:

### Bug Y: „und zwischen" trennt Multi-Routen nicht

Reale ÖBB-Description-Patterns wie:

```
Wegen Bauarbeiten zwischen Wien Hbf und Götzendorf, und zwischen
Wien Hbf und Gramatneusiedl.
```

Der bisherige Lookahead kannte nur `sowie\s+zwischen`. Plain „und zwischen" liefert keine Boundary → der `b`-Capture spannte den ganzen Satz → `finditer` surface'te nur **eine** Route, der Rest wurde verschluckt.

**Fix:** Lookahead um `und\s+zwischen` und `,\s*und` erweitert. Alle drei gängigen Joiner („sowie zwischen", „und zwischen", „, und") splitten jetzt korrekt.

### Verifikation

| Description | Vorher | Nachher |
|---|---|---|
| `…und Wien Meidling und zwischen Wien Hbf und Wien Praterstern.` | 1 Route | ✓ 2 Routen |
| `…und Götzendorf, und zwischen Wien Hbf und Gramatneusiedl.` | 1 Route | ✓ 2 Routen |
| `…und Mödling sowie zwischen Wien Hbf und Baden.` | 2 Routen | 2 Routen (Sanity) |
| `…und Mödling sind Verspätungen zu erwarten.` | 1 Route | 1 Route (Sanity, „und" ohne „zwischen" kein Splitter) |

## Tests

7 neue Tests in `tests/test_multi_zwischen.py`:
- „und zwischen" splittet korrekt
- „, und zwischen" (Real-Cache-Pattern) splittet korrekt
- „sowie zwischen" funktioniert weiter
- Single-Route mit trailing „und" wird NICHT geteilt
- Drei `zwischen`-Klauseln alle erkannt
- Multi Wien↔Pendler wird KEEPed
- Multi Pendler↔Pendler wird DROPed

## Test plan

- [x] `pytest tests/test_multi_zwischen.py` — 7/7 passed
- [x] Volle Suite: **1293 passed, 3 skipped** (nur pre-existing test_feed_lint Fail)
- [x] `mypy --strict src/ tests/` clean
- [x] `ruff check src/ tests/` clean

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_