### PR TITLE
fix(feed): drop dangling opening paren before truncation ellipsis

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -1385,6 +1385,15 @@ def _format_item_content(
                 truncated = truncated[:last_space]
             else:
                 break
+        # Drop a trailing unbalanced opening paren: real ÖBB clauses
+        # like "(jeweils 08:45 Uhr - 14:45 Uhr)" frequently land just
+        # past the opening "(" so the truncated form ended with
+        # "(jeweils 08:45 …" / "(22:00 …" — a dangling paren reads
+        # like a stray glyph before the ellipsis.
+        if truncated.count("(") > truncated.count(")"):
+            last_open = truncated.rfind("(")
+            if last_open >= 0:
+                truncated = truncated[:last_open].rstrip(_PUNCT_STRIP)
         summary = truncated.rstrip(_PUNCT_STRIP) + " …"
 
     # Für XML robust aufbereiten (CDATA schützt Sonderzeichen)

--- a/tests/test_truncation_paren_balance.py
+++ b/tests/test_truncation_paren_balance.py
@@ -1,0 +1,102 @@
+"""Regression tests for Bug 21A (unbalanced opening paren before ellipsis).
+
+Real ÖBB descriptions frequently include date/time clauses wrapped in
+parens like ``(jeweils 08:45 Uhr - 14:45 Uhr)``. After the 180-char
+truncation drops the partial last word and the strip-loop unwinds
+short tail tokens, several cache items still ended with a *dangling*
+opening paren — the closing ``)`` had been past the cut-off point
+and stripping the inner content didn't notice the orphan opener:
+
+    Cache item #6: "(23:30 …"
+    Cache item #11: "(22:00 …"
+    Cache item #1: "(jeweils 08:45 …"
+
+The fix: after the strip-loop, if the truncated text contains more
+``(`` than ``)``, drop everything from the last unbalanced ``(``
+onward. The truncation now lands on a complete word/date before the
+clause begins, so the ellipsis reads as intentional.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import cast
+
+from src import build_feed
+from src.feed_types import FeedItem
+
+
+def _format(raw_desc: str) -> str:
+    item = cast(
+        FeedItem,
+        {
+            "title": "stub",
+            "description": raw_desc,
+            "source": "ÖBB",
+            "category": "Störung",
+            "guid": "test",
+            "link": "",
+        },
+    )
+    now = datetime(2026, 5, 6, 12, 0, tzinfo=timezone.utc)
+    formatted = build_feed._format_item_content(
+        item, ident="t", starts_at=now, ends_at=None
+    )
+    return formatted.desc_text_truncated
+
+
+class TestTruncationDropsUnbalancedParen:
+    def test_jeweils_clause_dropped(self) -> None:
+        # The phrasing from cache item #1.
+        raw = (
+            "Wegen Bauarbeiten zwischen Flughafen Wien Bahnhof und "
+            "Wolfsthal Bahnhof am 19.02.2026 am 19.03.2026 am 16.04.2026 "
+            "am 21.05.2026 und am 18.06.2026 (jeweils 08:45 Uhr - "
+            "14:45 Uhr) keine REX 7 Züge fahren."
+        )
+        out = _format(raw)
+        # The dangling opening paren must not survive into the output.
+        assert "(jeweils" not in out
+        # Content before the paren is preserved.
+        assert "18.06.2026" in out
+
+    def test_time_paren_dropped(self) -> None:
+        # The phrasing from cache item #6.
+        raw = (
+            "Wegen Bauarbeiten zwischen Wien Hbf (U) und Wien Floridsdorf "
+            "Bahnhof (U) von 07.04.2026 (23:30 Uhr) bis 08.04.2026 "
+            "(03:52 Uhr), von 05.05.2026 (23:30 Uhr) bis 06.05.2026 "
+            "(03:52 Uhr) keine Züge."
+        )
+        out = _format(raw)
+        # The trailing dangling "(23:30 …" must not appear.
+        # (Earlier "(U)" / "(23:30 Uhr)" balanced parens are fine.)
+        if "…" in out:
+            content = out[:out.rindex(" […]")] if " […]" in out else out
+            # Count parens in the truncated content.
+            opens = content.count("(")
+            closes = content.count(")")
+            assert opens <= closes, f"Unbalanced: {content!r}"
+
+    def test_balanced_parens_kept(self) -> None:
+        # When the truncation lands on balanced parens, nothing extra
+        # is dropped.
+        raw = (
+            "Wegen Bauarbeiten von 03.10.2026 bis 05.10.2026 fahren "
+            "zwischen Wien Hbf (U) und Gramatneusiedl Bahnhof einige "
+            "Nahverkehrszüge nicht. Reisende werden gebeten Alternativen "
+            "zu nutzen die im Bereich der Innenstadt verfügbar sind."
+        )
+        out = _format(raw)
+        # The balanced "(U)" stays.
+        assert "(U)" in out
+
+    def test_no_truncation_for_short_summary(self) -> None:
+        # Short descriptions don't hit the truncation path at all.
+        raw = (
+            "Linie U6: Unregelmäßige Intervalle. Grund: Schadhaftes "
+            "Fahrzeug."
+        )
+        out = _format(raw)
+        assert "…" not in out
+        assert "Schadhaftes Fahrzeug" in out


### PR DESCRIPTION
## Summary

Filter audit round 21 closes the last family of awkward truncation tails surfaced from the cached ÖBB items.

### Bug 21A — dangling opening paren before ellipsis

Real ÖBB descriptions wrap date/time clauses in parens like `(jeweils 08:45 Uhr - 14:45 Uhr)`. The 180-char truncation frequently landed just past the opening `(`, leaving a dangling paren in the rendered tail:

```
"(23:30 …"
"(22:00 …"
"(jeweils 08:45 …"
```

The dangling paren reads like a stray glyph next to the ellipsis.

### Fix

After the existing strip-loop unwinds short tail tokens, the new step checks whether the truncated text now has more `(` than `)`. If so it drops everything from the last unbalanced `(` onward, re-strips trailing punctuation, and only then appends `" …"`. Cache items #1, #6 and #11 now end on a complete date or full word before the ellipsis instead of an orphan paren.

## Test plan

- [x] 4 new regression tests in `tests/test_truncation_paren_balance.py`
- [x] `pytest tests/` — 1443 passed, 3 skipped
- [x] `mypy --strict` — clean
- [x] `ruff check` — clean
- [x] Reproduction directly verified against cached ÖBB items #1, #6, #11

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_