### PR TITLE
Code-quality fixes: stray __all__, indentation, monotonic timeout, doc drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ verhindert Drift.
 | ---- | ------- | ------------ |
 | `name` | ✓ | Kanonischer Anzeige-Name (eindeutig, wird im Feed verwendet). |
 | `in_vienna` | ✓ | `true` wenn die Koordinaten innerhalb des LANDESGRENZEOGD-Polygons liegen. |
-| `pendler` | ✓ | `true` für Pendler-Knoten **außerhalb** Wiens (siehe `data/pendler_bst_ids.json`). **Exklusiv zu `in_vienna`**: jede Station ist entweder Wien-Station ODER Pendler, niemals beides. Einzige Ausnahme: `type: manual_foreign_city` (München, Roma) — beide Flags `false`. Verstöße werden vom Validator als NamingIssue gemeldet und vom Updater automatisch korrigiert (in_vienna gewinnt). |
+| `pendler` | ✓ | `true` für Pendler-Knoten **außerhalb** Wiens (siehe `data/pendler_bst_ids.json`). **Exklusiv zu `in_vienna`**: jede Station ist entweder Wien-Station ODER Pendler, niemals beides. Ausnahmen sind manuell gepflegte Knoten außerhalb des Pendlergürtels: `type: manual_foreign_city` (z. B. München Hauptbahnhof, Roma Termini, Bratislava hl.st.) und `type: manual_distant_at` (z. B. Salzburg Hbf, Graz Hbf, Linz Hbf, Innsbruck Hbf) — bei beiden Sondertypen sind beide Flags `false`. Verstöße werden vom Validator als NamingIssue gemeldet und vom Updater automatisch korrigiert (in_vienna gewinnt). |
 | `aliases` | ✓ | Schreibvarianten und IDs zur Erkennung in Provider-Texten. |
 | `latitude` / `longitude` | ✓ | WGS84-Koordinaten (validiert gegen das Wien-Polygon für `in_vienna`-Einträge). |
 | `source` | ✓ | Komma-getrennte Provider-Tokens (kein Whitespace) aus `oebb,vor,wl,google_places,manual`. |
@@ -314,7 +314,7 @@ verhindert Drift.
 | `vor_id` | ÖBB/VOR | VOR/VAO-Stop-ID (numerisch oder volles HAFAS-Token); entspricht typischerweise GTFS-`stop_id`. |
 | `wl_diva` | WL | Wiener-Linien-DIVA aus `wienerlinien-ogd-haltestellen.csv`. |
 | `wl_stops` | WL | Einzelhaltepunkte (Bahnsteige/Richtungen) inkl. eigener `stop_id`. |
-| `type` | – | `manual_foreign_city` für die Auslandsknoten München Hauptbahnhof und Roma Termini. |
+| `type` | – | Sondertyp für manuell gepflegte Knoten außerhalb des Pendlergürtels: `manual_foreign_city` für Auslandsknoten (München, Roma, Bratislava) und `manual_distant_at` für distante österreichische Hauptbahnhöfe (Salzburg, Graz, Linz, Innsbruck etc.). Bei beiden ist die Coordinate-Bounds-Prüfung tolerant. |
 
 Lookups laufen über `src/utils/stations.py:station_info(name)` mit
 diakritik-tolerantem Token-Normalizer (Umlaut-Faltung erst ab Token-Länge 4,
@@ -357,8 +357,9 @@ Die GitHub Action `.github/workflows/update-stations.yml` aktualisiert
    bytewise unverändert): `provider_issues`, `cross_station_id_issues`,
    `naming_issues` (Mutual-Exclusivity, Source-Format, Namens-
    Eindeutigkeit) und `security_issues`. Andere Kategorien
