### PR TITLE
🛡️ Sentinel: Redact OAuth bearer assertions and device-flow codes

### DIFF
--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -197,6 +197,13 @@ _SENSITIVE_QUERY_KEYS = frozenset({
     "clientassertiontype",
     "samlrequest",
     "samlresponse",
+    # OAuth 2.0 Device Authorization Grant (RFC 8628). `device_code` is a
+    # bearer-style secret that the client polls with; `user_code` is short-lived
+    # but still pairs the user with an in-flight grant. Neither is caught by
+    # the substring list (no "token"/"secret"/etc. in the normalized form),
+    # so they need an exact entry here.
+    "devicecode",
+    "usercode",
     # Additional sensitive tokens
     "bearer",
     # AWS and other cloud tokens
@@ -221,6 +228,11 @@ _SENSITIVE_KEY_SUBSTRINGS = frozenset({
     "email",
     "webhook",
     "glpat",
+    # SAML 2.0 / JWT Bearer Authorization Grant (RFC 7521/7522/7523):
+    # the `assertion` parameter carries a signed identity assertion (SAML XML
+    # or JWT). `client_assertion` is already an exact match above, but plain
+    # `assertion`, `saml_assertion`, etc. would otherwise slip past redaction.
+    "assertion",
     # Additional broad matching
     "session",
     "cookie",
@@ -282,6 +294,9 @@ _SENSITIVE_HEADER_PARTIALS = frozenset({
     "access-token",
     "access-key",
     "access-id",
+    # SAML/JWT bearer assertions are sometimes carried in headers (e.g.
+    # `Saml-Assertion`, `X-Subject-Assertion`); strip on cross-origin redirect.
+    "assertion",
 })
 
 

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -52,6 +52,11 @@ def sanitize_log_message(
     _keys = (
         r"client[-_.\s]*secret|access[-_.\s]*token|refresh[-_.\s]*token|[a-z0-9_.\-]*client[-_.\s]*id[a-z0-9_.\-]*|[a-z0-9_.\-]*signature|[a-z0-9_.\-]*password[a-z0-9_.\-]*|[a-z0-9_.\-]*e[-_.\s]*mail[a-z0-9_.\-]*|"
         r"client[-_.\s]*assertion[-_.\s]*type|client[-_.\s]*assertion|"
+        # Plain `assertion` (RFC 7521/7522/7523 — SAML 2.0 / JWT Bearer Auth Grant):
+        # carries a signed identity assertion that is effectively a credential.
+        # The optional [a-z0-9_.\-]* prefix/suffix also captures saml_assertion,
+        # subject_assertion, jwt_assertion, etc.
+        r"[a-z0-9_.\-]*assertion[a-z0-9_.\-]*|"
         r"saml[-_.\s]*request|saml[-_.\s]*response|"
         r"[a-z0-9_.\-]*accessid[a-z0-9_.\-]*|id[-_.\s]*token|[a-z0-9_.\-]*session[-_.\s]*id[a-z0-9_.\-]*|session|cookie|[a-z0-9_.\-]*apikey[a-z0-9_.\-]*|[a-z0-9_.\-]*secret[a-z0-9_.\-]*|ticket|[a-z0-9_.\-]*token|code|key|sig|sid|"
         r"nonce|state|"
@@ -73,7 +78,8 @@ def sanitize_log_message(
     # Explicitly supports hyphens for header style (e.g. Api-Key)
     _header_keys = (
         r"api[-_.\s]*key|token|secret|signature|password|auth|session|cookie|private|"
-        r"client[-_.\s]*assertion|saml[-_.\s]*request|saml[-_.\s]*response|nonce|state|"
+        r"client[-_.\s]*assertion|[a-z0-9_.\-]*assertion[a-z0-9_.\-]*|"
+        r"saml[-_.\s]*request|saml[-_.\s]*response|nonce|state|"
         r"credential|client[-_.\s]*id|passphrase|access[-_.\s]*key|e[-_.\s]*mail"
     )
 

--- a/tests/test_log_sanitization_oauth_saml.py
+++ b/tests/test_log_sanitization_oauth_saml.py
@@ -44,3 +44,30 @@ def test_nonce_state_redaction() -> None:
     msg = "state=xyz-123"
     assert "***" in sanitize_log_message(msg)
     assert "xyz-123" not in sanitize_log_message(msg)
+
+
+@pytest.mark.parametrize("key", [
+    # Plain assertion (RFC 7521/7522/7523 — SAML 2.0 / JWT Bearer Auth Grant)
+    "assertion",
+    "Assertion",
+    "ASSERTION",
+    # SAML assertion in non-OAuth contexts
+    "saml_assertion",
+    "SAML-Assertion",
+    "SamlAssertion",
+    # JWT-bearer assertion variants
+    "jwt_assertion",
+    "subject_assertion",
+])
+def test_assertion_key_redaction(key: str) -> None:
+    """RFC 7521-7523 `assertion` parameter carries a signed identity credential.
+
+    Without this redaction, a SAML 2.0 / JWT bearer assertion logged as part of
+    a request URL or error trace would expose the entire signed payload (user
+    identity claims, attribute statements, replayable within validity window).
+    """
+    secret = "eyJraWQiOiJzaWctMTIzIn0.signedSamlOrJwtAssertionPayload.signature"
+    msg = f"POST /token grant_type=urn:bearer {key}={secret}"
+    sanitized = sanitize_log_message(msg)
+    assert secret not in sanitized, f"{key} value leaked: {sanitized!r}"
+    assert "***" in sanitized

--- a/tests/test_sensitive_headers_dynamic.py
+++ b/tests/test_sensitive_headers_dynamic.py
@@ -28,6 +28,11 @@ def test_strip_dynamic_sensitive_headers(
             "Auth-Info": "creds000",
             "Cookie": "session=abc",
             "X-Custom-Password": "password1",
+            # SAML 2.0 / JWT bearer assertions can travel in headers as well.
+            # Without "assertion" in _SENSITIVE_HEADER_PARTIALS these would
+            # follow the redirect to the third-party host.
+            "Saml-Assertion": "<saml:Assertion>...</saml:Assertion>",
+            "X-Subject-Assertion": "eyJTAMLencodedClaims",
         }
 
         # Headers that should NOT be stripped (safe headers)

--- a/tests/test_url_sanitization_oauth.py
+++ b/tests/test_url_sanitization_oauth.py
@@ -25,3 +25,36 @@ def test_sanitize_saml_params() -> None:
 
     assert "base64_request" not in sanitized, "SAMLRequest leaked"
     assert "base64_response" not in sanitized, "SAMLResponse leaked"
+
+
+def test_sanitize_bearer_assertion_param() -> None:
+    """RFC 7521/7522/7523 — plain `assertion` param carries a signed credential.
+
+    The token endpoint of a SAML/JWT bearer flow receives the entire assertion
+    via the `assertion` query/body parameter. Without redaction, the signed
+    payload (with user identity claims) leaks into URL-bearing error logs.
+    """
+    secret = "eyJraWQiOiJzaWcifQ.signedAssertionPayload.signature"
+    url = (
+        "https://idp.example.com/token?grant_type=urn:ietf:params:oauth:grant-type:saml2-bearer"
+        f"&assertion={secret}"
+    )
+    sanitized = _sanitize_url_for_error(url)
+    assert secret not in sanitized, "assertion parameter leaked"
+
+
+def test_sanitize_device_flow_codes() -> None:
+    """RFC 8628 — `device_code` is a polling secret; `user_code` pairs the user.
+
+    Both parameters were previously not caught by URL-level redaction because
+    their normalized form (`devicecode` / `usercode`) does not contain any
+    sensitive substring (`token`, `secret`, etc.). They now have explicit
+    entries in the sensitive query-key set.
+    """
+    url = (
+        "https://example.com/oauth/token?grant_type=urn:ietf:params:oauth:grant-type:device_code"
+        "&device_code=secret-device-code-value&user_code=ABCD-EFGH"
+    )
+    sanitized = _sanitize_url_for_error(url)
+    assert "secret-device-code-value" not in sanitized, "device_code leaked"
+    assert "ABCD-EFGH" not in sanitized, "user_code leaked"


### PR DESCRIPTION
## 🚨 Severity
**MEDIUM** — Defense-in-depth / log-leak prevention. Three OAuth/SAML protocol parameters slipped through the URL, header, and log redaction layers and would have been written to logs in the clear.

## 💡 Vulnerability
The redaction lists in `src/utils/http.py` and `src/utils/logging.py` are extensive (`token`, `secret`, `key`, `password`, `nonce`, `state`, `client_assertion`, `SAMLRequest`, `SAMLResponse`, …) but missed three protocol-defined parameters whose normalized form contains none of the existing sensitive substrings:

| Parameter | RFC | What it carries |
| --- | --- | --- |
| `assertion` | 7521 / 7522 / 7523 | A **signed identity assertion** (SAML XML or JWT) used as the OAuth 2.0 authorization grant. Only `client_assertion` was on the exact-match list — plain `assertion`, `saml_assertion`, `subject_assertion`, etc. fell through. |
| `device_code` | 8628 § 3.4 | The bearer-style polling secret in the OAuth 2.0 Device Authorization Grant. The token endpoint accepts it as `device_code=<value>`. |
| `user_code` | 8628 § 3.3 | The short user-facing code that pairs the user with an in-flight grant. Often included in verification URIs. |

Reproducer (before the fix):

```python
>>> from src.utils.http import _sanitize_url_for_error
>>> from src.utils.logging import sanitize_log_message
>>> _sanitize_url_for_error("https://idp/token?assertion=eyJTAMLencodedSensitive")
'https://idp/token?assertion=eyJTAMLencodedSensitive'   # ← signed assertion leaked
>>> _sanitize_url_for_error("https://x/token?device_code=secret-device-code")
'https://x/token?device_code=secret-device-code'         # ← polling secret leaked
>>> sanitize_log_message("SAML_assertion=eyJTAMLencodedSensitive")
'SAML_assertion=eyJTAMLencodedSensitive'                 # ← also leaked in free-form logs
```

## 🎯 Impact
- A SAML 2.0 / JWT bearer `assertion` logged in a request URL or error trace exposes the full signed payload — user identity claims, attribute statements, and (within the validity window) a replayable assertion.
- A leaked `device_code` allows the holder to claim the in-flight access token at the token endpoint until the user-bound grant expires.
- `user_code` leakage is lower impact but enables targeted phishing of the legitimate user.

This codebase already enforces a comprehensive redaction policy across URL params, headers, and log messages; the gap was that "assertion" needed an entry in three independent redaction surfaces and "device_code/user_code" needed exact entries because their substrings (`code`) are not on the substring list (and adding `code` would cause false positives like `errorcode`/`statuscode`).

## 🔧 Fix
- `_SENSITIVE_KEY_SUBSTRINGS` (`src/utils/http.py`) → adds `"assertion"`. Catches every assertion variant in URL query parameters: plain `assertion`, `saml_assertion`, `subject_assertion`, `jwt_assertion`, …
- `_SENSITIVE_HEADER_PARTIALS` (`src/utils/http.py`) → adds `"assertion"`. Strips `Saml-Assertion`, `X-Subject-Assertion`, etc. on cross-origin redirects.
- `_SENSITIVE_QUERY_KEYS` (`src/utils/http.py`) → adds `"devicecode"` and `"usercode"`. Exact entries to avoid `errorcode`/`statuscode` false positives.
- `_keys` and `_header_keys` regex alternations (`src/utils/logging.py`) → adds `[a-z0-9_.\-]*assertion[a-z0-9_.\-]*` for free-form log messages and header-style logging.

Source change: 23 lines including comments. Well under the 50-line guideline.

## ✅ Verification
- New tests in `tests/test_log_sanitization_oauth_saml.py`, `tests/test_url_sanitization_oauth.py`, and `tests/test_sensitive_headers_dynamic.py`. Without the fix, **11 of the new tests fail** with the actual leaked secret visible in the assertion failure (verified by stashing the source change). With the fix, all 22 OAuth/SAML/header tests pass.
- Existing 80 sanitization tests across 11 files all pass — no regressions in the established redaction surface.
- Full `pytest` suite: 1587 passed, 3 skipped.
- `ruff check src/ tests/` and `mypy --strict` on both modified source files: clean.

https://claude.ai/code/session_017XhaCePvRDWQiKzQVVVrd8

---
_Generated by [Claude Code](https://claude.ai/code/session_017XhaCePvRDWQiKzQVVVrd8)_