### PR TITLE
ci(workflows): replace read-all with explicit minimal permissions

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -20,7 +20,8 @@ on:
   schedule:
     - cron: '29 19 * * 3'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   bandit:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,8 @@ on:
   schedule:
     - cron: '25 20 * * 2'
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analyze:

--- a/.github/workflows/mypy-strict.yml
+++ b/.github/workflows/mypy-strict.yml
@@ -6,7 +6,8 @@ on:
       - main
   pull_request:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: mypy-strict-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,8 @@ on:
       - main
   pull_request:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   pytest:


### PR DESCRIPTION
## Summary

Replaces `permissions: read-all` with explicit `contents: read` at the workflow level in `bandit.yml`, `codeql.yml`, `mypy-strict.yml` and `test.yml`. The job-level permissions in `bandit.yml` and `codeql.yml` already grant the additional scopes those jobs need (`security-events`, `actions`, `packages`), so the top-level scope can be tightened without affecting functionality.

## Context

The three open Code-Scanning alerts (#1717, #1718, #1719 — Checkov rule CKV2_GHA_1 "Ensure top-level permissions are not set to write-all") are **stale**:

- `bandit.yml`: already had `permissions: read-all` at the top level
- `update-google-places-stations.yml`: already had explicit `permissions: contents: read`
- `defender-for-devops.yml`: file no longer exists in the repository

The alerts reference line numbers from older versions of these files (e.g. `bandit.yml:25` is currently the `bandit:` job key) and would auto-close on the next Checkov scan. This PR additionally removes the broad `read-all` keyword from the four workflows that still used it, aligning every workflow on the least-privilege pattern already used by `update-*` and `seo-guard`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` passes for all four files
- [ ] CodeQL workflow run on this PR succeeds (writes to `security-events` via the job-level grant)
- [ ] Bandit workflow run on this PR succeeds (uploads SARIF via the job-level grant)
- [ ] `mypy-strict` and `test` workflows run unchanged (only need read access)
- [ ] Stale Checkov alerts (#1717, #1718, #1719) close after the next code-scanning run on `main`

---
_Generated by [Claude Code](https://claude.ai/code/session_0194vu5iZ21gSjQXKbCmgPe3)_