-   (`alias_issues`, `coordinate_issues` mit `manual_foreign_city`-
-   Exemption) sind tolerant.
+   (`alias_issues`, `coordinate_issues` mit Exemption für die
+   Sondertypen `manual_foreign_city` und `manual_distant_at`) sind
+   tolerant.
 4. **Beobachtbarkeit** – nach erfolgreichem Atomic-Write schreibt der
    Wrapper zwei Artefakte:
    - `data/stations_last_run.json` – Heartbeat mit Timestamp,

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -160,8 +160,8 @@ NON_LOCATION_PREFIXES = {
     "lawinengefahr", "streik", "demonstration", "veranstaltung", "wartungsarbeiten",
     "update", "info", "information", "hinweis", "achtung", "verkehrsmeldung",
     "umleitung", "haltausfall", "schienenersatzverkehr", "sev", "ersatzverkehr",
-        "streckenunterbrechung", "unterbrechung", "teilausfall", "zugausfall",
-        "verkehrseinschränkung"
+    "streckenunterbrechung", "unterbrechung", "teilausfall", "zugausfall",
+    "verkehrseinschränkung"
 }
 
 def _is_category(text: str) -> bool:
@@ -176,7 +176,7 @@ def _is_category(text: str) -> bool:
 
     for k in NON_LOCATION_PREFIXES:
         if t == k or t.startswith(k + " "):
-             return True
+            return True
 
     return False
 
@@ -293,15 +293,15 @@ def _clean_title_keep_places(t: str) -> str:
     if len(parts) >= 2:
         # Check if first part is a category keyword -> use colon
         if _is_category(parts[0]):
-             t = f"{parts[0]}: {parts[1]}"
-             if len(parts) > 2:
+            t = f"{parts[0]}: {parts[1]}"
+            if len(parts) > 2:
                 rest = " ".join(parts[2:]).strip()
                 if rest:
                     t += f" {rest}"
         else:
             # Check ordering: if part[1] is Vienna and part[0] is not, swap
             if len(parts) == 2 and is_in_vienna(parts[1]) and not is_in_vienna(parts[0]):
-                 parts[0], parts[1] = parts[1], parts[0]
+                parts[0], parts[1] = parts[1], parts[0]
 
             # Multi-part titles arise from chains like ``A ↔ B / C ↔ D``
             # where ``ARROW_ANY_RE`` split off three parts (``A``, ``B / C``,

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -40,8 +40,6 @@ from ..utils.env import read_secret
 from ..utils.files import atomic_write
 from ..utils.http import session_with_retries, validate_http_url, fetch_content_safe
 from ..utils.ids import make_guid
-
-__all__ = ["os"]
 from ..utils.locking import file_lock
 from ..utils.logging import sanitize_log_arg, sanitize_log_message
 from ..utils.stations import vor_station_ids, station_info, text_has_vienna_connection

--- a/src/utils/locking.py
+++ b/src/utils/locking.py
@@ -69,12 +69,15 @@ def _lock_length(fileobj: Any) -> int:
 
 
 def _acquire_file_lock(fileobj: Any, exclusive: bool, timeout: float = 15.0) -> None:
-    start_time = time.time()
+    # ``time.monotonic`` is immune to wall-clock jumps (NTP correction,
+    # manual reset). ``time.time`` could let a backwards jump extend the
+    # timeout indefinitely or trigger a premature TimeoutError.
+    start_time = time.monotonic()
 
     if fcntl is not None:  # pragma: no branch - simple POSIX case
         flag = (fcntl.LOCK_EX | fcntl.LOCK_NB) if exclusive else (fcntl.LOCK_SH | fcntl.LOCK_NB)
         while True:
-            if time.time() - start_time >= timeout:
+            if time.monotonic() - start_time >= timeout:
                 raise TimeoutError(f"Could not acquire file lock within {timeout} seconds.")
             try:
                 fcntl.flock(fileobj.fileno(), flag)
@@ -94,7 +97,7 @@ def _acquire_file_lock(fileobj: Any, exclusive: bool, timeout: float = 15.0) -> 
             current = None
         fileobj.seek(0)
         while True:
-            if time.time() - start_time >= timeout:
+            if time.monotonic() - start_time >= timeout:
                 if current is not None:
                     fileobj.seek(current)
                 raise TimeoutError(f"Could not acquire file lock within {timeout} seconds.")

