### PR TITLE
🛡️ Sentinel: [MEDIUM] Cap VOR fetch_events/fetch_vor_disruptions timeout (Slowloris Round 6)

### DIFF
--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -268,6 +268,29 @@ HTTP_TIMEOUT = min(
     _load_int_env("VOR_HTTP_TIMEOUT", DEFAULT_HTTP_TIMEOUT),
     DEFAULT_HTTP_TIMEOUT,
 )
+# Security: ``MAX_VOR_FETCH_TIMEOUT`` is the parameter-boundary Slowloris-defence
+# ceiling for the public ``fetch_events`` / ``fetch_vor_disruptions`` APIs. The
+# env-source clamp on ``HTTP_TIMEOUT`` above bounds operator-controlled config,
+# but the public ``timeout`` parameter bypassed it via
+# ``timeout or HTTP_TIMEOUT`` at ``_fetch_departure_board_for_station`` — a
+# caller passing ``timeout=99999`` (intentional misconfig, leaked CI env,
+# compromised secret store, or a hypothetical future ``VOR_FETCH_TIMEOUT`` env
+# var wired into a maintenance script) would let a sluggish or attacker-
+# controlled VAO peer hold a worker for ~28 hours per fetch, stalling the cron
+# pipeline. Capping at the public API entry point (defense-in-depth) means
+# every caller — current and future — inherits the ceiling. Same TIGHTEN-only
+# contract as ``MAX_OEBB_FETCH_TIMEOUT`` (``src/providers/oebb.py``) and
+# ``MAX_WL_FETCH_TIMEOUT`` (``src/providers/wl_fetch.py``) — the parameter-
+# boundary defense-in-depth pattern documented in the 2026-05-07 Slowloris-Cap
+# Drift Round 4 journal entry, applied to the VOR sibling that round
+# explicitly named as still-open ("VOR has env-source cap via
+# ``min(VOR_HTTP_TIMEOUT, DEFAULT_HTTP_TIMEOUT)`` but the public
+# ``fetch_events(timeout=99999)`` bypasses it via ``timeout or HTTP_TIMEOUT``").
+# Cap value matches the VOR-specific 15s ceiling (``DEFAULT_HTTP_TIMEOUT``)
+# rather than ``feed_config.MAX_PROVIDER_TIMEOUT`` (25s) because VOR has chosen
+# a tighter local Slowloris contract — orchestrator overrides at 25s are
+# already documented as needing to be tightened to VOR's 15s ceiling.
+MAX_VOR_FETCH_TIMEOUT = DEFAULT_HTTP_TIMEOUT
 # Security: ``MAX_STATIONS_PER_RUN`` controls the per-run fan-out of station
 # fetches. Each selected station consumes one VOR API quota slot, so a
 # benign-looking env override such as ``VOR_MAX_STATIONS_PER_RUN=99999``
