### PR TITLE
fix(filter): preserve compound -Bahnhof, dedup canonical routes, narrow Vienna fallbacks

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -427,6 +427,16 @@ _BAHNHOF_TRAILING_RE = re.compile(
     r"\s*\b(?:Hauptbahnhof|Bahnhof|Bahnhst|Hbf|Bhf|Bf)\b\.?",
     re.IGNORECASE,
 )
+# Variant that anchors at end-of-string AND rejects a leading hyphen so
+# compound proper nouns like ``Wien Franz-Josefs-Bahnhof`` keep the
+# trailing ``-Bahnhof`` intact. Stripping it produced a dangling
+# ``Wien Franz-Josefs-`` that leaked into dedup keys (and into visible
+# titles whenever the alias resolution in :func:`station_info` failed to
+# bridge the truncation).
+_BAHNHOF_TRAILING_END_RE = re.compile(
+    r"(?<![\-‐-―])\s+\b(?:Hauptbahnhof|Bahnhof|Bahnhst|Hbf|Bhf|Bf)\b\.?\s*$",
+    re.IGNORECASE,
+)
 _PARENS_TRAILING_RE = re.compile(r"\s*\(\s*[A-Za-z]\d*\s*\)\s*$")
 
 
@@ -450,7 +460,7 @@ def _normalize_endpoint_name(name: str) -> str:
     # Strip a single trailing Bahnhof/Hbf/Bf suffix (only at the end, so we
     # don't mangle names like "Wiener Neustadt Hauptbahnhof" → "Wiener Neustadt"
     # — which is actually what we want for lookup).
-    cleaned = re.sub(_BAHNHOF_TRAILING_RE.pattern + r"\s*$", "", cleaned, flags=re.IGNORECASE).strip()
+    cleaned = _BAHNHOF_TRAILING_END_RE.sub("", cleaned).strip()
     cleaned = re.sub(r"\s{2,}", " ", cleaned).strip()
 
     # If the endpoint absorbed a sentence boundary ("Mödling. Auch ..."),
@@ -1274,11 +1284,18 @@ def _format_route_title(routes: List[Tuple[str, str]], line_prefix: str = "") ->
     available (so ``Wien Westbf`` → ``Wien Westbahnhof``). The Vienna endpoint
     is placed first to keep the feed visually consistent. Multiple routes are
     joined with ``" / "`` to indicate that several segments are affected.
