### PR TITLE
fix(oebb): preserve all arrows when cleaning multi-route titles

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -281,7 +281,7 @@ def _clean_title_keep_places(t: str) -> str:
                         if c:
                             c = re.sub(r"\s+\(VOR\)$", "", c)
                         processed_subs.append(c)
-                    canon = "/ ".join(processed_subs)
+                    canon = " / ".join(processed_subs)
 
             if not canon:
                 canon = cleaned
@@ -303,11 +303,15 @@ def _clean_title_keep_places(t: str) -> str:
             if len(parts) == 2 and is_in_vienna(parts[1]) and not is_in_vienna(parts[0]):
                  parts[0], parts[1] = parts[1], parts[0]
 
-            t = f"{parts[0]} ↔ {parts[1]}"
-            if len(parts) > 2:
-                rest = " ".join(parts[2:]).strip()
-                if rest:
-                    t += f" {rest}"
+            # Multi-part titles arise from chains like ``A ↔ B / C ↔ D``
+            # where ``ARROW_ANY_RE`` split off three parts (``A``, ``B / C``,
+            # ``D``). Joining the tail with a plain space silently drops
+            # the inner ``↔`` separators so the latent intermediate read
+            # ``A ↔ B / C  D`` — only ``_format_route_title`` later
+            # rebuilt a clean title. Joining everything with `` ↔ ``
+            # keeps the inter-route arrows so the cleaner can be relied
+            # on as a stand-alone pre-processor too.
+            t = " ↔ ".join(parts)
     elif parts:
         t = parts[0]
     t = MULTI_ARROW_RE.sub(" ↔ ", t)

--- a/tests/test_oebb_multi_route_arrows.py
+++ b/tests/test_oebb_multi_route_arrows.py
@@ -1,0 +1,88 @@
+"""Regression tests for Bug 18A (multi-route arrows lost in title cleanup).
+
+``_clean_title_keep_places`` runs ``ARROW_ANY_RE.split`` to break the
+title into endpoints. For a chained title like ``A ↔ B / C ↔ D`` the
+split produces three parts (``A``, ``B / C``, ``D``). The previous
+join logic joined ``parts[0]`` and ``parts[1]`` with ↔ and then
+appended the remaining parts with a *plain space*, dropping the
+inner ↔ separator silently::
+
+    raw:     "Wien Hauptbahnhof ↔ Götzendorf / Wien Hauptbahnhof ↔ Gramatneusiedl"
+    cleaned: "Wien Hauptbahnhof ↔ Götzendorf/ Wien Hauptbahnhof Gramatneusiedl"
+
+The downstream ``_format_route_title`` rebuild masked the breakage in
+the live feed (it parses routes from the description, not the cleaned
+title), but any caller that uses ``_clean_title_keep_places`` as a
+stand-alone pre-processor saw the corruption.
+
+The fix:
+
+- Join all parts with `` ↔ `` so chained route titles round-trip.
+- Use `` / `` (with whitespace on both sides) when re-joining a
+  composite endpoint after the slash-split — the previous ``"/ "``
+  produced ``B/ C`` which looked like a typo.
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import _clean_title_keep_places
+
+
+class TestMultiRouteArrowsPreserved:
+    def test_two_route_chain_keeps_both_arrows(self) -> None:
+        raw = (
+            "Wien Hauptbahnhof ↔ Götzendorf / "
+            "Wien Hauptbahnhof ↔ Gramatneusiedl"
+        )
+        out = _clean_title_keep_places(raw)
+        assert out.count("↔") == 2
+        assert "Götzendorf" in out
+        assert "Gramatneusiedl" in out
+
+    def test_two_routes_with_pendler_endpoint(self) -> None:
+        raw = (
+            "Wien Mitte-Landstraße ↔ Flughafen Wien / "
+            "Wien Mitte-Landstraße ↔ Wien Floridsdorf"
+        )
+        out = _clean_title_keep_places(raw)
+        assert out.count("↔") == 2
+        assert "Flughafen Wien" in out
+        assert "Wien Floridsdorf" in out
+
+    def test_two_routes_with_line_prefix(self) -> None:
+        raw = (
+            "S 50: Wien Westbahnhof ↔ Wien Hütteldorf / "
+            "Wien Hütteldorf ↔ Tullnerbach-Pressbaum"
+        )
+        out = _clean_title_keep_places(raw)
+        assert out.startswith("S 50:")
+        assert out.count("↔") == 2
+
+    def test_three_routes_all_arrows_kept(self) -> None:
+        raw = "A ↔ B / C ↔ D / E ↔ F"
+        out = _clean_title_keep_places(raw)
+        assert out.count("↔") == 3
+
+
+class TestSingleRouteUnchanged:
+    def test_simple_route(self) -> None:
+        assert _clean_title_keep_places(
+            "Wien Hauptbahnhof ↔ Mödling"
+        ) == "Wien Hauptbahnhof ↔ Mödling"
+
+    def test_line_prefix_route(self) -> None:
+        out = _clean_title_keep_places(
+            "S40: Wien Franz-Josefs-Bahnhof ↔ Wien Heiligenstadt"
+        )
+        assert out == "S40: Wien Franz-Josefs-Bahnhof ↔ Wien Heiligenstadt"
+
+
+class TestSlashSpacing:
+    def test_composite_endpoint_uses_proper_spacing(self) -> None:
+        # A composite endpoint like ``Wien/ Flughafen Wien`` (with the
+        # slash-then-space form ÖBB sometimes uses) must round-trip
+        # with the proper `` / `` separator.
+        raw = "Bauarbeiten: Wien/ Flughafen Wien"
+        out = _clean_title_keep_places(raw)
+        # Must NOT contain the awkward ``X/ Y`` (no leading space).
+        assert "/ " not in out or " / " in out


### PR DESCRIPTION
## Summary

Filter audit round 18 closes a long-standing latent defect in `_clean_title_keep_places`.

### Bug 18A — multi-route arrows lost in title cleanup

`ARROW_ANY_RE.split` breaks chain-style titles like `A ↔ B / C ↔ D` into three parts (`A`, `B / C`, `D`). The previous join logic concatenated `parts[0] ↔ parts[1]` and then appended the remaining parts with a *plain space*, silently dropping the inner ↔ separator:

```
raw:     "Wien Hauptbahnhof ↔ Götzendorf / Wien Hauptbahnhof ↔ Gramatneusiedl"
cleaned: "Wien Hauptbahnhof ↔ Götzendorf/ Wien Hauptbahnhof Gramatneusiedl"
```

The downstream `_format_route_title` rebuilds a clean title from the description, so the corruption never reached `docs/feed.xml` — but `_clean_title_keep_places` is also exposed to callers (and to test suites) that use it as a stand-alone pre-processor. Joining all parts with ` ↔ ` keeps the chain intact for those callers.

### Polish

The slash-split rejoin in the canonical-name branch now uses ` / ` (with whitespace on both sides) instead of the awkward `"/ "` (slash without leading space) that produced `Wien/ Flughafen Wien`.

## Test plan

- [x] 7 new regression tests in `tests/test_oebb_multi_route_arrows.py`
- [x] `pytest tests/` — 1429 passed, 3 skipped
- [x] `mypy --strict` — clean
- [x] `ruff check` — clean
- [x] Verified all 4 OEBB cache items with multi-route titles round-trip correctly through `_clean_title_keep_places`

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_