### PR TITLE
security(logging): close BiDi-mark / Unicode-line-terminator gap in sanitize_log_message

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,42 @@
+## 2026-05-09 - BiDi-Mark / Unicode-Line-Terminator Gap in `sanitize_log_message`
+**Vulnerability:** The canonical log-injection / Trojan-Source defence
+(`src/utils/logging.py:_CONTROL_CHARS_RE`, used by every WARNING/ERROR
+site enforced via `test_sentinel_clear_text_logging_drift_utils`) covered
+ASCII C0/C1, the CVE-2021-42574 BiDi formatting controls
+(`‪-‮` and `⁦-⁩`), the zero-width family
+(`​-‍`), and the BOM (`﻿`) — but left five high-impact
+code points unhandled: `؜` (ARABIC LETTER MARK, ALM), `‎`
+(LRM), `‏` (RLM), ` ` (LINE SEPARATOR), ` ` (PARAGRAPH
+SEPARATOR). A hostile upstream payload routed through the canonical
+sanitiser could therefore (a) **forge log records** by embedding
+` `/` ` so any consumer that honours Unicode line
+terminators (ECMAScript-pre-2019 `JSON.parse`/`eval`, the GitHub
+PR-comment renderer, several YAML parsers, downstream SIEM splitters
+keying off Unicode whitespace) splits the sanitised entry into two
+records — letting the attacker inject fake `level=ERROR` markers,
+ts= prefixes, or whatever the operator triages on; or (b) **invert
+displayed text** in a Unicode-aware terminal via LRM/RLM/ALM, the same
+Trojan-Source primitive as the already-stripped `‪-‮` family
+but missing from every prior round of the regex. The companion regex
+in `src/utils/stations_validation.py:_UNSAFE_CHARS_RE` already covered
+` -‮`, so the codebase had divergent BiDi-defence shapes
+between the station validator and the canonical log sanitiser.
+**Learning:** When tightening BiDi / Unicode-line-terminator defences,
+audit the **union** across every sibling regex in the project — not
+just the one that surfaced the fix. The canonical pin lives in
+`_CONTROL_CHARS_RE` (`src/utils/logging.py`); the station validator's
+`_UNSAFE_CHARS_RE` is the closest sibling. Three follow-on rules: (1)
+Python's regex `\s` matches ` `/` ` (so they're already
+caught by `_UNSAFE_URL_CHARS` via `\s`) but does NOT match `‎`
+/`‏`/`؜`, so a `\s`-based defence is not equivalent to an
+explicit code-point list — the audit walker must enumerate. (2) The
+`_CONTROL_CHARS_RE.sub("")` step runs **after** `\n`/`\r`/`\t` are
+escaped to literal `\\n`/`\\r`/`\\t`, so the fix doesn't touch the
+existing newline-escape contract — only widens the strip set. (3) The
+new code points are byte-shape-similar to existing ones (BiDi marks /
+line terminators), so the regex extension is a single character-class
+union; no behavioural changes elsewhere.
+
 ## 2026-05-08 - Technical Debt Cleanup: Five OSM-First / Google-Fallback Resilience Optimisations + Documentation Sync (CI Smoke Gate, Strict Google Subset, Strict-Typed OSMTags, Passenger-Name Hierarchy, Autouse Breaker Reset)
 **Change:** Five interlocking improvements across the OSM-first directory enrichment pipeline plus a documentation pass that pulls the OSM-first / Google-second contract out of the `.jules/` journals and into the user-facing docs. The optimisations are listed in dependency order — each one closes a structural gap the rollback entry below (the GTFS-RT Stammstrecke removal) left in the surrounding pipeline:
 

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -6,9 +6,38 @@ import re
 from typing import Any
 
 # Precompiled regexes for sanitization
