### PR TITLE
fix(feed): drop duplicate summary + drop WL items with truncated title

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -87,16 +87,27 @@ def refresh_from_env() -> None:
 read_cache = _core_read_cache
 
 
-def _post_filter_wl(items: List[Any]) -> List[Any]:
-    """Defence-in-depth: normalise WL titles loaded from cache.
+# German prepositions/connectors that *require* a following object —
+# when a WL title ends with one of these alone (no object), the WL
+# source data was truncated mid-sentence and the meldung is useless.
+# Real cache item ``41E: Ersatzbus 41E hält gegenüber`` is the
+# canonical example — the user reads "stops opposite [nothing]".
+_INCOMPLETE_TITLE_TAIL_RE = re.compile(
+    r"\b(?:bei|gegen[üu]ber|an|in|vor|nach|zu|über|ueber|am|im|zur|zum)\s*$",
+    re.IGNORECASE,
+)
 
-    The WL cache is only refreshed periodically. Title-formatting fixes
-    (e.g. collapsing newlines per Bug 12A) therefore don't reach the
-    feed until the next refresh — cached items can carry titles with
-    embedded ``\\n``/``\\t`` characters that violate RSS/Atom single-
-    line conventions. We re-run the same whitespace normalisation that
-    ``_tidy_title_wl`` applies so cached titles stay single-line even
-    before the cache turns over.
+
+def _post_filter_wl(items: List[Any]) -> List[Any]:
+    """Defence-in-depth: normalise / drop bad WL items loaded from cache.
+
+    The WL cache is only refreshed periodically, so:
+
+    1. Title-formatting fixes (e.g. newline collapse per Bug 12A) need
+       to be re-applied at cache-read time.
+    2. WL itself sometimes serves data that's truncated mid-sentence —
+       ``Ersatzbus 41E hält gegenüber`` (with no location after
+       ``gegenüber``) is meaningless. Such items are dropped.
     """
     out: List[Any] = []
     for item in items:
@@ -109,6 +120,12 @@ def _post_filter_wl(items: List[Any]) -> List[Any]:
             if cleaned != title:
                 item = dict(item)
                 item["title"] = cleaned
+            # Drop items whose visible title ends with a preposition
+            # that demands an object — the WL source is clearly
+            # incomplete and the user gets no useful information.
+            title_body = cleaned.split(":", 1)[-1].strip() if ":" in cleaned else cleaned
+            if _INCOMPLETE_TITLE_TAIL_RE.search(title_body):
+                continue
         out.append(item)
     return out
 

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -1519,6 +1519,21 @@ def _format_item_content(
     if time_line:
         time_line = f"[{time_line.strip('[]')}]"
 
+    # Skip the summary entirely when it would just repeat the title
+    # body verbatim. WL Störung items like ``41E: Ersatzbus 41E halten
+    # bei Währinger Str 200`` produce a description that's identical
+    # to the title body after the line-prefix is stripped — surfacing
+    # both gives the user the same text twice. We compare casefold so
+    # ``Linie 11A: Verspätung.`` and ``Verspätung`` are not flagged
+    # as duplicates (different content).
+    if summary and title_out:
+        title_body_match = re.match(r"^[A-Za-z0-9/]+:\s*(\S.*)$", title_out)
+        title_body_compare = (
+            title_body_match.group(1).strip() if title_body_match else title_out
+        )
+        if title_body_compare and summary.casefold() == title_body_compare.casefold():
+            summary = ""
+
     # Combine
     desc_parts = []
     if summary:

--- a/tests/test_post_filter_wl_incomplete_title.py
+++ b/tests/test_post_filter_wl_incomplete_title.py
@@ -1,0 +1,78 @@
+"""Regression test for Bug 28A (WL items with mid-sentence-truncated title).
+
+Real WL source data sometimes serves an item whose description is
+genuinely incomplete — the trailing location is missing::
+
+    T: "41E: Ersatzbus 41E hält gegenüber"
+    D: "Gleisbauarbeiten\\nErsatzbus 41E\\nhält gegenüber"
+
+The text reads "stops opposite [nothing]" — meaningless to the user.
+The WL API for this item simply did not include the location, so the
+information cannot be recovered downstream.
+
+The fix drops such items in ``_post_filter_wl`` based on a regex
+that matches German prepositions/connectors at the end of the title
+body (``bei``, ``gegenüber``, ``an``, ``in``, ``vor``, ``nach``,
+``zu``, ``über``, ``am``, ``im``, ``zur``, ``zum``). Items whose
+preposition has an object after it (``halten gegenüber 93``,
+``halten bei Währinger Str 200``) stay in the feed.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from src.build_feed import _post_filter_wl
+
+
+class TestIncompleteTitleDropped:
+    def test_haelt_gegenueber_alone_dropped(self) -> None:
+        items: List[Dict[str, Any]] = [
+            {"title": "41E: Ersatzbus 41E hält gegenüber"}
+        ]
+        out = _post_filter_wl(items)
+        assert out == []
+
+    def test_haelt_gegenueber_with_object_kept(self) -> None:
+        items: List[Dict[str, Any]] = [
+            {"title": "44A: Busse halten Alszeile gegenüber 93"}
+        ]
+        out = _post_filter_wl(items)
+        assert len(out) == 1
+
+    def test_halten_bei_alone_dropped(self) -> None:
+        items: List[Dict[str, Any]] = [
+            {"title": "10A: Busse halten bei"}
+        ]
+        out = _post_filter_wl(items)
+        assert out == []
+
+    def test_halten_bei_with_object_kept(self) -> None:
+        items: List[Dict[str, Any]] = [
+            {"title": "41E: Ersatzbus 41E halten bei Währinger Str 200"}
+        ]
+        out = _post_filter_wl(items)
+        assert len(out) == 1
+
+    def test_normal_title_kept(self) -> None:
+        items: List[Dict[str, Any]] = [
+            {"title": "U6: Verspätung wegen Schadhaftem Fahrzeug"}
+        ]
+        out = _post_filter_wl(items)
+        assert len(out) == 1
+
+    def test_title_ending_in_an_dropped(self) -> None:
+        items: List[Dict[str, Any]] = [
+            {"title": "10A: Bus hält an"}
+        ]
+        out = _post_filter_wl(items)
+        assert out == []
+
+    def test_existing_newline_normalisation_still_works(self) -> None:
+        # Round 13's whitespace fix must continue to work alongside.
+        items: List[Dict[str, Any]] = [
+            {"title": "41E/10A: Ersatzbus 41E\nhält beim 10A"}
+        ]
+        out = _post_filter_wl(items)
+        assert len(out) == 1
+        assert out[0]["title"] == "41E/10A: Ersatzbus 41E hält beim 10A"

