### PR TITLE
fix(text): keep Wiener-Linien line codes compact in html_to_text

### DIFF
--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -40,7 +40,14 @@ _PREP_BULLET_RE = re.compile(
 _NEWLINE_CLEANUP_RE = re.compile(r"[ \t\r\f\v]*\n[ \t\r\f\v]*")
 _COLON_BULLET_RE = re.compile(r":\s*•\s*")
 _COLON_NEWLINE_RE = re.compile(r":\s*\n")
-_DIGIT_ALPHA_RE = re.compile(r"(\d)([A-Za-zÄÖÜäöüß])")
+# Insert a space between a digit and a following letter so concatenated
+# unit-style tokens like ``12Uhr`` render as ``12 Uhr``. A single trailing
+# uppercase letter, however, is a Wiener-Linien line-code suffix (``11A``,
+# ``27A``, ``5B``) and must stay glued — splitting produced visibly wrong
+# descriptions like ``Linie 11 A: …``.
+_DIGIT_ALPHA_RE = re.compile(
+    r"(\d)([A-Za-zÄÖÜäöüß][a-zäöüß]+|[a-zäöüß])"
+)
 _MULTI_BULLET_RE = re.compile(r"(?:\s*•\s*){2,}")
 _LEADING_BULLET_RE = re.compile(r"^\s*•\s*")
 _TRAILING_BULLET_RE = re.compile(r"\s*•\s*$")

--- a/tests/test_html_to_text.py
+++ b/tests/test_html_to_text.py
@@ -46,9 +46,18 @@ def test_preposition_bullet_stripping(html: str, expected: str) -> None:
 
 
 @pytest.mark.parametrize("html,expected", [
-    ("10A", "10 A"),
-    ("12A", "12 A"),
+    # Wiener-Linien line codes are conventionally written compact —
+    # ``11A``, ``5B``, ``27A`` — and must NOT be split. The previous
+    # behaviour ``11A → 11 A`` produced visibly wrong feed descriptions
+    # like ``Linie 11 A: Unregelmäßige Intervalle …``. (Bug 14A)
+    ("10A", "10A"),
+    ("12A", "12A"),
+    ("11A", "11A"),
+    ("5B", "5B"),
     ("U6", "U6"),
+    # Multi-character unit words still get split off for readability.
+    ("12Uhr", "12 Uhr"),
+    ("20kg", "20 kg"),
     ("2m", "2 m"),
 ])
 def test_line_codes_and_units(html: str, expected: str) -> None:

--- a/tests/test_line_code_compact.py
+++ b/tests/test_line_code_compact.py
@@ -1,0 +1,97 @@
+"""Regression tests for Bug 14A (Wiener-Linien line codes split into pieces).
+
+The HTML-to-text helper applied ``\\d → \\d ' '`` unconditionally before
+any letter, so concatenated tokens like ``11A`` (Wiener-Linien bus
+line) were rendered as ``11 A``. This propagated all the way to the
+feed: descriptions read ``Linie 11 A: Unregelmäßige Intervalle …``
+where Vienna's own naming convention uses the compact form ``11A``.
+
+Cache item #25 (``Linie 11A: Verkehrsüberlastung``) showed the bug
+directly when surfaced through the feed pipeline:
+
+    docs/feed.xml: <description>Linie 11 A: Unregelmäßige Intervalle…
+
+The fix tightens ``_DIGIT_ALPHA_RE`` to skip a single trailing
+uppercase letter (the Wiener-Linien line-code suffix) while still
+splitting multi-character unit words like ``12Uhr → 12 Uhr`` and
+``20kg → 20 kg``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils.text import html_to_text
+
+
+class TestLineCodesStayCompact:
+    @pytest.mark.parametrize(
+        "code",
+        ["10A", "11A", "12A", "27A", "5B", "13A", "26A", "41E", "62", "9", "U6", "S50"],
+    )
+    def test_compact_line_code_unchanged(self, code: str) -> None:
+        assert html_to_text(code) == code
+
+    def test_linie_prefix_keeps_compact_code(self) -> None:
+        # Real feed pattern: "Linie 11A: Verkehrsüberlastung". The
+        # space between the digit and the suffix-letter would have
+        # been inserted by the buggy regex, breaking the convention.
+        assert (
+            html_to_text("Linie 11A: Verkehrsüberlastung")
+            == "Linie 11A: Verkehrsüberlastung"
+        )
+
+    def test_linie_prefix_keeps_5b_compact(self) -> None:
+        assert (
+            html_to_text("Linie 5B: Polizeieinsatz")
+            == "Linie 5B: Polizeieinsatz"
+        )
+
+    def test_real_feed_description_kept_intact(self) -> None:
+        # Reproduction of the exact phrasing that surfaced in the feed
+        # before the fix.
+        text = (
+            "Linie 11A: Unregelmäßige Intervalle in beiden Richtungen. "
+            "Grund: Verkehrsüberlastung."
+        )
+        assert html_to_text(text) == text
+
+
+class TestUnitsStillSplit:
+    @pytest.mark.parametrize(
+        "before,after",
+        [
+            ("12Uhr", "12 Uhr"),
+            ("20kg", "20 kg"),
+            ("2m", "2 m"),
+            ("100km", "100 km"),
+            ("5min", "5 min"),
+            # Multi-letter capitalised word still splits.
+            ("12Mio", "12 Mio"),
+        ],
+    )
+    def test_unit_words_split(self, before: str, after: str) -> None:
+        assert html_to_text(before) == after
+
+
+class TestEdgeCases:
+    def test_multi_digit_with_letter_suffix(self) -> None:
+        # ÖBB regional service codes like ``REX 51`` arrive
+        # whitespace-separated; the digit-alpha rule never fires.
+        # Compact ``REX51`` stays compact.
+        assert html_to_text("REX51") == "REX51"
+
+    def test_year_followed_by_text(self) -> None:
+        # Year-followed-by-word still splits via the lowercase-first
+        # branch.
+        assert html_to_text("2026um") == "2026 um"
+
+    def test_year_followed_by_capital_word_splits(self) -> None:
+        assert html_to_text("2026Wien") == "2026 Wien"
+
+    def test_year_followed_by_single_capital_kept(self) -> None:
+        # Exotic but consistent: year-letter combinations like ``2026A``
+        # would be rare in real data, but the rule treats them as
+        # line-code-like and keeps them compact. This is fine — no real
+        # disambiguation case observed in cache.
+        assert html_to_text("2026A") == "2026A"


### PR DESCRIPTION
## Summary

Filter audit round 14 caught one real **user-visible** bug in `docs/feed.xml`.

### Bug 14A — line codes split apart in feed descriptions

`_DIGIT_ALPHA_RE` in `src/utils/text.py` inserted a space between any digit and any following letter:

```python
_DIGIT_ALPHA_RE = re.compile(r"(\d)([A-Za-zÄÖÜäöüß])")
...
txt = _DIGIT_ALPHA_RE.sub(r"\1 \2", txt)
```

This rule was meant to handle unit-like tokens (`12Uhr → 12 Uhr`) but also fired on Wiener-Linien line codes. The cache correctly stored:

```
"Linie 11A: Unregelmäßige Intervalle in beiden Richtungen. Grund: Verkehrsüberlastung."
```

…but the feed surfaced it as:

```xml
<description>Linie 11 A: Unregelmäßige Intervalle…</description>
```

Visible in the live feed for `11A`, `5B`, `27A`, `26A`. Vienna's own naming convention (and Wiener Linien's website) use the compact form.

### Fix

Tighten the regex so a single trailing uppercase letter (the line-code suffix shape) is exempted, while multi-character unit words still split:

```python
_DIGIT_ALPHA_RE = re.compile(
    r"(\d)([A-Za-zÄÖÜäöüß][a-zäöüß]+|[a-zäöüß])"
)
```

- `11A` → `11A` ✓ (single uppercase letter — line-code suffix)
- `12Uhr` → `12 Uhr` ✓ (uppercase + lowercase tail)
- `20kg` → `20 kg` ✓ (lowercase letter)
- `2m` → `2 m` ✓ (lowercase letter)
- `Linie 11A: Verspätung` → `Linie 11A: Verspätung` ✓

The pre-existing `test_line_codes_and_units` parametrisation locked in the broken behaviour with internally inconsistent expectations (test name said "line codes and units" but split both); both halves are now corrected.

## Test plan

- [x] 25 new regression tests in `tests/test_line_code_compact.py`
- [x] `tests/test_html_to_text.py::test_line_codes_and_units` updated to expect compact line codes
- [x] `pytest tests/` — 1403 passed, 3 skipped
- [x] `mypy --strict` — clean
- [x] `ruff check` — clean
- [x] Reproduction verified directly in `docs/feed.xml` lines that read `Linie 11 A` / `Linie 5 B`

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_