-# Extended to include BiDi control characters (Trojan Source) and Zero-Width characters
+# Strip BiDi control characters (Trojan Source: CVE-2021-42574), zero-width
+# characters, and Unicode line/paragraph separators that downstream consumers
+# treat as record terminators (ECMAScript-pre-2019 ``JSON.parse``/``eval``,
+# the GitHub PR-comment renderer, several YAML parsers, SIEM splitters that
+# key off Unicode whitespace). The character class union covers:
+#   * ``\x00-\x1f`` / ``\x7f-\x9f`` \u2014 ASCII C0 + DEL + C1 controls.
+#   * ``\u061c`` \u2014 Arabic Letter Mark (post-Unicode-6.3 BiDi control; same
+#     display-confusion blast radius as LRM/RLM but missing from every
+#     prior round of this regex).
+#   * ``\u200b-\u200f`` \u2014 ZWSP / ZWNJ / ZWJ / **LRM** / **RLM**. The
+#     ``\u200e``/``\u200f`` BiDi marks are the same Trojan-Source primitive
+#     as the already-stripped ``\u202a-\u202e`` family: a hostile payload
+#     prepends LRM/RLM to invert displayed text in a Unicode-aware terminal
+#     so an operator skimming a log misreads ``user=admin drop=table`` as
+#     the inverse.
+#   * ``\u2028-\u202e`` \u2014 Unicode **LINE SEPARATOR** (``\u2028``) /
+#     **PARAGRAPH SEPARATOR** (``\u2029``) plus the CVE-2021-42574 BiDi
+#     formatting controls (LRE/RLE/PDF/LRO/RLO at ``\u202a-\u202e``).
+#     ``\u2028``/``\u2029`` were the load-bearing gap \u2014 Python's regex
+#     ``\\s`` matches them, but ``_CONTROL_CHARS_RE`` did not. A hostile
+#     upstream JSON payload could therefore embed ``\u2028`` to forge a
+#     second log record in any consumer honouring Unicode line terminators.
+#   * ``\u2066-\u2069`` \u2014 LRI / RLI / FSI / PDI BiDi isolates (the second
+#     half of CVE-2021-42574).
+#   * ``\ufeff`` \u2014 Byte Order Mark (zero-width no-break space).
+# The companion regex in ``src/utils/stations_validation.py`` uses
+# ``\u2028-\u202e``; this file pins the canonical UNION (incl. ALM, LRM,
+# RLM) so every WARNING/ERROR site routed through the audit walker
+# (``test_sentinel_clear_text_logging_drift_utils``) inherits the same
+# defence floor.
 _CONTROL_CHARS_RE = re.compile(
-    r"[\x00-\x1f\x7f-\x9f\u200b-\u200d\u202a-\u202e\u2066-\u2069\ufeff]"
+    r"[\x00-\x1f\x7f-\x9f\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069\ufeff]"
 )
 _LOG_INJECTION_RE = re.compile(r"[\n\r\t]")
 # ANSI escape codes: comprehensive matching for CSI, OSC, Fe, and 2-byte sequences

