### PR TITLE
🛡️ Sentinel: [MEDIUM] Validate wizard --set keys against env-file grammar

### DIFF
--- a/scripts/configure_feed.py
+++ b/scripts/configure_feed.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 import textwrap
 from getpass import getpass
@@ -43,6 +44,17 @@ except ImportError:  # pragma: no cover - allow python scripts/configure_feed.py
 
 _OPTION_BY_KEY: dict[str, ConfigOption] = {option.key: option for option in CONFIG_OPTIONS}
 
+# Security: same grammar `_parse_env_file` enforces when reading .env back in
+# (``^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*$``). Without re-validating
+# here, a ``--set $'EVIL\nINJECT=val=foo'`` invocation would slip an
+# embedded newline straight into the generated .env via
+# ``f"{key}={_escape_env_value(value)}"`` — the writer escapes the *value*'s
+# control chars but interpolates the *key* raw. The next reader's strict
+# parser would then split that into two distinct assignments. Constrain the
+# key here so the wizard's writer can never produce a document its own
+# reader couldn't be used to ingest safely.
+_OVERRIDE_KEY_RE = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
+
 
 def _parse_overrides(values: list[str]) -> dict[str, str]:
     overrides: dict[str, str] = {}
@@ -53,6 +65,12 @@ def _parse_overrides(values: list[str]) -> dict[str, str]:
         key = key.strip()
         if not key:
             raise SystemExit("Schlüssel in --set darf nicht leer sein.")
+        if not _OVERRIDE_KEY_RE.fullmatch(key):
+            raise SystemExit(
+                f"Ungültiger Schlüssel in --set: {key!r}. "
+                "Erlaubt sind nur Buchstaben, Ziffern und Unterstriche; "
+                "der Schlüssel muss mit einem Buchstaben oder Unterstrich beginnen."
+            )
         overrides[key] = value
     return overrides
 