--- a/tests/test_summary_skip_when_duplicates_title.py
+++ b/tests/test_summary_skip_when_duplicates_title.py
@@ -1,0 +1,101 @@
+"""Regression tests for Bug 27A (summary just repeats the title body).
+
+After the Round 24/25 dedup strips a leading category prefix, many WL
+Störung items end up with a summary that exactly matches the title
+body (after the line-prefix is removed)::
+
+    T: "41E: Ersatzbus 41E halten bei Währinger Str 200"
+    D: "Ersatzbus 41E halten bei Währinger Str 200 [Seit 06.05.2026]"
+
+The user reads the same text twice — once as the title, once as the
+description summary — which is pure noise.
+
+The fix drops the summary entirely when its content is a verbatim
+case-insensitive copy of the title body. The description then renders
+as just the timeframe ``[Seit 06.05.2026]``.
+
+Cache items affected (live WL Störung at the time of writing):
+#27, #28, #30, #31, #32, #33, #35, #38.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import cast
+
+from src import build_feed
+from src.feed_types import FeedItem
+
+
+def _format(raw_title: str, raw_desc: str) -> tuple[str, str]:
+    item = cast(
+        FeedItem,
+        {
+            "title": raw_title,
+            "description": raw_desc,
+            "source": "Wiener Linien",
+            "category": "Störung",
+            "guid": "test",
+            "link": "",
+        },
+    )
+    now = datetime(2026, 5, 6, 12, 0, tzinfo=timezone.utc)
+    formatted = build_feed._format_item_content(
+        item, ident="t", starts_at=now, ends_at=None
+    )
+    return formatted.title_out, formatted.desc_text_truncated
+
+
+class TestSummaryDroppedWhenDuplicatesTitleBody:
+    def test_ersatzbus_duplicate_dropped(self) -> None:
+        title = "41E: Ersatzbus 41E hält gegenüber"
+        desc = "Ersatzbus 41E hält gegenüber"
+        _, out = _format(title, desc)
+        # Description should NOT contain a repeat of the title body.
+        assert "Ersatzbus" not in out
+        # The timeframe still appears.
+        assert "[Seit" in out
+
+    def test_kein_betrieb_duplicate_dropped(self) -> None:
+        title = "46: Kein Betrieb"
+        desc = "Kein Betrieb"
+        _, out = _format(title, desc)
+        assert "Kein Betrieb" not in out
+        assert "[Seit" in out
+
+    def test_busse_halten_duplicate_dropped(self) -> None:
+        title = "62A: Busse halten Breitenfurter Straße 236-238"
+        desc = "Busse halten Breitenfurter Straße 236-238"
+        _, out = _format(title, desc)
+        # Title body must not be duplicated.
+        assert "Breitenfurter Straße" not in out
+
+    def test_distinct_summary_kept(self) -> None:
+        # When the summary is genuinely different, it survives.
+        title = "U6: Verspätung wegen Schadhaftem Fahrzeug"
+        desc = "Linie U6: Unregelmäßige Intervalle in beiden Richtungen."
+        _, out = _format(title, desc)
+        assert "Unregelmäßige Intervalle" in out
+
+    def test_summary_contains_timeframe_extra(self) -> None:
+        # Even when the summary is just the title body, the timeframe
+        # is still appended so the description isn't empty.
+        title = "46: Kein Betrieb"
+        desc = "Kein Betrieb"
+        _, out = _format(title, desc)
+        assert out.strip().startswith("[")
+
+    def test_partial_match_does_not_drop(self) -> None:
+        # Summary contains MORE than the title body — must not drop.
+        title = "46: Kein Betrieb"
+        desc = "Kein Betrieb. Reisende werden gebeten Alternativen zu nutzen."
+        _, out = _format(title, desc)
+        assert "Reisende werden gebeten" in out
+
+    def test_case_insensitive_match(self) -> None:
+        # Casefold compare: ``Linie U6`` vs ``LINIE U6`` is the same.
+        title = "U6: Linie U6 gestört"
+        desc = "Linie U6 gestört"
+        _, out = _format(title, desc)
+        # Description body should not duplicate the title body.
+        assert "Linie U6 gestört" not in out

--- a/tests/test_title_category_dedup_v2.py
+++ b/tests/test_title_category_dedup_v2.py
@@ -48,20 +48,27 @@ def _format(raw_title: str, raw_desc: str) -> tuple[str, str]:
 
 class TestCategoryPrefixSecondPattern:
     def test_bauarbeiten_busse_halten_stripped(self) -> None:
-        # Cache item #38.
+        # Cache item #38. After Round 25 strips the leading
+        # "Bauarbeiten", the remaining summary equals the title body
+        # exactly. Round 27 then drops the whole summary so the user
+        # doesn't see the same text twice — desc becomes just the
+        # timeframe.
         title = "62A: Busse halten Breitenfurter Straße 236-238"
         desc = "Bauarbeiten Busse halten Breitenfurter Straße 236-238"
         _, out = _format(title, desc)
-        assert not out.startswith("Bauarbeiten")
-        assert out.startswith("Busse halten")
+        # Either the leading category was stripped (Round 25) and the
+        # title-body duplicate was then dropped (Round 27) — verify
+        # the awkward "Bauarbeiten" prefix is gone.
+        assert "Bauarbeiten" not in out
 
     def test_gleisbauarbeiten_ersatzbus_stripped(self) -> None:
-        # Cache item #28.
+        # Cache item #28. Round 25 strips "Gleisbauarbeiten", the
+        # remaining text equals the title body, Round 27 drops the
+        # duplicate.
         title = "41E: Ersatzbus 41E hält gegenüber"
         desc = "Gleisbauarbeiten Ersatzbus 41E hält gegenüber"
         _, out = _format(title, desc)
-        assert not out.startswith("Gleisbauarbeiten")
-        assert out.startswith("Ersatzbus 41E")
+        assert "Gleisbauarbeiten" not in out
 
     def test_no_match_no_strip(self) -> None:
         # Description starts with a category word but the title body's


### PR DESCRIPTION
## Summary

Filter audit rounds 27+28 close two related WL readability defects.

### Bug 27A — summary just repeats the title body

After the Round 24/25 dedup strips a leading category prefix, many WL Störung items end up with a summary that exactly matches the title body (after the line-prefix is removed):

```
T: "41E: Ersatzbus 41E hält gegenüber"
D: "Ersatzbus 41E hält gegenüber [Seit 06.05.2026]"
```

The user reads the same text twice. Fix: drop the summary entirely when its content is a verbatim case-insensitive copy of the title body. The description then renders as just the timeframe.

Cache items affected: WL Störung #27, #28, #30, #31, #32, #33, #35, #38.

### Bug 28A — WL items with mid-sentence-truncated title

User feedback: "Ersatzbus 41E hält gegenüber" looks unfinished. Confirmed against the live cache — WL source data sometimes serves items where the trailing location is genuinely missing:

```
T: "41E: Ersatzbus 41E hält gegenüber"
D: "Gleisbauarbeiten\nErsatzbus 41E\nhält gegenüber"
```

The text reads "stops opposite [nothing]" — meaningless without an object. The WL API for this item simply did not include the location, so the information cannot be recovered downstream.

Fix: extend `_post_filter_wl` to drop items whose title body ends with a German preposition that requires an object (`bei`, `gegenüber`, `an`, `in`, `vor`, `nach`, `zu`, `über`, `am`, `im`, `zur`, `zum`). Items whose preposition has an object (`halten gegenüber 93`, `halten bei Währinger Str 200`) are not affected.

## Test plan

- [x] 14 new regression tests across two test files
- [x] Round 25 tests adjusted (post-strip text is now dropped, not re-emitted)
- [x] `pytest tests/` — 1484 passed, 3 skipped
- [x] `mypy --strict` — clean
- [x] `ruff check` — clean
- [x] Reproduction directly verified against cached WL items

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M