### PR TITLE
fix(filter): WL post-filter, hyphenated line prefix, News-POI title fallback

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -87,8 +87,34 @@ def refresh_from_env() -> None:
 read_cache = _core_read_cache
 
 
+def _post_filter_wl(items: List[Any]) -> List[Any]:
+    """Defence-in-depth: normalise WL titles loaded from cache.
+
+    The WL cache is only refreshed periodically. Title-formatting fixes
+    (e.g. collapsing newlines per Bug 12A) therefore don't reach the
+    feed until the next refresh — cached items can carry titles with
+    embedded ``\\n``/``\\t`` characters that violate RSS/Atom single-
+    line conventions. We re-run the same whitespace normalisation that
+    ``_tidy_title_wl`` applies so cached titles stay single-line even
+    before the cache turns over.
+    """
+    out: List[Any] = []
+    for item in items:
+        if not isinstance(item, dict):
+            out.append(item)
+            continue
+        title = item.get("title")
+        if isinstance(title, str) and title:
+            cleaned = re.sub(r"\s+", " ", title).strip()
+            if cleaned != title:
+                item = dict(item)
+                item["title"] = cleaned
+        out.append(item)
+    return out
+
+
 def read_cache_wl() -> List[Any]:
-    return list(read_cache("wl") or [])
+    return _post_filter_wl(list(read_cache("wl") or []))
 
 
 def _post_filter_oebb(items: List[Any]) -> List[Any]:

--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -16,8 +16,12 @@ from typing import Any, Dict, List, Set, Tuple, Union
 # compared.
 _LINE_PREFIX_RE = re.compile(
     r"^\s*("
-    r"[A-Za-z]+\s*\d{1,3}[A-Za-z]?"  # ÖBB style: REX 7, S 50, RJX 12
-    r"(?:\s*/\s*[A-Za-z]+\s*\d{1,3}[A-Za-z]?)*"
+    # ÖBB style: REX 7, S 50, RJX 12. The optional ``-Bahn`` segment
+    # tolerates verbose spellings like ``S-Bahn 50`` and ``U-Bahn 6``
+    # so they can fuzzy-merge with the compact ``S 50`` / ``U6``
+    # variants from another provider.
+    r"[A-Za-z]+(?:-[Bb]ahn)?\s*\d{1,3}[A-Za-z]?"
+    r"(?:\s*/\s*[A-Za-z]+(?:-[Bb]ahn)?\s*\d{1,3}[A-Za-z]?)*"
     r"|[A-Za-z0-9]+(?:\s*/\s*[A-Za-z0-9]+){0,20}"  # WL style: 1/2, U6, 13A
     r")\s*:\s*"
 )
@@ -178,8 +182,12 @@ def _parse_title(title: str) -> Tuple[Set[str], str]:
 
     lines = set()
     for raw in lines_str.split("/"):
+        # Strip a verbose ``-Bahn`` suffix so "S-Bahn 50" and "S 50"
+        # produce the same canonical token "S50" — without this both
+        # would coexist in the feed for the same incident.
+        cleaned = re.sub(r"-bahn", "", raw, flags=re.IGNORECASE)
         # Drop inner whitespace so "REX 7" and "REX7" become the same token.
-        token = re.sub(r"\s+", "", raw).upper()
+        token = re.sub(r"\s+", "", cleaned).upper()
         if _LINE_TOKEN_RE.match(token):
             lines.add(token)
 

--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -524,7 +524,13 @@ def fetch_events(timeout: int = 20) -> List[Dict[str, Any]]:
             ):
                 continue
 
-            title_raw = (poi.get("title") or "Hinweis").strip()
+            # Mirror the TrafficInfo branch's title fallback so a POI
+            # with empty ``title`` but a populated ``name`` (real WL
+            # News payload shape) doesn't collapse to the literal
+            # placeholder "Hinweis".
+            title_raw = (
+                poi.get("title") or poi.get("name") or "Hinweis"
+            ).strip()
             title = _tidy_title_wl(title_raw)
             desc_raw = (poi.get("description") or "").strip()
             # Do NOT strip HTML here, we need to preserve links (Task 3)

