### PR TITLE
fix(oebb): preserve leading line prefix through _clean_title_keep_places

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -197,9 +197,33 @@ def _clean_description(text: str) -> str:
     return text.strip()
 
 
+# Recognises an ÖBB line marker at the very start of a title. The
+# prefix is split off before the segment iteration runs and re-attached
+# afterwards — without this, ``S40: Wien Franz-Josefs-Bahnhof ↔ Wien
+# Heiligenstadt`` produced ``Wien Heiligenstadt ↔ S40: Wien
+# Franz-Josefs-…`` because the Vienna-first reorder logic mistakenly
+# classifies ``S40: Wien Franz-Josefs-Bahnhof`` (with the line prefix
+# still glued on) as "not in Vienna" — the prefix breaks the
+# station_info lookup — and swaps the endpoints.
+_LEADING_LINE_PREFIX_RE = re.compile(
+    r"^\s*((?:REX|RJX|RJ|EC|ICE|IC|WB|NJ|CJX|S-Bahn|S|U-Bahn|U|R|D)\s*\d+[A-Za-z]?)\s*:\s*",
+    re.IGNORECASE,
+)
+
+
 def _clean_title_keep_places(t: str) -> str:
     t = (t or "").strip()
     t = html.unescape(t)
+
+    # Preserve a leading line marker (S40:, REX 7:, …) through the
+    # cleanup. The endpoint-reordering logic below would otherwise
+    # treat the prefix as part of the first endpoint and silently
+    # swap A↔B when only one side resolves to a Vienna station.
+    line_prefix = ""
+    line_match = _LEADING_LINE_PREFIX_RE.match(t)
+    if line_match:
+        line_prefix = line_match.group(1).strip()
+        t = t[line_match.end():]
 
     # Redundanz-Check: Wenn Titel „Text: Station“ ist und Station im Text vorkommt,
     # dann nur Text nehmen (z.B. "Aufzug in X defekt: X").
@@ -289,7 +313,14 @@ def _clean_title_keep_places(t: str) -> str:
     t = MULTI_ARROW_RE.sub(" ↔ ", t)
     t = re.sub(r"\s{2,}", " ", t)
     t = re.sub(r"&lt;|&gt;|&#60;|&#x3C;|&#62;|&#x3E;|[<>«»‹›]+", "", t)
-    return t.strip()
+    t = t.strip()
+    # Re-attach the leading line prefix that was split off above so
+    # downstream consumers (``_extract_line_prefix``) still recognise it.
+    if line_prefix and t:
+        t = f"{line_prefix}: {t}"
+    elif line_prefix:
+        t = line_prefix
+    return t
 
 # ---------------- Region / Filter Logic ----------------
 

