### PR TITLE
fix(stations): prefer extras-stored coords over name heuristic for in_vienna

### DIFF
--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -1590,12 +1590,39 @@ def _annotate_station_flags(
             info = locations.get(key)
             if info:
                 break
-        if info:
+        # Resolve in_vienna against the strongest available geo signal.
+        # Priority order:
+        #   (a) Fresh upstream LocationInfo from this run.
+        #   (b) Coords carried forward in ``extras`` by
+        #       ``_restore_existing_metadata`` from the prior
+        #       stations.json — already validated and inertia-merged.
+        #   (c) Name heuristic, last resort.
+        # Without (b), a single failed WL/ÖBB/VOR fetch (info=None) for a
+        # U-Bahn stop like "Stephansplatz" — whose name does NOT start
+        # with "Wien" — would silently flip ``in_vienna`` to False even
+        # though the persisted coords clearly fall inside the LANDESGRENZE
+        # polygon. The synthetic LocationInfo carries ``sources={"extras"}``
+        # so the WL-auto-promote check below remains a no-op for this path.
+        polygon_info: LocationInfo | None = info
+        if polygon_info is None:
+            extras_lat = station.extras.get("latitude")
+            extras_lon = station.extras.get("longitude")
+            if isinstance(extras_lat, int | float) and isinstance(
+                extras_lon, int | float
+            ):
+                polygon_info = LocationInfo(
+                    latitude=float(extras_lat),
+                    longitude=float(extras_lon),
+                    sources={"extras"},
+                )
+        if polygon_info is not None:
             # Coordinate Inertia (boundary-check layer): reuse the
             # previous polygon result when info coords haven't drifted
             # past STATION_DRIFT_TOLERANCE_METERS. See
             # ``_resolve_in_vienna_with_cache`` for the full rationale.
-            station.in_vienna = _resolve_in_vienna_with_cache(station, info)
+            station.in_vienna = _resolve_in_vienna_with_cache(
+                station, polygon_info
+            )
         else:
             station.in_vienna = _is_vienna_station(station.name)
         pendler_candidate = station.bst_id in pendler_ids

--- a/tests/test_update_station_directory_flags.py
+++ b/tests/test_update_station_directory_flags.py
@@ -81,6 +81,63 @@ def test_wl_vienna_station_does_not_become_pendler() -> None:
     assert station.pendler is False
 
 
+def test_extras_coords_override_name_heuristic_when_info_missing() -> None:
+    """When no fresh ``LocationInfo`` is available, ``_annotate_station_flags``
+    must fall back to the polygon check on extras-stored coords BEFORE the
+    name heuristic.
+
+    Regression: a U-Bahn stop like ``Stephansplatz`` carries valid coords in
+    ``extras`` (carried forward from the prior run by
+    ``_restore_existing_metadata``) but its name does NOT start with "Wien".
+    Without this fallback a single failed WL fetch flips ``in_vienna`` to
+    False because ``_is_vienna_station("Stephansplatz") == False``.
+    """
+    station = _make_station("Stephansplatz", bst_id="900900")
+    station.extras["latitude"] = 48.20849
+    station.extras["longitude"] = 16.37306
+
+    usd._annotate_station_flags([station], pendler_ids=set(), locations={})
+
+    assert station.in_vienna is True, (
+        "extras-stored coords inside the Vienna polygon must classify "
+        "in_vienna=True even when LocationInfo is missing"
+    )
+    assert station.pendler is False
+
+
+def test_extras_coords_keep_outside_station_pendler_eligible() -> None:
+    """The extras-coord fallback must also correctly classify outside
+    stations as in_vienna=False — otherwise a pendler-belt station with
+    extras coords would lose its pendler flag.
+    """
+    station = _make_station("Mödling", bst_id="1390")
+    station.extras["latitude"] = 48.085628
+    station.extras["longitude"] = 16.295474
+
+    usd._annotate_station_flags(
+        [station], pendler_ids={"1390"}, locations={}
+    )
+
+    assert station.in_vienna is False
+    assert station.pendler is True
+
+
+def test_name_heuristic_fires_only_when_no_coords_available() -> None:
+    """If extras has no coords AND no LocationInfo is provided, the
+    name heuristic remains the last-resort fallback (preserving legacy
+    behaviour for unenriched manual entries)."""
+    # No extras coords, no LocationInfo — the only signal is the name.
+    inside = _make_station("Wien Tunnelbach", bst_id="900901")
+    outside = _make_station("Tunnelbach", bst_id="900902")
+
+    usd._annotate_station_flags(
+        [inside, outside], pendler_ids=set(), locations={}
+    )
+
+    assert inside.in_vienna is True, "name starts with 'Wien' → True"
+    assert outside.in_vienna is False, "name does not match → False"
+
+
 def test_load_existing_treats_legacy_bst_id_entry_without_source_as_oebb(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Ground-truth audit of every station's stored `in_vienna` flag against `data/LANDESGRENZEOGD.json` returned **0 misclassifications today**, but uncovered a structural fragility worth fixing.

### The audit

A temporary script ran the production polygon classifier (`src.utils.stations.is_in_vienna`) against the persisted coordinates of all 196 stations and compared the result to the stored `in_vienna` boolean.

| Check | Result |
|---|---|
| Stations checked | 196 |
| Without coords (skipped) | 0 |
| Stored ↔ polygon discrepancies | **0** |
| Lat/Lon coord-swap candidates | 0 |
| Polygon parse → 1 polygon, 5637 vertices, bbox lat=[48.118, 48.323] lon=[16.182, 16.578] | ✓ matches Vienna |
| 10 spot-check landmarks (Stephansdom, Schönbrunn, Donauturm, Wien Hbf, Flughafen Schwechat, Wiener Neustadt Hbf, Klosterneuburg, Mödling, Bratislava, Schwechat town) | All correct |
| 8 stations within 500 m of polygon (canary cases — closest at 29 m) | All correct |
| Stale `_in_vienna_basis` cache traps | None — cache not yet populated post #1361 |

The existing `tests/test_station_coordinate_vienna_flags.py::test_coordinates_match_in_vienna_flag` already enforces this invariant on every CI run, which is why the data is clean.

### The structural fragility

In `_annotate_station_flags` (the cron's flag setter), the polygon decision was guarded by `if info:` only. When the upstream `LocationInfo` was unavailable (a single failed WL/ÖBB/VOR fetch), the code fell straight through to `_is_vienna_station(station.name)` — a name-based heuristic that returns `False` for any stop whose name doesn't start with `"Wien"`. The 10 U-Bahn stops in Wien with extracitized names — Stephansplatz, Schwedenplatz, Volkstheater, Stadtpark, Stubentor, Pilgramgasse, Neubaugasse, Messe – Prater, Kettenbrückengasse, Herrengasse — would silently flip to `in_vienna=False` until the next successful run.

Crucially, the station's `extras` dict still carried valid `latitude`/`longitude` from the prior run (carried forward by `_restore_existing_metadata`) — but those coords were never consulted.

### The fix

```python
polygon_info: LocationInfo | None = info
if polygon_info is None:
    extras_lat = station.extras.get("latitude")
    extras_lon = station.extras.get("longitude")
    if isinstance(extras_lat, int | float) and isinstance(extras_lon, int | float):
        polygon_info = LocationInfo(
            latitude=float(extras_lat),
            longitude=float(extras_lon),
            sources={"extras"},
        )
if polygon_info is not None:
    station.in_vienna = _resolve_in_vienna_with_cache(station, polygon_info)
else:
    station.in_vienna = _is_vienna_station(station.name)
```

Resolution priority: (a) fresh upstream `LocationInfo`, (b) extras-stored coords carried forward from prior run, (c) name heuristic as last resort. The synthetic `LocationInfo` carries `sources={"extras"}` so the legacy `"wl" in info.sources` auto-promote check below stays a no-op for this path — the WL-pendler-promotion semantics are preserved exactly.

### Regression tests

Three additions to `tests/test_update_station_directory_flags.py`:

1. `test_extras_coords_override_name_heuristic_when_info_missing` — Stephansplatz with extras coords + empty `locations` → must classify `in_vienna=True`. Would have failed pre-fix.
2. `test_extras_coords_keep_outside_station_pendler_eligible` — Mödling with extras coords + pendler whitelist → must stay `pendler=True, in_vienna=False`. Confirms outside stations also route correctly through the new path.
3. `test_name_heuristic_fires_only_when_no_coords_available` — paired stations `Wien Tunnelbach` / `Tunnelbach` with no coords anywhere → confirm the name heuristic still fires as the last-resort fallback (preserves legacy behaviour for unenriched manual entries).

## Test plan

- [x] `pytest -x -q` → 2248 passed / 3 skipped (full suite)
- [x] Targeted: `tests/test_update_station_directory_flags.py` + `test_in_vienna_cache.py` + `test_geo.py` + `test_is_in_vienna_coordinates.py` + `test_station_coordinate_vienna_flags.py` + `test_update_station_directory_pendler_candidates.py` → 60 passed / 1 skipped
- [x] `ruff check` on modified files → clean
- [x] `mypy` on modified files → clean
- [x] Temporary audit script deleted before commit (per task instructions)
- [x] No manual edits to `data/stations.json` — fix lives entirely in source code

https://claude.ai/code/session_012ScpqMHeJUbX722xL9DuSo

---
_Generated by [Claude Code](https://claude.ai/code/session_012ScpqMHeJUbX722xL9DuSo)_