### PR TITLE
🛡️ Sentinel: [MEDIUM] Pin BAUSTELLEN_DATA_URL to Stadt Wien OGD host

### DIFF
--- a/scripts/update_baustellen_cache.py
+++ b/scripts/update_baustellen_cache.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 from collections.abc import Iterable, Sequence
+from urllib.parse import urlparse
 
 from dateutil import parser as dtparser
 from requests.exceptions import RequestException
@@ -192,6 +193,41 @@ def _load_fallback(path: Path) -> dict[str, Any] | None:
     except json.JSONDecodeError as exc:
         LOGGER.error("Baustellen: Fallback-Datei %s enthält ungültiges JSON (%s)", path, exc)
         return None
+
+
+# Security: only accept env overrides that point at the official Stadt Wien
+# Open-Data host. ``data_url`` content is parsed and merged into the public
+# Baustellen feed cache (titles, descriptions, item links). An env-var
+# override to ``https://evil.com`` therefore lets an attacker inject arbitrary
+# construction notices into the public feed and (via JSON ``properties.HINWEIS``
+# fields and similar) attach attacker-controlled text under the project's
+# brand. ``validate_http_url()`` only checks SSRF/DNS-rebinding properties,
+# not host identity.
+_BAUSTELLEN_TRUSTED_HOSTS = frozenset({"data.wien.gv.at"})
+
+
+def _validated_baustellen_data_url(raw: str) -> str | None:
+    safe = validate_http_url(raw)
+    if not safe:
+        return None
+    host = (urlparse(safe).hostname or "").lower()
+    if host not in _BAUSTELLEN_TRUSTED_HOSTS:
+        return None
+    return cast(str, safe)
+
+
+def _resolve_data_url(candidate: str | None) -> str:
+    text = (candidate or "").strip()
+    if not text:
+        return DEFAULT_DATA_URL
+    validated = _validated_baustellen_data_url(text)
+    if validated is None:
+        LOGGER.warning(
+            "Baustellen: BAUSTELLEN_DATA_URL %r ist kein bekannter Stadt-Wien-OGD-Host; verwende Standard.",
+            text,
+        )
+        return DEFAULT_DATA_URL
+    return validated
 
 
 def _resolve_fallback_path(candidate: str | None) -> Path:
@@ -412,7 +448,7 @@ def _collect_events(payload: dict[str, Any]) -> list[dict[str, Any]]:
 
 def main() -> int:
     configure_logging()
-    data_url = os.getenv("BAUSTELLEN_DATA_URL", DEFAULT_DATA_URL).strip() or DEFAULT_DATA_URL
+    data_url = _resolve_data_url(os.getenv("BAUSTELLEN_DATA_URL"))
     fallback_path = _resolve_fallback_path(os.getenv("BAUSTELLEN_FALLBACK_PATH"))
     timeout_raw = os.getenv("BAUSTELLEN_TIMEOUT", "")
     timeout = 20

--- a/tests/test_update_baustellen_cache.py
+++ b/tests/test_update_baustellen_cache.py
@@ -98,3 +98,56 @@ def test_resolve_fallback_path_blocks_symlink_escape(tmp_path: Path) -> None:
         assert resolved == update_baustellen_cache.DEFAULT_FALLBACK_PATH
     finally:
         link.unlink(missing_ok=True)
