### PR TITLE
🛡️ Sentinel: [HIGH] Cap VOR_HTTP_TIMEOUT at Slowloris-defence ceiling

### DIFF
--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -251,7 +251,23 @@ def _compile_regex(name: str, default_pattern: str) -> re.Pattern[Any]:
 
 
 BOARD_DURATION_MIN = _load_int_env("VOR_BOARD_DURATION_MIN", DEFAULT_BOARD_DURATION_MIN)
-HTTP_TIMEOUT = _load_int_env("VOR_HTTP_TIMEOUT", DEFAULT_HTTP_TIMEOUT)
+# Security: ``DEFAULT_HTTP_TIMEOUT`` (15s) is the Slowloris-defence ceiling for
+# every VOR request — both the connect and read budget for ``fetch_content_safe``
+# at lines 1173 and 1436, plus the cache-update script at
+# ``scripts/update_vor_stations.py``. ``_load_int_env`` only enforces a lower
+# bound (``value > 0``), so a benign-looking env override such as
+# ``VOR_HTTP_TIMEOUT=99999`` (intentional misconfig, leaked CI env, or
+# compromised secret store) would silently let a single sluggish or attacker-
+# controlled upstream peer hold a worker for ~28 hours. Combined with
+# ``VOR_MAX_WORKERS=10`` and the per-run station fan-out, a handful of
+# slow-drip responses would exhaust the thread pool and stall the whole feed
+# build. The env var stays useful for *tightening* the timeout (e.g. 5s in
+# tests with a stub server) but can never raise it above the documented
+# Slowloris ceiling.
+HTTP_TIMEOUT = min(
+    _load_int_env("VOR_HTTP_TIMEOUT", DEFAULT_HTTP_TIMEOUT),
+    DEFAULT_HTTP_TIMEOUT,
+)
 MAX_STATIONS_PER_RUN = _load_int_env(
     "VOR_MAX_STATIONS_PER_RUN", DEFAULT_MAX_STATIONS_PER_RUN
 )

--- a/tests/test_vor_env.py
+++ b/tests/test_vor_env.py
@@ -68,6 +68,29 @@ def test_invalid_int_env_uses_defaults(
     importlib.reload(vor)
 
 
+def test_http_timeout_capped_at_slowloris_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Security: VOR_HTTP_TIMEOUT must never exceed DEFAULT_HTTP_TIMEOUT (15s),
+    # which is the Slowloris-defence ceiling for both connect and read
+    # budgets. An env override (intentional misconfig, leaked CI env, or
+    # compromised secret store) that raised the timeout would let a single
+    # sluggish or attacker-controlled upstream peer hold a worker for hours,
+    # exhausting the thread pool (VOR_MAX_WORKERS=10) and stalling the feed
+    # build. The env var may still *tighten* the timeout below the ceiling.
+    monkeypatch.setenv("VOR_HTTP_TIMEOUT", "99999")
+    importlib.reload(vor)
+    assert vor.HTTP_TIMEOUT == vor.DEFAULT_HTTP_TIMEOUT == 15
+
+    monkeypatch.setenv("VOR_HTTP_TIMEOUT", "5")
+    importlib.reload(vor)
+    assert vor.HTTP_TIMEOUT == 5
+
+    monkeypatch.delenv("VOR_HTTP_TIMEOUT", raising=False)
+    importlib.reload(vor)
+    assert vor.HTTP_TIMEOUT == vor.DEFAULT_HTTP_TIMEOUT
+
+
 def test_max_requests_per_day_capped_at_contract_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## 🚨 Severity: HIGH

## 💡 Vulnerability
`src/providers/vor.py` had

```python
HTTP_TIMEOUT = _load_int_env("VOR_HTTP_TIMEOUT", DEFAULT_HTTP_TIMEOUT)
```

`_load_int_env` only enforces a lower bound (`value > 0`), so any positive integer is accepted. The constant feeds the `timeout=` argument of every `fetch_content_safe` call in the VOR provider (lines 1173 and 1436) plus `scripts/update_vor_stations.py`. An env override such as `VOR_HTTP_TIMEOUT=99999` (intentional misconfig, leaked CI env, or compromised secret store) silently disables the Slowloris defence on every VOR request.

## 🎯 Impact
A sluggish or attacker-controlled upstream peer can hold a worker for ~28 hours per request. Combined with `VOR_MAX_WORKERS=10` and the per-run station fan-out, a handful of slow-drip responses would exhaust the thread pool and stall the whole feed build — a one-shot DoS triggered by a single env-var change.

The same pattern was already journaled when fixing `VOR_MAX_REQUESTS_PER_DAY`: that entry explicitly named `HTTP_TIMEOUT` as a candidate needing the same `min(env, DEFAULT)` treatment.

## 🔧 Fix
Mirror the merged `MAX_REQUESTS_PER_DAY` cap: wrap `_load_int_env` in `min(..., DEFAULT_HTTP_TIMEOUT)` so the env var can still *tighten* the timeout below the ceiling (e.g. `5` in tests with a stub server) but can never raise it above the documented 15-second budget. A security comment at the call site names the threat model and the affected call sites.

## ✅ Verification
- New `tests/test_vor_env.py:test_http_timeout_capped_at_slowloris_ceiling` covers all three cases:
  - `VOR_HTTP_TIMEOUT=99999` ⇒ capped to `DEFAULT_HTTP_TIMEOUT` (15)
  - `VOR_HTTP_TIMEOUT=5` ⇒ allowed to tighten to 5
  - unset ⇒ default 15
- Existing `test_invalid_int_env_uses_defaults` still passes (invalid input still returns default; `min(15, 15) == 15`).
- Full suite: `pytest tests/ -x -q` ⇒ 1652 passed, 3 skipped.
- `ruff check` and `bandit` clean for the touched files; pre-existing unrelated lint findings in `tests/test_provider_plugins.py` and `src/utils/http.py` were not touched.

## 📎 Scope
- `src/providers/vor.py`: 18 lines (security comment + 3-line `min(...)` call)
- `tests/test_vor_env.py`: 23 lines (new test)
- Total: 40 insertions, 1 deletion — well under the 50-line guideline.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FYx7eCCf8R9PmknmvsWRA9)_