--- a/tests/test_merge_hyphenated_line_prefix.py
+++ b/tests/test_merge_hyphenated_line_prefix.py
@@ -1,0 +1,76 @@
+"""Regression tests for Bug 13B (hyphenated line prefix not merged).
+
+``_LINE_PREFIX_RE`` in ``src/feed/merge.py`` previously required a
+contiguous letter group followed by digits, so the verbose spellings
+``S-Bahn 50:`` and ``U-Bahn 6:`` failed to match. Items carrying those
+titles silently bypassed the fuzzy-merge step, leaving two duplicate
+items in the feed for the same incident reported under different
+prefix styles.
+
+The fix:
+
+- The regex now tolerates an optional ``-Bahn`` segment between the
+  letter group and the digit group.
+- ``_parse_title`` strips ``-bahn`` (case-insensitive) before tokenising
+  so ``S-Bahn 50`` collapses to the canonical ``S50`` token — matching
+  the compact ``S 50`` / ``S50`` produced by other providers.
+"""
+
+from __future__ import annotations
+
+from src.feed.merge import _parse_title, deduplicate_fuzzy
+
+
+class TestHyphenatedLinePrefix:
+    def test_s_bahn_50_recognised(self) -> None:
+        lines, name = _parse_title("S-Bahn 50: Wien Westbahnhof")
+        assert lines == {"S50"}
+        assert name == "Wien Westbahnhof"
+
+    def test_u_bahn_6_recognised(self) -> None:
+        lines, name = _parse_title("U-Bahn 6: Heiligenstadt")
+        assert lines == {"U6"}
+        assert name == "Heiligenstadt"
+
+    def test_compact_s50_unchanged(self) -> None:
+        # The previous behaviour for compact prefixes must stay intact.
+        lines, name = _parse_title("S 50: Wien Westbahnhof")
+        assert lines == {"S50"}
+        assert name == "Wien Westbahnhof"
+
+    def test_s_bahn_collapses_to_same_token_as_s_compact(self) -> None:
+        # Round-trip: both spellings now produce identical line sets,
+        # which is what fuzzy-merge needs for the dedup decision.
+        lines_a, _ = _parse_title("S-Bahn 50: Foo")
+        lines_b, _ = _parse_title("S 50: Foo")
+        assert lines_a == lines_b
+
+    def test_multi_line_prefix_with_hyphenated(self) -> None:
+        # Slash-separated prefix must still parse all tokens, hyphen-
+        # form included.
+        lines, _ = _parse_title("S-Bahn 50/U-Bahn 6: Bauarbeiten")
+        assert lines == {"S50", "U6"}
+
+
+class TestHyphenatedLinePrefixMerging:
+    def test_hyphenated_and_compact_merge(self) -> None:
+        items = [
+            {
+                "title": "S-Bahn 50: Bauarbeiten Wien Westbahnhof",
+                "description": "ÖBB report.",
+                "guid": "oebb_g1",
+                "provider": "oebb",
+                "source": "oebb",
+            },
+            {
+                "title": "S 50: Bauarbeiten Wien Westbahnhof",
+                "description": "VOR report.",
+                "guid": "vor_g1",
+                "provider": "vor",
+                "source": "vor",
+            },
+        ]
+        merged = deduplicate_fuzzy(items)
+        # Without the hyphen-tolerance fix, the items would not match
+        # and both would survive — verify exactly one item remains.
+        assert len(merged) == 1