--- a/tests/test_sentinel_log_injection_bidi_gap.py
+++ b/tests/test_sentinel_log_injection_bidi_gap.py
@@ -1,0 +1,164 @@
+"""Sentinel: close the BiDi-mark / Unicode-line-terminator gap in
+``sanitize_log_message``.
+
+Threat model
+------------
+``sanitize_log_message`` is the canonical log-injection / Trojan-Source
+defence shared across every WARNING/ERROR site in ``src/`` and
+``scripts/`` — the audit walker in
+``test_sentinel_clear_text_logging_drift_utils`` enforces that every bound
+exception flows through it. Pre-fix the underlying ``_CONTROL_CHARS_RE``
+covers ASCII C0/C1, the CVE-2021-42574 BiDi formatting controls
+(LRE/RLE/PDF/LRO/RLO and LRI/RLI/FSI/PDI), the zero-width family
+(ZWSP/ZWNJ/ZWJ) and the BOM, but leaves five high-impact code points
+unhandled:
+
+* ``U+2028`` LINE SEPARATOR — splits a single sanitised log entry into
+  two records in any consumer that honours Unicode line terminators
+  (ECMAScript-pre-2019 ``JSON.parse``/``eval``, the GitHub PR-comment
+  renderer, several YAML parsers, downstream SIEM splitters that key off
+  Unicode whitespace). The forged second record can carry a
+  ``ts=…`` line, a fake ``level=ERROR`` marker, anything the operator
+  triages on.
+* ``U+2029`` PARAGRAPH SEPARATOR — same family as U+2028, also matched
+  by ``\\s`` in Python's regex but missed by ``_CONTROL_CHARS_RE``.
+* ``U+200E`` LRM / ``U+200F`` RLM — invisible BiDi marks. Same Trojan-
+  Source primitive as the already-stripped ``U+202A-U+202E``: a hostile
+  payload prepends LRM/RLM to invert displayed text in a Unicode-aware
+  terminal so an operator skimming a log misreads ``user=admin
+  drop=table`` as ``drop=table user=admin`` (or the inverse).
+* ``U+061C`` ARABIC LETTER MARK — the post-Unicode-6.3 BiDi control
+  character. Same display-confusion blast radius as LRM/RLM and missing
+  from every prior round.
+
+The vulnerable code path is independent of the existing ``\\n``/``\\r``
+escape: those are replaced *after* ANSI stripping but *before*
+``_CONTROL_CHARS_RE.sub("")``, so they never fall through. The five
+characters above are NOT in the escape list and NOT in the regex, so they
+slip through verbatim.
+
+The companion regex in ``src/utils/stations_validation.py``
+(``_UNSAFE_CHARS_RE``) already covers ``\\u2028-\\u202e``, so the
+codebase has divergent BiDi-defence shapes between the station validator
+and the canonical log sanitiser. This file pins the union as the
+canonical floor.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils.logging import sanitize_log_message
+
+# ---------------------------------------------------------------------------
+# Canonical "must be stripped" characters
+# ---------------------------------------------------------------------------
+
+_BIDI_AND_LINE_TERMINATOR_CHARS: tuple[tuple[str, str], ...] = (
+    ("؜", "U+061C ARABIC LETTER MARK"),
+    ("‎", "U+200E LEFT-TO-RIGHT MARK"),
+    ("‏", "U+200F RIGHT-TO-LEFT MARK"),
+    (" ", "U+2028 LINE SEPARATOR"),
+    (" ", "U+2029 PARAGRAPH SEPARATOR"),
+)
+
+# ---------------------------------------------------------------------------
+# PoC: each unhandled character slips past sanitize_log_message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("char,name", _BIDI_AND_LINE_TERMINATOR_CHARS)
+def test_sanitize_log_message_strips_bidi_and_line_terminators(
+    char: str, name: str
+) -> None:
+    """Each unhandled BiDi / line-terminator code point must be removed.
+
+    Pre-fix this asserts FAIL — the canonical sanitiser leaves the code
+    point in place, so a hostile upstream payload can forge log lines
+    (U+2028/U+2029) or visually invert operator-readable content
+    (U+061C / U+200E / U+200F). Post-fix the union of all five is
+    stripped from the output.
+    """
+    payload = f"prefix{char}suffix"
+    sanitized = sanitize_log_message(payload)
+
+    assert char not in sanitized, (
+        f"{name} ({char!r}) leaked through sanitize_log_message: {sanitized!r}"
+    )
+
+
+def test_sanitize_log_message_strips_compound_bidi_payload() -> None:
+    """A multi-character compound payload must be fully neutralised.
+
+    Mirrors the realistic shape an attacker would inject — a chain of
+    BiDi marks plus a Unicode line terminator — to confirm the regex
+    treats the whole family as a single class rather than punching
+    holes per character.
+    """
+    payload = (
+        "user=victim "
+        "level=ERROR ts=hostile‮payload"
+        "‎injected؜"
+    )
+    sanitized = sanitize_log_message(payload)
+
+    for char, name in _BIDI_AND_LINE_TERMINATOR_CHARS:
+        assert char not in sanitized, (
+            f"{name} survived in compound payload: {sanitized!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression: pre-existing behaviour must keep working
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_log_message_preserves_newline_escape_contract() -> None:
+    """Real ``\\n``/``\\r``/``\\t`` continue to be escaped (not stripped).
+
+    The fix tightens ``_CONTROL_CHARS_RE`` only — the two-step pipeline
+    (ANSI strip → newline ESCAPE → control-char strip) MUST remain
+    intact so existing tests (``test_json_log_leak``, the audit walker)
+    keep passing.
+    """
+    sanitized = sanitize_log_message("a\nb\rc\td")
+    assert sanitized == "a\\nb\\rc\\td"
+
+
+def test_sanitize_log_message_preserves_existing_bidi_strip_contract() -> None:
+    """The existing CVE-2021-42574 BiDi / zero-width strip MUST persist.
+
+    Anchors the families covered by the prior regex so a future regex
+    refactor cannot accidentally narrow what's already protected.
+    """
+    payload = (
+        "x‪y‫z‬A‭B‮C"  # LRE/RLE/PDF/LRO/RLO
+        "⁦D⁧E⁨F⁩G"          # LRI/RLI/FSI/PDI
+        "​H‌I‍J"                 # ZWSP/ZWNJ/ZWJ
+        "﻿K"                                # BOM
+    )
+    sanitized = sanitize_log_message(payload)
+
+    for already_covered in (
+        "‪", "‫", "‬", "‭", "‮",
+        "⁦", "⁧", "⁨", "⁩",
+        "​", "‌", "‍",
+        "﻿",
+    ):
+        assert already_covered not in sanitized, (
+            f"Pre-existing BiDi/ZW strip regressed: {already_covered!r} "
+            f"survived in {sanitized!r}"
+        )
+
+
+def test_sanitize_log_message_with_strip_disabled_still_redacts_secrets() -> None:
+    """``strip_control_chars=False`` (traceback path) keeps redaction.
+
+    Even when control-char stripping is disabled (e.g. for traceback
+    readability), the secret-redaction patterns must still fire — the
+    fix only touches the strip path, not the redact path.
+    """
+    payload = 'config: api_key = "ABCDEFGHIJKLMNOPQRST"'
+    sanitized = sanitize_log_message(payload, strip_control_chars=False)
+    assert "ABCDEFGHIJKLMNOPQRST" not in sanitized
+    assert "***" in sanitized


### PR DESCRIPTION
## Summary

Closes a five-codepoint gap in the canonical log-injection / Trojan-Source defence (`src/utils/logging.py:_CONTROL_CHARS_RE`, used by every WARNING/ERROR site enforced via `test_sentinel_clear_text_logging_drift_utils`). The pre-fix regex covered ASCII C0/C1, the CVE-2021-42574 BiDi formatting controls (`U+202A-U+202E`, `U+2066-U+2069`), the zero-width family (`U+200B-U+200D`), and the BOM (`U+FEFF`) — but left these unhandled:

| Code point | Name                         | Attack primitive                                                                                                                                                                                            |
|-----------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `U+061C`  | ARABIC LETTER MARK           | Post-Unicode-6.3 BiDi control. Same display-confusion blast radius as `U+202A-U+202E` but missing from every prior round.                                                                                    |
| `U+200E`  | LEFT-TO-RIGHT MARK           | Invisible BiDi mark. Same Trojan-Source primitive: invert displayed text in a Unicode-aware terminal so an operator skimming a log misreads `user=admin drop=table` as the inverse.                          |
| `U+200F`  | RIGHT-TO-LEFT MARK           | Mirror of LRM.                                                                                                                                                                                              |
| `U+2028`  | LINE SEPARATOR               | **Forge log records.** Splits a single sanitised entry into two records in any consumer honouring Unicode line terminators (ECMAScript-pre-2019 `JSON.parse`/`eval`, the GitHub PR-comment renderer, several YAML parsers, downstream SIEM splitters keying off Unicode whitespace). The forged second record can carry `level=ERROR`, ts= prefixes, anything operator triages on. |
| `U+2029`  | PARAGRAPH SEPARATOR          | Same family as `U+2028`. Python's regex `\s` matches both, but `_CONTROL_CHARS_RE` (an explicit code-point class) did not.                                                                                  |

## Audit-trail consistency

The companion regex in `src/utils/stations_validation.py:_UNSAFE_CHARS_RE` already covered `U+2028-U+202E`, so the codebase had divergent BiDi-defence shapes between the station validator and the canonical log sanitiser. This PR pins the **union** as the canonical floor (canonical pin lives in `_CONTROL_CHARS_RE`).

## Fix shape

Single character-class union extension. The strip step still runs **after** `\n`/`\r`/`\t` are escaped to literal `\\n`/`\\r`/`\\t`, so the existing newline-escape contract (covered by `tests/test_json_log_leak.py`) is unchanged — the fix only widens the strip set.

## PoC

`tests/test_sentinel_log_injection_bidi_gap.py` (9 cases):
- **5 parametrised assertions** on the unhandled code points (each fails pre-fix, passes post-fix).
- **1 compound attack payload** mirroring a realistic injection shape (LRM + LS + RLO + ALM combined).
- **3 regression anchors:** newline-escape contract, pre-existing BiDi/ZW strip, secret redaction with `strip_control_chars=False`.

Pre-fix: 6 fails / 3 pass. Post-fix: 9 pass.

## Test plan
- [x] PoC test fails pre-fix on each unhandled code point (verified locally).
- [x] PoC test passes post-fix (9/9).
- [x] `python scripts/run_static_checks.py` green (ruff, mypy, bandit, secret scanner, C901, pip-audit).
- [x] `pytest` green (2257 passed / 3 skipped, +9 new tests).
- [x] No regression on `tests/test_json_log_leak.py` (newline escape contract).
- [x] No regression on `tests/test_ansi_sanitization.py` (ANSI strip pipeline).
- [x] No regression on `tests/test_sentinel_clear_text_logging_drift_utils.py` (audit walker).

https://claude.ai/code/session_01FYF3AzhctvFAFRuHS21Ljv

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYF3AzhctvFAFRuHS21Ljv)_