### PR TITLE
⚡ Apex: cut test suite by 42% — kill 25s busy-loop in test_thread_pool_cleanup

### DIFF
--- a/.jules/apex.md
+++ b/.jules/apex.md
@@ -1,0 +1,19 @@
+# Apex ⚡ Performance Architect — Journal
+
+Companion log to `.jules/sentinel.md`. Apex documents performance bottlenecks
+and optimization patterns; Sentinel documents security learnings. Together
+they form the project's institutional memory for cross-cutting non-feature
+work.
+
+Format mirrors Sentinel: only entries that capture a unique architectural
+finding, a reusable optimization pattern, or an edge case where speed
+conflicted with another property and how it was resolved. Routine micro-
+optimizations belong in the PR description, not the journal.
+
+---
+
+## 2026-05-07 - Suite-Time Bottleneck: `wait`-Mocked Loops Busy-Spin Against Real-Time Deadlines
+**Bottleneck:** `tests/test_thread_pool_cleanup.py::test_thread_pool_cleanup` was 25.02s — alone responsible for ~39% of the total suite wall-clock time (64.19s). The test's stated purpose is small: assert that `_collect_items` instantiates a `ThreadPoolExecutor` and uses it as a context manager. It correctly mocked `ThreadPoolExecutor`, `iter_providers`, and `wait`, but mocked `wait` to return `(set(), set())` — empty done set. The `_collect_items` loop's deadline-eviction branch (`while pending: ... if deadline is not None and now >= deadline: expired.append(future)`) reads `now` from `perf_counter()`, which advances with real wall-clock. The mocked `wait()` returned instantly but the loop kept polling `perf_counter()` until `feed_config.PROVIDER_TIMEOUT` (default 25s) had elapsed in real time. Net: a tight, CPU-bound 25-second spin in CI on every run.
+**Why it matters beyond this single test:** the same anti-pattern can recur whenever a unit test mocks one half of a deadline-driven loop. If the loop reads time from a real clock (`perf_counter()`, `time.time()`, `time.monotonic()`) AND the mocked half returns instantly, the test executes the loop against real time. Future tests that mock `wait`, `select`, `poll`, or `socket.recv` while leaving deadlines intact will inherit the same spin.
+**Optimization applied:** patch `feed_config.PROVIDER_TIMEOUT` to a small positive value (`0.05` — 50 ms) so the deadline arrives almost immediately. The test's actual assertions (`MockExecutor.called`, `__enter__/__exit__` triggered) are unchanged; the timeout is purely a numeric tuning of the deadline math. Result: 25.02s → 0.08s for that test, suite total 64.19s → 37.50s (~42% faster).
+**Pattern for future tests:** when mocking concurrency primitives in `_collect_items`-shaped loops, also patch the timeout/deadline constant from `feed_config` to a small positive value. The deadline-eviction branch is the loop's only natural exit when the mocked wait can't deliver a "done" future. This applies equally to `wait`, `as_completed`, and any future helper that sits between the loop and the executor.

--- a/tests/test_thread_pool_cleanup.py
+++ b/tests/test_thread_pool_cleanup.py
@@ -27,7 +27,19 @@ def test_thread_pool_cleanup() -> None:
 
         mock_iter.return_value = [ProviderSpec(env_var="TEST_ENV", loader=mock_loader, cache_key="")]
 
-        with patch("src.build_feed.feed_config.get_bool_env", return_value=True):
+        # Performance: shrink the deadline-polling window in ``_collect_items``
+        # from the default 25s down to ~50ms. The surrounding loop guards a
+        # ``while pending: ... wait(...) ... if deadline is not None and now
+        # >= deadline:`` polling pattern; with ``wait`` mocked to return
+        # ``(set(), set())`` the call returns instantly but ``perf_counter()``
+        # advances with real wall-clock, so the loop busy-spins until the
+        # deadline arrives. The default PROVIDER_TIMEOUT=25s therefore
+        # dominated the suite runtime (~39% of the entire test wall-clock).
+        # The test only asserts that ThreadPoolExecutor is instantiated and
+        # used as a context manager — the deadline value is irrelevant to
+        # those assertions, so any small positive number works.
+        with patch("src.build_feed.feed_config.get_bool_env", return_value=True), \
+             patch.object(build_feed.feed_config, "PROVIDER_TIMEOUT", 0.05):
             # Mock ThreadPoolExecutor
             with patch("src.build_feed.ThreadPoolExecutor") as MockExecutor:
                 mock_instance = MockExecutor.return_value


### PR DESCRIPTION
## ⚡ Apex Performance — first PR

The Sentinel audit just declared a clean bill of health. Apex's first scan turned up **one large, no-risk performance bottleneck — entirely in test code, untouching production**.

## Bottleneck

`tests/test_thread_pool_cleanup.py::test_thread_pool_cleanup` was **25.02s — alone responsible for ~39 % of total suite wall-clock** (64.19s / 1900 tests). The test's stated purpose is tiny: assert that `_collect_items` instantiates a `ThreadPoolExecutor` and uses it as a context manager.

It correctly mocked `ThreadPoolExecutor`, `iter_providers`, and `wait` — but mocked `wait` to return `(set(), set())` (empty done set). The surrounding `_collect_items` loop reads `now` from `perf_counter()` for deadline-eviction:

```python
while pending:
    now = perf_counter()
    for future in list(pending):
        deadline = deadlines.get(future)
        if deadline is not None and now >= deadline:
            expired.append(future)
    ...
    wait(pending, timeout=wait_timeout, return_when=FIRST_COMPLETED)
```

So the mocked `wait()` returned instantly but the surrounding loop kept polling `perf_counter()` until `feed_config.PROVIDER_TIMEOUT` (default 25 s) had elapsed in **real wall-clock time** before the deadline check finally evicted the (Mock) future.

Net: a tight, CPU-bound 25-second spin in CI on every run.

## Fix

Patch `feed_config.PROVIDER_TIMEOUT` to `0.05` (50 ms) for the duration of this one test. The deadline arrives almost immediately. The test's assertions (`MockExecutor.called`, `__enter__/__exit__` triggered) are unchanged — the timeout is purely a numeric tuning of the deadline math.

Touches **no production code**.

## Measured impact

| Metric | Before | After | Δ |
|---|---|---|---|
| Single test call | 25.02 s | **0.08 s** | **313× faster** |
| Suite total | 64.19 s | **37.50 s** | **−26.69 s (≈ 42 % faster)** |

Confirmed across two consecutive runs (37.5 s, 38.7 s). Tests: **1900 passed, 3 skipped** (unchanged from the green baseline). Ruff and mypy --strict 1.10.1 (project pin) clean.

## Journal

New `.jules/apex.md` companion to `sentinel.md`, with an inaugural entry documenting the **generalised pattern** for future contributors: *when mocking concurrency primitives in `_collect_items`-shaped loops, also patch the deadline/timeout constant so the loop's natural exit branch fires instead of busy-spinning against the real clock.* Same shape applies to future tests that mock `wait`, `as_completed`, `select`, or `socket.recv` while leaving deadlines intact.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ScpqMHeJUbX722xL9DuSo)_