--- a/tests/test_post_filter_wl.py
+++ b/tests/test_post_filter_wl.py
@@ -1,0 +1,96 @@
+"""Regression tests for Bug 13A (WL cache items keep stale newline titles).
+
+Audit round 12 fixed ``_tidy_title_wl`` so it collapses any whitespace
+run including isolated ``\\n``/``\\t``. But the WL cache is only
+refreshed periodically; cached items stored before the fix continued
+to surface in the feed with embedded newlines until the next refresh.
+
+The fix mirrors the existing ``_post_filter_oebb`` pattern: a defence-
+in-depth normalisation pass that re-applies ``\\s+ → ' '`` to titles
+loaded from cache. Items without a string title pass through
+untouched.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from src.build_feed import _post_filter_wl
+
+
+class TestPostFilterWlNormalisesTitles:
+    def test_single_newline_collapsed(self) -> None:
+        items: List[Dict[str, Any]] = [
+            {"title": "41E/10A: Ersatzbus 41E\nhält beim 10A"}
+        ]
+        out = _post_filter_wl(items)
+        assert out[0]["title"] == "41E/10A: Ersatzbus 41E hält beim 10A"
+
+    def test_multiple_newlines_collapsed(self) -> None:
+        items: List[Dict[str, Any]] = [
+            {
+                "title": (
+                    "41E/200: Ersatzbus 41E\nhalten bei\nWähringer Str 200"
+                )
+            }
+        ]
+        out = _post_filter_wl(items)
+        assert out[0]["title"] == (
+            "41E/200: Ersatzbus 41E halten bei Währinger Str 200"
+        )
+
+    def test_carriage_return_and_tab_collapsed(self) -> None:
+        items: List[Dict[str, Any]] = [{"title": "Foo\r\nBar\tBaz"}]
+        out = _post_filter_wl(items)
+        assert out[0]["title"] == "Foo Bar Baz"
+
+    def test_clean_title_unchanged(self) -> None:
+        items: List[Dict[str, Any]] = [{"title": "U6: Störung Praterstern"}]
+        out = _post_filter_wl(items)
+        assert out[0]["title"] == "U6: Störung Praterstern"
+
+    def test_other_fields_preserved(self) -> None:
+        items: List[Dict[str, Any]] = [
+            {
+                "title": "Foo\nBar",
+                "description": "preserved\nas\nis",
+                "guid": "wl-1",
+                "pubDate": "2026-05-06T12:00:00Z",
+            }
+        ]
+        out = _post_filter_wl(items)
+        # Title cleaned, but other fields untouched.
+        assert out[0]["title"] == "Foo Bar"
+        assert out[0]["description"] == "preserved\nas\nis"
+        assert out[0]["guid"] == "wl-1"
+
+    def test_input_dict_not_mutated(self) -> None:
+        # Defence: the post-filter must not modify the caller's dict.
+        original = {"title": "Foo\nBar"}
+        items: List[Dict[str, Any]] = [original]
+        _post_filter_wl(items)
+        assert original["title"] == "Foo\nBar"  # unchanged
+
+
+class TestPostFilterWlPassesThrough:
+    def test_non_dict_items_pass_through(self) -> None:
+        items: List[Any] = ["not-a-dict", 42, None]
+        assert _post_filter_wl(items) == items
+
+    def test_dict_without_title_passes_through(self) -> None:
+        items: List[Dict[str, Any]] = [{"foo": "bar"}]
+        out = _post_filter_wl(items)
+        assert out == items
+
+    def test_dict_with_none_title_passes_through(self) -> None:
+        items: List[Dict[str, Any]] = [{"title": None}]
+        out = _post_filter_wl(items)
+        assert out == items
+
+    def test_dict_with_empty_title_passes_through(self) -> None:
+        items: List[Dict[str, Any]] = [{"title": ""}]
+        out = _post_filter_wl(items)
+        assert out == items
+
+    def test_empty_list(self) -> None:
+        assert _post_filter_wl([]) == []

--- a/tests/test_wl_news_title_fallback.py
+++ b/tests/test_wl_news_title_fallback.py
@@ -1,0 +1,48 @@
+"""Regression tests for Bug 13C (WL News POI title fallback).
+
+The TrafficInfo branch of ``fetch_events`` falls back through three
+layers: ``ti.get("title") or ti.get("name") or "Meldung"``. The News
+POI branch only had two: ``poi.get("title") or "Hinweis"``. When the
+WL API returned a POI with empty ``title`` but a populated ``name``,
+the resulting feed item collapsed to the literal placeholder
+``"Hinweis"`` plus the auto-generated context suffix, losing the
+user-meaningful headline that was sitting in the ``name`` field.
+
+The fix mirrors the TrafficInfo fallback: ``poi.get("title") or
+poi.get("name") or "Hinweis"``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def test_news_poi_title_fallback_uses_name() -> None:
+    # Static source-code check: the patched line must include the
+    # three-step fallback through ``name``.
+    path = Path(__file__).resolve().parent.parent / "src" / "providers" / "wl_fetch.py"
+    source = path.read_text(encoding="utf-8")
+
+    # The fallback should exist for the News-POI branch.
+    pattern = re.compile(
+        r'poi\.get\("title"\)\s*or\s*poi\.get\("name"\)\s*or\s*"Hinweis"',
+        re.DOTALL,
+    )
+    assert pattern.search(source), (
+        "News-POI title fallback must include poi.get('name') as middle step"
+    )
+
+
+def test_traffic_info_title_fallback_unchanged() -> None:
+    # The TrafficInfo branch already had the right fallback — this
+    # guards against accidental regression.
+    path = Path(__file__).resolve().parent.parent / "src" / "providers" / "wl_fetch.py"
+    source = path.read_text(encoding="utf-8")
+
+    pattern = re.compile(
+        r'ti\.get\("title"\)\s*or\s*ti\.get\("name"\)\s*or\s*"Meldung"',
+    )
+    assert pattern.search(source), (
+        "TrafficInfo title fallback must preserve ti.get('name') middle step"
+    )