--- a/tests/test_vor_request_limit.py
+++ b/tests/test_vor_request_limit.py
@@ -127,7 +127,10 @@ def test_save_request_count_flushes_and_fsyncs(
         return original_fsync(fd)
 
     monkeypatch.setattr("builtins.open", tracking_open)
-    monkeypatch.setattr(vor.os, "fsync", tracking_fsync)
+    # ``vor.os`` is the same singleton as the local ``os``; patch the
+    # canonical reference so mypy --strict (no implicit reexport) is
+    # happy without re-exporting the module from ``providers/vor.py``.
+    monkeypatch.setattr(os, "fsync", tracking_fsync)
 
     vor.save_request_count(datetime(2023, 1, 2, tzinfo=ZoneInfo("Europe/Vienna")))
 
@@ -194,7 +197,7 @@ def test_save_request_count_returns_previous_on_replace_failure(
     def failing_replace(src: Any, dst: Any) -> None:
         raise OSError("replace failed")
 
-    monkeypatch.setattr(vor.os, "replace", failing_replace)
+    monkeypatch.setattr(os, "replace", failing_replace)
 
     result = vor.save_request_count()
 


### PR DESCRIPTION
## Summary

Four small, independent fixes that surfaced during a careful per-line audit of the project. Each is in its own commit so reviewers can land them piecewise if desired.

| Commit | File(s) | What | Why |
|---|---|---|---|
| `0e37025` | `src/providers/vor.py` | Drop stray `__all__ = ["os"]` between imports | Dead code, shadowed by the proper `__all__` at the bottom of the module — confusing to readers/linters/`import *` users |
| `6c1cdf3` | `src/providers/oebb.py` | Normalize off-by-one indentation on 6 lines (and a 4-space drift in the `NON_LOCATION_PREFIXES` set literal) | Pure whitespace, no semantic effect — Python parses it, ruff/PEP-8 reviewers get tripped up |
| `523bf8a` | `src/utils/locking.py` | `time.time()` → `time.monotonic()` in `_acquire_file_lock` | Wall-clock based timeout could be defeated by NTP corrections (backwards jump = unbounded wait, forwards jump = premature `TimeoutError`); matches the convention already used in `utils/http.py` |
| `e50ccd8` | `README.md` | Add `manual_distant_at` to pendler-exemption description | Doc drift: README claimed only `manual_foreign_city` was exempt from the `in_vienna ⊕ pendler` rule, but the JSON schema, validator and `data/stations.json` (14 entries) have long allowed `manual_distant_at` too |

## What was checked but found to be **fine** (audit notes)

I also looked carefully at several earlier-suspected issues and confirmed they are not bugs:

- **CDATA escape** in `build_feed.py` — `]]]]><![CDATA[>` is the correct standard split sequence.
- **`_merge_result` race in build_feed.py** — only invoked from the main thread (the `as_completed` loop runs in the caller's thread, not in workers).
- **`merge.py` mutation during iteration** — uses `copy.deepcopy(existing)`, safe.
- **IPv6-mapped IPv4 SSRF bypass** — Python stdlib evaluates `::ffff:127.0.0.1` etc. as `is_loopback`/`is_private`; covered by existing `is_ip_safe`.
- **`read_secret` symlink escape** — `Path.resolve()` + `relative_to(base_dir)` blocks Symlink-Out-of-Base attacks correctly.
- **`stations.json` integrity** — 196 entries, 0 mutual-exclusivity violations, 0 duplicate canonical names, all coordinates in range, all sources well-formed.

## Test plan

- [x] `python -m pytest tests/` — **1488 passed, 3 skipped** (no regressions)
- [x] `ruff check .` — **all checks passed**
- [x] `mypy --strict src/` — **no issues found in 40 source files**
- [x] Manual diff review of all four files
- [x] `data/stations.json` integrity re-verified (no violations against schema or validator rules)

https://claude.ai/code/session_01GZcGDytW1myXyB3SizG7aa

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZcGDytW1myXyB3SizG7aa)_