### PR TITLE
ci(manual-full-refresh): add GTFS Stammstrecke cache refresh step

### DIFF
--- a/.github/workflows/manual-full-refresh.yml
+++ b/.github/workflows/manual-full-refresh.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Refresh VOR cache
         run: python scripts/update_vor_cache.py
 
+      - name: Refresh GTFS Stammstrecke cache
+        run: python scripts/update_gtfs_cache.py
+
       # ----- 2) Stationsverzeichnis aktualisieren -----
       - name: Refresh VOR stop list (best-effort)
         run: |


### PR DESCRIPTION
## Summary

Add the missing `GTFS Stammstrecke cache` refresh step to `.github/workflows/manual-full-refresh.yml` so the manual sammel-workflow honours its stated contract *„aktualisiert in einem Lauf saemtliche Caches"*.

## Background

PR #1352 added the GTFS Stammstrecke cache as a separate cache-driven provider:

- `cache/gtfs_stammstrecke/events.json` (persistent state)
- `scripts/update_gtfs_cache.py` (write half, runs every 30 minutes via `update-gtfs-cache.yml`)
- `src/providers/gtfs_stammstrecke.py` (read half, consumed by `build_feed`)

The four other cache scripts (`update_baustellen_cache.py`, `update_wl_cache.py`, `update_oebb_cache.py`, `update_vor_cache.py`) are all invoked from `manual-full-refresh.yml`, but the new GTFS script was not added when the cache-driven refactor landed. A manual trigger therefore leaves the Stammstrecke cache at whatever the last 30-minute cron run wrote — inconsistent with the workflow's documented "alles neu" semantics.

## Change

```diff
       - name: Refresh VOR cache
         run: python scripts/update_vor_cache.py

+      - name: Refresh GTFS Stammstrecke cache
+        run: python scripts/update_gtfs_cache.py
+
       # ----- 2) Stationsverzeichnis aktualisieren -----
```

Placed structurally between VOR (the last per-source cache) and the station-directory section. The script:

- needs no secrets (the GTFS-RT endpoint is public + trusted-host allow-listed);
- is offline-resilient (Circuit Breaker + `fetch_content_safe` + trusted-host validation, all return non-zero exit codes that the orchestrator handles via `set -e`);
- matches the existing one-liner pattern of the other four refresh steps.

## Test plan

- [x] `python -m pytest --timeout=60`: 2277 passed, 3 skipped
- [x] `mypy --no-pretty src tests`: clean
- [x] `ruff check`: clean
- [x] No code changes — only a YAML addition mirroring the existing pattern
- [x] CI status will validate the workflow YAML syntax via the on-PR checks


---
_Generated by [Claude Code](https://claude.ai/code/session_01EyDHP8qDMAyFAkNxzAWcaJ)_