### PR TITLE
feat(geo): coordinate inertia — absorb upstream API drift in stations.json

### DIFF
--- a/cache/vor_929f1c/last_run.json
+++ b/cache/vor_929f1c/last_run.json
@@ -1,9 +1,8 @@
 {
   "daily_limit": 100,
-  "events_collected": 0,
-  "last_run_at": "2026-05-08T22:13:03.435833+00:00",
-  "last_run_at_local": "2026-05-09T00:13:03.435833+02:00",
-  "requests_used_today": 3,
+  "last_run_at": "2026-05-08T23:12:04.365751+00:00",
+  "last_run_at_local": "2026-05-09T01:12:04.365751+02:00",
+  "requests_used_today": 1,
   "stations_queried": 2,
-  "status": "ok"
+  "status": "api_unreachable"
 }

--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -47,6 +47,7 @@ try:  # pragma: no cover - convenience for module execution
         read_capped_text,
         validate_zip_archive_safe,
     )
+    from src.utils.geo import apply_coordinate_inertia
     from src.utils.http import fetch_content_safe, session_with_retries
     from src.utils.stations import is_in_vienna as _is_point_in_vienna
 except ModuleNotFoundError:  # pragma: no cover - fallback when installed as package
@@ -56,6 +57,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when installed as pac
         read_capped_text,
         validate_zip_archive_safe,
     )
+    from utils.geo import apply_coordinate_inertia  # type: ignore[no-redef]
     from utils.http import fetch_content_safe, session_with_retries  # type: ignore[no-redef]
     from utils.stations import is_in_vienna as _is_point_in_vienna  # type: ignore[no-redef]
 
@@ -261,6 +263,24 @@ class Station:
 
     def update_from_entry(self, entry: Mapping[str, object]) -> None:
         base_keys = {"bst_id", "bst_code", "name", "in_vienna", "pendler", "vor_id"}
+
+        # Coordinate Inertia: capture the existing coords BEFORE the
+        # generic extras-loop (below) overwrites them. We use these
+        # later to decide whether to absorb upstream drift via
+        # ``apply_coordinate_inertia``.
+        existing_lat_raw = self.extras.get("latitude")
+        existing_lon_raw = self.extras.get("longitude")
+        existing_lat = (
+            float(existing_lat_raw)
+            if isinstance(existing_lat_raw, int | float)
+            else None
+        )
+        existing_lon = (
+            float(existing_lon_raw)
+            if isinstance(existing_lon_raw, int | float)
+            else None
+        )
+
         for key, value in entry.items():
             if key == "vor_id":
                 if self.vor_id is None and isinstance(value, str) and value.strip():
@@ -272,12 +292,23 @@ class Station:
 
         lat = entry.get("latitude") or entry.get("_lat")
         lng = entry.get("longitude") or entry.get("_lng")
-        if isinstance(lat, int | float):
-            latitude = float(lat)
-            self.extras["latitude"] = latitude
-        if isinstance(lng, int | float):
-            longitude = float(lng)
-            self.extras["longitude"] = longitude
+        new_lat = float(lat) if isinstance(lat, int | float) else None
+        new_lon = float(lng) if isinstance(lng, int | float) else None
+
+        # Resolve the final coordinate via the inertia helper. Drifts
+        # below ``STATION_DRIFT_TOLERANCE_METERS`` (default 150 m) are
+        # absorbed — the existing coords win, eliminating churn-only
+        # diffs in ``data/stations.json``. Drifts at or above the
+        # threshold are accepted as legitimate relocations. First-time
+        # coords (no existing) and missing-from-upstream cases are
+        # handled by the helper's rules 1+2.
+        merged_lat, merged_lon = apply_coordinate_inertia(
+            existing_lat, existing_lon, new_lat, new_lon
+        )
+        if merged_lat is not None:
+            self.extras["latitude"] = merged_lat
+        if merged_lon is not None:
+            self.extras["longitude"] = merged_lon
 
 
 @dataclass

--- a/src/places/normalize.py
+++ b/src/places/normalize.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import math
 import unicodedata
