### PR TITLE
docs: architecture map (Mermaid) + educational pillar docstrings

### DIFF
--- a/.jules/scribe.md
+++ b/.jules/scribe.md
@@ -1,0 +1,150 @@
+# Scribe 🪶 DX & Cartography — Journal
+
+Seventh and final companion log to the project's institutional-memory
+journals (`sentinel.md`, `apex.md`, `purist.md`, `surgeon.md`,
+`omega.md`, `saboteur.md`). Scribe documents knowledge-surface work:
+diagrams, architectural maps, and educational docstrings that turn
+the mechanical masterpiece into a human-readable system.
+
+Format mirrors the sister journals: only entries that capture a
+unique DX pattern or a new architectural artifact.
+
+---
+
+## 2026-05-07 - Scribe Pass: Architecture Map + Pillar Docstrings
+
+### The architecture as I now understand it
+
+After Sentinel, Apex, Purist, Surgeon, Omega, and Saboteur, the system
+has acquired enough sophistication that no single file tells the
+whole story. Here is the synthesis:
+
+**Five layered defences against the network:**
+
+1. **Process-level** — `build_feed.main` is the failure unit. A
+   corrupt write fails the whole cron, never ships a half-built feed.
+2. **Provider-level** (bulkhead) — `_collect_items` runs each
+   provider in a per-future try/except inside a
+   `ThreadPoolExecutor` with Apex-Phase-1 deadline-eviction. One
+   provider's exception cannot drop the others' items.
+3. **Call-level** — `request_safe` is a 14-helper security state
+   machine that enforces SSRF + DNS-rebinding TOCTOU + Slowloris +
+   payload-cap on every outgoing HTTP request.
+4. **Transport-level** — `JitterRetry` (urllib3 with ±20% jitter) +
+   `PinnedHTTPSAdapter` (per-IP TLS pin keeping SNI on the original
+   hostname).
+5. **Payload-level** — Zero-Trust top-level type validation +
+   `RecursionError` catch (Saboteur's bug fix) + `MAX_PAYLOAD_SIZE`
+   (10 MB).
+
+**The data pipeline** (now diagrammed in `docs/architecture.md` §1)
+flows: cron → `build_feed.main` → `_collect_items` → split into
+cache vs network fetchers → ThreadPoolExecutor (network) → per-provider
+`fetch_events` → `request_safe` → upstream → `_merge_result` →
+`_dedupe_items` + `deduplicate_fuzzy` → `_make_rss` + `atomic_write`.
+
+**The complexity hierarchy** (post-Surgeon + Omega):
+
+- Top-level orchestrators (`_collect_items`, `request_safe`,
+  `fetch_events` per provider) — read like security policies, each
+  line is a Sentinel-audited or Apex-tuned step.
+- Helper functions (`_categorize_providers`, `_drain_completed_futures`,
+  `_send_https_pinned`, `_strip_redirect_secrets`, `_resolve_poor_title`,
+  etc.) — each owns one cohesive concern with a docstring naming the
+  invariant or attack vector it preserves.
+- Primitives (`CircuitBreaker`, `ProviderSpec`, `_ProviderBuckets`)
+  — small, strictly-typed, no third-party dependencies.
+
+### Diagrams created
+
+`docs/architecture.md` (new, 5 sections, ~290 lines):
+
+| § | Diagram | Audience |
+|---|---|---|
+| 1 | Sequence diagram: Transit Data Fetching Pipeline | New contributor tracing a full request flow |
+| 2 | Flowchart: `request_safe` security state machine | Reviewer auditing a security-adjacent change |
+| 3 | Component diagram: Resilience-layer stack | Operator reasoning about why a provider failed |
+| 4 | Flowchart: Provider plugin contract | Author of a new provider |
+
+All four are GitHub-rendered Mermaid blocks, accompanied by prose
+that explains the *why* (not just the *what*) of each step.
+
+The README's `## Systemüberblick` section now opens with a callout
+pointing readers at the new architecture map — a one-line bridge
+that costs nothing but pays back the moment a new contributor lands
+in the codebase.
+
+### Educational docstrings added
+
+Three top-level pillars previously had **brief** or **missing**
+docstrings. Each now carries a multi-paragraph educational explanation
+following Google-style with explicit ``Args``, ``Returns``,
+``Raises``, and ``See Also`` sections:
+
+| Function | Before | After |
+|---|---|---|
+| `src/build_feed.py::_collect_items` | ❌ no docstring | 6-paragraph orchestration narrative + cross-refs to `surgeon.md` and `apex.md` |
+| `src/utils/http.py::request_safe` | brief Args/Returns/Raises | full security-pipeline narrative + 14-step ordering + cross-ref to `omega.md` |
+| `src/utils/circuit_breaker.py::CircuitBreaker` | concise + tiny example | full state-machine ASCII art + "When to use vs. urllib3 retries" comparison + canonical adoption pattern |
+
+The 14 `request_safe` helpers and the 7 `_collect_items` helpers
+already had Sentinel/Surgeon/Omega-quality docstrings naming their
+invariants — the Scribe pass focused on the *orchestrators*, which
+are the entry points a junior dev opens first.
+
+### Patterns for future Scribe passes
+
+1. **Document the orchestrator, not the helper.** Helpers tend to
+   accumulate good docstrings during refactors (Surgeon, Omega) because
+   the extraction author had to explain *why* they extracted that
+   block. The orchestrator survives those refactors with the brief
+   one-liner from years ago. After every major refactor pass, audit
+   the orchestrator's docstring against the new internal structure.
+
+2. **Diagrams should explain *order*, not just *components*.** The
+   `request_safe` flowchart is valuable not because it lists 14
+   helpers (the docstrings already do that) but because it shows the
+   *order* in which they fire. Order is the part code reading does
+   not surface easily.
+
+3. **A README callout is high-leverage.** A single sentence at the
+   top of the system overview — "see `docs/architecture.md` for the
+   visual map" — is the difference between a new contributor finding
+   the diagrams or never knowing they exist. A diagram nobody opens
+   is useless.
+
+4. **Cross-link the journals from the visible surface.** The
+   `.jules/*.md` journals have rich audit history but are
+   discoverable only by file-tree exploration. Each architecture
+   diagram in `docs/architecture.md` links back to the relevant
+   journal entries (Sentinel for security gates, Apex for
+   performance, etc.), making the institutional memory navigable.
+
+5. **Educational docstrings should name historical context.**
+   `request_safe`'s new docstring references "the joint Sentinel +
+   Surgeon refactor that extracted these 14 helpers from the original
+   280-line monolith." That sentence does double duty: it explains
+   the current shape AND warns the next refactorer that there's a
+   reason the helpers exist.
+
+### Verification
+
+- `pytest`: 1937 passed, 3 skipped (unchanged — Scribe touches no
+  application logic, only documentation/strings).
+- `ruff check src/ tests/`: All checks passed!
+- `python3 -m mypy --no-pretty src tests` (CI-pinned 1.10.1):
+  Success: no issues found in 381 source files.
+- All Mermaid blocks fenced as ` ```mermaid ` (GitHub-renderable).
+- All docstrings follow PEP-257; sections (`Args:`, `Returns:`,
+  `Raises:`, `See Also:`, `Example:`) are Google-style and Sphinx-
+  compatible.
+
+### Cross-journal links
+
+- **Sentinel** + **Apex** + **Purist** + **Surgeon** + **Omega** +
+  **Saboteur** — the six engineering passes whose work the Scribe
+  pass *describes* without modifying. Each has a journal entry
+  cross-referenced from `docs/architecture.md`.
+- The architecture map is now the canonical answer to "where does X
+  fit in the system" — questions previously answered only by reading
+  the source.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ komplette Referenzdokumentation für die VOR/VAO-ReST-API enthalten.
 
 ## Systemüberblick
 
+> **🪶 Architektur-Karte für neue Mitwirkende:** Eine visuelle
+> Erklärung des Fetch-Pipelines, der `request_safe`-Sicherheitskette
+> und der Resilience-Schichten findet sich in
+> [`docs/architecture.md`](docs/architecture.md) (mit Mermaid-Diagrammen).
+
 Der Feed-Build folgt einem klaren Ablauf:
 
 1. **Provider-Caches** – Je Provider existiert ein Update-Kommando (`python -m src.cli cache update <provider>`) sowie eine GitHub Action, die den

--- a/cache/vor_929f1c/last_run.json
+++ b/cache/vor_929f1c/last_run.json
@@ -1,7 +1,7 @@
 {
   "daily_limit": 100,
-  "last_run_at": "2026-05-07T19:07:11.566678+00:00",
-  "last_run_at_local": "2026-05-07T21:07:11.566678+02:00",
+  "last_run_at": "2026-05-07T19:22:20.893236+00:00",
+  "last_run_at_local": "2026-05-07T21:22:20.893236+02:00",
   "requests_used_today": 1,
   "stations_queried": 2,
   "status": "api_unreachable"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,284 @@
+# Architecture Map — Wien ÖPNV Feed
+
+This document is the visual companion to the README and the `.jules/`
+journals. It is written for a developer joining the project six months
+from now: someone who needs to understand **how the system fits
+together** before diving into any one file.
+
+The diagrams below are rendered automatically by GitHub. If you are
+reading this in a non-Mermaid-aware viewer, the same information is
+also expressed prose-first under each diagram.
+
+---
+
+## 1. The Transit Data Fetching Pipeline
+
+The headline workflow: a cron job (or GitHub Action) launches
+`python -m src.build_feed`, which orchestrates 4–5 transit-data
+providers in parallel, deduplicates the merged events, and writes a
+single RSS feed.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Cron as cron / GH Action
+    participant Build as build_feed.main
+    participant Collect as _collect_items
+    participant Cache as Cache fetchers<br/>(WL+ÖBB cache)
+    participant Pool as ThreadPoolExecutor
+    participant WL as WL.fetch_events
+    participant OEBB as ÖBB.fetch_events
+    participant VOR as VOR.fetch_events
+    participant Safe as request_safe
+    participant Up as Upstream API
+    participant Merge as _merge_result
+    participant Dedupe as _dedupe_items + deduplicate_fuzzy
+    participant RSS as _make_rss + atomic_write
+
+    Cron->>Build: invoke
+    Build->>Collect: _collect_items(report)
+    Collect->>Collect: _categorize_providers
+    Note over Collect: split into cache_fetchers<br/>(sync, disk-bound) and<br/>network_fetchers (async)
+
+    Collect->>Cache: sequential read
+    Cache-->>Merge: list[FeedItem]
+    Merge->>Collect: items.extend(...)
+
+    Collect->>Pool: _run_network_fetchers
+    par WL
+        Pool->>WL: submit fetch
+        WL->>Safe: request_safe(session, url, ...)
+        Safe->>Up: HTTPS GET (pinned IP)
+        Up-->>Safe: response
+        Safe-->>WL: validated body
+        WL-->>Merge: list[FeedItem]
+    and ÖBB
+        Pool->>OEBB: submit fetch
+        OEBB->>Safe: request_safe(session, url, ...)
+        Safe->>Up: HTTPS GET (pinned IP)
+        Up-->>Safe: response
+        Safe-->>OEBB: validated body
+        OEBB-->>Merge: list[FeedItem]
+    and VOR
+        Pool->>VOR: submit fetch
+        VOR->>Safe: request_safe (per station)
+        Safe->>Up: HTTPS GET (pinned IP)
+        Up-->>Safe: response
+        Safe-->>VOR: validated body
+        VOR-->>Merge: list[FeedItem]
+    end
+
+    Note over Pool: Apex-Phase-1 deadline-eviction loop:<br/>per-future timeout vs perf_counter()<br/>cancels stragglers
+
+    Merge->>Collect: items list
+    Collect-->>Build: combined items
+    Build->>Dedupe: strict identity dedupe
+    Dedupe->>Dedupe: deduplicate_fuzzy
+    Note over Dedupe: Apex-Phase-2 parallel<br/>token-cache O(n) regex
+    Dedupe-->>Build: deduped items
+    Build->>RSS: _make_rss + atomic_write
+    RSS-->>Cron: docs/feed.xml
+```
+
+**Why each step matters:**
+
+- **`_categorize_providers`** decides which providers can run synchronously (their loader has a `_provider_cache_name` attribute → reads from disk) vs. asynchronously (real network fetch). Separating them up front keeps the executor pool focused on I/O-bound work.
+- **The `par … and …` block** is the **bulkhead**: a crash in any one provider's `fetch_events` is caught by `_drain_completed_futures` and recorded as that provider's error, while the others continue. This is what makes the system never "all-down on one bad upstream."
+- **The Apex-Phase-1 callout** is critical: without bounded `wait()` timeouts the loop would busy-spin against `perf_counter()` (see `.jules/apex.md` 2026-05-07 entry).
+- **`request_safe`** is the security state machine — see diagram §2 below.
+- **`deduplicate_fuzzy`** is Apex-Phase-2 territory: the parallel `merged_cache` reduces O(n²) regex re-parsing to O(n) (see `.jules/apex.md`).
+
+---
+
+## 2. The `request_safe` Security State Machine
+
+`request_safe` is a single 75-line orchestrator that calls 14 cohesive
+security helpers in a strict order. Each helper documents the attack
+vector it mitigates. The flowchart below shows the order; the prose
+beneath summarizes why each gate exists.
+
+```mermaid
+flowchart TD
+    A[request_safe entry] --> B{timeout is None?}
+    B -- yes --> C[timeout = DEFAULT_TIMEOUT<br/>Slowloris default]
+    B -- no --> D[strip allow_redirects<br/>+ stream from kwargs]
+    C --> D
+    D --> E[init headers as<br/>CaseInsensitiveDict]
+    E --> F[_merge_request_hooks<br/><i>attaches _check_response_security</i>]
+    F --> G[_compute_total_time_budget<br/><i>tuple → sum</i>]
+    G --> H[for attempt in 0..max_redirects]
+
+    H --> I[_check_total_budget_or_raise<br/><i>Slowloris across redirects</i>]
+    I --> J[_per_request_timeout<br/><i>cap to remaining</i>]
+    J --> K[validate_http_url<br/><i>SSRF guard</i>]
+    K --> L{scheme}
+
+    L -- http --> M[_send_http_pinned<br/><i>DNS-rebinding TOCTOU</i>]
+    L -- https --> N[_resolve_target_ip<br/><i>private-IP guard</i>]
+    N --> O[_send_https_pinned<br/><i>SNI/Host pin via adapter</i>]
+
+    M --> P[with ctx as r:]
+    O --> P
+    P --> Q{_is_redirect?<br/>MagicMock-safe}
+
+    Q -- yes --> R[_process_redirect:<br/>1. cap check<br/>2. _strip_redirect_secrets<br/>3. _apply_method_downgrade<br/>4. _drop_host_header]
+    R --> H
+
+    Q -- no --> S{raise_for_status?}
+    S -- yes --> T[r.raise_for_status]
+    S -- no --> U
+    T --> U[_validate_content_type<br/><i>WAF/proxy block</i>]
+    U --> V[_compute_read_timeout<br/><i>Slowloris on read</i>]
+    V --> W[read_response_safe<br/><i>MAX_PAYLOAD_SIZE cap</i>]
+    W --> X[r._content = content<br/>return r]
+
+    H -. exception .-> Y[catch RequestException]
+    Y --> Z[_sanitize_exception_msg<br/><i>strip URLs from error</i>]
+    Z -.-> AA([raise sanitized])
+```
+
+**Why each gate exists** (also in helper docstrings):
+
+| Gate | Mitigates |
+|---|---|
+| Slowloris default timeout | Caller forgetting to pass timeout → indefinite hang |
+| Disable auto-redirects | DNS-rebinding TOCTOU between safety check and connect |
+| `_merge_request_hooks` | Silent skip of `_check_response_security` IP-verification |
+| `_compute_total_time_budget` (tuple sum) | Adversary chaining redirects to stretch wall-clock budget |
+| `_check_total_budget_or_raise` | Slowloris across redirects |
+| `_per_request_timeout` | Per-step timeout decay across the chain |
+| `validate_http_url` | SSRF via internal/private hostnames |
+| `_resolve_target_ip` | SSRF via DNS resolution returning a private IP |
+| `_send_http_pinned` | DNS-rebinding TOCTOU on plain HTTP |
+| `_send_https_pinned` | DNS-rebinding TOCTOU on HTTPS + SNI/Host mismatch |
+| `_is_redirect` (MagicMock guard) | False-positive redirects in mock-based tests |
+| `_strip_redirect_secrets` | Token / credential leak across origins |
+| `_apply_method_downgrade` | RFC-7231 method preservation/downgrade compliance |
+| `_drop_host_header` | SNI/Host mismatch on the redirected request |
+| `_validate_content_type` | WAF/proxy block-page misinterpretation (text/html attack) |
+| `_compute_read_timeout` | Slowloris on the body-read side |
+| `read_response_safe` | Payload-size cap (MAX_PAYLOAD_SIZE = 10 MB) |
+| `_sanitize_exception_msg` | Sensitive URLs leaking into error messages and logs |
+
+The full audit lives in `.jules/omega.md` (2026-05-07 entry).
+
+---
+
+## 3. Resilience-Layer Stack
+
+The system has five layered defences against a hostile network or
+upstream. Each layer has its own scope; together they form
+defence-in-depth.
+
+```mermaid
+flowchart LR
+    subgraph "Process level"
+        A[build_feed.main]
+    end
+    subgraph "Provider level (bulkhead)"
+        B[_collect_items<br/>per-provider try/except]
+        C[ThreadPoolExecutor<br/>+ deadline eviction]
+    end
+    subgraph "Call level (Saboteur + Sentinel)"
+        D[CircuitBreaker<br/><i>opt-in primitive</i>]
+        E[request_safe<br/><i>14 security helpers</i>]
+    end
+    subgraph "Transport level (Sentinel)"
+        F[urllib3 JitterRetry<br/>±20% backoff]
+        G[PinnedHTTPSAdapter<br/>per-IP TLS pin]
+    end
+    subgraph "Payload level (Saboteur)"
+        H[isinstance type check]
+        I[RecursionError catch]
+        J[MAX_PAYLOAD_SIZE 10MB]
+    end
+
+    A --> B
+    B --> C
+    C --> D
+    D --> E
+    E --> F
+    F --> G
+    G --> H
+    H --> I
+    I --> J
+    J --> A
+```
+
+**Layer-by-layer rationale:**
+
+- **Process level** — the cron entry point. If `main()` raises, the cron run is the failure unit; this is intentional so a corrupt write doesn't ship a half-built feed.
+- **Provider level** — `_collect_items` wraps each provider's loader in a try/except so one provider's exception cannot drop the others' items. The ThreadPoolExecutor + Apex-Phase-1 deadline-eviction loop bounds wall-clock for unresponsive providers.
+- **Call level** — `request_safe` is the per-call security state machine (§2). `CircuitBreaker` is a Saboteur-pass primitive available for adoption (currently used by Google Places and as a pattern reference for future providers).
+- **Transport level** — `JitterRetry` (in `session_with_retries`) handles transient 5xx / connection-reset with jittered exponential backoff. `PinnedHTTPSAdapter` keeps the TLS handshake's SNI on the original hostname while the TCP connect targets the resolved (vetted) IP.
+- **Payload level** — once bytes arrive, every provider validates the top-level type (Zero-Trust shape), handles `RecursionError` from JSON depth-bombs, and operates within the 10 MB body cap.
+
+---
+
+## 4. Provider Plugin Contract
+
+Adding a new provider takes three steps. The diagram shows what your
+new module must export and how `_collect_items` discovers it.
+
+```mermaid
+flowchart TB
+    A[Your new module:<br/>src/providers/yourapi.py] --> B[def fetch_events<br/>timeout: int = 25<br/>-&gt; list[FeedItem]]
+    A --> C[Optional:<br/>fetch_events._provider_cache_name<br/><i>marks as disk-bound</i>]
+
+    D[Registration:<br/>register_provider env_var, loader<br/>cache_key=...] --> E[ProviderSpec stored in registry]
+    E --> F[iter_providers] --> G[_collect_items.<br/>_categorize_providers]
+    G --> H{_provider_cache_name<br/>set?}
+    H -- yes --> I[cache_fetchers<br/><i>sync</i>]
+    H -- no --> J[network_fetchers<br/><i>async via executor</i>]
+```
+
+**Required contract:**
+
+```python
+# src/providers/yourapi.py
+from src.feed_types import FeedItem
+
+def fetch_events(timeout: int = 25) -> list[FeedItem]:
+    """Return a list of typed feed items for this provider.
+
+    Must NOT raise on network errors — log and return an empty list.
+    Must NOT block longer than ``timeout`` seconds total.
+    Must validate top-level payload shape before parsing (Zero-Trust).
+    """
+    ...
+```
+
+**Recommended adoption pattern (Saboteur's CircuitBreaker):**
+
+```python
+from src.utils.circuit_breaker import CircuitBreaker, CircuitBreakerOpen
+
+_BREAKER = CircuitBreaker("yourapi", failure_threshold=5, recovery_timeout=120.0)
+
+def fetch_events(timeout: int = 25) -> list[FeedItem]:
+    try:
+        return _BREAKER.call(_actual_fetch, timeout=timeout)
+    except CircuitBreakerOpen:
+        log.warning("yourapi breaker open; returning empty list")
+        return []
+```
+
+The breaker logs its own state transitions, so operators see
+`CircuitBreaker[yourapi]: CLOSED → OPEN after 5 consecutive failures`
+in the build log without any extra wiring.
+
+---
+
+## 5. Cross-references
+
+- **Security audit history** → `.jules/sentinel.md`
+- **Performance optimisations** → `.jules/apex.md`
+- **Static-analysis hygiene** → `.jules/purist.md`
+- **Complexity refactors** → `.jules/surgeon.md`
+- **`request_safe` joint refactor** → `.jules/omega.md`
+- **Chaos audit + RecursionError fix** → `.jules/saboteur.md`
+- **DX / docs / cartography** → `.jules/scribe.md` (this document's companion)
+
+The `.jules/` journals are the project's institutional memory. When
+adding a new defence, optimisation, or refactor, append an entry there
+and (if the change is architecturally visible) update this map.

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -1076,6 +1076,55 @@ def _run_network_fetchers(
 
 
 def _collect_items(report: RunReport | None = None) -> list[FeedItem]:
+    """Run all enabled providers and merge their items into a single list.
+
+    This is the central data-collection orchestrator of the build. It:
+
+    1. Initialises the provider registry (lazy-loads plugins on first call).
+    2. Categorises providers via :func:`_categorize_providers` into:
+       - **cache fetchers** — loaders whose ``_provider_cache_name``
+         attribute marks them as disk-bound (read from a local cache);
+         run sequentially since the bottleneck is disk I/O, not network.
+       - **network fetchers** — real upstream HTTP fetches; run
+         concurrently in a :class:`ThreadPoolExecutor`.
+    3. Wires up a :func:`register_cache_alert_hook` so that warnings
+       emitted by the cache layer (e.g. "cache for VOR is 6h stale")
+       attach to the run report instead of just logging.
+    4. Runs cache fetchers via :func:`_run_cache_fetchers` (synchronous).
+    5. Runs network fetchers via :func:`_run_network_fetchers`, which
+       wraps each loader in a per-future timeout, evicts stragglers via
+       a deadline-eviction loop (Apex Phase 1), and merges results
+       through :func:`_merge_result`.
+    6. Provides per-provider exception isolation — a crash in one
+       loader becomes an error entry on the run report, not an abort.
+       This is the project's primary bulkhead: a hostile or unhealthy
+       upstream cannot bring down the other providers' data.
+
+    The function intentionally accepts a ``RunReport`` to keep the
+    health-reporting side-effect explicit. Tests inject a fresh report
+    per call; production paths receive one from
+    :func:`_invoke_collect_items`.
+
+    Args:
+        report: Optional :class:`RunReport` to record provider
+            successes, errors, and cache alerts into. If ``None``, a
+            fresh report is constructed from
+            :func:`provider_statuses` so the function is safe to call
+            standalone (tests, ad-hoc invocations).
+
+    Returns:
+        A list of :class:`FeedItem` dictionaries, concatenated from
+        every successful provider in the order they completed. The
+        result is **not** deduplicated; callers (typically
+        :func:`main`) run :func:`_dedupe_items` and
+        :func:`deduplicate_fuzzy` afterwards.
+
+    See Also:
+        - ``docs/architecture.md`` §1 for the full sequence diagram.
+        - ``.jules/surgeon.md`` for the seven-phase extraction history.
+        - ``.jules/apex.md`` for the deadline-eviction-loop performance
+          fix this orchestrator depends on.
+    """
     init_providers()
     if report is None:
         report = RunReport(provider_statuses())

--- a/src/utils/circuit_breaker.py
+++ b/src/utils/circuit_breaker.py
@@ -68,22 +68,93 @@ class CircuitState(Enum):
 class CircuitBreaker:
     """Three-state circuit breaker with auto-recovery.
 
+    State machine (see ``docs/architecture.md`` §3 for the rendered
+    component diagram)::
+
+        CLOSED ── failure_threshold consecutive failures ──▶ OPEN
+           ▲                                                   │
+           │ probe-call success            recovery_timeout    │
+           │                                       elapses     │
+           │                                                   ▼
+           │                                              HALF_OPEN
+           │                                                   │
+           └──────── probe-call failure ──────────▶ OPEN ──────┘
+
+    The breaker is reentrant (``threading.RLock``) and lazy: the
+    ``OPEN → HALF_OPEN`` transition is evaluated on every read of the
+    :attr:`state` property, so the auto-recovery does not require a
+    background thread.
+
+    When to use this vs. ``urllib3`` retries
+    ----------------------------------------
+
+    The two primitives solve different problems and stack
+    complementarily:
+
+    - **urllib3 retries** (configured via :func:`session_with_retries`,
+      using ``JitterRetry`` with ±20% jitter) are *per-call* — they
+      handle transient errors within a single request attempt
+      (connection reset, 429, 503). They do not remember failures
+      across calls; a fully-down upstream gets retried on every call.
+
+    - **CircuitBreaker** is *per-process, per-upstream* — it remembers
+      a streak of failures across calls. After ``failure_threshold``
+      consecutive failures, every subsequent call short-circuits with
+      :class:`CircuitBreakerOpen` for ``recovery_timeout`` seconds.
+      This prevents self-DDoS against a known-down upstream.
+
+    The recommended adoption pattern for a new provider (and the only
+    pattern in use today by Google Places) is to *wrap* the
+    network-fetcher entry point with the breaker, leaving the
+    underlying ``session_with_retries`` retry policy unchanged::
+
+        _BREAKER = CircuitBreaker("yourapi", failure_threshold=5,
+                                   recovery_timeout=300.0)
+
+        def fetch_events(timeout: int = 25) -> list[FeedItem]:
+            try:
+                return _BREAKER.call(_actual_fetch, timeout=timeout)
+            except CircuitBreakerOpen:
+                log.warning("yourapi breaker open; returning empty list")
+                return []
+
     Args:
-        name: Human-readable identifier for log messages.
-        failure_threshold: Number of consecutive failures in CLOSED that
-            trip the breaker to OPEN. Default 5.
+        name: Human-readable identifier used in log messages
+            (``CircuitBreaker[name]: …``). Choose a name that uniquely
+            identifies the protected upstream so operators can grep
+            for it in build logs.
+        failure_threshold: Number of consecutive failures while
+            CLOSED that trip the breaker to OPEN. Defaults to 5,
+            which matches the existing ``places/client.py`` and
+            ``vor.py`` Emergency-Stop thresholds.
         recovery_timeout: Seconds the breaker stays OPEN before
-            transitioning to HALF_OPEN. Default 60.
-        clock: Override the time source (used in tests). Must return a
-            monotonic float. Default ``time.monotonic``.
+            transitioning to HALF_OPEN. Defaults to 60. Tune higher
+            (e.g. 300) for upstreams that take a long time to
+            recover from outages, lower for upstreams where a
+            transient blip is the more common failure mode.
+        clock: Override the monotonic time source. Used by tests to
+            drive the recovery-timeout transition deterministically.
+            Defaults to :func:`time.monotonic`.
+
+    Raises:
+        ValueError: If ``failure_threshold`` is non-positive or
+            ``recovery_timeout`` is negative.
 
     Example:
-        >>> breaker = CircuitBreaker("vor", failure_threshold=5, recovery_timeout=300)
+        >>> breaker = CircuitBreaker("vor", failure_threshold=5,
+        ...                          recovery_timeout=300.0)
         >>> try:
         ...     result = breaker.call(lambda: requests.get(api_url))
         ... except CircuitBreakerOpen:
         ...     log.warning("VOR breaker open; skipping fetch")
         ...     result = None
+
+    See Also:
+        - ``docs/architecture.md`` §3 (resilience-layer stack) and §4
+          (provider plugin contract) for visual context.
+        - ``.jules/saboteur.md`` for the design-rationale entry that
+          motivated this primitive over the three pre-existing
+          ad-hoc resilience implementations.
     """
 
     def __init__(

--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -1813,24 +1813,96 @@ def request_safe(
     raise_for_status: bool = True,
     **kwargs: Any,
 ) -> requests.Response:
-    """Perform an HTTP request with DNS pinning and size limits to prevent DoS/SSRF.
+    """Perform an HTTP request through the project's security state machine.
+
+    This function is the *only* place in the codebase that issues real
+    HTTP requests to untrusted upstreams. Every transit-API call,
+    every cache-refresh fetch, and every health-check goes through
+    here. As such, it is the load-bearing pillar for the project's
+    defence-in-depth posture.
+
+    The pipeline runs each call through 14 cohesive security helpers
+    in a strict order. Each helper has its own docstring naming the
+    attack vector it mitigates; the high-level sequence is:
+
+    1. Default a missing timeout (Slowloris baseline).
+    2. Disable automatic redirects (we handle them manually to defeat
+       DNS-rebinding TOCTOU between safety check and connect).
+    3. Merge caller hooks with the response-IP-verification security
+       hook (:func:`_check_response_security`).
+    4. Compute the total time budget across the redirect chain
+       (tuple ``(connect, read)`` is summed to defeat budget-stretch
+       attacks).
+    5. For each redirect step (capped by ``session.max_redirects``):
+       a. Enforce the cumulative time budget.
+       b. Compute a per-request timeout decay.
+       c. Validate the URL (SSRF guard).
+       d. Pin the connection: HTTP via :func:`_pin_url_to_ip`; HTTPS
+          via the cached :class:`PinnedHTTPSAdapter`. The TLS handshake
+          uses the original hostname for SNI; the TCP connect targets
+          the resolved (vetted) IP.
+       e. Inspect the response: redirect → :func:`_process_redirect`
+          (strips secrets, downgrades method per RFC-7231, drops Host
+          header) and continue; otherwise validate Content-Type and
+          stream the body via :func:`read_response_safe` under the
+          ``MAX_PAYLOAD_SIZE`` cap.
+    6. Sanitize any leaked URLs in error messages before re-raising.
+
+    See ``docs/architecture.md`` §2 for the rendered flowchart and
+    ``.jules/omega.md`` for the joint Sentinel+Surgeon refactor that
+    extracted these 14 helpers from the original 280-line monolith.
 
     Args:
-        session: The requests session to use.
-        url: The URL to fetch.
-        method: HTTP method (default: "GET").
-        max_bytes: Maximum allowed response body size in bytes (default: 10MB).
-        timeout: Request timeout in seconds.
-        allowed_content_types: Optional list of allowed MIME types.
-        raise_for_status: If True, call raise_for_status() on the response (default: True).
-        **kwargs: Additional arguments passed to session.request().
+        session: The :class:`requests.Session` to use. The session's
+            adapters supply retry / jitter / pool-management; only the
+            request itself routes through this function's pinned
+            adapter.
+        url: The URL to fetch. Must pass :func:`validate_http_url`'s
+            SSRF guard (no internal/private hostnames, no
+            unsupported schemes).
+        method: HTTP method (default ``"GET"``). 303 redirects always
+            downgrade to GET; 301/302 downgrade POST→GET; 307/308
+            preserve the method.
+        max_bytes: Maximum allowed response body size (default
+            ``MAX_PAYLOAD_SIZE`` = 10 MB). Enforced both via the
+            ``Content-Length`` header pre-check and via streaming in
+            :func:`read_response_safe`.
+        timeout: Request timeout in seconds. Accepts ``int``,
+            ``float``, ``(connect, read)`` tuple, or ``None`` (which
+            is replaced by :data:`DEFAULT_TIMEOUT` to defend against
+            Slowloris). For tuples, the SUM is used as the total
+            budget across the entire redirect chain.
+        allowed_content_types: Optional MIME-type allow-list. When
+            ``None``, ``text/html`` is implicitly blocked (defends
+            against WAF / proxy block-page misinterpretation). When
+            a list/set is given, the response's MIME must match
+            exactly; missing ``Content-Type`` raises :class:`ValueError`.
+        raise_for_status: If ``True`` (default), invoke
+            :meth:`Response.raise_for_status` on the final response.
+            Set ``False`` only when the caller needs to inspect 4xx/5xx
+            payloads (e.g. ``Retry-After`` parsing).
+        **kwargs: Additional keyword arguments forwarded to
+            :meth:`Session.request`. The ``allow_redirects``, ``stream``,
+            and ``hooks`` keys are stripped/managed by this function
+            and must not be supplied by the caller.
 
     Returns:
-        The requests.Response object with content consumed and attached to ._content.
+        The :class:`requests.Response` with its body consumed and
+        attached to ``._content``. The response context manager has
+        already been closed; the caller can read ``.content`` /
+        ``.text`` / ``.json()`` freely.
 
     Raises:
-        ValueError: If URL is unsafe, Content-Type is invalid, or body size exceeds max_bytes.
-        requests.RequestException: For network errors.
+        ValueError: If the URL fails SSRF validation, the
+            ``Content-Type`` is invalid/missing/disallowed, or the
+            body exceeds ``max_bytes``.
+        requests.Timeout: If the cumulative time budget is exceeded
+            (either pre-flight or during body streaming).
+        requests.TooManyRedirects: If the redirect chain exceeds
+            ``session.max_redirects`` (default 10).
+        requests.RequestException: For network errors. The ``args``
+            of the exception are sanitized to strip any URLs that
+            might have contained query-string secrets.
     """
     # Security: Enforce default timeout to prevent Slowloris attacks if caller forgets it
     if timeout is None:


### PR DESCRIPTION
## Summary

**Scribe Pass** — DX cartography. Documents the system that Sentinel, Apex, Purist, Surgeon, Omega, and Saboteur built. **Zero application logic touched**; only docstrings and a new architecture map.

### New: `docs/architecture.md`

Five GitHub-rendered Mermaid diagrams with prose explanations:

| § | Diagram | Audience |
|---|---|---|
| 1 | **Sequence diagram** — Transit Data Fetching Pipeline | New contributor tracing a full request flow |
| 2 | **Flowchart** — `request_safe` security state machine (14 gates with attack-vector annotations) | Reviewer auditing a security-adjacent change |
| 3 | **Component diagram** — Resilience-layer stack (5 layers: process → bulkhead → call → transport → payload) | Operator reasoning about why a provider failed |
| 4 | **Flowchart** — Provider plugin contract | Author of a new provider |
| 5 | Cross-references to all six `.jules/*.md` journals | — |

`README.md` gets a one-sentence callout pointing readers at the new map — the "diagram nobody opens is useless" rule.

### Pillar docstrings upgraded

Three top-level orchestrators previously had brief or missing docstrings. Each now carries a multi-paragraph educational narrative (Google-style, Sphinx-compatible):

| Function | Before | After |
|---|---|---|
| `src/build_feed.py::_collect_items` | ❌ **zero** docstring | 6-paragraph orchestration narrative + cross-refs to `surgeon.md` and `apex.md` |
| `src/utils/http.py::request_safe` | brief Args/Returns/Raises | full security-pipeline narrative + 14-step ordering + cross-ref to `omega.md` |
| `src/utils/circuit_breaker.py::CircuitBreaker` | concise + tiny example | ASCII state-machine + **"When to use this vs. urllib3 retries"** comparison + canonical adoption pattern |

The 14 `request_safe` helpers (Omega) and 7 `_collect_items` helpers (Surgeon) already had high-quality "Mitigates: <attack>" / "Phase X:" docstrings — Scribe focused on the orchestrators that junior devs open first.

### Seventh journal: `.jules/scribe.md`

Documents the architecture-as-Scribe-now-understands-it synthesis, the four diagrams, the three pillars, and **five reusable patterns** for future Scribe passes:

1. Document the orchestrator, not the helper (refactors leave it stale)
2. Diagrams explain *order*, not just *components*
3. A README callout is high-leverage (one sentence makes diagrams findable)
4. Cross-link journals from the visible surface
5. Educational docstrings should name historical context (warns the next refactorer)

### What this PR does NOT do

- ❌ No application logic changed
- ❌ No refactor (Surgeon's territory)
- ❌ No security gate altered (Sentinel/Omega's territory)
- ❌ No performance tuning (Apex's territory)
- ✅ Just words, diagrams, and one README callout

## Test plan

- [x] `pytest` — **1937 passed, 3 skipped** (unchanged — no logic touched)
- [x] `ruff check src/ tests/` — **All checks passed!**
- [x] `python3 -m mypy --no-pretty src tests` (CI-pinned 1.10.1) — **Success: no issues found in 381 source files**
- [x] All 4 Mermaid blocks fenced as ` ```mermaid ` (GitHub-renderable)
- [x] All docstrings PEP-257 compliant; sections (`Args:`, `Returns:`, `Raises:`, `See Also:`, `Example:`) Google-style + Sphinx-compatible

https://claude.ai/code/session_012ScpqMHeJUbX722xL9DuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_012ScpqMHeJUbX722xL9DuSo)_