### PR TITLE
Sentinel: detect Stripe rk_live_, rk_test_, whsec_ token variants

### DIFF
--- a/src/utils/secret_scanner.py
+++ b/src/utils/secret_scanner.py
@@ -90,6 +90,23 @@ _KNOWN_TOKENS = [
     # key exists somewhere in the same repo. Treated as a distinct finding so the
     # report calls out *which* environment leaked.
     (re.compile(r"(?<![A-Za-z0-9])sk_test_[0-9a-zA-Z]{24}(?![A-Za-z0-9])"), "Stripe Test Secret Key gefunden"),
+    # Stripe restricted API keys (``rk_live_`` / ``rk_test_``). Restricted keys
+    # carry a scoped subset of permissions, but a leak still grants the API
+    # access defined by that scope (charges, customers, payouts, …) and is
+    # high-impact for the affected resource. Format mirrors ``sk_*``: prefix
+    # plus a 24-char alphanumeric body. Distinct reasons per environment so
+    # the report identifies which key tier leaked.
+    (re.compile(r"(?<![A-Za-z0-9])rk_live_[0-9a-zA-Z]{24}(?![A-Za-z0-9])"), "Stripe Restricted Live Key gefunden"),
+    (re.compile(r"(?<![A-Za-z0-9])rk_test_[0-9a-zA-Z]{24}(?![A-Za-z0-9])"), "Stripe Restricted Test Key gefunden"),
+    # Stripe webhook signing secret (``whsec_``). Leakage is not an API
+    # credential but lets an attacker forge webhook payloads that the
+    # application's signature verification will accept — so any
+    # webhook-driven business logic (refunds, account upgrades, fulfilment)
+    # can be triggered by a network adversary. Body is base64-ish, ``32+``
+    # chars in practice; pattern stays alphanumeric to match Stripe's
+    # current format and avoid colliding with the ``[A-Za-z0-9+/=_-]``
+    # entropy fallback's character class.
+    (re.compile(r"(?<![A-Za-z0-9])whsec_[A-Za-z0-9]{32,}(?![A-Za-z0-9])"), "Stripe Webhook Signing Secret gefunden"),
     (re.compile(r"(?<![A-Za-z0-9])xoxb-[0-9]{10,}-[0-9]{10,}-[a-zA-Z0-9]{24}(?![A-Za-z0-9])"), "Slack Bot Token gefunden"),
     (re.compile(r"(?<![A-Za-z0-9])xoxp-[0-9]{10,}-[0-9]{10,}-[0-9]{10,}-[a-zA-Z0-9]{32}(?![A-Za-z0-9])"), "Slack User Token gefunden"),
     # Slack OAuth-app access token (configuration token issued via the OAuth flow,

--- a/tests/test_secret_scanner_token_taxonomy.py
+++ b/tests/test_secret_scanner_token_taxonomy.py
@@ -99,3 +99,70 @@ def test_secret_scanner_slack_xoxa_does_not_overlap_with_xoxb(tmp_path: Path) ->
 
     assert "Slack Bot Token gefunden" in reasons
     assert "Slack Refresh Token gefunden" in reasons
+
+
+@pytest.mark.parametrize(
+    ("prefix", "expected_reason"),
+    [
+        ("rk_live_", "Stripe Restricted Live Key gefunden"),
+        ("rk_test_", "Stripe Restricted Test Key gefunden"),
+    ],
+)
+def test_secret_scanner_detects_stripe_restricted_keys(
+    tmp_path: Path, prefix: str, expected_reason: str
+) -> None:
+    file_path = tmp_path / f"stripe_{prefix.rstrip('_')}.py"
+    secret = prefix + "A1b2C3d4E5f6G7h8I9j0K1l2"  # 24-char body
+    file_path.write_text(f'STRIPE_RESTRICTED = "{secret}"\n', encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+
+    assert findings, f"Should detect Stripe {prefix} key"
+    assert secret not in [f.match for f in findings]
+    reasons = [f.reason for f in findings]
+    assert expected_reason in reasons, reasons
+
+
+def test_secret_scanner_distinguishes_all_stripe_variants(tmp_path: Path) -> None:
+    """Live/test secret, restricted, and webhook secret all produce distinct findings."""
+    file_path = tmp_path / "stripe_all.py"
+    sk_live = "sk_live_" + "L" * 24
+    sk_test = "sk_test_" + "T" * 24
+    rk_live = "rk_live_" + "R" * 24
+    rk_test = "rk_test_" + "Q" * 24
+    file_path.write_text(
+        "\n".join(
+            [
+                f'STRIPE_SK_LIVE = "{sk_live}"',
+                f'STRIPE_SK_TEST = "{sk_test}"',
+                f'STRIPE_RK_LIVE = "{rk_live}"',
+                f'STRIPE_RK_TEST = "{rk_test}"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+    reasons = {f.reason for f in findings}
+
+    assert "Stripe Live Secret Key gefunden" in reasons
+    assert "Stripe Test Secret Key gefunden" in reasons
+    assert "Stripe Restricted Live Key gefunden" in reasons
+    assert "Stripe Restricted Test Key gefunden" in reasons
+
+
+def test_secret_scanner_detects_stripe_webhook_signing_secret(tmp_path: Path) -> None:
+    """Webhook signing secrets enable forged webhook events; must be detected."""
+    file_path = tmp_path / "stripe_webhook.py"
+    # Real Stripe webhook secrets are typically 32+ alphanumeric characters
+    # after the prefix; use 38 here to exercise the {32,} body bound.
+    secret = "whsec_" + "Ab1Cd2Ef3Gh4Ij5Kl6Mn7Op8Qr9St0Uv1Wx2Yz"
+    file_path.write_text(f'STRIPE_WEBHOOK_SECRET = "{secret}"\n', encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+
+    assert findings, "Should detect Stripe webhook signing secret"
+    assert secret not in [f.match for f in findings]
+    reasons = [f.reason for f in findings]
+    assert "Stripe Webhook Signing Secret gefunden" in reasons, reasons


### PR DESCRIPTION
## Summary

Closes a known gap in `_KNOWN_TOKENS` (`src/utils/secret_scanner.py`) that the previous journal audit on 2026-05-06 flagged as missing: three Stripe token variants — restricted live/test API keys (`rk_live_` / `rk_test_`) and webhook signing secrets (`whsec_`). Without specific patterns these leaked tokens fell back to the generic high-entropy detector, which suppresses precise issuer attribution and is easier to silence with a per-line ignore.

🚨 **Severity:** MEDIUM (security enhancement)

💡 **Vulnerability / Gap**
- `_KNOWN_TOKENS` already covered Stripe `sk_live_` and `sk_test_` after #1281, but the audit explicitly noted that Stripe's full prefix taxonomy also includes `rk_live_`, `rk_test_`, and `whsec_`. Those three were never added.
- Webhook signing secrets are the highest-impact of the three: a leaked `whsec_*` lets a network adversary forge webhook payloads that pass Stripe's signature verification, triggering any business logic the application drives off webhooks (refunds, fulfilment, account upgrades).
- Restricted keys (`rk_*`) carry scoped Stripe API access; a leak still grants the privileges defined by that scope, and the test-environment variant signals a live key is likely co-located.

🎯 **Impact when exploited**
- Faster issuer attribution and revocation when any of these credentials accidentally ship into the repo or a logged artefact.
- Eliminates the gap where `whsec_*` would only be partially flagged by the entropy fallback, and `rk_*` keys (24-char alphanumeric body after a non-`_` separator) would be missed by `sk_*` patterns.

🔧 **Fix**
- Three new entries in `_KNOWN_TOKENS` with anchored prefixes and distinct German-language reasons mirroring the existing live/test-secret split, so the report identifies which key tier leaked.
- Patterns sit immediately after the existing `sk_test_` entry (before `_HIGH_ENTROPY_RE`) so issuer attribution wins over the generic fallback.

✅ **Verification**
- `pytest tests/test_secret_scanner_token_taxonomy.py` — 9 passed (4 new tests added: parametrized `rk_live_/rk_test_` detection, multi-variant distinguishing test, dedicated `whsec_` test).
- `pytest tests/ -k secret_scanner` — 64 passed (no regressions across existing scanner tests).
- `pytest tests/` — 1689 passed, 3 skipped (full suite green).
- `python scripts/scan_secrets.py` — no findings on this repo (no false positives introduced).
- `ruff check` on changed files — clean.
- `mypy --strict src/utils/secret_scanner.py` — clean.

## Test plan
- [x] New patterns detect their respective token variants and report distinct reasons
- [x] Existing Stripe `sk_live_`/`sk_test_` and Slack patterns continue to match
- [x] No false positives against the repository itself
- [x] Lint and mypy pass on changed files
- [x] Full test suite green

https://claude.ai/code/session_01B5BoyLfMkkwbpipFTqpVi1

---
_Generated by [Claude Code](https://claude.ai/code/session_01B5BoyLfMkkwbpipFTqpVi1)_