### PR TITLE
🛠️ The Fixer: Resolve Auditor General findings

### DIFF
--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -1,4 +1,3 @@
-import copy
 import hashlib
 import re
 from typing import Any
@@ -326,15 +325,26 @@ def deduplicate_fuzzy(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     1. Significant name overlap (tokens or substring).
     2. > 30% line overlap.
 
-    Performance: maintains a parallel ``merged_cache`` list of pre-computed
-    ``(lines, name, normalized_name, tokens)`` tuples mirroring
-    ``merged_items``. Without it, every inner-loop iteration recomputed
-    ``_parse_title`` + ``_normalize_name`` × 2 + ``_get_tokens`` × 2 (each
-    with its own internal ``_normalize_name``) for the same ``existing``
-    entry, giving an O(n²) regex workload for what is fundamentally an
-    O(n) parse problem. The cache reduces total parse work from O(n²) to
-    O(n); set-comparison work in the inner loop stays O(n²) but operates
-    on already-built sets, which is purely arithmetic and far cheaper.
+    Performance:
+
+    * **Parse cache (Apex pillar).** Maintains a parallel ``merged_cache``
+      list of pre-computed ``(lines, name, normalized_name, tokens)``
+      tuples mirroring ``merged_items``. Without it, every inner-loop
+      iteration recomputed ``_parse_title`` + ``_normalize_name`` × 2 +
+      ``_get_tokens`` × 2 (each with its own internal ``_normalize_name``)
+      for the same ``existing`` entry, giving an O(n²) regex workload for
+      what is fundamentally an O(n) parse problem. The cache reduces
+      total parse work from O(n²) to O(n); set-comparison work in the
+      inner loop stays O(n²) but operates on already-built sets, which
+      is purely arithmetic and far cheaper.
+    * **Shallow merge copy.** The merge branches use ``dict(existing)`` /
+      ``dict(item)`` instead of ``copy.deepcopy`` because every mutation
+      below targets a top-level scalar key (``description``, ``title``,
+      ``guid``, ``_identity``, ``_calculated_identity``, the four date
+      keys handled by ``_promote_newer_dates``). No nested structure is
+      mutated in place — assignments replace the whole value — so the
+      original dict's nested references stay untouched. Drops the
+      per-merge cost from O(item-size) deep traversal to O(top-level-keys).
     """
     merged_items: list[dict[str, Any]] = []
     # Parallel cache mirroring merged_items[idx] — same length, same order.
@@ -387,9 +397,16 @@ def deduplicate_fuzzy(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
                     # Case 1: Existing is VOR, Item is ÖBB -> Keep Existing, merge ÖBB desc if useful
                     if is_vor_existing and is_oebb_item:
-                        # Create a copy to avoid mutating the original 'existing' reference
-                        # if it came from the input list or was already modified.
-                        new_existing = copy.deepcopy(existing)
+                        # Shallow copy is sufficient and intentional: every
+                        # mutation below targets a top-level scalar key
+                        # (``description``, ``_identity``, ``_calculated_identity``,
+                        # the four date fields handled by ``_promote_newer_dates``).
+                        # No nested structure is mutated in place — assignments
+                        # replace the whole value — so the original dict's
+                        # nested references stay untouched. Replaces a former
+                        # ``copy.deepcopy(existing)`` call that was an O(item-size)
+                        # allocation on every merge in an O(n²) loop.
+                        new_existing = dict(existing)
 
                         desc_vor = new_existing.get("description", "") or ""
                         desc_oebb = item.get("description", "") or ""
@@ -417,10 +434,11 @@ def deduplicate_fuzzy(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
                     # Case 2: Existing is ÖBB, Item is VOR -> Replace Existing with Item
                     if is_oebb_existing and is_vor_item:
-                        # We replace the existing item content with the new item (VOR)
-                        # We create a new object to avoid mutating the original 'existing' reference
-                        # if it came from the input list.
-                        new_existing = copy.deepcopy(item)
+                        # Shallow copy of ``item`` for the same reason as Case 1:
+                        # only top-level keys are mutated. The deep-copy here was
+                        # paying for nested datetime / list traversal that no
+                        # subsequent code touches.
+                        new_existing = dict(item)
 
                         desc_oebb = existing.get("description", "") or ""
                         desc_vor = item.get("description", "") or ""
@@ -447,7 +465,12 @@ def deduplicate_fuzzy(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
                     # Standard Merge Logic (Peers)
 
-                    existing_copy = copy.deepcopy(existing)
+                    # Same shallow-copy rationale as the VOR/ÖBB branches above —
+                    # the peer-merge mutates ``title``, ``description``, ``guid``,
+                    # ``_identity``, ``_calculated_identity`` and the date fields,
+                    # all top-level scalars. The previous ``copy.deepcopy`` was
+                    # the dominant allocator inside the O(n²) merge loop.
+                    existing_copy = dict(existing)
 
                     # 1. Combine Lines
                     all_lines = sorted(list(lines | ex_lines))


### PR DESCRIPTION
## Beschreibung der Änderung

Resolves the three findings from the Auditor General's verdict on the
prior `main`:

1. **Local-vs-origin desync.** The local working tree had drifted ~80
   commits behind `origin/main`, missing the Slowloris timeout caps
   (`MAX_WL_FETCH_TIMEOUT`, `MAX_OEBB_FETCH_TIMEOUT`,
   `MAX_VOR_FETCH_TIMEOUT`) and the `src/utils/circuit_breaker.py`
   primitive. **Resolution:** `git fetch origin && git reset --hard
   origin/main` — verified post-sync that:
   - `src/utils/circuit_breaker.py` exists (11,940 bytes).
   - `wl_fetch.py:511`, `oebb.py:1545-1550`, `vor.py:1675` all clamp
     `timeout = min(timeout, MAX_*_FETCH_TIMEOUT)`.

2. **O(n²) regex re-parse.** Already eliminated upstream via the
   parallel `merged_cache` list (`merge.py:345`). No work needed —
   verified by reading the post-sync source. The Auditor's claim was
   based on the stale local `main`.

3. **`copy.deepcopy` in the inner-loop hot path** (`merge.py:392, 423, 450`).
   This was the remaining live finding. Replaced all three calls with
   shallow `dict(existing)` / `dict(item)`. Every mutation in the
   merge branches targets a top-level scalar key (`description`,
   `title`, `guid`, `_identity`, `_calculated_identity`, the four
   date keys handled by `_promote_newer_dates`) — no nested structure
   is mutated in place, so the shallow copy preserves the
   "don't mutate the caller's dict" invariant. Drops per-merge cost
   from O(item-size) deep traversal to O(top-level-keys). Removed the
   now-unused `import copy`.

## Ticket-Referenz

Auditor General verdict (this conversation, no GitHub issue) — Steps 1, 2 and 3 of the readiness checklist.

## Out-of-scope debt I'm deliberately NOT tackling

- The 8 pre-existing `mypy --strict` errors in `src/utils/http.py`
  (urllib3/dnspython untyped subclass shapes). Verified pre-existing
  by re-running `mypy` on a clean tree before any edits.
- `src/utils/cache.py` does not catch `RecursionError` and has no
  cache-size cap. Practical risk is low (cache files are
  repo-controlled), but flagged in the verdict — left for a follow-up
  PR if the team agrees it's worth a hardening round.
- Two `deepcopy` calls remain in `src/places/merge.py` (Google Places
  enrichment, runs on a different cron). Not on the feed-build hot
  path; out of scope for this PR.

---

## Seven-discipline review checklist

### 🛡 Sentinel — Security
- [x] No new HTTP request bypasses `request_safe` — **no HTTP code touched**.
- [x] No new `# nosec` marker hides a real vulnerability — none added.
- [x] No new SSRF / redirect / DNS-rebinding surface introduced — N/A.
- [x] If a new external host is contacted, the URL allowlist is updated — N/A.

### ⚡ Apex — Performance
- [x] **No `copy.deepcopy(items)` or unnecessary defensive copies on
  data-pipeline hot paths.** This PR is precisely about removing three
  such copies (`merge.py:392, 423, 450`).
- [x] **No new O(n²) regex re-parsing in pairwise loops.** The
  `merged_cache` parallel list (already in upstream `main`) caches
  `(lines, name, normalized_name, tokens)` per merged item; the inner
  loop never re-parses. Verified by reading the loop end-to-end.
- [x] No `wait()`-mocked test loop without a small `feed_config.PROVIDER_TIMEOUT` patch — N/A, no test-loop changes.

### 💧 Purist — Static analysis
- [x] `ruff check src/ tests/` is clean — verified: `All checks passed!`.
- [x] `python3 -m mypy` is clean for new/modified code — verified: 0 new errors. The 8 pre-existing errors in `src/utils/http.py` are unchanged (untyped urllib3/dnspython subclasses).
- [x] No `# type: ignore` or `# noqa` added to hide a structural issue — none added.
- [x] No new mypy-allowlist entries — none needed.

### 🥼 Surgeon — Complexity
- [x] **No new function exceeds C901 = 15** — verified via
  `python scripts/check_complexity.py`:
  ```
  baseline functions: 23
  new violations    : 0
  increased         : 0
  ```
- [x] If a refactor reduces a baselined function below threshold, baseline regenerated — `deduplicate_fuzzy` is not on the baseline (its complexity is unchanged by this edit; only the body-statement contents were swapped).
- [x] Extracted helpers are pure functions where possible — no new helpers introduced; the existing `_promote_newer_dates`, `_compute_overlap_cache`, `_has_significant_overlap_cached` shape is preserved.

### Ω Omega — Joint Sentinel + Surgeon
- [x] If `request_safe` or any of its 14 helpers were touched — **not touched**.
- [x] New security helpers carry a docstring beginning `Mitigates:` — N/A, no security helper added.

### 🧨 Saboteur — Resilience
- [x] Hostile-payload paths return `{}` / `[]` / `None` (fail-closed) — merge.py operates on already-validated cached items, no new payload entry-point.
- [x] `RecursionError` is caught alongside `JSONDecodeError` / `ET.ParseError` — N/A, no parser added or modified.
- [x] If a new provider is added, it uses `CircuitBreaker` — **no provider added**.
- [x] **Provider-level bulkhead preserved** — no orchestration code touched. `build_feed.py:920-929` per-future try/except remains.

### 🪶 Scribe — Developer experience
- [x] **New public functions / classes have PEP-257 docstrings** — `deduplicate_fuzzy` docstring updated to document both the parse cache (Apex pillar) and the new shallow-copy rationale.
- [x] Architecturally-visible changes update `docs/architecture.md` — this is a perf-only refactor inside an existing function; no architectural surface changes.
- [x] If this PR introduces a new pattern, an entry in the relevant `.jules/*.md` journal explains the rationale — no new pattern; this is an existing pattern (`dict(...)` shallow copy is widely used elsewhere in the project).

---

## Local verification commands

All commands run on this branch before push:

```bash
git fetch origin && git reset --hard origin/main   # ✅ synced; circuit_breaker.py + caps verified
ruff check src/ tests/ scripts/                    # ✅ All checks passed
python3 -m mypy                                    # ✅ no new errors (8 pre-existing in http.py)
python scripts/check_complexity.py                 # ✅ 0 new violations above 15
python -m pytest --timeout=60                      # ✅ 1948 passed, 3 skipped (40.6s)
python -m pytest tests/test_*merge*.py             # ✅ 38 passed (incl. trace test)
```

## Why shallow copy is safe — proof by exhaustion

Mutations on each branch of the merge loop, listed exhaustively:

| Branch | Lines | Mutations |
|---|---|---|
| Case 1 (VOR existing + ÖBB item) | merge.py:401-420 | `new_existing["description"]`, `new_existing["_identity"]`, `new_existing.pop("_calculated_identity")`, `_promote_newer_dates(new_existing, item)` (top-level date keys), `merged_items[idx] = new_existing`, cache slot |
| Case 2 (ÖBB existing + VOR item) | merge.py:423-446 | `new_existing["description"]`, `_promote_newer_dates(new_existing, existing)`, `new_existing["_identity"]`, `new_existing.pop("_calculated_identity")`, `merged_items[idx] = new_existing`, cache slot |
| Peer merge | merge.py:454-516 | `existing_copy["title"]`, `existing_copy["description"]`, `_promote_newer_dates(existing_copy, item)`, `existing_copy["guid"]`, `existing_copy["_identity"]`, `existing_copy.pop("_calculated_identity")`, `merged_items[idx] = existing_copy`, cache slot |

**Every mutation is a top-level key assignment or pop. No `.append()`,
no `[i] = …` on a nested list, no nested `dict.update()`. Shallow copy
is sufficient.**

https://claude.ai/code/session_017NPAFFFJ3ovWsnzNxk1rss

---
_Generated by [Claude Code](https://claude.ai/code/session_017NPAFFFJ3ovWsnzNxk1rss)_