### PR TITLE
fix: correct minor data and log inconsistencies

### DIFF
--- a/data/stations.json
+++ b/data/stations.json
@@ -1043,7 +1043,7 @@
       "name": "Wiener Neustadt Hauptbahnhof",
       "in_vienna": false,
       "pendler": true,
-      "vor_id": "900300",
+      "vor_id": "430521000",
       "aliases": [
         "900300",
         "Wiener Neustadt Hauptbahnhof",

--- a/scripts/update_oebb_cache.py
+++ b/scripts/update_oebb_cache.py
@@ -55,8 +55,8 @@ def main() -> int:
         return 1
 
     if not items:
-        logger.error(
-            "Fetched 0 events (unexpected empty list); keeping existing cache."
+        logger.warning(
+            "Fetched 0 events; keeping existing cache."
         )
         return 1
 

--- a/scripts/update_vor_stations.py
+++ b/scripts/update_vor_stations.py
@@ -33,7 +33,7 @@ log = logging.getLogger("update_vor_stations")
 
 STATIC_VOR_ENTRIES: tuple[dict[str, object], ...] = (
     {
-        "vor_id": "900300",
+        "vor_id": "430521000",
         "name": "Wiener Neustadt Hauptbahnhof",
         "in_vienna": False,
         "pendler": True,

--- a/scripts/update_wl_cache.py
+++ b/scripts/update_wl_cache.py
@@ -47,8 +47,8 @@ def main() -> int:
         return 1
 
     if not items:
-        logger.error(
-            "Fetched 0 events (unexpected empty list); keeping existing cache."
+        logger.warning(
+            "Fetched 0 events; keeping existing cache."
         )
         return 1
 

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -485,8 +485,11 @@ def _find_gtfs_issues(
 
 _UNSAFE_CHARS_RE = re.compile(r"[<>\x00-\x08\x0b\x0c\x0e-\x1f\u2028-\u202e\u2066-\u2069]")
 
-# Historically VOR identifiers were six digits starting with "9". In practice some
-# legitimate identifiers are five digits (e.g. "93010"), so we accept either.
+# Pattern for the synthetic ``bst_id``/``bst_code`` values assigned to
+# VOR-sourced station entries (e.g. ``900100``–``900112`` for the Wien
+# departure-board stops). Real VOR/HAFAS stop IDs are 9 digits and live in the
+# ``vor_id`` field — they are not validated here. The 5-digit form is kept as
+# a tolerated fallback for legacy synthetic ids such as ``93010``.
 _VOR_ID_PATTERN = re.compile(r"9\d{4,5}")
 
 

--- a/tests/test_vor_stations_directory.py
+++ b/tests/test_vor_stations_directory.py
@@ -163,7 +163,9 @@ def test_vor_alias_with_municipality_prefix() -> None:
 def test_vor_does_not_override_station_directory() -> None:
     info = station_info("Wiener Neustadt Hbf")
     assert info is not None
-    assert info.vor_id == "900300"
+    # vor_id holds the real HAFAS/VOR stop ID; the synthetic 900300 token
+    # remains available as an alias for legacy lookups.
+    assert info.vor_id == "430521000"
     # The canonical name now uses the full "Hauptbahnhof" form; the
     # abbreviated "Wiener Neustadt Hbf" remains a recognized alias that
     # resolves to this canonical record.


### PR DESCRIPTION
## Summary

Three small follow-ups that fell out of an audit pass over the project. None
of them changes runtime behaviour for end users; the goal is to keep the data
consistent with the rest of the directory and the logs/comments honest.

### 1. `data/stations.json` — Wiener Neustadt Hbf gets its real HAFAS ID

The entry stored `vor_id: "900300"` (a synthetic token). The other pendler
entries created via `STATIC_VOR_ENTRIES` (Guntramsdorf Bahnhof, Neunkirchen
NÖ, …) follow the inverse convention: real 9-digit HAFAS ID in `vor_id`,
synthetic 900xxx in `bst_id`/`bst_code`. The real HAFAS ID `430521000` is
already present in `aliases` and matches `data/vor-haltestellen.mapping.json`,
so the swap is purely a normalisation. `900300` stays as an alias for
backward-compatible lookups, and `bst_id`/`bst_code` (`1499`/`Nb`) — the
ÖBB-side identifiers — are untouched.

`scripts/update_vor_stations.py` (the source of truth that regenerates
`stations.json`) is updated in lockstep so the next CI regen does not flip the
value back.

### 2. `update_wl_cache.py` / `update_oebb_cache.py` — empty result is not an error

`logger.error("Fetched 0 events (unexpected empty list)…")` ran on every
quiet-period run where a provider legitimately returned `[]`. Demoted to
`logger.warning("Fetched 0 events; keeping existing cache.")` — the script
still returns `1` so the cache is not overwritten with empty data, but the
event no longer triggers error-level alerting.

### 3. `_VOR_ID_PATTERN` comment in `stations_validation.py`

The old comment claimed *"Historically VOR identifiers were six digits
starting with '9'."* That description fits the synthetic `bst_id`/`bst_code`
values (`900100`–`900112`) the validator actually checks against, but is
misleading for real VOR/HAFAS stop IDs (9 digits, lives in `vor_id`).
Rewrote the comment to spell out exactly which field the regex applies to.

## Test plan

- [x] `pytest --ignore=tests/manual` — 1541 passed, 3 skipped
- [x] `mypy src/` — Success: no issues found in 40 source files
- [x] `ruff check src/ scripts/` — All checks passed
- [x] `validate_stations(data/stations.json)` — 0 issues across all categories
- [x] Updated `test_vor_does_not_override_station_directory` to assert the
  new `vor_id` value
- [x] Verified no other code or test references the old `900300` value
  beyond the already-updated locations

https://claude.ai/code/session_01KKhfXhyQP933QKjUHpgr5S

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKhfXhyQP933QKjUHpgr5S)_