### PR TITLE
fix(stations): exempt manual-distant types from bounds + sort source tokens

### DIFF
--- a/data/stations.json
+++ b/data/stations.json
@@ -788,7 +788,7 @@
       ],
       "latitude": 48.194766,
       "longitude": 16.386274,
-      "source": "oebb,google_places",
+      "source": "google_places,oebb",
       "wl_diva": "60201091",
       "wl_stops": [
         {
@@ -5784,7 +5784,7 @@
       "longitude": 16.376413,
       "name": "Wien Hauptbahnhof",
       "pendler": false,
-      "source": "vor,google_places",
+      "source": "google_places,vor",
       "vor_id": "490134900",
       "wl_diva": "60201349",
       "wl_stops": [

--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -504,15 +504,18 @@ def _normalize_sources(value: object | None) -> list[str]:
 
 
 def _merge_sources(*values: object | None) -> str:
-    merged: list[str] = []
-    seen: set[str] = set()
+    """Merge multiple source-token lists into a single comma-separated string.
+
+    Output is alphabetically sorted so that two callers that emit the same
+    set of providers in different orders produce identical strings —
+    e.g. "google_places,oebb" instead of "oebb,google_places". The sort
+    matches the convention already used by ``src/places/merge.py:182``.
+    """
+    merged: set[str] = set()
     for value in values:
         for item in _normalize_sources(value):
-            if item in seen:
-                continue
-            seen.add(item)
-            merged.append(item)
-    return ",".join(merged)
+            merged.add(item)
+    return ",".join(sorted(merged))
 
 
 def _ensure_sorted_aliases(entry: dict[str, object]) -> None:

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -445,6 +445,15 @@ def _find_coordinate_issues(
             continue
 
         if not (min_lat <= latitude <= max_lat) or not (min_lon <= longitude <= max_lon):
+            entry_type_raw = entry.get("type")
+            entry_type = entry_type_raw.strip() if isinstance(entry_type_raw, str) else None
+            if entry_type in ("manual_foreign_city", "manual_distant_at"):
+                # Manual cross-country entries (München, Roma, Berlin Hbf,
+                # Salzburg Hbf etc.) carry coordinates that are by design
+                # outside the Wien-Region bounding box. The schema docstring
+                # explicitly tolerates this — skip the bounds check and
+                # don't pollute the report with 21 false positives.
+                continue
             swapped_hint = min_lat <= longitude <= max_lat and min_lon <= latitude <= max_lon
             if swapped_hint:
                 reason = f"coordinates look swapped (lat={latitude}, lon={longitude})"

--- a/tests/test_station_validation.py
+++ b/tests/test_station_validation.py
@@ -164,6 +164,61 @@ def test_coordinate_validation_detects_missing_and_out_of_bounds(tmp_path: Path)
     )
 
 
+def test_coordinate_validation_exempts_manual_distant_types(tmp_path: Path) -> None:
+    """Manual cross-country entries (München Hauptbahnhof, Salzburg Hbf,
+    Berlin Hbf) carry coordinates that lie by design outside the Wien-
+    Region default bounding box. The schema docstring explicitly tolerates
+    out-of-bounds for type='manual_foreign_city' and
+    type='manual_distant_at' — the validator must not report them as
+    coordinate_issues."""
+    stations = [
+        {
+            "name": "Berlin Hbf",
+            "aliases": ["Berlin Hbf"],
+            "latitude": 52.525,
+            "longitude": 13.369,
+            "source": "manual",
+            "type": "manual_foreign_city",
+            "in_vienna": False,
+            "pendler": False,
+        },
+        {
+            "name": "Salzburg Hbf",
+            "aliases": ["Salzburg Hbf"],
+            "latitude": 47.8131,
+            "longitude": 13.0454,
+            "source": "manual",
+            "type": "manual_distant_at",
+            "in_vienna": False,
+            "pendler": False,
+        },
+        # A regular OEBB station with out-of-bounds coordinates must
+        # still trigger an issue — the exemption applies only to manual
+        # cross-country entries.
+        {
+            "bst_id": 99,
+            "bst_code": "X99",
+            "name": "Regular OOB",
+            "aliases": ["Regular OOB"],
+            "latitude": 60.0,
+            "longitude": 25.0,
+            "source": "oebb",
+            "in_vienna": False,
+            "pendler": True,
+        },
+    ]
+    path = tmp_path / "stations.json"
+    path.write_text(json.dumps(stations), encoding="utf-8")
+
+    report = validate_stations(path)
+
+    issue_names = sorted(i.name for i in report.coordinate_issues)
+    assert issue_names == ["Regular OOB"], (
+        f"manual_foreign_city/manual_distant_at must be exempt from "
+        f"the bounds check; got issues for: {issue_names}"
+    )
+
+
 def test_markdown_rendering_contains_cross_station_id_section() -> None:
     """to_markdown() must render cross_station_id_issues in counts and detail."""
     issue = CrossStationIDIssue(

--- a/tests/test_update_wl_stations_merge.py
+++ b/tests/test_update_wl_stations_merge.py
@@ -157,3 +157,22 @@ def test_unmatched_wl_entry_is_appended(stations_path: Path) -> None:
     assert entry["source"] == "wl"
     assert entry["wl_diva"] == "60209999"
     assert entry["aliases"] == ["Neue Station"]
+
+
+def test_merge_sources_emits_alphabetical_order() -> None:
+    """``_merge_sources`` must produce a deterministic alphabetical
+    ordering so two callers with the same set of providers (in any
+    order) yield identical strings. Regression for the inconsistent
+    "google_places,oebb" vs "oebb,google_places" duplication that
+    snuck into stations.json across PRs."""
+    assert update_wl_stations._merge_sources("oebb", "google_places") == "google_places,oebb"
+    assert update_wl_stations._merge_sources("google_places", "oebb") == "google_places,oebb"
+    assert (
+        update_wl_stations._merge_sources("vor", "google_places", "wl")
+        == "google_places,vor,wl"
+    )
+    # idempotent: pre-sorted input stays sorted, dedup wins
+    assert (
+        update_wl_stations._merge_sources("google_places,vor", "vor", "wl")
+        == "google_places,vor,wl"
+    )


### PR DESCRIPTION
## Summary

Zwei kosmetische Clean-ups aus dem Audit nach PR #1233. Beide nicht-blockierend, reduzieren aber Validierungs-Lärm und geben dem Verzeichnis eine deterministische Form.

### 1. Coordinate-Validator: Exception für manual-distante Types

Das Schema-Docstring sagt explizit dass `manual_foreign_city` und das neue `manual_distant_at` "im Coordinate-Validator als out-of-bounds toleriert" werden — der Validator hat aber den `type`-Feld nie geprüft. Resultat: **21 false-positive `coordinate_issues`** für München, Roma, Berlin, Salzburg, Graz, Linz etc. die den Report aufblähten.

Fix in `_find_coordinate_issues`: wenn out-of-bounds und `type ∈ {manual_foreign_city, manual_distant_at}` → skip. Reguläre ÖBB/VOR-Stationen mit out-of-bounds Coords werden weiterhin gemeldet.

| Metrik | Vorher | Nachher |
|---|---|---|
| coordinate_issues | 21 | **0** |

### 2. Source-Token-Reihenfolge alphabetisch

`places/merge.py:182` nutzt schon `",".join(sorted(sources))`, aber `update_wl_stations._merge_sources` preservierte first-seen-order. Das führte zu inkonsistenten Source-Strings für dieselben Provider-Sets:

| Inkonsistenz | Stationen |
|---|---|
| `google_places,oebb` (alphabetisch) | 2 |
| `oebb,google_places` (Reihenfolge nach Anhang) | 1 (Wien Rennweg) |
| `google_places,vor` (alphabetisch) | 1 |
| `vor,google_places` (Reihenfolge nach Anhang) | 1 (Wien Hauptbahnhof) |

Fix: `_merge_sources` baut jetzt ein `set()` + `sorted()`-join. Plus einmaliger Data-Clean der 2 betroffenen Einträge.

## Test plan

- [x] 2 neue Regression-Tests:
  - `test_coordinate_validation_exempts_manual_distant_types` (verifiziert auch dass reguläre OOB-Stationen weiter gemeldet werden)
  - `test_merge_sources_emits_alphabetical_order` (Idempotenz + Dedup)
- [x] Full test suite: 1488 passed, 1 skipped, 2 deselected (`test_feed_lint` ist pre-existierende Cache-Flake)
- [x] `ruff check` clean
- [x] **Validation: 0 in ALLEN Kategorien** (war: 21 coordinate_issues)
- [x] Manual verification: Wien Rennweg `source` = "google_places,oebb", Wien Hauptbahnhof `source` = "google_places,vor"

https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQV1ghGHMZbGTbP4462TZk)_