+
+    Routes that resolve to the same canonical endpoint pair (e.g. one
+    description writes ``St. Pölten`` while another writes ``St.Pölten``)
+    are deduplicated here — the upstream extraction keys on raw casefold
+    text so whitespace variants both survive. Without this pass the
+    formatted title repeats the same route twice.
     """
     if not routes:
         return ""
 
     formatted: List[str] = []
+    seen_canon: set[Tuple[str, str]] = set()
     for raw_a, raw_b in routes:
         info_a = station_info(raw_a)
         info_b = station_info(raw_b)
@@ -1296,6 +1313,14 @@ def _format_route_title(routes: List[Tuple[str, str]], line_prefix: str = "") ->
         b_in_vienna = bool(info_b and info_b.in_vienna)
         if b_in_vienna and not a_in_vienna:
             name_a, name_b = name_b, name_a
+
+        # Dedup against already-rendered routes after canonical resolution.
+        canon_key: Tuple[str, str] = tuple(  # type: ignore[assignment]
+            sorted((name_a.casefold(), name_b.casefold()))
+        )
+        if canon_key in seen_canon:
+            continue
+        seen_canon.add(canon_key)
 
         formatted.append(f"{name_a} ↔ {name_b}")
 

--- a/src/utils/stations.py
+++ b/src/utils/stations.py
@@ -670,9 +670,13 @@ def is_in_vienna(lat: object, lon: object | None = None) -> bool:
             if info:
                 return bool(info.in_vienna)
             import os
-            city_token = os.getenv("WIEN_TOKEN", "wien")
+            # _normalize_token casefolds and strips noise — apply the same
+            # normalisation to the env-derived city token so a deployer
+            # setting WIEN_TOKEN="Wien" (or any cased variant) still
+            # matches against the casefolded incoming station name.
+            city_token = _normalize_token(os.getenv("WIEN_TOKEN", "wien"))
             token = _normalize_token(lat)
-            if token == city_token or token.startswith(city_token + " "):
+            if city_token and (token == city_token or token.startswith(city_token + " ")):
                 return True
         return False
 
@@ -819,8 +823,13 @@ def text_has_vienna_connection(text: str) -> bool:
     if re.search(r"\b(flughafen wien|airport vienna|vienna airport)\b", text_for_matching, re.IGNORECASE):
         return True
 
-    # 2. Prüfe auf das eigenständige Wort "Wien" (z.B. als Richtungshinweis) oder U-Bahn
-    if re.search(r"\b(wien|vienna|u-bahn)\b", cleaned, re.IGNORECASE):
+    # 2. Prüfe auf das eigenständige Wort "Wien" / "Vienna".
+    # Achtung: ein nacktes "U-Bahn" allein ist NICHT spezifisch genug —
+    # "Berliner U-Bahn", "Münchner U-Bahn-Linie U4" oder "Hamburger U-Bahn"
+    # würden sonst als Wien-Bezug gewertet und als ÖBB-Item ins Feed
+    # rutschen, obwohl die Meldung eine fremde Stadt betrifft. Daher: für
+    # U-Bahn-Mention zusätzlich Wien-Wort fordern.
+    if re.search(r"\b(wien|vienna)\b", cleaned, re.IGNORECASE):
         return True
 
     # 3. Kontextsensitive Erkennung für U1-U6:

--- a/tests/test_compound_bahnhof_preserved.py
+++ b/tests/test_compound_bahnhof_preserved.py
@@ -1,0 +1,64 @@
+"""Regression tests for Bug 11A (compound ``-Bahnhof`` truncation).
+
+ÖBB descriptions and titles regularly mention ``Wien
+Franz-Josefs-Bahnhof`` — a hyphen-compound proper noun where ``Bahnhof``
+is part of the station name itself, not a generic suffix. The previous
+``_BAHNHOF_TRAILING_RE`` matched ``Bahnhof`` at end-of-string regardless
+of the preceding character, so normalisation produced the dangling
+``Wien Franz-Josefs-`` form. Alias resolution in ``stations.json`` happened
+to bridge the truncation today, but:
+
+- Visible titles read ``Wien Franz-Josefs- ↔ Wien Heiligenstadt`` whenever
+  the alias chain breaks (e.g. directory drift, missing entry).
+- Dedup keys in ``_extract_routes`` used the truncated form, so the same
+  route written ``Wien Franz-Josefs-Bahnhof`` and ``Wien Franz-Josefs``
+  would deduplicate correctly only because both fall through to the same
+  truncation — a fragile coincidence.
+
+The fix anchors the trailing-suffix regex at end-of-string AND adds a
+negative lookbehind that rejects a hyphen (or any Unicode dash) before
+the suffix. ``Wien Hauptbahnhof`` and ``Wiener Neustadt Hauptbahnhof``
+keep their existing trim because the suffix is space-separated.
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import _normalize_endpoint_name
+
+
+class TestCompoundBahnhofPreserved:
+    def test_wien_franz_josefs_bahnhof_kept_intact(self) -> None:
+        assert _normalize_endpoint_name("Wien Franz-Josefs-Bahnhof") == (
+            "Wien Franz-Josefs-Bahnhof"
+        )
+
+    def test_franz_josefs_bahnhof_kept_intact(self) -> None:
+        # Without the Wien prefix — same protection applies.
+        assert _normalize_endpoint_name("Franz-Josefs-Bahnhof") == (
+            "Franz-Josefs-Bahnhof"
+        )
+
+    def test_wien_hauptbahnhof_still_strips(self) -> None:
+        # Standard suffix removal must continue to work.
+        assert _normalize_endpoint_name("Wien Hauptbahnhof") == "Wien"
+
+    def test_wiener_neustadt_hauptbahnhof_still_strips(self) -> None:
+        assert _normalize_endpoint_name("Wiener Neustadt Hauptbahnhof") == (
+            "Wiener Neustadt"
+        )
+
+    def test_wien_hbf_still_strips(self) -> None:
+        assert _normalize_endpoint_name("Wien Hbf") == "Wien"
+
+    def test_moedling_bf_still_strips(self) -> None:
+        assert _normalize_endpoint_name("Mödling Bf") == "Mödling"
+
+    def test_compound_with_endash_kept_intact(self) -> None:
+        # Defence in depth: en-dash and em-dash compounds also stay intact.
+        assert _normalize_endpoint_name("Foo–Bahnhof").endswith("Bahnhof")
+        assert _normalize_endpoint_name("Foo—Bahnhof").endswith("Bahnhof")
+
+    def test_st_poelten_hauptbahnhof_still_strips(self) -> None:
+        # St. Pölten Hauptbahnhof — abbreviation-with-period must keep
+        # behaving the same: trim "Hauptbahnhof" off, leave "St. Pölten".
+        assert _normalize_endpoint_name("St. Pölten Hauptbahnhof") == "St. Pölten"