+
+
+def test_resolve_data_url_default_when_unset() -> None:
+    assert (
+        update_baustellen_cache._resolve_data_url(None)
+        == update_baustellen_cache.DEFAULT_DATA_URL
+    )
+    assert (
+        update_baustellen_cache._resolve_data_url("")
+        == update_baustellen_cache.DEFAULT_DATA_URL
+    )
+    assert (
+        update_baustellen_cache._resolve_data_url("   ")
+        == update_baustellen_cache.DEFAULT_DATA_URL
+    )
+
+
+def test_resolve_data_url_accepts_official_host() -> None:
+    """The Stadt Wien OGD host is the only legitimate override target."""
+    candidate = (
+        "https://data.wien.gv.at/daten/geo?service=WFS&typeName=ogdwien:BAUSTELLEOGD"
+    )
+    resolved = update_baustellen_cache._resolve_data_url(candidate)
+    assert resolved == candidate
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # Arbitrary attacker-controlled host
+        "https://evil.example.com/baustellen.json",
+        # Suffix attack: looks like the official host but isn't
+        "https://data.wien.gv.at.evil.com/baustellen.json",
+        # Different Vienna subdomain (e.g., not OGD)
+        "https://www.wien.gv.at/baustellen.json",
+        # Different OGD provider
+        "https://data.gv.at/baustellen.json",
+    ],
+)
+def test_resolve_data_url_rejects_untrusted_host(
+    caplog: pytest.LogCaptureFixture, url: str
+) -> None:
+    """An env-controlled URL pointing outside the OGD allowlist must NOT be used."""
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="update_baustellen_cache")
+    resolved = update_baustellen_cache._resolve_data_url(url)
+    # Must fall back to the default — no fetch goes to the attacker.
+    assert resolved == update_baustellen_cache.DEFAULT_DATA_URL
+    assert any(
+        "kein bekannter Stadt-Wien-OGD-Host" in record.getMessage()
+        for record in caplog.records
+    )


### PR DESCRIPTION
## 🚨 Severity: MEDIUM

## 💡 Vulnerability

`scripts/update_baustellen_cache.py` reads `BAUSTELLEN_DATA_URL` from the environment and only runs `validate_http_url()` on it. As established in PRs #1258 and #1262, that helper is an SSRF/DNS-rebinding guard — not a host-identity guard. So `BAUSTELLEN_DATA_URL=https://evil.com` sails through and the script fetches the JSON payload from the attacker, then merges every feature into the public Baustellen feed cache:

- `properties.BEZEICHNUNG/MASSNAHME/...` → `<title>`
- `properties.HINWEIS/INFO/BESCHREIBUNG/...` → free-text in `<description>`
- `properties.BEZIRK/STATUS/VERKEHRSMASSNAHME` → context fields rendered into the description
- `properties.STRASSE/VON/BIS` → location lines

Every Baustellen item in the public RSS feed would then be attacker-supplied.

## 🎯 Impact

- **Reputation/integrity**: fabricated construction notices appear under the project's name and Stadt Wien's data brand
- **Phishing/scam vectors**: free-text fields inside `description` can carry attacker-crafted text or URLs that subscribers see and click
- **Defamation**: malicious notices targeting specific districts, addresses, lines

The bar to set the env var is the usual one — CI-pipeline injection, container env, mistaken deploy config. Same threat model as #1262.

## 🔧 Fix

Direct application of the `_validated_*_url()` pattern used by PR #1262 for `WL_RSS_URL`/`OEBB_RSS_URL`. A frozenset allowlist of the official upstream host (`data.wien.gv.at`) with a small `_resolve_data_url()` wrapper that strips/empties the env value, hands it through `validate_http_url()`, then re-checks the hostname before accepting. Anything outside the allowlist falls back to `DEFAULT_DATA_URL` with a warning.

Diff: +37 / -1 in `scripts/update_baustellen_cache.py`. No tests rely on overriding `BAUSTELLEN_DATA_URL` to non-default hosts, so legitimate CI keeps working.

## ✅ Verification

6 new tests in `tests/test_update_baustellen_cache.py`:

- **3 default cases** — `None`, empty string, whitespace-only → fall back to `DEFAULT_DATA_URL`
- **1 positive** — official Stadt Wien OGD host accepted
- **4 parametrised negatives** — arbitrary attacker host, suffix attack (`data.wien.gv.at.evil.com`), wrong subdomain (`www.wien.gv.at`), wrong provider (`data.gv.at`); each asserts both the safe fallback and the warning log

Full repo: **1558 passed, 3 skipped**. Ruff and mypy --strict clean on the touched files (one type-cast on `validate_http_url`'s return value to satisfy mypy --strict in the script's import path, mirroring existing patterns in the same file).

---
_Generated by [Claude Code](https://claude.ai/code/session_012ScpqMHeJUbX722xL9DuSo)_