### PR TITLE
🛡️ Sentinel: Pin SITE_BASE_URL host through validate_http_url

### DIFF
--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -12,7 +12,6 @@ import sys
 import xml.etree.ElementTree as ET  # nosec B405 - used for XML generation, not parsing untrusted input
 from pathlib import Path
 from collections.abc import Iterable
-from urllib.parse import urlparse
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -21,9 +20,11 @@ if str(REPO_ROOT) not in sys.path:
 
 try:
     from src.utils.files import atomic_write
+    from src.utils.http import validate_http_url
 except ModuleNotFoundError:
     # Fallback if src is not a package or run differently
     from utils.files import atomic_write  # type: ignore[no-redef]
+    from utils.http import validate_http_url  # type: ignore[no-redef]
 
 DOCS_DIR = REPO_ROOT / "docs"
 DEFAULT_BASE_URL = "https://origamihase.github.io/wien-oepnv"
@@ -37,18 +38,27 @@ logger = logging.getLogger(__name__)
 
 
 def _is_valid_base_url(candidate: str) -> bool:
-    """Validate the base URL to prevent sitemap injection via env overrides."""
+    """Validate the base URL to prevent sitemap injection via env overrides.
+
+    Security: ``SITE_BASE_URL`` is interpolated into every ``<loc>`` element
+    of the published sitemap (and into ``robots.txt``'s ``Sitemap:``
+    directive). Any host that survives this check is taken as authoritative
+    by every search engine that crawls the site, so the validation must
+    reject the same classes of values that ``validate_http_url`` rejects
+    elsewhere in the project: IP literals, reserved/internal TLDs
+    (``.local``, ``.internal``, ``.test``, ``.example``, ``.localhost`` …),
+    DNS-rebinding wildcards (``nip.io`` and friends), embedded credentials,
+    and non-http(s) schemes. ``check_dns=False`` because we don't talk to
+    the URL, we embed it — DNS state at sitemap generation time is
+    irrelevant to whether the URL is a safe target for embedding.
+    """
     if _UNSAFE_URL_CHARS.search(candidate):
         return False
-    parsed = urlparse(candidate)
-    if parsed.scheme.lower() not in {"http", "https"}:
-        return False
-    if not parsed.hostname:
-        return False
-    # Disallow embedded credentials to avoid leaking secrets into sitemap URLs.
-    if parsed.username or parsed.password:
-        return False
-    return True
+    # Delegating to validate_http_url consolidates the URL-safety policy
+    # (TLDs, IP literals, credentials, scheme, length cap) with the
+    # provider/HTTP layers; previously a localhost/internal-TLD override
+    # would silently land in the published sitemap.
+    return validate_http_url(candidate, check_dns=False) is not None
 
 
 def _base_url() -> str:

--- a/tests/scripts/test_generate_sitemap_security.py
+++ b/tests/scripts/test_generate_sitemap_security.py
@@ -33,3 +33,51 @@ def test_base_url_accepts_valid_https(monkeypatch: pytest.MonkeyPatch) -> None:
     module = _load_module()
     monkeypatch.setenv("SITE_BASE_URL", "https://example.com/base/")
     assert cast(Any, module)._base_url() == "https://example.com/base"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Loopback / IP-literal hosts must not land in the published sitemap.
