### PR TITLE
fix(feed): also drop lone line markers and unwind compound truncation tails

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -1357,17 +1357,35 @@ def _format_item_content(
     # Harte Begrenzung für den TV-Screen (max. 180 Zeichen)
     if len(summary) > 180:
         truncated = summary[:175].rsplit(' ', 1)[0]
-        # If truncation lands on a short German abbreviation token like
-        # "bzw.", "ca.", "z.B.", "u.a.", drop it — the visual result
-        # "Word bzw. …" looks more like a glitch than an intentional
-        # ellipsis. We treat any token of <=5 chars ending in a period
-        # as an abbreviation.
-        last_space = truncated.rfind(' ')
-        if last_space > 0:
+        # Strip trailing artifacts left behind by the partial-word drop:
+        # • short German abbreviation tokens ("bzw.", "ca.", "z.B.",
+        #   "u.a.", "ggf.") — visually "Word bzw. …" looks like a
+        #   glitch instead of an intentional ellipsis.
+        # • short letter-only line markers ("IC", "RJX", "REX", "S",
+        #   "U") that the rsplit isolated after dropping the partial
+        #   number — "IC 1110, IC 1113, IC …" should become
+        #   "IC 1110, IC 1113 …".
+        # • interleaved stray punctuation (",", ";", ")", "-") that
+        #   would otherwise hold the tail open across iterations,
+        #   e.g. "Uhr -" leaves "Uhr" exposed only after the dash is
+        #   stripped.
+        _PUNCT_STRIP = ' ,;:-)/'
+        for _ in range(3):
+            truncated = truncated.rstrip(_PUNCT_STRIP)
+            last_space = truncated.rfind(' ')
+            if last_space <= 0:
+                break
             tail = truncated[last_space + 1:]
-            if tail.endswith('.') and len(tail) <= 5:
+            tail_stripped = tail.rstrip('.')
+            if (
+                len(tail) <= 5
+                and tail_stripped
+                and tail_stripped.isalpha()
+            ):
                 truncated = truncated[:last_space]
-        summary = truncated.rstrip(' ,;:-') + " …"
+            else:
+                break
+        summary = truncated.rstrip(_PUNCT_STRIP) + " …"
 
     # Für XML robust aufbereiten (CDATA schützt Sonderzeichen)
     title_out = _sanitize_text(raw_title)

--- a/tests/test_truncation_line_marker.py
+++ b/tests/test_truncation_line_marker.py
@@ -1,0 +1,92 @@
+"""Regression tests for Bug 20A (lone line-marker before truncation ellipsis).
+
+After Round 19's abbreviation cleanup, real ÖBB cache items still
+exposed two awkward truncation tails:
+
+* ``IC 1110, IC 1113, IC …`` — the rsplit dropped the partial number
+  but left the line-marker letters ``IC`` standing alone, which read
+  as a glitch.
+* ``Uhr - 1`` → ``Uhr -`` → after the dash strip → ``Uhr`` followed
+  by ``…``: a lone unit token. Strictly speaking ``Uhr`` is the
+  German word for "o'clock", so an ellipsis next to it implies the
+  text continues mid-time-stamp.
+
+The fix iterates the strip step: drop trailing punctuation, then drop
+short letter-only tokens (≤5 chars, no digits), and repeat. This
+unwinds compound tails like ``Uhr - 1`` → ``Uhr -`` → ``Uhr`` → drop.
+The same rule handles ``IC`` and ``REX`` line markers without numbers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import cast
+
+from src import build_feed
+from src.feed_types import FeedItem
+
+
+def _format(raw_desc: str) -> str:
+    item = cast(
+        FeedItem,
+        {
+            "title": "stub",
+            "description": raw_desc,
+            "source": "ÖBB",
+            "category": "Störung",
+            "guid": "test",
+            "link": "",
+        },
+    )
+    now = datetime(2026, 5, 6, 12, 0, tzinfo=timezone.utc)
+    formatted = build_feed._format_item_content(
+        item, ident="t", starts_at=now, ends_at=None
+    )
+    return formatted.desc_text_truncated
+
+
+class TestTruncationLineMarker:
+    def test_lone_ic_dropped(self) -> None:
+        # Construct a string where the truncation lands on a partial
+        # IC train number, leaving "IC" alone.
+        raw = (
+            "Wegen Bauarbeiten zwischen Wien Westbahnhof und Wien Hütteldorf "
+            "fahren von 03.06.2026 (23:00 Uhr) bis 08.06.2026 (04:00 Uhr) "
+            "die Züge IC 1110, IC 1113, IC 1115, IC 1117 nicht."
+        )
+        out = _format(raw)
+        assert "IC …" not in out, out
+        assert "IC 1113" in out
+
+    def test_lone_uhr_dropped_after_dash(self) -> None:
+        # Construct a tail where rsplit leaves "Uhr -" then dash strip
+        # exposes "Uhr" alone.
+        raw = (
+            "Wegen Bauarbeiten zwischen Wien und Wolfsthal am 19.02.2026 "
+            "am 19.03.2026 am 16.04.2026 am 21.05.2026 und am 18.06.2026 "
+            "(jeweils 08:45 Uhr - 14:45 Uhr) keine Züge."
+        )
+        out = _format(raw)
+        assert "Uhr …" not in out, out
+
+    def test_lone_rex_dropped(self) -> None:
+        # Total length must exceed 180 to trigger truncation.
+        raw = "x " * 90 + "REX 7"
+        out = _format(raw)
+        assert "REX …" not in out
+        assert " …" in out
+
+    def test_compound_uhr_dash_chain_unwound(self) -> None:
+        # Compound: tail is "Uhr - 1" → "Uhr -" → "Uhr" → drop.
+        raw = "x " * 90 + "Uhr - 12345"
+        out = _format(raw)
+        assert "Uhr …" not in out
+        # The "Uhr" residue must not appear right before the ellipsis.
+        assert "Uhr" not in out[-15:]
+
+    def test_normal_long_word_kept_when_truncated(self) -> None:
+        # Surviving last token is long enough — stays untouched.
+        raw = ("x " * 90) + "Verkehrsunfall hat sich ereignet"
+        out = _format(raw)
+        # Truncation hits, ellipsis appears.
+        assert " …" in out


### PR DESCRIPTION
## Summary

Filter audit round 20 closes two more truncation tail artefacts that survived round 19's German-abbreviation drop, both reproducible against the cached ÖBB items in `cache/oebb_c40d21/events.json`.

### Bug 20A — line-marker letters and unit tokens left dangling

Real cache items surfaced two awkward tails in the live `docs/feed.xml`:

```
"... die Züge IC 1110, IC 1113, IC …"
"... (jeweils 08:45 Uhr …"
```

- The `IC` case: rsplit dropped the partial number but left the line-marker letters `IC` standing alone before the ellipsis.
- The `Uhr` case: rsplit gave `... 08:45 Uhr -`; the trailing-punctuation strip removed the dash, exposing a lone `Uhr` (unit token without its number partner). This reads as if the timestamp was cut mid-stream.

### Fix

The strip step now iterates: drop trailing punctuation, then drop short letter-only tokens (≤5 chars, no digits, optional trailing period for abbreviations), repeat. This unwinds compound tails like `Uhr - 1` → `Uhr -` → `Uhr` → drop, and gives `IC` / `REX` / `RJX` line markers the same treatment they needed.

## Test plan

- [x] 5 new regression tests in `tests/test_truncation_line_marker.py`
- [x] `pytest tests/` — 1439 passed, 3 skipped
- [x] `mypy --strict` — clean
- [x] `ruff check` — clean
- [x] Reproduction directly verified against cached ÖBB items #1, #6, #13

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_