### PR TITLE
fix(wl): collapse newlines in titles, mask two-word street addresses

### DIFF
--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -147,7 +147,9 @@ def _stop_names_from_related(rel_stops: List[Any]) -> List[str]:
 # ---------------- Kontext für Titel ----------------
 
 def _normalize_whitespace(value: str) -> str:
-    return re.sub(r"\s{2,}", " ", value or "").strip()
+    # Collapse any whitespace run (incl. isolated newlines and tabs) to a
+    # single space so titles and labels stay single-line for RSS/Atom.
+    return re.sub(r"\s+", " ", value or "").strip()
 
 
 def _split_extra(extra: str) -> Optional[Tuple[str, str]]:

--- a/src/providers/wl_lines.py
+++ b/src/providers/wl_lines.py
@@ -73,7 +73,26 @@ DATE_FULL_RE = re.compile(r"\b\d{1,2}\.\d{1,2}\.(?:\d{2}|\d{4})\b")
 DATE_SHORT_RE = re.compile(r"\b\d{1,2}\.\d{1,2}\b")
 TIME_RE = re.compile(r"\b\d{1,2}:\d{2}\b")
 ADDRESS_NO_RE = re.compile(
-    r"\b([A-Za-zÄÖÜäöüß\-]+(?:gasse|straße|strasse|platz|allee|weg|steig|ufer|brücke|kai|ring|gürtel|lände|damm|markt))\s+\d+\b",
+    # Two shapes covered:
+    #   1) Compound street names where the suffix is glued onto the prefix
+    #      ("Wienerstraße 12", "Pasettistraße 200"). Suffix list is the
+    #      common Wien street terminology.
+    #   2) Two-word forms with a space and an abbreviation
+    #      ("Währinger Str 200", "Mariahilfer Str. 12", "Dornbacher
+    #      Straße 85"). Without this branch the trailing number was
+    #      picked up as a transit-line code by ``LINE_CODE_RE`` and
+    #      surfaced in the cached title prefix as ``41E/200``.
+    r"\b("
+    r"[A-Za-zÄÖÜäöüß\-]+"
+    r"(?:gasse|straße|strasse|platz|allee|weg|steig|ufer|brücke|kai|ring|gürtel|lände|damm|markt)"
+    r"|"
+    r"[A-Za-zÄÖÜäöüß\-]+\s+(?:Straße|Strasse|Str\.?|Gasse|Platz|Allee|Weg|Steig|Ufer|Brücke|Kai|Ring|Gürtel|Lände|Damm|Markt)"
+    r")"
+    # Numeric tail: house number, optional range ("236-238"), and optional
+    # alpha suffix ("12a"). Without the range, "Breitenfurter Straße
+    # 236-238" leaves "-238" behind which then matches LINE_CODE_RE as
+    # a phantom line.
+    r"\s+\d+(?:\s*[-–—/]\s*\d+)?[A-Za-z]?\b",
     re.IGNORECASE,
 )
 ADDRESS_NO_PRE_RE = re.compile(

--- a/src/providers/wl_text.py
+++ b/src/providers/wl_text.py
@@ -83,7 +83,15 @@ def _is_informative(rest: str) -> bool:
 
 
 def _tidy_title_wl(title: str) -> str:
-    """Entfernt generische Label am Anfang, wenn danach informativer Text steht."""
+    """Entfernt generische Label am Anfang, wenn danach informativer Text steht.
+
+    Real WL feed titles sometimes carry embedded newlines (``"Ersatzbus
+    41E\\nhält beim 10A"``) that survived the previous ``\\s{2,}``
+    collapse — a single newline matches ``\\s`` exactly once and so was
+    preserved verbatim. RSS/Atom titles are single-line by convention,
+    so we now collapse ANY whitespace run (including isolated newlines
+    or tabs) to a single space.
+    """
 
     t = (title or "").strip()
     if len(t) > 500:
@@ -95,7 +103,7 @@ def _tidy_title_wl(title: str) -> str:
         t = stripped
     t = re.sub(r"[<>«»‹›]+", "", t)  # spitze Klammern/Anführungen
     t = re.sub(r"\s+ab\s+\d{1,2}\.\d{1,2}\.(?:\d{4})?", "", t, flags=re.IGNORECASE)
-    return re.sub(r"\s{2,}", " ", t).strip(" -–—:/\t")
+    return re.sub(r"\s+", " ", t).strip(" -–—:/\t")
 
 
 # ---------------- Datum aus Titel extrahieren ----------------

--- a/tests/test_wl_address_two_word_streets.py
+++ b/tests/test_wl_address_two_word_streets.py
@@ -1,0 +1,92 @@
+"""Regression tests for Bug 12B (two-word street names with house numbers).
+
+Real Wiener-Linien titles sometimes include addresses like:
+
+* ``Währinger Str 200`` (two words, abbreviated suffix without period)
+* ``Mariahilfer Str. 12`` (two words, abbreviated with period)
+* ``Dornbacher Straße 85`` (two words, full suffix)
+* ``Breitenfurter Straße 236-238`` (two words, full suffix, range)
+* ``Lerchenfelder Gürtel 12`` (two words, alternative suffix)
+
+The previous ``ADDRESS_NO_RE`` only matched compounds where the suffix
+was glued to the prefix (``Wienerstraße 12``), so the trailing house
+number escaped the masking pass and ``LINE_CODE_RE`` picked it up as a
+phantom transit line. The cached event #26 in
+``cache/wl_9d709a/events.json`` actually rendered as
+``41E/200: Ersatzbus 41E …`` with ``200`` mistaken for a line.
+
+The fix adds a second alternation for ``<word>\\s+(?:Straße|Str\\.?|
+Gasse|Platz|Allee|Weg|Steig|Ufer|Brücke|Kai|Ring|Gürtel|Lände|Damm|
+Markt)\\s+\\d+(?:\\s*[-–—/]\\s*\\d+)?[A-Za-z]?`` so two-word street
+names AND number ranges (``236-238``, ``12a``, ``200/2``) are correctly
+masked before line detection runs.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from src.providers.wl_lines import (
+    ADDRESS_NO_RE,
+    _detect_line_pairs_from_text,
+)
+
+
+class TestAddressRegexMatchesTwoWordStreets:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Währinger Str 200",
+            "Mariahilfer Str. 12",
+            "Dornbacher Straße 85",
+            "Breitenfurter Straße 236-238",
+            "Lerchenfelder Gürtel 12",
+            "Wienerstraße 200",
+            "Pasettistraße 200",
+        ],
+    )
+    def test_two_word_streets_match(self, text: str) -> None:
+        m = ADDRESS_NO_RE.search(text)
+        assert m is not None, f"Address regex must match {text!r}"
+        # The match must consume the trailing number (or range).
+        assert re.search(r"\d", m.group(0))
+
+
+class TestLineDetectionDoesNotPickAddressNumbers:
+    def test_waehringer_str_200_no_phantom_line(self) -> None:
+        # The real cache item that exposed the bug.
+        pairs = _detect_line_pairs_from_text(
+            "Ersatzbus 41E halten bei Währinger Str 200"
+        )
+        line_tokens = [tok for tok, _ in pairs]
+        assert "200" not in line_tokens
+        assert "41E" in line_tokens
+
+    def test_breitenfurter_strasse_range_no_phantom_lines(self) -> None:
+        pairs = _detect_line_pairs_from_text(
+            "Bauarbeiten Busse halten Breitenfurter Straße 236-238"
+        )
+        line_tokens = [tok for tok, _ in pairs]
+        assert "236" not in line_tokens
+        assert "238" not in line_tokens
+
+    def test_dornbacher_strasse_no_phantom_line(self) -> None:
+        pairs = _detect_line_pairs_from_text(
+            "Linie 43A Dornbacher Straße 85"
+        )
+        line_tokens = [tok for tok, _ in pairs]
+        assert "85" not in line_tokens
+        assert "43A" in line_tokens
+
+    def test_real_lines_still_detected(self) -> None:
+        # Defence: actual line codes must still be found.
+        pairs = _detect_line_pairs_from_text("U6 gesperrt")
+        assert ("U6", "U6") in pairs
+
+    def test_two_lines_still_detected(self) -> None:
+        pairs = _detect_line_pairs_from_text("13A und U4 betroffen")
+        line_tokens = [tok for tok, _ in pairs]
+        assert "13A" in line_tokens
+        assert "U4" in line_tokens

--- a/tests/test_wl_line_parsing_regressions.py
+++ b/tests/test_wl_line_parsing_regressions.py
@@ -5,14 +5,16 @@ from src.providers.wl_lines import _detect_line_pairs_from_text
 @pytest.mark.parametrize("text,expected_lines", [
     ("Gleisschaden Züge halten Währinger Gürtel ggü. 164", []),
     ("Bauarbeiten Thaliastraße 45", []),
-    ("Unfall Lerchenfelder Gürtel 12", ["12"]), # Current limitation: spaces in street names not handled
-    ("Unfall Lerchenfeldergürtel 12", []),      # Handled by new suffix
+    # Two-word street names ("Lerchenfelder Gürtel", "Währinger Gürtel")
+    # are now handled by the extended ``ADDRESS_NO_RE`` pattern (Bug 12B).
+    ("Unfall Lerchenfelder Gürtel 12", []),
+    ("Unfall Lerchenfeldergürtel 12", []),
     ("Störung bei Nr. 5", []),
     ("Feuer bei Objekt 123", []),
     ("Tür 12 klemmt", []),
     ("Linie U6 fährt nicht", ["U6"]),
     ("Verspätung Linie 13A", ["13A"]),
-    ("Währinger Gürtel 164", ["164"]),          # Current limitation: Space in "Währinger Gürtel" not handled
+    ("Währinger Gürtel 164", []),
 ])
 def test_address_masking(text: str, expected_lines: list[str]) -> None:
     pairs = _detect_line_pairs_from_text(text)

--- a/tests/test_wl_title_no_newlines.py
+++ b/tests/test_wl_title_no_newlines.py
@@ -1,0 +1,58 @@
+"""Regression tests for Bug 12A (newlines preserved in WL feed titles).
+
+Real Wiener-Linien API responses sometimes carry titles like::
+
+    "Ersatzbus 41E\\nhält beim 10A"
+    "Ersatzbus 41E\\nhalten bei\\nWähringer Str 200"
+
+The previous ``_tidy_title_wl`` and ``_normalize_whitespace`` collapsed
+only ``\\s{2,}`` runs, so a single ``\\n`` between words survived
+verbatim. RSS/Atom titles must be single-line, and the cached items
+in ``cache/wl_9d709a/events.json`` showed the artefact directly.
+
+The fix tightens both helpers to ``\\s+`` so any whitespace run —
+including isolated newlines or tabs — collapses to a single space.
+"""
+
+from __future__ import annotations
+
+from src.providers.wl_fetch import _normalize_whitespace
+from src.providers.wl_text import _tidy_title_wl
+
+
+class TestTidyTitleWlSingleLine:
+    def test_single_newline_collapsed(self) -> None:
+        assert _tidy_title_wl("Ersatzbus 41E\nhält beim 10A") == (
+            "Ersatzbus 41E hält beim 10A"
+        )
+
+    def test_two_newlines_collapsed(self) -> None:
+        assert _tidy_title_wl(
+            "Ersatzbus 41E\nhalten bei\nWähringer Str 200"
+        ) == "Ersatzbus 41E halten bei Währinger Str 200"
+
+    def test_carriage_return_collapsed(self) -> None:
+        assert _tidy_title_wl("Foo\r\nBar") == "Foo Bar"
+
+    def test_tab_collapsed(self) -> None:
+        assert _tidy_title_wl("Foo\tBar") == "Foo Bar"
+
+    def test_normal_title_unchanged(self) -> None:
+        # No-newline titles must keep working.
+        assert _tidy_title_wl("U6: Störung Praterstern") == (
+            "U6: Störung Praterstern"
+        )
+
+
+class TestNormalizeWhitespaceSingleLine:
+    def test_normalize_whitespace_collapses_newline(self) -> None:
+        assert _normalize_whitespace("foo\nbar") == "foo bar"
+
+    def test_normalize_whitespace_collapses_tabs_and_runs(self) -> None:
+        assert _normalize_whitespace("foo \t  \n bar") == "foo bar"
+
+    def test_normalize_whitespace_empty(self) -> None:
+        assert _normalize_whitespace("") == ""
+
+    def test_normalize_whitespace_strips_outer(self) -> None:
+        assert _normalize_whitespace("  foo bar  ") == "foo bar"


### PR DESCRIPTION
## Summary

Filter audit round 12 found two real bugs in the Wiener-Linien provider, both visible directly in `cache/wl_9d709a/events.json`.

### Bug 12A — newlines preserved in WL titles
`_tidy_title_wl` and `_normalize_whitespace` collapsed only `\s{2,}` runs. A single `\n` between words matches `\s` exactly once, so it was preserved verbatim. Cached items in WL had titles like:

```
"Ersatzbus 41E\nhält beim 10A"
"41E/200: Ersatzbus 41E\nhalten bei\nWähringer Str 200"
```

RSS/Atom titles must be single-line. Fix tightens both helpers to `\s+` so any whitespace run (including isolated newlines or tabs) collapses to a single space.

### Bug 12B — phantom line codes from two-word street addresses
`ADDRESS_NO_RE` only matched compound street names where the suffix was glued to the prefix (`Wienerstraße 12`). Two-word Vienna names — `Währinger Str 200`, `Mariahilfer Str. 12`, `Dornbacher Straße 85`, `Lerchenfelder Gürtel 12` — and number ranges (`Breitenfurter Straße 236-238`) escaped the masking pass. The trailing house number then matched `LINE_CODE_RE` and surfaced as a phantom transit-line code: cached item #26 rendered as `41E/200: …` with `200` mistaken for a Wiener-Linien line.

Fix adds a second alternation that handles space-separated street names with or without an abbreviation period (`Str` / `Str.` / `Straße`), and consumes optional ranges (`236-238`, `200/2`) and alpha suffixes (`12a`).

## Test plan

- [x] 21 new regression tests across 2 files
- [x] `tests/test_wl_line_parsing_regressions.py` updated — two parametrisations that previously documented the limitation now correctly expect `[]`
- [x] `pytest tests/` — 1355 passed, 3 skipped
- [x] `mypy --strict` — clean
- [x] `ruff check` — clean
- [x] Cache reproduction verified before/after

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_