@@ -1640,6 +1663,16 @@ def fetch_vor_disruptions(station_ids: list[str] | None = None, timeout: int | N
     Fetch disruptions for the given stations using the departureBoard endpoint.
     Iterates over the configured or provided stations and extracts warnings/infos.
     """
+    # Security: clamp ``timeout`` at MAX_VOR_FETCH_TIMEOUT to defeat the
+    # Slowloris vector documented at the constant declaration above.
+    # ``min(timeout or MAX_VOR_FETCH_TIMEOUT, MAX_VOR_FETCH_TIMEOUT)`` preserves
+    # the existing ``timeout or HTTP_TIMEOUT`` fallback semantics for None/0 and
+    # additionally clamps any caller-provided value above the ceiling.
+    # ``min(...)`` instead of ``if ...:`` to avoid bumping the McCabe complexity
+    # of this baselined function (``.c901-baseline.txt``: ``fetch_vor_disruptions
+    # 17``). Covers the public ``fetch_events`` entry point too, since
+    # ``fetch_events`` delegates to ``fetch_vor_disruptions``.
+    timeout = min(timeout or MAX_VOR_FETCH_TIMEOUT, MAX_VOR_FETCH_TIMEOUT)
     token = refresh_access_credentials()
     if not token:
         log.warning("Kein VOR Access Token konfiguriert – überspringe Abruf.")

--- a/tests/test_vor_fetch_timeout_cap.py
+++ b/tests/test_vor_fetch_timeout_cap.py
@@ -1,0 +1,146 @@
+"""Verify ``vor.fetch_events`` / ``fetch_vor_disruptions`` cap timeout at ``MAX_VOR_FETCH_TIMEOUT``.
+
+``src/providers/vor.py:fetch_vor_disruptions`` (and its delegating wrapper
+``fetch_events``) consume ``timeout`` as the per-request budget for
+``fetch_content_safe`` (via ``_fetch_departure_board_for_station``: ``timeout
+or HTTP_TIMEOUT``). The env-source clamp on ``HTTP_TIMEOUT`` —
+``min(VOR_HTTP_TIMEOUT, DEFAULT_HTTP_TIMEOUT)`` — bounds operator-controlled
+config, but a caller-provided ``timeout=99999`` was previously truthy and
+bypassed the ``or HTTP_TIMEOUT`` fallback entirely, letting a sluggish or
+attacker-controlled VAO peer hold a worker for ~28 hours per fetch (Slowloris
+vector). Capping at the public API entry point (defense-in-depth) means every
+caller — current and future — inherits the ceiling. TIGHTEN-only contract
+mirrors ``MAX_OEBB_FETCH_TIMEOUT`` (``src/providers/oebb.py``) and
+``MAX_WL_FETCH_TIMEOUT`` (``src/providers/wl_fetch.py``) — same parameter-
+boundary defense-in-depth pattern, applied to the VOR sibling that the
+2026-05-07 Round 4 journal entry explicitly named as still-open.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import src.providers.vor as vor
+from src.providers.vor import MAX_VOR_FETCH_TIMEOUT, fetch_events, fetch_vor_disruptions
+
+
+def test_max_vor_fetch_timeout_matches_default_http_timeout() -> None:
+    # The cap matches ``DEFAULT_HTTP_TIMEOUT`` (15 seconds), the VOR-specific
+    # Slowloris ceiling — chosen rather than ``feed_config.MAX_PROVIDER_TIMEOUT``
+    # (25 seconds) because VOR has documented a tighter local contract.
+    assert MAX_VOR_FETCH_TIMEOUT == vor.DEFAULT_HTTP_TIMEOUT
+    assert MAX_VOR_FETCH_TIMEOUT == 15
+    assert MAX_VOR_FETCH_TIMEOUT >= 1
+
+
+def _install_recorder(
+    monkeypatch: pytest.MonkeyPatch, recorded: dict[str, Any]
+) -> None:
+    """Replace VOR's network surface with a stub that records the timeout
+    propagated to ``_fetch_departure_board_for_station`` and returns no data
+    (so the rest of ``fetch_vor_disruptions`` short-circuits cleanly without a
+    network)."""
+
+    def fake_refresh_access_credentials() -> str:
+        return "stub-token"
+
+    def fake_load_request_count() -> tuple[str, int]:
+        return ("2099-01-01", 0)
+
+    def fake_get_configured_stations() -> list[str]:
+        return ["12345"]
+
+    def fake_select_stations_for_run(station_ids: list[str]) -> list[str]:
+        return list(station_ids)
+
+    def fake_fetch_departure_board_for_station(
+        station_id: str,
+        now_local: Any,
+        counter: Any = None,
+        session: Any = None,
+        timeout: Any = None,
+    ) -> None:
+        recorded["timeout"] = timeout
+        return None
+
+    monkeypatch.setattr(vor, "refresh_access_credentials", fake_refresh_access_credentials)
+    monkeypatch.setattr(vor, "load_request_count", fake_load_request_count)
+    monkeypatch.setattr(vor, "get_configured_stations", fake_get_configured_stations)
+    monkeypatch.setattr(vor, "select_stations_for_run", fake_select_stations_for_run)
+    monkeypatch.setattr(
+        vor,
+        "_fetch_departure_board_for_station",
+        fake_fetch_departure_board_for_station,
+    )
+
+
+def test_fetch_vor_disruptions_clamps_huge_timeout_to_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller passing ``timeout=99999`` would otherwise let a sluggish or
+    attacker-controlled VAO peer stall a worker for ~28 hours. Verify the cap
+    collapses the value to ``MAX_VOR_FETCH_TIMEOUT``."""
+    recorded: dict[str, Any] = {}
+    _install_recorder(monkeypatch, recorded)
+
+    with pytest.raises(vor.RequestException):
+        fetch_vor_disruptions(timeout=99999)
+    assert recorded["timeout"] == MAX_VOR_FETCH_TIMEOUT
+
+
+def test_fetch_vor_disruptions_at_cap_passes_cap_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """At the cap exactly the value passes through unchanged — verifies the
+    cap clamps to its documented value, not silently to a tighter bound."""
+    recorded: dict[str, Any] = {}
+    _install_recorder(monkeypatch, recorded)
+
+    with pytest.raises(vor.RequestException):
+        fetch_vor_disruptions(timeout=MAX_VOR_FETCH_TIMEOUT)
+    assert recorded["timeout"] == MAX_VOR_FETCH_TIMEOUT
+
+
+def test_fetch_vor_disruptions_below_cap_passes_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A small ``timeout`` (e.g. 5) must pass through unchanged — the cap
+    must not change the unclamped behaviour for legitimate values (tests
+    and tighter operator overrides)."""
+    recorded: dict[str, Any] = {}
+    _install_recorder(monkeypatch, recorded)
+
+    with pytest.raises(vor.RequestException):
+        fetch_vor_disruptions(timeout=5)
+    assert recorded["timeout"] == 5
+
+
+def test_fetch_vor_disruptions_none_timeout_uses_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``timeout=None`` (the default) must resolve to ``MAX_VOR_FETCH_TIMEOUT``
+    — the existing ``timeout or HTTP_TIMEOUT`` fallback semantics are preserved
+    by the ``timeout or MAX_VOR_FETCH_TIMEOUT`` form."""
+    recorded: dict[str, Any] = {}
+    _install_recorder(monkeypatch, recorded)
+
+    with pytest.raises(vor.RequestException):
+        fetch_vor_disruptions()
+    assert recorded["timeout"] == MAX_VOR_FETCH_TIMEOUT
+
+
+def test_fetch_events_delegates_clamp_to_fetch_vor_disruptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ``fetch_events`` public wrapper delegates to
+    ``fetch_vor_disruptions(station_ids, timeout=timeout)`` — verify the
+    clamp applies through the wrapper too so both ``__all__`` entry points
+    inherit the ceiling without per-wrapper duplicate clamps."""
+    recorded: dict[str, Any] = {}
+    _install_recorder(monkeypatch, recorded)
+
+    with pytest.raises(vor.RequestException):
+        fetch_events(timeout=99999)
+    assert recorded["timeout"] == MAX_VOR_FETCH_TIMEOUT


### PR DESCRIPTION
## 🚨 Severity: MEDIUM

Closes the last named-but-uncapped sibling in the Slowloris-Cap drift family. The 2026-05-07 Slowloris Round 4 journal entry explicitly named VOR as still-open: *"VOR has env-source cap via `HTTP_TIMEOUT = min(_load_int_env(...), DEFAULT_HTTP_TIMEOUT)` at the env-read site, but the public `fetch_events(timeout=99999)` bypasses it via `timeout or HTTP_TIMEOUT`."* Round 5 (PR #1324) closed the WL sibling; this Round 6 closes VOR.

## 💡 Vulnerability

`src/providers/vor.py:fetch_vor_disruptions(station_ids, timeout: int | None = None)` and its delegating wrapper `fetch_events(...)` consumed `timeout` as the per-request budget for `fetch_content_safe` (via `_fetch_departure_board_for_station`):

```python
content = fetch_content_safe(
    active_session,
    endpoint,
    params=params,
    timeout=timeout or HTTP_TIMEOUT,   # caller-provided truthy timeout bypasses HTTP_TIMEOUT clamp
    ...
)
```

The env-source clamp on `HTTP_TIMEOUT = min(VOR_HTTP_TIMEOUT, DEFAULT_HTTP_TIMEOUT)` bounds operator-controlled config but **a caller-provided `timeout=99999`** is truthy, so the `or HTTP_TIMEOUT` fallback is skipped entirely.

## 🎯 Impact

A future caller passing an env-controlled or user-controlled value (intentional misconfig, leaked CI env, compromised secret store, or a hypothetical future `VOR_FETCH_TIMEOUT` env var wired into a maintenance script) using `timeout=99999` would let a sluggish or attacker-controlled VAO peer hold a worker for **~28 hours per fetch**, stalling the cron pipeline.

## 🔧 Fix

Defense-in-depth clamp **at the public entry point** so both `__all__` exports inherit the ceiling:

```python
MAX_VOR_FETCH_TIMEOUT = DEFAULT_HTTP_TIMEOUT  # 15s VOR-specific Slowloris ceiling

def fetch_vor_disruptions(station_ids: list[str] | None = None, timeout: int | None = None) -> list[FeedItem]:
    timeout = min(timeout or MAX_VOR_FETCH_TIMEOUT, MAX_VOR_FETCH_TIMEOUT)
    ...
```

- `fetch_events` already delegates to `fetch_vor_disruptions(station_ids, timeout=timeout)` — single clamp covers both public APIs.
- `min()` form (no new McCabe branch) keeps `fetch_vor_disruptions` at its baselined complexity 17.
- `timeout or MAX_VOR_FETCH_TIMEOUT` preserves the existing `timeout or HTTP_TIMEOUT` fallback semantics for `None`/`0`.
- Cap at **15s** (`DEFAULT_HTTP_TIMEOUT`) — VOR's documented local Slowloris ceiling — rather than the global `MAX_PROVIDER_TIMEOUT` (25s), because VOR has chosen a tighter local contract via its existing env-source clamp.
- TIGHTEN-only contract mirrors `MAX_OEBB_FETCH_TIMEOUT` and `MAX_WL_FETCH_TIMEOUT`.
- Total diff: 33 lines src + 1 new test file (146 lines).

## ✅ Verification

- `tests/test_vor_fetch_timeout_cap.py` covers the canonical matrix:
  - constant matches `DEFAULT_HTTP_TIMEOUT` (15)
  - `99999` → cap (clamps huge value)
  - at-cap → cap (cap value passes through)
  - `5` → unchanged (legitimate test override passes through)
  - `None` → cap (preserves existing fallback semantics)
  - `fetch_events(timeout=99999)` → cap (delegation path covered)
- Full test suite: **1948 passed, 3 skipped** (1942 + 6 new, no regressions)
- `ruff check`: clean
- `mypy --strict`: clean (41 source files)
- `bandit -r src/providers/vor.py`: clean
- C901 complexity gate: clean (no McCabe regression — `fetch_vor_disruptions` stays at baselined 17)

## 🌐 Global Sweep Status

After this fix, all public `fetch_events`/`fetch_*` functions across `src/providers/*.py` and `src/places/*.py` that accept a `timeout` parameter are capped:

| Provider | Public API | Cap |
|---|---|---|
| OEBB | `fetch_events` | `MAX_OEBB_FETCH_TIMEOUT = 25` (Round 4) |
| WL | `fetch_events` | `MAX_WL_FETCH_TIMEOUT = 25` (Round 5, PR #1324) |
| VOR | `fetch_events`, `fetch_vor_disruptions` | `MAX_VOR_FETCH_TIMEOUT = 15` (Round 6, **this PR**) |

**GLOBAL TIMEOUT SWEEP: After this PR merges, 0 uncapped surfaces remain.**


---
_Generated by [Claude Code](https://claude.ai/code/session_01EaXQDX22rcn2sxy4NYVoHd)_