+        "http://localhost:8080",
+        "http://127.0.0.1",
+        "https://192.168.1.1",
+        "https://[::1]",
+        # Reserved / internal TLDs (RFC 6761, RFC 2606, container DNS) — would
+        # leak internal hostnames into the sitemap if accepted.
+        "https://app.internal",
+        "https://my.local",
+        "https://example.test",
+        "https://example.invalid",
+        "https://service.cluster",
+        "https://api.svc",
+        # Wildcard DNS rebinding services that resolve to loopback.
+        "http://127.0.0.1.nip.io",
+        "https://example.nip.io",
+    ],
+)
+def test_base_url_rejects_internal_and_ip_hosts(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """Stricter validation must reject hosts that would corrupt the public
+    sitemap (and the matching robots.txt ``Sitemap:`` directive)."""
+    from typing import cast, Any
+    module = _load_module()
+    monkeypatch.setenv("SITE_BASE_URL", value)
+    assert cast(Any, module)._base_url() == cast(Any, module).DEFAULT_BASE_URL.rstrip(
+        "/"
+    )
+
+
+def test_base_url_rejects_embedded_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existing rejection — re-asserted after the validate_http_url swap so a
+    future regression in the helper doesn't silently let credentials into a
+    publicly-served URL."""
+    from typing import cast, Any
+    module = _load_module()
+    monkeypatch.setenv("SITE_BASE_URL", "https://user:pass@example.com")
+    assert cast(Any, module)._base_url() == cast(Any, module).DEFAULT_BASE_URL.rstrip(
+        "/"
+    )


### PR DESCRIPTION
## 🚨 Severity
**MEDIUM** — Defense-in-depth on a publicly-served artefact. The sitemap base URL had a thinner validation policy than every other env-controlled URL in the project.

## 💡 Vulnerability
`scripts/generate_sitemap.py:_is_valid_base_url` accepted any URL that satisfied four checks: no whitespace/control chars, http(s) scheme, non-empty hostname, no embedded credentials. This was strictly weaker than `src/utils/http.py:validate_http_url`, the helper every other env-controlled URL in the project goes through. As a result, `SITE_BASE_URL=http://localhost:8080` (or `192.168.1.1`, `app.internal`, `my.local`, `service.cluster`, `127.0.0.1.nip.io`, …) silently passed and the value flowed into:

- every `<loc>` element of `docs/sitemap.xml` (auto-committed by the SEO Verify workflow on every push touching `docs/**`),
- the `robots.txt` `Sitemap:` directive that points crawlers at the sitemap.

Search engines treat whichever host survives this check as authoritative; whoever can set the env on a runner can therefore steer every external link in the published sitemap to an arbitrary host.

Reproducer (before the fix):

```python
>>> import os; os.environ['SITE_BASE_URL'] = 'http://localhost:8080'
>>> module._base_url()
'http://localhost:8080'                                    # ← embedded into <loc>
>>> os.environ['SITE_BASE_URL'] = 'http://127.0.0.1.nip.io'
>>> module._base_url()
'http://127.0.0.1.nip.io'                                  # ← rebinds to loopback
>>> os.environ['SITE_BASE_URL'] = 'https://app.internal'
>>> module._base_url()
'https://app.internal'                                     # ← leaks internal hostname
```

## 🎯 Impact
- **SEO/phishing redirection:** the project's GitHub Pages domain owns substantial search-engine recognition for Vienna ÖPNV terms. Redirecting `<loc>` URLs to an attacker host transfers ranking and lands users on attacker pages whenever they click through search results.
- **Internal-host leakage:** an internal hostname embedded in a publicly-served sitemap discloses infrastructure that the rest of the codebase carefully treats as private.
- **DNS-rebinding wildcards** (`nip.io`, etc.) effectively republish loopback URLs — accepted by the old check, blocked by the central helper.

The journal already has two prior entries on the exact pattern (provider URL pinning, `OUT_PATH_STATIONS` containment); the sitemap base URL was the last env-controlled URL still bypassing the central allowlist.

## 🔧 Fix
- `_is_valid_base_url` now delegates to `validate_http_url(candidate, check_dns=False)`. That helper already enforces: IP-literal rejection (including IPv6), reserved/internal TLDs (`local`, `internal`, `test`, `example`, `invalid`, `svc`, `cluster`, `arpa`, `kubernetes`, …), DNS-rebinding wildcards, embedded credentials, scheme/port/length caps, and IDNA NFKC normalization.
- `check_dns=False` because the sitemap script never calls the URL — it just embeds it. DNS state at generation time is irrelevant to whether the URL is safe to *publish*.
- Removed the now-unused `urlparse` import.

Source change: 32 lines including comments. Well under the 50-line guideline.

## ✅ Verification
- New parametrized tests in `tests/scripts/test_generate_sitemap_security.py` cover loopback, RFC 1918, IPv6 `[::1]`, `.internal/.local/.test/.invalid/.svc/.cluster`, `nip.io` rebinding, and embedded credentials. Existing accept-case (`https://example.com/base/`) and reject-cases (`javascript:`, control chars) re-asserted.
- Full local pytest suite: **1608 passed, 3 skipped**.
- `ruff check src/ scripts/ tests/` and `mypy --strict` on `src/`: clean.

https://claude.ai/code/session_017XhaCePvRDWQiKzQVVVrd8

---
_Generated by [Claude Code](https://claude.ai/code/session_017XhaCePvRDWQiKzQVVVrd8)_