### PR TITLE
fix(feed): strip duplicated category prefix from description start

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -1323,6 +1323,48 @@ def _format_item_content(
     summary = summary.replace(" • ", " ").replace("•", " ")
     summary = _WHITESPACE_CLEANUP_RE.sub(" ", summary).strip()
 
+    # Strip a leading category word that just repeats the title body.
+    # Real WL Hinweis items render with an H2 like ``Gleisbauarbeiten``
+    # which becomes the title body and *also* the first word of the
+    # description. The user sees::
+    #
+    #   T: "9/40/41/42: Gleisbauarbeiten"
+    #   D: "Gleisbauarbeiten Wegen umfangreicher Gleisbauarbeiten …"
+    #
+    # which reads as a duplicated word at the start of the description.
+    # We only strip when the duplicated leading word is one of the
+    # well-known WL/ÖBB construction-category nouns; this avoids
+    # collapsing e.g. ``Ersatzverkehr zwischen X und Y`` (which is a
+    # complete clause, not a category prefix) when the title also says
+    # ``Ersatzverkehr``.
+    _CATEGORY_PREFIX_WORDS = {
+        "bauarbeiten",
+        "gleisbauarbeiten",
+        "straßenbauarbeiten",
+        "strassenbauarbeiten",
+        "rohrleitungsarbeiten",
+        "kranarbeiten",
+        "veranstaltung",
+    }
+    title_match = re.match(r"^[A-Za-z0-9/]+:\s*(\S.*)$", raw_title or "")
+    title_body = title_match.group(1).strip() if title_match else (raw_title or "").strip()
+    if title_body and summary:
+        first_title_word = title_body.split()[0]
+        first_summary_word = summary.split()[0] if summary else ""
+        if (
+            first_title_word
+            and first_summary_word
+            and first_title_word.casefold() == first_summary_word.casefold()
+            and first_title_word.casefold() in _CATEGORY_PREFIX_WORDS
+        ):
+            leading = re.match(
+                rf"^{re.escape(first_summary_word)}\s*[:.,;–—-]?\s+",
+                summary,
+                re.IGNORECASE,
+            )
+            if leading:
+                summary = summary[leading.end():].strip()
+
     # Extrahiere maximal die ersten zwei Sätze.
     # Boundary regex: a real sentence end is a period after a letter (not a
     # digit — German dates use ``17. Februar``) followed by whitespace and

--- a/tests/test_title_category_dedup.py
+++ b/tests/test_title_category_dedup.py
@@ -1,0 +1,122 @@
+"""Regression tests for Bug 24A (title category word duplicated in description).
+
+Real WL Hinweis items render with an HTML ``<h2>`` (e.g.
+``Gleisbauarbeiten``) which becomes the title body AND the first
+word of the description. The user then sees:
+
+    T: "9/40/41/42: Gleisbauarbeiten"
+    D: "Gleisbauarbeiten Wegen umfangreicher Gleisbauarbeiten im Bereich Aumannplatz …"
+
+That leading word reads as a duplicated category prefix.
+
+The fix strips the leading category word from the summary when:
+
+- The title body's first word equals the summary's first word
+  (case-insensitive).
+- That word is one of the well-known construction-category nouns
+  (``Bauarbeiten``, ``Gleisbauarbeiten``, ``Straßenbauarbeiten``,
+  ``Rohrleitungsarbeiten``, ``Kranarbeiten``, ``Veranstaltung``).
+
+The category-word allowlist keeps the rule conservative so it
+doesn't collapse legitimate clauses like ``Ersatzverkehr zwischen X
+und Y`` (where the title also says ``Ersatzverkehr``) — the word
+``Ersatzverkehr`` carries semantic content, not just a category.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import cast
+
+from src import build_feed
+from src.feed_types import FeedItem
+
+
+def _format(raw_title: str, raw_desc: str) -> tuple[str, str]:
+    item = cast(
+        FeedItem,
+        {
+            "title": raw_title,
+            "description": raw_desc,
+            "source": "Wiener Linien",
+            "category": "Hinweis",
+            "guid": "test",
+            "link": "",
+        },
+    )
+    now = datetime(2026, 5, 6, 12, 0, tzinfo=timezone.utc)
+    formatted = build_feed._format_item_content(
+        item, ident="t", starts_at=now, ends_at=None
+    )
+    return formatted.title_out, formatted.desc_text_truncated
+
+
+class TestCategoryRedundancyStripped:
+    def test_gleisbauarbeiten_stripped(self) -> None:
+        title = "9/40/41/42: Gleisbauarbeiten"
+        desc = (
+            "Gleisbauarbeiten Wegen umfangreicher Gleisbauarbeiten im "
+            "Bereich Aumannplatz kommt es zu Änderungen im Liniennetz."
+        )
+        _, out = _format(title, desc)
+        assert out.startswith("Wegen umfangreicher")
+
+    def test_strassenbauarbeiten_stripped(self) -> None:
+        title = "24A: Straßenbauarbeiten"
+        desc = (
+            "Straßenbauarbeiten Wegen Bauarbeiten im Bereich der "
+            "Breitenleer Straße werden die Linien 24A und N24 umgeleitet."
+        )
+        _, out = _format(title, desc)
+        assert not out.startswith("Straßenbauarbeiten")
+        assert out.startswith("Wegen Bauarbeiten")
+
+    def test_rohrleitungsarbeiten_stripped(self) -> None:
+        title = "49A/50A/50B/N49: Rohrleitungsarbeiten"
+        desc = (
+            "Rohrleitungsarbeiten Wegen Bauarbeiten im Bereich Linzer "
+            "Straße werden die Linien 50A und N49 umgeleitet."
+        )
+        _, out = _format(title, desc)
+        assert not out.startswith("Rohrleitungsarbeiten")
+
+    def test_two_word_title_strips_first_word(self) -> None:
+        # Cache item ``56A/58B/60A: Bauarbeiten Friedensstraße`` has a
+        # two-word title body. We only require the FIRST word to match
+        # the summary's first word.
+        title = "56A/58B/60A: Bauarbeiten Friedensstraße"
+        desc = (
+            "Bauarbeiten Wegen Straßenbauarbeiten im Bereich "
+            "Friedensstraße kommt es zu Umleitungen."
+        )
+        _, out = _format(title, desc)
+        assert not out.startswith("Bauarbeiten ")
+        assert out.startswith("Wegen Straßenbauarbeiten")
+
+
+class TestNonCategoryWordsPreserved:
+    def test_ersatzverkehr_not_stripped(self) -> None:
+        # The leading word ``Ersatzverkehr`` is NOT in the category
+        # allowlist — it's a complete clause head, not a category
+        # prefix. Must be preserved.
+        title = "S1: Ersatzverkehr"
+        desc = "Ersatzverkehr zwischen Floridsdorf und Praterstern."
+        _, out = _format(title, desc)
+        assert out.startswith("Ersatzverkehr")
+
+    def test_no_match_no_strip(self) -> None:
+        # Title and description don't share a first word — no strip.
+        title = "53A/54A/54B: Ablenkung ab 8. Mai"
+        desc = (
+            "Veranstaltung Wegen einer Veranstaltung am Wolfrathplatz "
+            "werden die Busse umgeleitet."
+        )
+        _, out = _format(title, desc)
+        # Both "Veranstaltung" mentions stay.
+        assert out.startswith("Veranstaltung")
+
+    def test_short_summary_unchanged(self) -> None:
+        title = "U6: Verspätung"
+        desc = "Linie U6: Unregelmäßige Intervalle wegen schadhaftem Fahrzeug."
+        _, out = _format(title, desc)
+        assert out.startswith("Linie U6")


### PR DESCRIPTION
## Summary

Filter audit round 24 closes a real WL Hinweis readability defect surfaced by cached items #5, #7, #9.

### Bug 24A — duplicated category prefix at start of description

Wiener-Linien items render with an HTML `<h2>` like `Gleisbauarbeiten` that becomes both the title body AND the first word of the description. The user sees the same word twice back-to-back:

```
T: "9/40/41/42: Gleisbauarbeiten"
D: "Gleisbauarbeiten Wegen umfangreicher Gleisbauarbeiten im Bereich Aumannplatz …"
```

### Fix

Strip the leading category word from the summary when:

- The title body's first word equals the summary's first word (case-insensitive).
- That word is one of the well-known construction-category nouns (`Bauarbeiten`, `Gleisbauarbeiten`, `Straßenbauarbeiten`, `Rohrleitungsarbeiten`, `Kranarbeiten`, `Veranstaltung`).

The category-word allowlist keeps the rule conservative so it doesn't collapse legitimate clauses like `Ersatzverkehr zwischen X und Y` (where `Ersatzverkehr` is a complete clause head, not a category prefix).

## Test plan

- [x] 7 new regression tests in `tests/test_title_category_dedup.py`
- [x] `pytest tests/` — 1460 passed, 3 skipped
- [x] `mypy --strict` — clean
- [x] `ruff check` — clean
- [x] Reproduction directly verified against cached WL items #5, #7, #9

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_