-from typing import Final
+
+# The canonical Haversine implementation lives in ``src.utils.geo``;
+# re-export under the legacy ``haversine_m`` name so existing
+# ``src.places.merge`` callers keep working without churn.
+from ..utils.geo import calculate_distance_meters as haversine_m
 
 __all__ = ["normalize_name", "haversine_m"]
-
-_EARTH_RADIUS_M: Final = 6_371_000.0
 
 
 def _strip_accents(value: str) -> str:
@@ -26,25 +27,3 @@ def normalize_name(name: str) -> str:
     stripped = " ".join(name.strip().split())
     lowered = stripped.casefold()
     return _strip_accents(lowered)
-
-
-def haversine_m(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
-    """Return the great-circle distance between two coordinates in metres."""
-    if not (math.isfinite(lat1) and math.isfinite(lng1) and math.isfinite(lat2) and math.isfinite(lng2)):
-        raise ValueError("Coordinates must be finite numbers")
-    if not (-90.0 <= lat1 <= 90.0 and -90.0 <= lat2 <= 90.0):
-        raise ValueError("Latitude must be between -90.0 and 90.0")
-    if not (-180.0 <= lng1 <= 180.0 and -180.0 <= lng2 <= 180.0):
-        raise ValueError("Longitude must be between -180.0 and 180.0")
-
-    phi1 = math.radians(lat1)
-    phi2 = math.radians(lat2)
-    d_phi = math.radians(lat2 - lat1)
-    d_lambda = math.radians(lng2 - lng1)
-
-    sin_half_d_phi = math.sin(d_phi / 2.0)
-    sin_half_d_lambda = math.sin(d_lambda / 2.0)
-
-    a = sin_half_d_phi ** 2 + math.cos(phi1) * math.cos(phi2) * sin_half_d_lambda ** 2
-    c = 2.0 * math.atan2(math.sqrt(a), math.sqrt(max(0.0, 1.0 - a)))
-    return _EARTH_RADIUS_M * c

--- a/src/utils/geo.py
+++ b/src/utils/geo.py
@@ -1,0 +1,169 @@
+"""Geographic utilities — distance computation and coordinate inertia.
+
+This module is the project's single source of truth for geo-spatial
+math. It exposes:
+
+* :func:`calculate_distance_meters` — great-circle distance between two
+  WGS-84 GPS coordinates, computed with the Haversine formula. The
+  implementation is dependency-free (stdlib ``math`` only) and rejects
+  non-finite or out-of-range inputs early so a malformed upstream payload
+  cannot poison downstream callers.
+* :data:`STATION_DRIFT_TOLERANCE_METERS` — the coordinate-inertia
+  threshold used by ``scripts/update_station_directory.py`` to decide
+  whether an upstream API's new coordinate replaces the existing one.
+* :func:`apply_coordinate_inertia` — the inertia helper that returns
+  either the existing coords (drift below threshold, absorb the noise)
+  or the new coords (genuine relocation beyond threshold).
+
+Why coordinate inertia?
+
+Large transit stations (airports, multi-platform mainline stations)
+have a "valid" coordinate that legitimately varies by 10–50 m
+depending on the data provider's chosen reference point (entrance,
+platform centre, ticketing kiosk). Each upstream refresh nudges the
+recorded coordinate by a few metres; without dampening, every refresh
+cycle pollutes ``data/stations.json`` with churn-only diffs and
+breaks brittle ``pytest.approx`` test assertions on the new values.
+
+The 150 m threshold is well above typical inter-provider drift
+(most stations stay within ~30 m even after years of provider
+re-surveys) and well below any real station relocation (a station
+that moves 150+ m has effectively been rebuilt). Tunes naturally
+between "absorb noise" and "track legitimate moves".
+
+The duplicate Haversine implementation in ``src/places/normalize.py``
+is now a thin re-export of :func:`calculate_distance_meters` so the
+formula lives in exactly one place.
+"""
+from __future__ import annotations
+
+import math
+from typing import Final
+
+__all__ = [
+    "STATION_DRIFT_TOLERANCE_METERS",
+    "apply_coordinate_inertia",
+    "calculate_distance_meters",
+]
+
+_EARTH_RADIUS_M: Final = 6_371_000.0
+
+#: Maximum coordinate drift (in metres) that the inertia helper will
+#: absorb before accepting an upstream re-survey. See module docstring
+#: for tuning rationale.
+STATION_DRIFT_TOLERANCE_METERS: Final = 150.0
+
+
+def calculate_distance_meters(
+    lat1: float, lon1: float, lat2: float, lon2: float
+) -> float:
+    """Return the great-circle distance between two WGS-84 coordinates.
+
+    Computes the Haversine distance — the shortest path along the
+    surface of a sphere of radius :data:`_EARTH_RADIUS_M`. The formula
+    is accurate to ~0.5% over typical inter-station distances; that
+    error is well below the inertia threshold and irrelevant for any
+    use within the project.
+
+    Args:
+        lat1: Latitude of the first point in decimal degrees.
+        lon1: Longitude of the first point in decimal degrees.
+        lat2: Latitude of the second point in decimal degrees.
+        lon2: Longitude of the second point in decimal degrees.
+
+    Returns:
+        Distance between the two points in metres (float, ≥ 0).
+
+    Raises:
+        ValueError: If any input is non-finite (NaN/inf) or outside
+            the valid lat/lon ranges (``-90 ≤ lat ≤ 90``,
+            ``-180 ≤ lon ≤ 180``).
+    """
+    if not (
+        math.isfinite(lat1)
+        and math.isfinite(lon1)
+        and math.isfinite(lat2)
+        and math.isfinite(lon2)
+    ):
+        raise ValueError("Coordinates must be finite numbers")
+    if not (-90.0 <= lat1 <= 90.0 and -90.0 <= lat2 <= 90.0):
+        raise ValueError("Latitude must be between -90.0 and 90.0")
+    if not (-180.0 <= lon1 <= 180.0 and -180.0 <= lon2 <= 180.0):
+        raise ValueError("Longitude must be between -180.0 and 180.0")
+
+    phi1 = math.radians(lat1)
+    phi2 = math.radians(lat2)
+    d_phi = math.radians(lat2 - lat1)
+    d_lambda = math.radians(lon2 - lon1)
+
+    sin_half_d_phi = math.sin(d_phi / 2.0)
+    sin_half_d_lambda = math.sin(d_lambda / 2.0)
+
+    a = (
+        sin_half_d_phi**2
+        + math.cos(phi1) * math.cos(phi2) * sin_half_d_lambda**2
+    )
+    c = 2.0 * math.atan2(math.sqrt(a), math.sqrt(max(0.0, 1.0 - a)))
+    return _EARTH_RADIUS_M * c
+
+
+def apply_coordinate_inertia(
+    existing_lat: float | None,
+    existing_lon: float | None,
+    new_lat: float | None,
+    new_lon: float | None,
+    tolerance_m: float = STATION_DRIFT_TOLERANCE_METERS,
+) -> tuple[float | None, float | None]:
+    """Return the coordinate pair that should replace the existing one.
+
+    Implements "coordinate inertia": absorb upstream-API coordinate
+    drift below ``tolerance_m`` so ``data/stations.json`` does not
+    churn on every refresh cycle. The resolution rules are:
+
+    1. **No new coords** (either component is ``None``) → keep
+       existing. The upstream payload didn't supply usable coords for
+       this station, so there's nothing to merge.
+    2. **No existing coords** → accept new. First-time coords for a
+       station are always taken as authoritative.
+    3. **Both present** → compute Haversine distance.
+       * Below ``tolerance_m`` → keep existing (absorbed drift).
+       * At or above ``tolerance_m`` → accept new (genuine relocation).
+    4. **Invalid coords** (out of range / non-finite) → accept new
+       (ValueError from the distance helper is treated as "no
+       comparable existing coord", same as rule 2). This trusts the
+       upstream over a corrupt local cache.
+
+    Args:
+        existing_lat: Existing latitude or ``None``.
+        existing_lon: Existing longitude or ``None``.
+        new_lat: Newly fetched latitude or ``None``.
+        new_lon: Newly fetched longitude or ``None``.
+        tolerance_m: Inertia threshold in metres. Defaults to
+            :data:`STATION_DRIFT_TOLERANCE_METERS`. Override in tests
+            or to tighten/loosen for specific station classes.
+
+    Returns:
+        ``(latitude, longitude)`` tuple — either the existing pair
+        (when drift was absorbed) or the new pair (when the new
+        coordinates are authoritative). Either component can be
+        ``None`` only when both input pairs were ``None``.
+    """
+    # Rule 1: no new coords → keep existing.
+    if new_lat is None or new_lon is None:
+        return existing_lat, existing_lon
+
+    # Rule 2: no existing coords → accept new.
+    if existing_lat is None or existing_lon is None:
+        return new_lat, new_lon
+
+    # Rules 3 & 4: compare distance, accept new on invalid input.
+    try:
+        drift = calculate_distance_meters(
+            existing_lat, existing_lon, new_lat, new_lon
+        )
+    except ValueError:
+        return new_lat, new_lon
+
+    if drift < tolerance_m:
+        return existing_lat, existing_lon
+    return new_lat, new_lon

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -287,3 +287,64 @@ def reset_circuit_breakers() -> Iterator[None]:
         reset = getattr(breaker, "reset", None)
         if callable(reset):
             reset()
+
+
+# ---------------------------------------------------------------------------
+# Coordinate-proximity test helper
+#
+# Replacement for the brittle ``pytest.approx(<lat>) ; pytest.approx(<lon>)``
+# pattern in tests that pin station coordinates. ``pytest.approx`` uses a
+# default relative tolerance of ~1e-6 which at lat=48° is roughly 5 cm
+# east-west — far tighter than any upstream API's coordinate stability,
+# so every refresh of ``data/stations.json`` would otherwise break tests
+# even when the new coords are operationally equivalent (same building,
+# different platform reference).
+#
+# ``assert_coords_close`` instead measures the great-circle distance
+# between the obtained and expected coords and asserts it is within
+# ``max_meters``. Same semantics as ``apply_coordinate_inertia`` so
+# tests and production agree on what "the same point" means.
+# ---------------------------------------------------------------------------
+
+def assert_coords_close(
+    lat1: float | None,
+    lon1: float | None,
+    lat2: float,
+    lon2: float,
+    max_meters: float = 150.0,
+) -> None:
+    """Assert two coordinate pairs are within ``max_meters`` of each other.
+
+    The first pair (``lat1``/``lon1``) is the value under test and is
+    typed ``float | None`` to match the project's ``StationInfo``
+    shape — many station-lookup return types expose coordinates as
+    optional. ``None`` is rejected with an explicit assertion failure
+    so the caller doesn't have to thread ``assert info.latitude is
+    not None`` boilerplate through every test.
+
+    Args:
+        lat1: First-pair latitude (typically the value under test).
+            ``None`` is treated as a test failure.
+        lon1: First-pair longitude. ``None`` → test failure.
+        lat2: Second-pair latitude (the expected value).
+        lon2: Second-pair longitude.
+        max_meters: Maximum allowed great-circle distance, defaults to
+            150 m to match :data:`STATION_DRIFT_TOLERANCE_METERS`.
+
+    Raises:
+        AssertionError: If either of ``lat1`` / ``lon1`` is ``None``,
+            or the two points are further apart than ``max_meters``.
+            The error message names both pairs and the measured
+            distance for easy diagnosis.
+    """
+    from src.utils.geo import calculate_distance_meters
+
+    assert lat1 is not None and lon1 is not None, (
+        f"obtained coordinates were None (lat={lat1!r}, lon={lon1!r}); "
+        f"expected ({lat2}, {lon2})"
+    )
+    distance = calculate_distance_meters(lat1, lon1, lat2, lon2)
+    assert distance <= max_meters, (
+        f"coordinates ({lat1}, {lon1}) and ({lat2}, {lon2}) are "
+        f"{distance:.1f} m apart (max allowed: {max_meters} m)"
+    )

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -1,0 +1,147 @@
+"""Tests for ``src/utils/geo.py``.
+
+Covers:
+
+* ``calculate_distance_meters`` — Haversine basics, edge cases, and
+  input validation.
+* ``apply_coordinate_inertia`` — the four resolution rules (no-new,
+  no-existing, drift-below-threshold, drift-above-threshold) plus the
+  invalid-coord fallback.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from src.utils.geo import (
+    STATION_DRIFT_TOLERANCE_METERS,
+    apply_coordinate_inertia,
+    calculate_distance_meters,
+)
+
+
+# ---------- calculate_distance_meters ----------
+
+
+def test_distance_zero_for_same_point() -> None:
+    assert calculate_distance_meters(48.2, 16.4, 48.2, 16.4) == pytest.approx(0.0)
+
+
+def test_distance_one_degree_latitude_at_equator() -> None:
+    """1° of latitude is ~111 km everywhere on Earth."""
+    distance = calculate_distance_meters(0.0, 0.0, 1.0, 0.0)
+    assert 110_000 < distance < 112_000
+
+
+def test_distance_known_route_wien_hbf_to_flughafen() -> None:
+    """Wien Hbf (48.185, 16.376) to Flughafen Wien (48.120, 16.564) is
+    ~16 km along the great circle. Use a wide tolerance — the Haversine
+    on an oblate Earth has ~0.5% systematic bias."""
+    distance = calculate_distance_meters(48.185, 16.376, 48.120, 16.564)
+    assert 14_000 < distance < 18_000
+
+
+def test_distance_symmetric() -> None:
+    forward = calculate_distance_meters(48.0, 16.0, 49.0, 17.0)
+    backward = calculate_distance_meters(49.0, 17.0, 48.0, 16.0)
+    assert forward == pytest.approx(backward)
+
+
+def test_distance_rejects_nan() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        calculate_distance_meters(float("nan"), 16.0, 48.0, 17.0)
+
+
+def test_distance_rejects_inf() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        calculate_distance_meters(48.0, 16.0, float("inf"), 17.0)
+
+
+def test_distance_rejects_out_of_range_lat() -> None:
+    with pytest.raises(ValueError, match="Latitude"):
+        calculate_distance_meters(91.0, 16.0, 48.0, 17.0)
+
+
+def test_distance_rejects_out_of_range_lon() -> None:
+    with pytest.raises(ValueError, match="Longitude"):
+        calculate_distance_meters(48.0, 181.0, 48.0, 17.0)
+
+
+def test_distance_extreme_corners() -> None:
+    """North pole to South pole — half the earth's circumference."""
+    distance = calculate_distance_meters(-90.0, 0.0, 90.0, 0.0)
+    expected = math.pi * 6_371_000.0  # half-circumference
+    assert distance == pytest.approx(expected, rel=0.01)
+
+
+# ---------- apply_coordinate_inertia ----------
+
+
+def test_inertia_no_new_keeps_existing() -> None:
+    """Rule 1: no new coords → keep existing."""
+    result = apply_coordinate_inertia(48.0, 16.0, None, None)
+    assert result == (48.0, 16.0)
+
+
+def test_inertia_partial_new_keeps_existing() -> None:
+    """Rule 1 (partial): only one of the new coords is present →
+    treat as no usable update."""
+    assert apply_coordinate_inertia(48.0, 16.0, 49.0, None) == (48.0, 16.0)
+    assert apply_coordinate_inertia(48.0, 16.0, None, 17.0) == (48.0, 16.0)
+
+
+def test_inertia_no_existing_accepts_new() -> None:
+    """Rule 2: first-time coords always taken as authoritative."""
+    assert apply_coordinate_inertia(None, None, 48.0, 16.0) == (48.0, 16.0)
+
+
+def test_inertia_partial_existing_accepts_new() -> None:
+    """Rule 2 (partial): half-existing coords are unusable; accept new."""
+    assert apply_coordinate_inertia(48.0, None, 49.0, 17.0) == (49.0, 17.0)
+    assert apply_coordinate_inertia(None, 16.0, 49.0, 17.0) == (49.0, 17.0)
+
+
+def test_inertia_below_threshold_keeps_existing() -> None:
+    """Rule 3a: drift below tolerance → keep existing (absorbed)."""
+    # Vienna airport: shift latitude by ~5 m (<< 150 m tolerance)
+    existing = (48.12056, 16.563659)
+    new_lat = 48.12056 + 5e-5  # ~5.5 m north
+    result = apply_coordinate_inertia(*existing, new_lat, 16.563659)
+    assert result == existing  # absorbed
+
+
+def test_inertia_at_threshold_accepts_new() -> None:
+    """Rule 3b: drift at/above tolerance → accept new (relocation)."""
+    # Same airport but shift latitude by ~200 m (>> 150 m tolerance).
+    # 0.002 deg lat ≈ 222 m at this latitude.
+    existing = (48.12056, 16.563659)
+    new = (48.12056 + 0.002, 16.563659)
+    result = apply_coordinate_inertia(*existing, *new)
+    assert result == new
+
+
+def test_inertia_custom_tolerance() -> None:
+    """Threshold is overridable per call."""
+    existing = (48.0, 16.0)
+    # 0.001° lat at 48°N is ~111 m — between the default 150 m
+    # and a tight 50 m threshold.
+    new = (48.001, 16.0)
+    # Default: 111 m < 150 m → absorbed
+    assert apply_coordinate_inertia(*existing, *new) == existing
+    # Tight: 111 m > 50 m → accepted
+    assert apply_coordinate_inertia(
+        *existing, *new, tolerance_m=50.0
+    ) == new
+
+
+def test_inertia_rule4_invalid_existing_accepts_new() -> None:
+    """Rule 4: invalid existing coords (out-of-range) are treated as
+    'no comparable existing' — accept new."""
+    # Existing lat=999 is out of range → ValueError → accept new
+    assert apply_coordinate_inertia(999.0, 16.0, 49.0, 17.0) == (49.0, 17.0)
+
+
+def test_inertia_default_tolerance_constant() -> None:
+    """The exported constant matches the documented value."""
+    assert STATION_DRIFT_TOLERANCE_METERS == 150.0

--- a/tests/test_vor_stations_directory.py
+++ b/tests/test_vor_stations_directory.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 
 from src.utils.stations import station_info, vor_station_ids
+from tests.conftest import assert_coords_close
 
 
 def test_vor_lookup_by_id() -> None:
@@ -16,8 +17,9 @@ def test_vor_lookup_by_id() -> None:
     assert info.name == "Wien Hauptbahnhof"
     assert info.vor_id == "490134900"
     assert info.in_vienna is True
-    assert info.latitude == pytest.approx(48.185184)
-    assert info.longitude == pytest.approx(16.376413)
+    # Spatial assertion (Haversine ≤ 150 m) — absorbs upstream
+    # coordinate re-surveys without breaking the test.
+    assert_coords_close(info.latitude, info.longitude, 48.185184, 16.376413)
 
 
 def test_vor_bst_code_prefers_directory_entry(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -146,12 +148,11 @@ def test_vor_lookup_by_alias() -> None:
         "430470800",
     )
     assert info.in_vienna is False
-    # Coordinates are sourced from the upstream VOR/ÖBB station directory
-    # and drift slightly on each refresh. Updated 2026-05-08 after the
-    # upstream re-survey shifted latitude by ~6m. Re-update if station
-    # data refresh shifts these again.
-    assert info.latitude == pytest.approx(48.1200338)
-    assert info.longitude == pytest.approx(16.5640677)
+    # Spatial assertion (Haversine ≤ 150 m) — Flughafen Wien's
+    # coordinates drift between provider re-surveys (entrance vs.
+    # platform-centre reference); drift up to 150 m is absorbed.
+    # See ``src/utils/geo.py`` for the inertia rationale.
+    assert_coords_close(info.latitude, info.longitude, 48.12056, 16.563659)
 
 
 def test_vor_alias_with_municipality_prefix() -> None:


### PR DESCRIPTION
## Summary

Implements **Coordinate Inertia** — three-layer defence against upstream-API GPS drift that was causing constant `data/stations.json` churn and brittle `pytest.approx` test failures (most recently #1359, where Flughafen Wien needed a manual coord update).

| Layer | Where | Purpose |
|---|---|---|
| 1. Math | `src/utils/geo.py` | `calculate_distance_meters` (Haversine), `STATION_DRIFT_TOLERANCE_METERS = 150.0` |
| 2. Production merge | `scripts/update_station_directory.py::Station.update_from_entry` | Drift < 150 m → keep existing coords (no diff). Drift ≥ 150 m → accept relocation. |
| 3. Test assertions | `tests/conftest.py::assert_coords_close` | Spatial-proximity asserts, replaces brittle `pytest.approx(lat); pytest.approx(lon)` |

## Why 150 m

Above typical inter-provider drift (most stations stay within ~30 m even after years of re-surveys) and well below any real station relocation (a station that moves 150+ m has effectively been rebuilt). `apply_coordinate_inertia` exposes `tolerance_m` as a kwarg so tests and special-case callers can tighten or loosen it.

## Resolution rules (in `apply_coordinate_inertia`)

1. **No new coords** (either component is `None`) → keep existing
2. **No existing coords** → accept new (first-time)
3. **Both present** → Haversine distance:
   - `< tolerance_m` → keep existing (absorbed drift)
   - `≥ tolerance_m` → accept new (legitimate relocation)
4. **Invalid coords** (out-of-range, non-finite) → `ValueError` from helper → accept new (treated as "no comparable existing", trusts upstream over corrupt local cache)

## Refactoring

`tests/test_vor_stations_directory.py` — the two coordinate assertions at L19-20 and L153-154 now use `assert_coords_close`. The 2026-05-08 manual update on Flughafen Wien (`48.1200338 / 16.5640677`, see #1359) is reverted to the canonical `48.12056 / 16.563659`; the spatial assertion absorbs the upstream drift without any test-side maintenance.

`tests/test_is_in_vienna_coordinates.py` was scanned per the task brief but contains no `pytest.approx` patterns — only boolean inside-polygon checks. No changes needed.

The duplicate Haversine in `src/places/normalize.py` is now a thin re-export of `calculate_distance_meters` so the formula lives in exactly one place.

## How this stabilizes `data/stations.json`

**Before:** every upstream refresh of WL/VOR/ÖBB/GTFS data shifted a handful of station coords by 5-30 m. Each shift produced a churn-only diff in `stations.json` (no operational change, just float noise). `pytest.approx`'s default ≈1e-6 relative tolerance — about 5 cm at Vienna's latitude — broke the next test run, forcing manual test-fix PRs (most recent: #1359).

**After:** the `Station.update_from_entry` merge absorbs drift below 150 m by reusing the existing coord, so no diff lands in `stations.json` for sub-threshold noise. Tests assert spatial proximity (Haversine ≤ 150 m) so they survive every legitimate refresh. `stations.json` ratchets **only on genuine relocations** (≥150 m), which are operationally meaningful and review-worthy.

## New tests (`tests/test_geo.py`, 18 cases)

- `calculate_distance_meters`: zero-distance same-point, 1° latitude (~111 km), real-world Wien Hbf → Flughafen Wien (~16 km), symmetry, NaN/inf/out-of-range rejection, polar extremes
- `apply_coordinate_inertia`: all four resolution rules, partial-coord cases, custom tolerance, invalid existing fallback, default-tolerance constant pin

## Test plan

- [x] `pytest` — **2229 passed, 3 skipped** (was 2211 → +18 from `test_geo.py`)
- [x] `pytest tests/test_geo.py` — 18 passed in 0.35s
- [x] `pytest tests/test_vor_stations_directory.py` — 10 passed in 0.41s
- [x] `ruff check src/ tests/ scripts/` — All checks passed!
- [x] `python3 -m mypy --no-pretty src tests` (CI-pinned 1.10.1) — Success: no issues found in 407 source files
- [x] `scripts/run_static_checks.py` — EXIT 0
- [x] `scripts/check_complexity.py` — EXIT 0 (23 baselined, 0 new)

https://claude.ai/code/session_012ScpqMHeJUbX722xL9DuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_012ScpqMHeJUbX722xL9DuSo)_