--- a/tests/test_oebb_line_prefix_preserved.py
+++ b/tests/test_oebb_line_prefix_preserved.py
@@ -1,0 +1,102 @@
+"""Regression tests for Bug 17A (line prefix swallowed by Vienna-first reorder).
+
+``_clean_title_keep_places`` runs an "endpoint reorder" step that puts
+the Vienna station first when only one of the two split parts resolves
+against the directory. Before the fix, an ÖBB title like::
+
+    "S40: Wien Franz-Josefs-Bahnhof ↔ Wien Heiligenstadt"
+
+resulted in::
+
+    "Wien Heiligenstadt ↔ S40: Wien Franz-Josefs-"
+
+because:
+
+1. ``ARROW_ANY_RE`` split into ``["S40: Wien Franz-Josefs-Bahnhof",
+   "Wien Heiligenstadt"]``.
+2. ``is_in_vienna("S40: Wien Franz-Josefs-Bahnhof")`` returned False —
+   the line prefix breaks the ``station_info`` lookup.
+3. ``is_in_vienna("Wien Heiligenstadt")`` returned True.
+4. The reorder swapped the parts; the line prefix ended up in the
+   middle of the title.
+
+The downstream ``_format_route_title`` rebuild masked the user-visible
+breakage in the most common case, but the corrupted intermediate
+leaked through whenever ``_extract_routes`` returned no Wien-relevant
+routes (e.g. for single-station fallthrough).
+
+The fix splits the leading line marker off at the very start of
+``_clean_title_keep_places`` and re-attaches it after the reorder
+runs. The reorder no longer sees the prefix at all.
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import _clean_title_keep_places, _extract_line_prefix
+
+
+class TestLinePrefixPreservedThroughCleanup:
+    def test_s40_prefix_kept_no_reorder(self) -> None:
+        raw = "S40: Wien Franz-Josefs-Bahnhof ↔ Wien Heiligenstadt"
+        out = _clean_title_keep_places(raw)
+        # Line prefix on the LEFT, original endpoint order preserved.
+        assert out.startswith("S40:")
+        assert "Wien Franz-Josefs-Bahnhof ↔ Wien Heiligenstadt" in out
+        # And nowhere does the prefix end up in the middle.
+        assert " S40:" not in out
+        assert "↔ S40" not in out
+
+    def test_rex7_prefix_kept(self) -> None:
+        raw = "REX 7: Wien Floridsdorf ↔ Flughafen Wien"
+        assert _clean_title_keep_places(raw).startswith("REX 7:")
+
+    def test_u6_prefix_kept_with_canonical_expansion(self) -> None:
+        # U6: Heiligenstadt ↔ Floridsdorf — the canonical-name expansion
+        # turns "Heiligenstadt" into "Wien Heiligenstadt"; the prefix
+        # must still survive at the start.
+        out = _clean_title_keep_places("U6: Heiligenstadt ↔ Floridsdorf")
+        assert out.startswith("U6:")
+        assert "Wien Heiligenstadt" in out
+
+    def test_rjx_prefix_kept(self) -> None:
+        raw = "RJX 12: Wien Hauptbahnhof ↔ Salzburg"
+        assert _clean_title_keep_places(raw).startswith("RJX 12:")
+
+    def test_s_bahn_long_form_prefix_kept(self) -> None:
+        # The verbose "S-Bahn" form (now that round-13 added its line-
+        # parser support) must also survive the cleanup.
+        raw = "S-Bahn 50: Wien Westbahnhof ↔ St. Pölten"
+        out = _clean_title_keep_places(raw)
+        assert out.startswith("S-Bahn 50:")
+
+
+class TestExtractLinePrefixRoundTrip:
+    def test_extract_after_cleanup_returns_prefix(self) -> None:
+        # The downstream pipeline calls ``_extract_line_prefix`` on the
+        # cleaned title. The prefix must round-trip cleanly so that
+        # ``_format_route_title`` re-attaches it on the rebuild.
+        cleaned = _clean_title_keep_places(
+            "S40: Wien Franz-Josefs-Bahnhof ↔ Wien Heiligenstadt"
+        )
+        prefix, rest = _extract_line_prefix(cleaned)
+        assert prefix == "S40"
+        assert "Wien Franz-Josefs-Bahnhof" in rest
+        assert "Wien Heiligenstadt" in rest
+
+    def test_extract_after_cleanup_for_combo_with_category(self) -> None:
+        # "S 50: Bauarbeiten: Wien Westbf …" combines a line prefix with
+        # an inner category prefix. Only "S 50" should remain at the
+        # front; "Bauarbeiten:" is stripped by the segment iteration.
+        cleaned = _clean_title_keep_places(
+            "S 50: Bauarbeiten: Wien Westbf Wien Hütteldorf/Tullnerbach-Pressbaum"
+        )
+        prefix, _ = _extract_line_prefix(cleaned)
+        assert prefix == "S 50"
+        assert "Bauarbeiten" not in cleaned
+
+
+class TestNoPrefixNoChange:
+    def test_no_line_prefix_unchanged(self) -> None:
+        # A title without a line prefix must still pass through.
+        raw = "Wien Hauptbahnhof ↔ Mödling"
+        assert _clean_title_keep_places(raw) == "Wien Hauptbahnhof ↔ Mödling"


### PR DESCRIPTION
## Summary

Filter audit round 17 caught one cosmetic-but-real defect in the title cleanup pipeline.

### Bug 17A — line prefix swallowed by Vienna-first reorder

`_clean_title_keep_places` runs an "endpoint reorder" step that puts the Vienna station first when only one of the two split parts resolves against the directory. For an ÖBB title like:

```
S40: Wien Franz-Josefs-Bahnhof ↔ Wien Heiligenstadt
```

the line prefix `S40:` was glued onto the first endpoint when `ARROW_ANY_RE` split the string. Then `is_in_vienna("S40: Wien Franz-Josefs-Bahnhof")` returned False (the prefix breaks the `station_info` lookup), so the reorder mistakenly classified the part as "not in Vienna" and swapped:

```
Wien Heiligenstadt ↔ S40: Wien Franz-Josefs-…
```

with the line prefix sitting in the middle of the title. The downstream `_format_route_title` rebuild masked the breakage in most cases, but the corrupted intermediate leaked through whenever `_extract_routes` returned no Wien-relevant routes (single-station fallthrough).

### Fix

Split the leading line marker (`S40:`, `REX 7:`, `U6:`, `RJX 12:`, `S-Bahn 50:` …) off at the very start of `_clean_title_keep_places` and re-attach it after the reorder runs. The reorder no longer sees the prefix at all.

## Test plan

- [x] 8 new regression tests in `tests/test_oebb_line_prefix_preserved.py`
- [x] `pytest tests/` — 1422 passed, 3 skipped
- [x] `mypy --strict` — clean
- [x] `ruff check` — clean
- [x] Pre-existing `test_s50_line_prefix_preserved_in_title` still passes
- [x] Real cache reproduction verified for OEBB item #0 (`S40: Wien Franz-Josefs-Bahnhof ↔ Wien Heiligenstadt`)

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_