### PR TITLE
fix: drei verifizierte Bugs (Stations-Koords, Merge-Duplikat, OEBB-Log)

### DIFF
--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -431,17 +431,7 @@ def deduplicate_fuzzy(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                         elif desc2:
                             existing_copy["description"] = desc2
 
-                    for date_key in ("pubDate", "pubdate", "pub_date", "updated"):
-                        existing_date = existing_copy.get(date_key)
-                        item_date = item.get(date_key)
-                        if existing_date and item_date:
-                            try:
-                                if item_date > existing_date:
-                                    existing_copy[date_key] = item_date
-                            except TypeError:
-                                pass  # non-comparable types — leave existing unchanged
-                        elif item_date and not existing_date:
-                            existing_copy[date_key] = item_date
+                    _promote_newer_dates(existing_copy, item)
 
                     # 4. Update GUID
                     # We create a new deterministic GUID based on the new title.

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -1240,7 +1240,7 @@ def _fetch_xml(url: str, timeout: int = 25) -> Optional[ET.Element]:
                                 wait_seconds = max(0.0, delta)
                             except Exception as parse_exc:
                                 log.warning("Failed to parse Retry-After header", exc_info=parse_exc)
-                    log.warning("ÖBB RSS Rate-Limit (Retry-After: %s)", header)
+                    log.warning("ÖBB RSS Rate-Limit (Retry-After: %s)", sanitize_log_arg(header))
 
                 if attempt == 0:
                      if wait_seconds > 0:

--- a/src/utils/stations.py
+++ b/src/utils/stations.py
@@ -139,17 +139,27 @@ def _coerce_float(value: object | None) -> float | None:
 
 
 def _coerce_lat(value: object | None) -> float | None:
-    """Coerce value to a valid latitude."""
+    """Coerce value to a valid latitude.
+
+    Bounds span Europe so the directory can store distant terminus
+    stations (Berlin, Roma, Praha, Venezia, Zagreb, Budapest-Keleti).
+    The Wien containment decision lives in :func:`is_in_vienna`'s
+    polygon test, not in these bounds.
+    """
     val = _coerce_float(value)
-    if val is not None and (46.0 <= val <= 49.5):
+    if val is not None and (35.0 <= val <= 65.0):
         return val
     return None
 
 
 def _coerce_lon(value: object | None) -> float | None:
-    """Coerce value to a valid longitude."""
+    """Coerce value to a valid longitude.
+
+    See :func:`_coerce_lat` for the rationale behind the European
+    bounds.
+    """
     val = _coerce_float(value)
-    if val is not None and (9.0 <= val <= 17.5):
+    if val is not None and (-10.0 <= val <= 30.0):
         return val
     return None
 

--- a/tests/test_station_distant_coordinates.py
+++ b/tests/test_station_distant_coordinates.py
@@ -1,0 +1,50 @@
+"""Regression tests for distant terminus station coordinates.
+
+The directory carries a handful of long-distance terminus stations
+(Berlin Hbf, Roma Termini, Praha hl.n., Venezia S.L., Zagreb Glavni
+kolodvor, Budapest-Keleti). Their coordinates lie outside the Austrian
+Bounding-Box that ``_coerce_lat``/``_coerce_lon`` historically enforced,
+which silently dropped one component of each pair (latitude or
+longitude, depending on which value crossed the bound). The bounds now
+span Europe so both components survive.
+"""
+
+from __future__ import annotations
+
+from src.utils.stations import is_in_vienna, station_info
+
+
+_DISTANT_TERMINI = (
+    "Berlin Hbf",
+    "Roma Termini",
+    "Praha hl.n.",
+    "Venezia Santa Lucia",
+    "Zagreb Glavni kolodvor",
+    "Budapest-Keleti",
+)
+
+
+def test_distant_termini_keep_both_coordinates() -> None:
+    for name in _DISTANT_TERMINI:
+        info = station_info(name)
+        assert info is not None, f"{name} is missing from stations.json"
+        assert info.latitude is not None, (
+            f"{name} latitude was dropped — bounds in _coerce_lat may have "
+            f"regressed to Austria-only"
+        )
+        assert info.longitude is not None, (
+            f"{name} longitude was dropped — bounds in _coerce_lon may have "
+            f"regressed to Austria-only"
+        )
+
+
+def test_distant_termini_are_outside_vienna_polygon() -> None:
+    # The wider bounds must NOT make foreign cities resolve as in-Vienna.
+    # The polygon test still does the actual containment check.
+    for name in _DISTANT_TERMINI:
+        info = station_info(name)
+        assert info is not None
+        assert info.latitude is not None and info.longitude is not None
+        assert is_in_vienna(info.latitude, info.longitude) is False, (
+            f"{name} resolves as in-Vienna — polygon test broke"
+        )


### PR DESCRIPTION
## Summary

Drei kleine, verifizierte Bugs aus einem ausführlichen Code-Audit:

- **`src/utils/stations.py`** — `_coerce_lat`/`_coerce_lon` enforcten Österreich-Bounds (46–49.5°N / 9–17.5°E), wodurch sechs ausländische Endbahnhöfe (Berlin, Roma, Praha, Venezia, Zagreb, Budapest-Keleti) eine halbierte Koordinate erhielten. Bounds auf Europa erweitert (35–65°N / 10°W–30°E); die polygonbasierte Wien-Prüfung in `is_in_vienna` filtert weiterhin korrekt.
- **`src/feed/merge.py`** — Der Standard-Peer-Merge-Pfad in `deduplicate_fuzzy` enthielt eine wortgleiche Inline-Kopie der `_promote_newer_dates`-Schleife. Drift-Risiko bei künftigen Datumsfeld-Erweiterungen geschlossen — Verhalten bleibt bit-genau identisch.
- **`src/providers/oebb.py`** — `log.warning("ÖBB RSS Rate-Limit (Retry-After: %s)", header)` loggte den server-kontrollierten `Retry-After`-Header ohne Sanitisierung, während die umliegenden Warnungen `sanitize_log_arg` konsequent verwenden. Lücke geschlossen analog zur VOR-Sanitization.

## Test plan

- [x] Neue Regressionstests in `tests/test_station_distant_coordinates.py` (alle 6 Termini behalten beide Koordinaten; polygon-Test schließt sie weiterhin aus Wien aus)
- [x] `pytest tests/ --ignore=tests/manual` — **1495 passed, 3 skipped** (vorher: 1493 passed)
- [x] Bestehende Pubdate-Promotion-Tests (`tests/test_merge_pubdate_promotion.py`) bestehen unverändert
- [x] `ruff check src/ tests/test_station_distant_coordinates.py` — All checks passed
- [x] `mypy --strict src/utils/stations.py src/feed/merge.py src/providers/oebb.py` — no issues

https://claude.ai/code/session_01MVi32GfCuccqFs1US2ZYRt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVi32GfCuccqFs1US2ZYRt)_