### PR TITLE
fix(wl): drop Störung items without a line code

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -97,6 +97,14 @@ _INCOMPLETE_TITLE_TAIL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# WL Störung items must carry a line prefix (``U6:``, ``41E:``,
+# ``9/40/41/42:``); without it the user can't tell which line is
+# affected and the meldung is useless. Real cache items
+# ``Verkehrsunfall Betrieb ab Nordbrücke`` and ``Fahrtbehinderung
+# wegen Verkehrsunfall`` carry ``_identity='wl|störung|L=|D=...'``
+# (empty line set) and a title without a leading line marker.
+_WL_LINE_PREFIX_RE = re.compile(r"^[A-Za-z0-9]+(?:/[A-Za-z0-9]+)*\s*:\s+\S")
+
 
 def _post_filter_wl(items: list[Any]) -> list[Any]:
     """Defence-in-depth: normalise / drop bad WL items loaded from cache.
@@ -108,6 +116,12 @@ def _post_filter_wl(items: list[Any]) -> list[Any]:
     2. WL itself sometimes serves data that's truncated mid-sentence —
        ``Ersatzbus 41E hält gegenüber`` (with no location after
        ``gegenüber``) is meaningless. Such items are dropped.
+    3. WL Störung items occasionally arrive without any
+       ``relatedLines`` AND without a line code in the title — for
+       example ``Verkehrsunfall Betrieb ab Nordbrücke``. The line
+       prefix is the key signal for transit-line attribution; without
+       it the user can't tell which line is affected, so we drop
+       these too.
     """
     out: list[Any] = []
     for item in items:
@@ -125,6 +139,12 @@ def _post_filter_wl(items: list[Any]) -> list[Any]:
             # incomplete and the user gets no useful information.
             title_body = cleaned.split(":", 1)[-1].strip() if ":" in cleaned else cleaned
             if _INCOMPLETE_TITLE_TAIL_RE.search(title_body):
+                continue
+            # Drop WL Störung items without a line prefix — WL didn't
+            # provide a line code and the user can't disambiguate the
+            # affected line from the title alone.
+            category = item.get("category")
+            if category == "Störung" and not _WL_LINE_PREFIX_RE.match(cleaned):
                 continue
         out.append(item)
     return out

--- a/tests/test_post_filter_wl_no_line_prefix.py
+++ b/tests/test_post_filter_wl_no_line_prefix.py
@@ -1,0 +1,88 @@
+"""Regression test for Bug 29A (WL Störung items without a line code).
+
+Real WL Störung items occasionally arrive from the OGD API without
+any ``relatedLines`` AND without a line code anywhere in the title
+text. The fallback ``_detect_line_pairs_from_text`` then produces an
+empty line set, ``_ensure_line_prefix`` is a no-op, and the final
+title surfaces as e.g.:
+
+    "Verkehrsunfall Betrieb ab Nordbrücke"
+    "Fahrtbehinderung wegen Verkehrsunfall"
+
+The user has no way to tell which line is affected, so the meldung
+is unusable in a transit feed.
+
+The fix extends ``_post_filter_wl`` to drop WL Störung items whose
+title doesn't start with a line-prefix pattern (``U6:``, ``41E:``,
+``9/40/41/42:``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.build_feed import _post_filter_wl
+
+
+class TestStoerungWithoutLinePrefixDropped:
+    def test_verkehrsunfall_no_line_dropped(self) -> None:
+        items: list[dict[str, Any]] = [
+            {
+                "title": "Verkehrsunfall Betrieb ab Nordbrücke",
+                "category": "Störung",
+            }
+        ]
+        out = _post_filter_wl(items)
+        assert out == []
+
+    def test_fahrtbehinderung_no_line_dropped(self) -> None:
+        items: list[dict[str, Any]] = [
+            {
+                "title": "Fahrtbehinderung wegen Verkehrsunfall",
+                "category": "Störung",
+            }
+        ]
+        out = _post_filter_wl(items)
+        assert out == []
+
+    def test_with_line_prefix_kept(self) -> None:
+        items: list[dict[str, Any]] = [
+            {
+                "title": "26: Fahrtbehinderung Verkehrsunfall",
+                "category": "Störung",
+            }
+        ]
+        out = _post_filter_wl(items)
+        assert len(out) == 1
+
+    def test_compound_line_prefix_kept(self) -> None:
+        items: list[dict[str, Any]] = [
+            {
+                "title": "9/40/41/42: Gleisbauarbeiten",
+                "category": "Störung",
+            }
+        ]
+        out = _post_filter_wl(items)
+        assert len(out) == 1
+
+    def test_u_bahn_prefix_kept(self) -> None:
+        items: list[dict[str, Any]] = [
+            {
+                "title": "U6: Verspätung wegen Schadhaftem Fahrzeug",
+                "category": "Störung",
+            }
+        ]
+        out = _post_filter_wl(items)
+        assert len(out) == 1
+
+    def test_hinweis_without_prefix_kept(self) -> None:
+        # Only Störung is dropped — Hinweis items can have unusual
+        # title shapes without a line prefix and should be left alone.
+        items: list[dict[str, Any]] = [
+            {
+                "title": "Sonderbetrieb Wings for Life Run",
+                "category": "Hinweis",
+            }
+        ]
+        out = _post_filter_wl(items)
+        assert len(out) == 1


### PR DESCRIPTION
## Summary

User feedback: a feed item appeared with title `Verkehrsunfall Betrieb ab Nordbrücke` and description `[Am 08.05.2026]` — no line code, no useful information.

### Bug 29A — WL Störung items without a line code

Confirmed against the live cache. WL OGD occasionally serves a Störung item without `relatedLines` AND without a line code anywhere in the title text. The cached `_identity` carries an empty line set (`L=`) and the rendered feed entry shows:

```
T: "Verkehrsunfall Betrieb ab Nordbrücke"
D: "[Am 08.05.2026]"
```

Without a line code the user has no way to tell which line is affected; the meldung is unusable in a transit feed.

Two such items in the current cache (both Verkehrsunfall around Nordbrücke):
- `Verkehrsunfall Betrieb ab Nordbrücke`
- `Fahrtbehinderung wegen Verkehrsunfall`

### Fix

Extend `_post_filter_wl` to drop WL Störung items whose title doesn't match the line-prefix pattern (`U6:`, `41E:`, `9/40/41/42:`). Hinweis items are left untouched — they occasionally have unusual title shapes without a line prefix that are still informative.

## Test plan

- [x] 6 new regression tests in `tests/test_post_filter_wl_no_line_prefix.py`
- [x] All earlier WL post-filter tests still pass
- [x] `pytest tests/` — 2036 passed, 3 skipped
- [x] `mypy --strict` — clean
- [x] `ruff check` — clean
- [x] Reproduction directly verified against current cache (2 items dropped)

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_