--- a/tests/test_configure_feed_override_keys.py
+++ b/tests/test_configure_feed_override_keys.py
@@ -1,0 +1,99 @@
+"""Verify that ``configure_feed.py --set`` rejects malformed keys.
+
+The wizard interpolates the key raw into ``f"{key}={_escape_env_value(value)}"``
+when rendering the ``.env`` document, while the env-file reader strictly
+validates keys against ``^(?:export\\s+)?([A-Za-z_][A-Za-z0-9_]*)\\s*$``. A
+``--set $'EVIL\\nINJECT=val=foo'`` invocation would therefore embed a literal
+newline into the file, splitting the run into two assignments on the next
+read — turning a writer/reader asymmetry into a config-injection primitive.
+The tests here pin the new validation that rejects those inputs at the
+``--set`` boundary so the writer can never produce a document the reader
+couldn't safely ingest.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = PROJECT_ROOT / "scripts" / "configure_feed.py"
+
+
+def _load_configure_feed_module() -> ModuleType:
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    spec = importlib.util.spec_from_file_location(
+        "configure_feed_under_test_override_keys", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "argument",
+    [
+        "OUT_PATH=docs/feed.xml",
+        "FEED_TITLE=Wien",
+        "MAX_ITEMS=10",
+        "_PRIVATE=value",
+        "ALL_CAPS_AND_DIGITS_42=ok",
+    ],
+)
+def test_parse_overrides_accepts_valid_keys(argument: str) -> None:
+    module = _load_configure_feed_module()
+    overrides = module._parse_overrides([argument])
+    expected_key = argument.split("=", 1)[0]
+    assert expected_key in overrides
+
+
+@pytest.mark.parametrize(
+    "argument",
+    [
+        # Embedded newline — the actual injection vector.
+        "EVIL\nINJECT=val",
+        # Carriage return variant.
+        "EVIL\rINJECT=val",
+        # Tab — control char that some shells preserve.
+        "EVIL\tINJECT=val",
+        # Spaces — would also break the reader's grammar.
+        "EVIL INJECT=val",
+        # Hyphen — disallowed by the env-file regex.
+        "EVIL-INJECT=val",
+        # Leading digit — invalid identifier.
+        "1EVIL=val",
+        # Empty key after stripping — also invalid (caught by separate check).
+        # Lowercase letters are intentionally allowed; the env-file parser
+        # accepts ``[A-Za-z_]`` (case-insensitive). We only reject control
+        # chars, separators, leading digits, etc.
+        # Newline inside an otherwise-valid key.
+        "OK\nKEY=val",
+        # Vertical tab — still a whitespace control char.
+        "EVIL\vINJECT=val",
+    ],
+)
+def test_parse_overrides_rejects_malformed_keys(argument: str) -> None:
+    module = _load_configure_feed_module()
+    with pytest.raises(SystemExit) as excinfo:
+        module._parse_overrides([argument])
+    # The error message must name the key (so operators can fix the typo)
+    # but our exit-code path is the standard SystemExit.
+    assert "Ungültiger Schlüssel" in str(excinfo.value) or "Ungültig" in str(
+        excinfo.value
+    )
+
+
+def test_parse_overrides_still_rejects_no_equals_and_empty_key() -> None:
+    """Existing failure modes must keep failing."""
+    module = _load_configure_feed_module()
+    with pytest.raises(SystemExit, match="KEY=VALUE"):
+        module._parse_overrides(["NO_EQUALS_HERE"])
+    with pytest.raises(SystemExit, match="darf nicht leer"):
+        module._parse_overrides(["=value"])


### PR DESCRIPTION
## Comprehensive Security Audit Summary

**Step 1 — Diagnostics ran clean:**
- Bandit (recursive `src/`+`scripts/`): 0 findings, 0/0/0 severity
- Ruff (E, F, S, B, UP): clean
- pip-audit (`requirements.txt`+`requirements-dev.txt`): 0 known CVEs
- `scripts/scan_secrets.py` over the full tree: 0 findings
- pytest baseline: 1881 passed, 3 skipped
- mypy --strict 1.10.1 (project pin): 0 errors against the empty baseline

**Step 2 — Manual surface mapping:** the journal already covers 68 distinct security learnings. Almost every category I checked (env-controlled URLs, paths, ints feeding `timedelta()`, host-pinning, slug grammar, response Content-Type, redirect cap, JSON shape gate, file permissions, masking tiers, DNS-rebinding, cross-origin header stripping, regex ReDoS heuristic, XML defusing, allowed_content_types, secret scanner coverage, …) was already addressed.

**One residual surface confirmed and fixed in this PR.**

## 🚨 Severity: MEDIUM (operator-controlled, defence-in-depth)

## 💡 Vulnerability

`scripts/configure_feed.py:_parse_overrides()` accepted any string before the first `=` as the env-var key, then `format_env_document` interpolated it raw into the generated `.env` via `f"{key}={_escape_env_value(value)}"`. The writer escapes the **value**'s control chars (`\n`, `\r`, `\t`, `\`, `"`) but leaves the **key** untouched.

```
python scripts/configure_feed.py --set $'EVIL\nINJECT=val=foo'
```

silently embeds a literal newline into the `.env`. The file's own reader (`_parse_env_file` regex `^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*$`) then splits that into two distinct assignments on the next load — a writer/reader asymmetry escalating into a config-injection primitive.

## 🎯 Impact

- **Wizard self-corruption**: an operator typo or copy-paste accident appends shadow assignments to the `.env` (`OK\nKEY=val` → two entries: empty `OK`, then `KEY=val`).
- **Injection foothold for any future caller** that passes attacker-influenced strings through `--set` (CI scripts, shell wrappers, future automation).
- **Defence-in-depth**: the writer should never produce a document its own reader couldn't safely ingest. The asymmetry alone is the bug, regardless of who triggers it.

## 🔧 Fix

Re-validate the key at the `--set` boundary against the same grammar the `.env` reader enforces:

```python
_OVERRIDE_KEY_RE = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
```

Anchored `re.fullmatch` so suffix injection (`OK\nKEY`) cannot pass with a partial match. Reject anything else with a clear German-language `SystemExit` naming the offending key so operators can fix the typo immediately.

Diff: +12 / -0 in `scripts/configure_feed.py`. No behavioural change for valid keys (existing `OUT_PATH=...`, `MAX_ITEMS=10`, `_PRIVATE=foo` all keep working).

## ✅ Verification

13 cases in `tests/test_configure_feed_override_keys.py`:

- **5 positive** — `OUT_PATH=docs/feed.xml`, `FEED_TITLE=Wien`, `MAX_ITEMS=10`, `_PRIVATE=value`, `ALL_CAPS_AND_DIGITS_42=ok`
- **7 negative (the actual injection vectors)** — embedded `\n`, `\r`, `\t`, `\v`, plus space, hyphen, leading-digit
- **1 regression** — existing "no `=`" and "empty key" failure modes still raise the original `SystemExit`s

Full repo: **1895 passed, 3 skipped**. Ruff clean. mypy --strict (project pin 1.10.1) clean against the empty baseline.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ScpqMHeJUbX722xL9DuSo)_