### PR TITLE
🛡️ Sentinel: zero-trust per-entry guard in VOR mapping validator

### DIFF
--- a/scripts/validate_vor_mapping.py
+++ b/scripts/validate_vor_mapping.py
@@ -29,6 +29,23 @@ def main() -> int:
 
     errors = 0
     for i, entry in enumerate(data):
+        # Zero Trust: a JSON-decoded list does not guarantee object elements.
+        # A tampered or hand-edited mapping could contain scalars / nulls /
+        # nested lists that would crash the validator with AttributeError on
+        # ``.get()`` and bypass the documented "Found N errors" exit path.
+        # Mirror the per-entry guard already applied to every other reader of
+        # ``vor-haltestellen.mapping.json`` (``src/providers/vor.py``,
+        # ``scripts/enrich_station_aliases.py``,
+        # ``scripts/update_station_directory.py``,
+        # ``scripts/update_wl_stations.py``).
+        if not isinstance(entry, dict):
+            print(
+                f"Entry {i} is not a JSON object (got {type(entry).__name__})",
+                file=sys.stderr,
+            )
+            errors += 1
+            continue
+
         vor_id = entry.get("vor_id")
         name = entry.get("station_name") or "Unknown"
 

--- a/tests/scripts/test_validate_vor_mapping.py
+++ b/tests/scripts/test_validate_vor_mapping.py
@@ -1,0 +1,84 @@
+"""Tests for the VOR mapping ID validator script."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import validate_vor_mapping as validator
+
+
+@pytest.fixture
+def in_tmp_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Run the validator with ``tmp_path/data`` as the mapping location."""
+    (tmp_path / "data").mkdir()
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def _write_mapping(repo: Path, payload: object) -> None:
+    target = repo / "data" / "vor-haltestellen.mapping.json"
+    target.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_validator_accepts_valid_mapping(
+    in_tmp_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_mapping(
+        in_tmp_repo,
+        [
+            {"station_name": "Wien Hbf", "vor_id": "490132000"},
+            {"station_name": "Wien Mitte", "vor_id": "490137000"},
+        ],
+    )
+
+    assert validator.main() == 0
+    captured = capsys.readouterr()
+    assert "Validation successful" in captured.out
+
+
+def test_validator_reports_invalid_format(
+    in_tmp_repo: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _write_mapping(
+        in_tmp_repo, [{"station_name": "Wien Hbf", "vor_id": "abc"}]
+    )
+
+    assert validator.main() == 1
+    captured = capsys.readouterr()
+    assert "Invalid VOR ID format" in captured.err
+
+
+@pytest.mark.parametrize(
+    "bad_entry",
+    [
+        None,
+        42,
+        "not-an-object",
+        ["nested", "list"],
+        True,
+    ],
+)
+def test_validator_rejects_non_object_entries(
+    in_tmp_repo: Path,
+    capsys: pytest.CaptureFixture[str],
+    bad_entry: object,
+) -> None:
+    """Zero Trust: non-dict entries must be rejected, not crash with AttributeError.
+
+    Without the per-entry isinstance guard, a tampered or hand-edited mapping
+    with scalar / null / nested-list elements would crash the validator with
+    ``AttributeError: '<type>' object has no attribute 'get'`` instead of
+    going through the documented "Found N errors" exit path.
+    """
+    _write_mapping(
+        in_tmp_repo,
+        [{"station_name": "Wien Hbf", "vor_id": "490132000"}, bad_entry],
+    )
+
+    assert validator.main() == 1
+    captured = capsys.readouterr()
+    assert "is not a JSON object" in captured.err
+    assert "Found 1 errors" in captured.err


### PR DESCRIPTION
## 🚨 Severity: MEDIUM

## 💡 Vulnerability

`scripts/validate_vor_mapping.py` verified that the outer JSON payload of
`data/vor-haltestellen.mapping.json` was a list, but iterated each element
calling `entry.get("vor_id")` without checking the element was actually a
dict. A tampered or hand-edited mapping containing scalars, `null`, or
nested lists slipped past the outer guard and crashed the validator with
`AttributeError: '<type>' object has no attribute 'get'`, bypassing the
documented "Found N errors" exit path.

## 🎯 Impact

The validator is the canonical defence against malformed mapping files.
If it crashes with an unhandled traceback instead of reporting structured
errors, an operator running it locally to verify a contributed mapping
update would see a Python stack trace and might dismiss the file as
"broken tooling" rather than recognise it as a malformed payload. In CI
or scripted contexts the non-zero exit happens for the wrong reason and
masks the real defect.

This also closes the last **cross-tree drift gap** for this on-disk
file. The Zero-Trust per-entry shape guard already lives on every other
reader of `data/vor-haltestellen.mapping.json`:

- `src/providers/vor.py:_load_station_name_map`
- `scripts/enrich_station_aliases.py:_load_vor_mapping`
- `scripts/update_station_directory.py:_load_vor_name_to_id_map`
- `scripts/update_wl_stations.py:load_vor_mapping`

This validator was the fifth consumer, missing the same guard.

## 🔧 Fix

Add a per-entry `isinstance(entry, dict)` guard before calling `.get()`.
Non-dict entries are now reported through the standard error-counting
path with the offending type included in the message, so the validator
exits with the documented `Found N errors.` summary instead of an
unhandled traceback.

## ✅ Verification

- 7 new parametrised tests cover the happy path, the pre-existing
  format-mismatch path, and 5 non-dict entry shapes (`None`, `int`,
  `str`, `list`, `bool`). Reverting the guard makes the parametrised
  cases fail with `AttributeError`, confirming the test catches the
  vulnerability.
- `pytest` full suite: 1696 passed, 3 skipped (no regressions).
- `ruff check` clean on both changed files.
- `mypy` clean on `scripts/validate_vor_mapping.py`.

https://claude.ai/code/session_01LduHayTSAif6PU5Ayoq7T2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LduHayTSAif6PU5Ayoq7T2)_