--- a/tests/test_route_canonical_dedup.py
+++ b/tests/test_route_canonical_dedup.py
@@ -1,0 +1,87 @@
+"""Regression tests for Bug 11C (route dedup misses whitespace variants).
+
+Real ÖBB descriptions sometimes carry the same station name in two
+spellings — the title may use ``St. Pölten Hauptbahnhof`` while the
+description writes ``St.Pölten Hbf`` (no space after the period). The
+upstream extraction in ``_extract_routes`` keys on raw casefold text, so
+both spellings produce different keys and both survive into
+``_format_route_title``. The formatted title then repeats the route::
+
+    "S 50: Wien Hütteldorf ↔ Tullnerbach-Pressbaum
+        / Wien Westbahnhof ↔ St. Pölten Hauptbahnhof
+        / Wien Westbahnhof ↔ Wien Hütteldorf
+        / Wien Westbahnhof ↔ St. Pölten Hauptbahnhof"   ← duplicate
+
+(The duplicate is from the cached event #12 in
+``cache/oebb_c40d21/events.json``.)
+
+The fix deduplicates routes inside ``_format_route_title`` based on the
+*canonical* endpoint pair (after ``station_info`` resolution and
+``(VOR)``-suffix stripping) so whitespace variants of the same station
+collapse correctly.
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import _format_route_title
+
+
+class TestRouteCanonicalDedup:
+    def test_st_poelten_with_and_without_space_dedups(self) -> None:
+        # Two raw spellings of the same destination — title must show
+        # only one Wien Westbahnhof ↔ St. Pölten line.
+        routes = [
+            ("Wien Westbahnhof", "St. Pölten"),
+            ("Wien Westbahnhof", "St.Pölten"),
+        ]
+        title = _format_route_title(routes)
+        # Exactly one occurrence of the route after dedup.
+        assert title.count("↔") == 1
+        assert "St. Pölten Hauptbahnhof" in title
+
+    def test_real_cache_item_12_no_duplicate(self) -> None:
+        # Reproduction of the cache item: 4 raw routes, one of which is a
+        # whitespace duplicate of another. Output must have 3 routes.
+        routes = [
+            ("Wien Hütteldorf", "Tullnerbach-Pressbaum"),
+            ("Wien Westbahnhof", "St. Pölten"),
+            ("Wien Westbahnhof", "Wien Hütteldorf"),
+            ("Wien Westbahnhof", "St.Pölten"),
+        ]
+        title = _format_route_title(routes, "S 50")
+        # 3 unique routes → 3 ↔ separators
+        assert title.count("↔") == 3
+        # ensure the duplicate is gone
+        assert title.count("St. Pölten Hauptbahnhof") == 1
+
+    def test_distinct_routes_kept(self) -> None:
+        # Defence: when routes are genuinely different, all are kept.
+        routes = [
+            ("Wien Hbf", "Mödling"),
+            ("Wien Hbf", "Baden"),
+            ("Wien Hbf", "Wiener Neustadt"),
+        ]
+        title = _format_route_title(routes)
+        assert title.count("↔") == 3
+
+    def test_orientation_swap_does_not_create_duplicate(self) -> None:
+        # The Vienna-first orientation already canonicalises A/B order, so
+        # ("Wien", "Mödling") and ("Mödling", "Wien") must dedup to one
+        # route.
+        routes = [
+            ("Wien Hbf", "Mödling"),
+            ("Mödling", "Wien Hbf"),
+        ]
+        title = _format_route_title(routes)
+        assert title.count("↔") == 1
+
+
+class TestRouteDedupCompound:
+    def test_compound_franz_josefs_route_renders_correctly(self) -> None:
+        # Bug 11A interaction: the compound proper noun must render
+        # without the dangling-hyphen artefact.
+        routes = [("Wien Franz-Josefs-Bahnhof", "Wien Heiligenstadt")]
+        title = _format_route_title(routes, "S40")
+        assert title == "S40: Wien Franz-Josefs-Bahnhof ↔ Wien Heiligenstadt"
+        assert "Franz-Josefs-Bahnhof" in title
+        assert "Franz-Josefs- " not in title  # no dangling-hyphen artefact

--- a/tests/test_text_vienna_connection_strict.py
+++ b/tests/test_text_vienna_connection_strict.py
@@ -1,0 +1,89 @@
+"""Regression tests for Bug 11D / 11E.
+
+Bug 11D — ``text_has_vienna_connection`` previously matched a bare
+``\\bu-bahn\\b`` token, so any text mentioning the German word
+"U-Bahn" — including foreign-city contexts like ``Berliner U-Bahn``,
+``Münchner U-Bahn`` or ``Hamburger U-Bahn`` — was flagged as
+Wien-relevant. This is the last-resort fallback used by the ÖBB filter
+when no explicit route or station was identified, so a foreign U-Bahn
+mention in an ÖBB feed item slipped through silently.
+
+Bug 11E — ``is_in_vienna(name)`` falls back to comparing a normalised
+station-name token against the ``WIEN_TOKEN`` env-var (default
+``"wien"``). The env value was used raw, so a deployer setting
+``WIEN_TOKEN="Wien"`` (capital W) broke the comparison: the normalised
+incoming token is lowercase, the env value isn't.
+
+The fixes:
+
+- Drop the standalone ``u-bahn`` keyword from the Wien-detection regex
+  in ``text_has_vienna_connection``. U1-U6 line context is still
+  matched separately when accompanied by typical Wien-shorthand
+  patterns ("Linie U6 gesperrt", "(U2)", …).
+- Pass the env-derived city token through ``_normalize_token`` so a
+  cased env value still matches.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils.stations import is_in_vienna, text_has_vienna_connection
+
+
+class TestTextHasViennaConnection:
+    def test_berliner_u_bahn_does_not_match(self) -> None:
+        assert text_has_vienna_connection("Berliner U-Bahn unterbrochen") is False
+
+    def test_muenchner_u_bahn_does_not_match(self) -> None:
+        assert text_has_vienna_connection("Münchner U-Bahn gestört") is False
+
+    def test_die_u_bahn_nach_berlin_does_not_match(self) -> None:
+        assert (
+            text_has_vienna_connection("Die U-Bahn nach Berlin fährt") is False
+        )
+
+    def test_frankfurter_u_bahn_does_not_match(self) -> None:
+        assert text_has_vienna_connection("Frankfurter U-Bahn-Anlage") is False
+
+    def test_wien_u_bahn_still_matches(self) -> None:
+        # The Wien word remains the dominant signal.
+        assert text_has_vienna_connection("Wien U-Bahn") is True
+
+    def test_u6_gesperrt_with_wien_station_matches(self) -> None:
+        # Wien station alias resolution still keeps this true.
+        assert (
+            text_has_vienna_connection(
+                "U6 gesperrt zwischen Stephansplatz und Karlsplatz"
+            )
+            is True
+        )
+
+    def test_linie_u6_with_wien_word_matches(self) -> None:
+        assert text_has_vienna_connection("Linie U6 Wien") is True
+
+
+class TestIsInViennaWienTokenNormalisation:
+    def test_default_wien_lowercase_token(
+        self, monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        # Default WIEN_TOKEN ("wien") still works for variations of the
+        # incoming station name.
+        monkeypatch.delenv("WIEN_TOKEN", raising=False)
+        assert is_in_vienna("Wien Mitte-Landstraße") is True
+
+    def test_wien_token_capitalised_env_still_matches(
+        self, monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        # A deployer setting WIEN_TOKEN="Wien" (capital W) used to
+        # silently break the fallback because the env value was
+        # compared raw against a casefolded name token.
+        monkeypatch.setenv("WIEN_TOKEN", "Wien")
+        # Use a name that is NOT in the directory so we hit the fallback.
+        assert is_in_vienna("Wien Foobarbaz") is True
+
+    def test_wien_token_uppercase_env_still_matches(
+        self, monkeypatch: "pytest.MonkeyPatch"
+    ) -> None:
+        monkeypatch.setenv("WIEN_TOKEN", "WIEN")
+        assert is_in_vienna("Wien Foobarbaz") is True


### PR DESCRIPTION
## Summary

Filter audit round 11 found four real bugs across `oebb.py` and `utils/stations.py`. Two surface directly in the live ÖBB cache; the other two tighten the Wien-relevance fallbacks against false-positive matches.

### Bug 11A — compound `-Bahnhof` truncation
`_BAHNHOF_TRAILING_RE` stripped `Bahnhof` from `Wien Franz-Josefs-Bahnhof` → dangling `Wien Franz-Josefs-`. Alias resolution in `station_info` masked it for lookups, but dedup keys and any code path that doesn't go through `station_info` showed the artefact. Fix anchors the trailing-suffix regex at end-of-string and adds a negative lookbehind rejecting a leading hyphen / en-dash / em-dash.

### Bug 11C — duplicate routes from whitespace variants
`_format_route_title` keyed on raw casefold tuples. Cache item #12 has both `St. Pölten` (from title) and `St.Pölten` (from desc) — same canonical station, different keys, so the formatted title rendered the route twice:

```
S 50: Wien Hütteldorf ↔ Tullnerbach-Pressbaum
    / Wien Westbahnhof ↔ St. Pölten Hauptbahnhof
    / Wien Westbahnhof ↔ Wien Hütteldorf
    / Wien Westbahnhof ↔ St. Pölten Hauptbahnhof   ← duplicate
```

Fix dedups routes after canonical resolution (post-`station_info`, post-`(VOR)`-strip, post-orientation-swap).

### Bug 11D — `text_has_vienna_connection` over-eager `u-bahn` keyword
The fallback matched `\bu-bahn\b` standalone, flagging foreign-city mentions like `Berliner U-Bahn`, `Münchner U-Bahn` and `Hamburger U-Bahn-Anlage` as Wien-relevant. Fix removes the standalone keyword; U1-U6 still match contextually (`Linie U6`, `(U2)`, …).

### Bug 11E — `WIEN_TOKEN` env var case-sensitive
`is_in_vienna(name)` compared a casefolded station-name token against the raw env value. A deployer setting `WIEN_TOKEN="Wien"` silently broke the fallback. Fix passes the env value through `_normalize_token` before comparison.

## Test plan

- [x] 23 new regression tests across 3 files (8 + 6 + 9)
- [x] `pytest tests/` — 1334 passed, 3 skipped (unrelated `test_feed_lint` cache-age failure pre-dates this branch)
- [x] `mypy --strict` — clean on all modified files
- [x] `ruff check` — clean
- [x] Cache reproduction verified before/after each fix

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_