### PR DESCRIPTION
## Summary

Filter audit round 13 found three real bugs across the WL provider, the cross-provider merge logic, and the cache-read defence-in-depth pass.

### Bug 13A — WL cache items keep stale newline titles
`read_cache_wl` returned cached items verbatim, so the newline-collapse fix from round 12 only reaches the feed after the next cache refresh. Cached items #24 and #26 in `cache/wl_9d709a/events.json` still carry titles like:

```
"41E/10A: Ersatzbus 41E\nhält beim 10A"
"41E/200: Ersatzbus 41E\nhalten bei\nWähringer Str 200"
```

Fix mirrors the existing `_post_filter_oebb` pattern: a cheap `\s+ → ' '` pass on string titles guarantees single-line titles regardless of when the cache was last refreshed.

### Bug 13B — hyphenated line prefix not merged (previously deferred Bug M2)
`_LINE_PREFIX_RE` in `feed/merge.py` required a contiguous letter group followed by digits, so `S-Bahn 50:` and `U-Bahn 6:` failed to match. Two providers reporting the same incident under different prefix styles silently produced two duplicate items in the feed. The regex now tolerates an optional `-Bahn` segment, and `_parse_title` strips `-bahn` before tokenising so verbose and compact forms collapse to the same canonical token (`S50`, `U6`).

### Bug 13C — WL News POI title fallback missing
The WL News-POI branch fell back through `poi.get("title") or "Hinweis"`. The TrafficInfo branch already used the three-step `ti.get("title") or ti.get("name") or "Meldung"` fallback. POIs with empty `title` but populated `name` therefore collapsed to the literal `"Hinweis"` placeholder, losing the user-meaningful headline. Now mirrors the TrafficInfo fallback.

## Test plan

- [x] 19 new regression tests across 3 files
- [x] `pytest tests/` — 1374 passed, 3 skipped
- [x] `mypy --strict` — clean
- [x] `ruff check` — clean
- [x] Cache reproduction verified before/after

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_