### PR TITLE
chore: update VOR cache

### DIFF
--- a/cache/vor_929f1c/last_run.json
+++ b/cache/vor_929f1c/last_run.json
@@ -1,7 +1,7 @@
 {
   "daily_limit": 100,
-  "last_run_at": "2026-05-07T17:48:06.579277+00:00",
-  "last_run_at_local": "2026-05-07T19:48:06.579277+02:00",
+  "last_run_at": "2026-05-07T17:52:25.394963+00:00",
+  "last_run_at_local": "2026-05-07T19:52:25.394963+02:00",
   "requests_used_today": 1,
   "stations_queried": 2,
   "status": "api_unreachable"


### PR DESCRIPTION
## Summary

Routine VOR cache timestamp refresh from local pytest runs. The test suite touches `cache/vor_929f1c/last_run.json` as a side-effect, so every pytest run dirties the file. This is the standard `chore: update VOR cache [skip ci]` pattern used elsewhere in the repo's history.

No code changes; cache-only.

## Test plan

- [x] No code changes — file is a runtime cache artifact
- [x] `[skip ci]` marker in commit prevents redundant CI runs

https://claude.ai/code/session_012ScpqMHeJUbX722xL9DuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_012ScpqMHeJUbX722xL9DuSo)_