### PR TITLE
security(logging): unconditionally strip BiDi marks across strip_control_chars=False paths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,88 @@
+## 2026-05-09 - BiDi-Mark Drift Round 2: `strip_control_chars=False` Sibling Paths Bypass `_CONTROL_CHARS_RE` Entirely
+**Vulnerability:** The 2026-05-09 (Round 1, PR #1363) closure of the BiDi /
+Unicode-line-terminator gap landed `؜` ALM, `‎/‏` LRM/RLM,
+` / ` line/paragraph separators inside
+`src/utils/logging.py:_CONTROL_CHARS_RE`. That regex is gated by the
+`strip_control_chars=True` (default) branch of `sanitize_log_message` —
+the `strip_control_chars=False` branch (which exists to keep readable
+`\n`/`\r`/`\t` in tracebacks) bypasses `_CONTROL_CHARS_RE.sub("")`
+entirely. **Five sibling sanitiser paths** opt out of the strip and
+therefore re-leaked the entire BiDi / zero-width / line-terminator
+family verbatim into the public `feed_health.json` artefact, the
+GitHub Issue body submitted by `submit_auto_issue`, every
+`log.exception(...)` traceback rendered by `SafeFormatter`/
+`SafeJSONFormatter`, and every network-level exception text routed
+through `request_safe`:
+1. `src/feed/reporting.py:clean_message` — canonical sanitiser for every
+   provider success/empty/error/disabled detail, every global warning,
+   every global error message, plus `RunReport.exception_message`.
+   Internally calls `sanitize_log_message(message, strip_control_chars=False)`
+   then collapses `\s+` to a single space; Python's `\s` matches
+   ` `/` ` but NOT the BiDi family
+   (`؜`/`‎`/`‏`/`‪-‮`/`⁦-⁩`) or the
+   zero-width family (`​`/`‌`/`‍`/`﻿`).
+2. `src/feed/reporting.py:_sanitize_log_detail` — same drift via
+   `clean_message` for diagnostic-string scrubbing.
+3. `src/utils/http.py:_sanitize_exception_msg` — rewrites every
+   `RequestException.args[0]` produced by `request_safe`. Pre-fix the
+   sanitised text is then routed through every WARNING/ERROR site that
+   logs `str(exc)` from a network call.
+4. `src/feed/logging_safe.py:SafeFormatter.formatException` — renders the
+   traceback for every `log.exception(...)` call in the production feed
+   builder. Pre-fix the BiDi marks in the bound exception text slip into
+   the final formatted log line (only `\n`/`\r` are escaped at the very
+   end via `.replace`).
+5. `src/feed/logging_safe.py:SafeJSONFormatter.formatException` — same
+   drift for the structured JSON formatter; with `ensure_ascii=False` on
+   the `json.dumps` step, BiDi marks are preserved as raw Unicode in the
+   structured payload ingested by downstream SIEM/observability stacks.
+
+**Exploit shape:** A hostile upstream payload — VOR API response, OSM
+Overpass diagnostic, OEBB error body, station name in `stations.json`,
+malformed JSON HTTP error — embeds `‮` RLO + `‬` PDF (or
+`‎` LRM, or ` ` LINE SEPARATOR). Routed through any of the
+five paths above, the marks reach (a) the public Markdown body of the
+auto-submitted GitHub issue and the SIEM splitting on Unicode line
+terminators (forge a second log record carrying a fake `level=ERROR`,
+`ts=…`, or whatever the operator triages on), or (b) the operator's
+Unicode-aware terminal / GitHub Issue renderer / IDE log viewer
+(invert displayed text à la CVE-2021-42574 so `user=admin drop=table`
+is misread as the inverse).
+
+**Fix:** Promote the BiDi / zero-width / line-terminator family to an
+**unconditional** pre-pass in `sanitize_log_message` — independent of
+the `strip_control_chars` flag. The flag now only gates the ASCII
+control-char escape (`\n`→`\\n`, `\r`→`\\r`, `\t`→`\\t`) and the
+`_CONTROL_CHARS_RE` strip (which still includes the same code points as
+defence in depth). The new `_INVISIBLE_DANGEROUS_RE` covers `؜`,
+`​-‏`, ` -‮`, `⁦-⁩`, `﻿` — the strict
+subset of `_CONTROL_CHARS_RE` that has NO readability value AND is a
+documented log-injection / Trojan-Source primitive. Since the strip
+runs before the `if strip_control_chars:` gate, every one of the five
+sibling paths inherits the defence in a single cut without breaking
+the readable-newline contract those callers rely on for traceback
+formatting.
+
+**Learning:** Round 1's `_CONTROL_CHARS_RE` extension was *necessary
+but not sufficient*. Whenever a sanitiser carries a feature flag that
+gates a defensive strip, audit which other call paths flip the flag in
+the OPPOSITE direction — those paths are still on the pre-fix shape
+and bypass the regex entirely. The CodeQL/sanitiser-walker pattern
+(`test_sentinel_clear_text_logging_drift_utils`) only covers the
+default-True path; sibling helpers that set the flag to False
+(traceback-readable formatters, exception-msg rewriters, the
+`feed_health.json` cleaning pipeline) need their own audit floor.
+Concretely: split a sanitiser's *defensive strip* into two tiers —
+"strip always" (no readability cost — invisible glyphs, BiDi marks,
+zero-width, line/paragraph separators, BOM) and "strip if flag set"
+(`\n`/`\r`/`\t` and ASCII C0/C1 controls that DO carry readability
+weight). Always-strip the first tier. Flag-gate only the second. The
+companion regex in `src/utils/stations_validation.py:_UNSAFE_CHARS_RE`
+is also narrower than `_INVISIBLE_DANGEROUS_RE` — that's a deliberate
+deferral (station-validator scope is structural validation, not log
+sanitisation), but flag it as the next drift candidate if a future
+round audits station-data flow into log emit.
+
 ## 2026-05-09 - BiDi-Mark / Unicode-Line-Terminator Gap in `sanitize_log_message`
 **Vulnerability:** The canonical log-injection / Trojan-Source defence
 (`src/utils/logging.py:_CONTROL_CHARS_RE`, used by every WARNING/ERROR

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -39,6 +39,24 @@ from typing import Any
 _CONTROL_CHARS_RE = re.compile(
     r"[\x00-\x1f\x7f-\x9f\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069\ufeff]"
 )
+# Always-strip set: invisible Unicode characters that have NO readability
+# value and are pure log-injection / Trojan-Source primitives. The 2026-05-09
+# round (PR #1363) added these code points to ``_CONTROL_CHARS_RE`` so the
+# ``strip_control_chars=True`` (default) path strips them. The drift was the
+# ``strip_control_chars=False`` branch \u2014 used by ``clean_message``,
+# ``_sanitize_log_detail`` (``src/feed/reporting.py``),
+# ``_sanitize_exception_msg`` (``src/utils/http.py``),
+# ``SafeFormatter.formatException`` and ``SafeJSONFormatter.formatException``
+# (``src/feed/logging_safe.py``) \u2014 which bypasses ``_CONTROL_CHARS_RE``
+# entirely to preserve readable ``\n``/``\r``/``\t`` in tracebacks. That
+# leaks the BiDi / zero-width / line-terminator family verbatim into the
+# public ``feed_health.json`` artefact and the GitHub Issue body submitted
+# by ``submit_auto_issue``. Stripping unconditionally (independent of the
+# flag) closes every sibling path in one cut while preserving the readable
+# newline contract every ``strip_control_chars=False`` caller relies on.
+_INVISIBLE_DANGEROUS_RE = re.compile(
+    r"[\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069\ufeff]"
+)
 _LOG_INJECTION_RE = re.compile(r"[\n\r\t]")
 # ANSI escape codes: comprehensive matching for CSI, OSC, Fe, and 2-byte sequences
 # Matches:
@@ -154,6 +172,16 @@ def sanitize_log_message(
         for secret in secrets:
             if secret:
                 sanitized = sanitized.replace(secret, "***")
+
+    # Always strip BiDi / zero-width / Unicode line-terminator characters.
+    # These have no readability value but are documented log-injection
+    # (CVE-2021-42574) and Trojan-Source primitives. Stripping unconditionally
+    # closes the ``strip_control_chars=False`` sibling paths
+    # (``clean_message``, ``_sanitize_log_detail``, ``_sanitize_exception_msg``,
+    # ``SafeFormatter.formatException``, ``SafeJSONFormatter.formatException``)
+    # while preserving the readable ``\n``/``\r``/``\t`` contract those
+    # callers rely on for traceback formatting.
+    sanitized = _INVISIBLE_DANGEROUS_RE.sub("", sanitized)
 
     # Prevent log injection by escaping newlines and control characters
     if strip_control_chars:

--- a/tests/test_sentinel_log_injection_bidi_gap_round2.py
+++ b/tests/test_sentinel_log_injection_bidi_gap_round2.py
@@ -1,0 +1,281 @@
+"""Sentinel: close BiDi-mark / Unicode-line-terminator drift in every
+``strip_control_chars=False`` code path.
+
+Threat model — Round 2
+----------------------
+PR #1363 (journaled 2026-05-09) closed the BiDi-mark gap in
+``_CONTROL_CHARS_RE`` so the canonical ``sanitize_log_message`` now
+strips ``U+061C`` ALM, ``U+200E/U+200F`` LRM/RLM, and the Unicode line
+terminators (``U+2028``/``U+2029``) when ``strip_control_chars=True``
+(the default).
+
+Round 1 did NOT touch the ``strip_control_chars=False`` branch — every
+caller that opted out of the control-char strip continues to drop the
+``_CONTROL_CHARS_RE.sub("")`` step entirely. That branch exists to
+preserve readable ``\\n``/``\\r``/``\\t`` in tracebacks but it also
+leaks the BiDi/zero-width/line-terminator family that has no readability
+value:
+
+* ``src/feed/reporting.py:clean_message`` is the canonical sanitiser
+  for every provider detail, every warning, every error message that
+  feeds the public ``feed_health.json`` artefact AND the GitHub Issue
+  body submitted by ``submit_auto_issue``.
+* ``src/utils/http.py:_sanitize_exception_msg`` rewrites
+  ``RequestException.args[0]`` for every network-level error caught
+  by ``request_safe`` — the exception text is then routed through
+  every WARNING / ERROR site that logs ``str(exc)``.
+* ``src/feed/logging_safe.py:SafeFormatter.formatException`` and
+  ``SafeJSONFormatter.formatException`` render the traceback for
+  every ``log.exception(...)`` call in the production feed builder.
+
+A hostile upstream payload (a VOR API response, an OSM Overpass
+diagnostic, an OEBB error body, a station name in
+``stations.json``) that contains ``U+202E`` RLO + ``U+202C`` PDF can
+therefore:
+
+1. **Forge log records** in any consumer that honours Unicode line
+   terminators (ECMAScript-pre-2019 ``JSON.parse``/``eval``, the
+   GitHub PR-comment renderer, several YAML parsers, downstream SIEM
+   splitters that key off Unicode whitespace) by routing
+   ``U+2028``/``U+2029`` through ``clean_message``. Even though
+   ``clean_message`` collapses ``\\s+`` to a single space (which catches
+   ``U+2028``/``U+2029`` because Python's ``\\s`` matches Unicode line
+   terminators), the BiDi and zero-width family is NOT in ``\\s`` —
+   they slip through verbatim into the rendered Markdown body.
+2. **Invert displayed text** (Trojan-Source / CVE-2021-42574) in any
+   Unicode-aware terminal, GitHub Issue renderer, IDE log viewer, or
+   SIEM dashboard so an operator triaging the public artefact misreads
+   ``user=admin drop=table`` as the inverse.
+
+This file pins the union of the BiDi / zero-width / line-terminator
+family as the ALWAYS-stripped floor — independent of the
+``strip_control_chars`` flag — so every sibling sanitiser path (not
+just the default-True path) inherits the defence.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from src.feed.logging_safe import SafeFormatter, SafeJSONFormatter
+from src.feed.reporting import _sanitize_log_detail, clean_message
+from src.utils.http import _sanitize_exception_msg
+from src.utils.logging import sanitize_log_message
+
+# Canonical "must be stripped" set: invisible Unicode characters that
+# have NO readability value AND are documented log-injection /
+# Trojan-Source primitives. This MUST be stripped regardless of the
+# ``strip_control_chars`` flag.
+_INVISIBLE_DANGEROUS_CHARS: tuple[tuple[str, str], ...] = (
+    ("؜", "U+061C ARABIC LETTER MARK"),
+    ("​", "U+200B ZERO WIDTH SPACE"),
+    ("‌", "U+200C ZERO WIDTH NON-JOINER"),
+    ("‍", "U+200D ZERO WIDTH JOINER"),
+    ("‎", "U+200E LEFT-TO-RIGHT MARK"),
+    ("‏", "U+200F RIGHT-TO-LEFT MARK"),
+    (" ", "U+2028 LINE SEPARATOR"),
+    (" ", "U+2029 PARAGRAPH SEPARATOR"),
+    ("‪", "U+202A LRE"),
+    ("‫", "U+202B RLE"),
+    ("‬", "U+202C PDF"),
+    ("‭", "U+202D LRO"),
+    ("‮", "U+202E RLO"),
+    ("⁦", "U+2066 LRI"),
+    ("⁧", "U+2067 RLI"),
+    ("⁨", "U+2068 FSI"),
+    ("⁩", "U+2069 PDI"),
+    ("﻿", "U+FEFF BOM / ZWNBSP"),
+)
+
+
+@pytest.mark.parametrize("char,name", _INVISIBLE_DANGEROUS_CHARS)
+def test_sanitize_log_message_strips_bidi_with_strip_control_chars_disabled(
+    char: str, name: str
+) -> None:
+    """Pre-fix asserts FAIL — the ``strip_control_chars=False`` branch
+    bypasses ``_CONTROL_CHARS_RE.sub("")`` entirely, so every BiDi /
+    zero-width / line-terminator code point survives verbatim.
+
+    Post-fix the BiDi/zero-width family is stripped UNCONDITIONALLY
+    (independent of the ``strip_control_chars`` flag) since these have
+    no readability value and are pure log-injection / Trojan-Source
+    primitives.
+    """
+    payload = f"prefix{char}suffix"
+    sanitized = sanitize_log_message(payload, strip_control_chars=False)
+    assert char not in sanitized, (
+        f"{name} ({char!r}) leaked through "
+        f"sanitize_log_message(strip_control_chars=False): {sanitized!r}"
+    )
+
+
+def test_clean_message_strips_bidi_marks() -> None:
+    """``clean_message`` (the canonical sanitiser for every provider
+    detail / warning / error rendered into ``feed_health.json`` and
+    the GitHub Issue body) MUST strip BiDi / zero-width characters.
+
+    Pre-fix: ``clean_message`` calls
+    ``sanitize_log_message(strip_control_chars=False)`` then collapses
+    ``\\s+`` to a single space. Python's ``\\s`` matches
+    ``U+2028``/``U+2029`` but NOT the BiDi family
+    (``U+061C``/``U+200E``/``U+200F``/``U+202A-U+202E``/
+    ``U+2066-U+2069``) or the zero-width family
+    (``U+200B``/``U+200C``/``U+200D``/``U+FEFF``).
+    """
+    payload = (
+        "user=admin‮drop=table‬"
+        "‎injected؜"
+        " forged_record"
+    )
+    cleaned = clean_message(payload)
+    for char, name in _INVISIBLE_DANGEROUS_CHARS:
+        assert char not in cleaned, (
+            f"{name} ({char!r}) survived clean_message: {cleaned!r}"
+        )
+
+
+def test_sanitize_log_detail_strips_bidi_marks() -> None:
+    """``_sanitize_log_detail`` (used to clean provider-supplied
+    diagnostic strings before posting them to the issue body) MUST
+    strip the same BiDi / zero-width family.
+
+    Pre-fix this delegates to ``clean_message`` which carries the same
+    drift; post-fix the unconditional strip in ``sanitize_log_message``
+    closes both call paths in one cut.
+    """
+    payload = "OSM diagnostic: ‮rm -rf /‬ done"
+    sanitized = _sanitize_log_detail(payload)
+    assert "‮" not in sanitized
+    assert "‬" not in sanitized
+
+
+def test_http_sanitize_exception_msg_strips_bidi_marks() -> None:
+    """``_sanitize_exception_msg`` rewrites every
+    ``RequestException.args[0]`` produced by ``request_safe``. Pre-fix
+    this returns ``sanitize_log_message(msg, strip_control_chars=False)``
+    so a hostile remote that embeds BiDi marks in an HTTP error body
+    can ship them straight into every downstream
+    ``logger.error("... %s ...", str(exc))`` site.
+    """
+    payload = (
+        "ConnectionError: failed to fetch "
+        "https://example.com/path?q=v"
+        "‮injected_marker‬؜"
+    )
+    sanitized = _sanitize_exception_msg(payload)
+    assert "‮" not in sanitized
+    assert "‬" not in sanitized
+    assert "؜" not in sanitized
+
+
+def test_safe_formatter_format_exception_strips_bidi_marks() -> None:
+    """The traceback rendered by ``SafeFormatter.formatException`` is
+    appended to every log record carrying ``exc_info``. Pre-fix the
+    formatter passes ``strip_control_chars=False`` to preserve readable
+    newlines, but that also lets the BiDi family slip through into the
+    final formatted log line.
+    """
+    formatter = SafeFormatter("%(message)s")
+    try:
+        raise ValueError(
+            "VOR error: ‮payload‬ with bidi ؜ marks"
+        )
+    except ValueError:
+        import sys
+
+        ei: Any = sys.exc_info()
+        rendered = formatter.formatException(ei)
+
+    assert "‮" not in rendered
+    assert "‬" not in rendered
+    assert "؜" not in rendered
+
+
+def test_safe_json_formatter_format_exception_strips_bidi_marks() -> None:
+    """``SafeJSONFormatter.formatException`` shares the same drift —
+    the JSON-formatted log line carries the rendered traceback verbatim
+    (``ensure_ascii=False`` preserves Unicode), so a BiDi mark in an
+    upstream exception slips through into structured logs ingested by
+    downstream SIEM/observability stacks.
+    """
+    formatter = SafeJSONFormatter()
+    try:
+        raise RuntimeError(
+            "Hostile: ‎inverted‏  forged"
+        )
+    except RuntimeError:
+        import sys
+
+        ei: Any = sys.exc_info()
+        rendered = formatter.formatException(ei)
+
+    assert "‎" not in rendered
+    assert "‏" not in rendered
+    assert " " not in rendered
+
+
+def test_safe_formatter_format_strips_bidi_in_traceback() -> None:
+    """End-to-end: a real ``log.exception`` call carrying BiDi marks
+    in the bound exception text MUST emit a sanitised final line.
+
+    This proves the fix lands at the formatter integration layer, not
+    just in the ``formatException`` helper — rules out a regression
+    where the traceback is sanitised but the message is not (or vice
+    versa).
+    """
+    formatter = SafeFormatter("%(message)s")
+    record = logging.LogRecord(
+        name="test",
+        level=logging.ERROR,
+        pathname=__file__,
+        lineno=42,
+        msg="upstream payload ‮payload‬",
+        args=(),
+        exc_info=None,
+    )
+    rendered = formatter.format(record)
+    assert "‮" not in rendered
+    assert "‬" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# Regression: pre-existing contracts must keep working
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_log_message_strip_disabled_still_preserves_newlines() -> None:
+    """The whole point of ``strip_control_chars=False`` is to keep
+    ``\\n``/``\\r``/``\\t`` for traceback readability. The fix must
+    preserve that contract — only invisible-dangerous Unicode goes
+    away unconditionally; ASCII line breaks survive.
+    """
+    payload = "line1\nline2\rline3\tindent"
+    sanitized = sanitize_log_message(payload, strip_control_chars=False)
+    assert "\n" in sanitized
+    assert "\r" in sanitized
+    assert "\t" in sanitized
+
+
+def test_sanitize_log_message_strip_disabled_redacts_secrets() -> None:
+    """Re-anchor the existing PR #1363 contract — the redact path
+    fires regardless of the strip flag. Defends against a regression
+    where the unconditional invisible-strip refactor accidentally
+    short-circuits the secret-redact patterns.
+    """
+    payload = 'config: api_key = "ABCDEFGHIJKLMNOPQRST"'
+    sanitized = sanitize_log_message(payload, strip_control_chars=False)
+    assert "ABCDEFGHIJKLMNOPQRST" not in sanitized
+    assert "***" in sanitized
+
+
+def test_sanitize_log_message_default_path_unchanged() -> None:
+    """The default ``strip_control_chars=True`` path keeps Round 1
+    behaviour: ``\\n`` is escaped to literal ``\\\\n``, ``\\r`` to
+    ``\\\\r``, ``\\t`` to ``\\\\t``, and the BiDi/zero-width family is
+    stripped (now via the unconditional pre-pass).
+    """
+    payload = "a\nb\rc\td"
+    sanitized = sanitize_log_message(payload)
+    assert sanitized == "a\\nb\\rc\\td"


### PR DESCRIPTION
## Summary

Round-2 closure of the 2026-05-09 BiDi-mark / Unicode-line-terminator gap (PR #1363).

PR #1363 added `؜` ALM, `‎/‏` LRM/RLM, ` / ` line/paragraph separators to `_CONTROL_CHARS_RE`, but only the `strip_control_chars=True` (default) branch of `sanitize_log_message` applies that regex. **Five sibling sanitiser paths flip the flag to `False`** to preserve readable `\n`/`\r`/`\t` in tracebacks and therefore bypass `_CONTROL_CHARS_RE.sub("")` entirely:

| Path | Drift surface |
| --- | --- |
| `src/feed/reporting.py:clean_message` | Canonical sanitiser for every provider success/empty/error/disabled detail, every global warning/error, plus `RunReport.exception_message`. Routed into the public `feed_health.json` artefact AND the GitHub Issue body submitted by `submit_auto_issue`. |
| `src/feed/reporting.py:_sanitize_log_detail` | Diagnostic-string scrubbing — same drift via `clean_message`. |
| `src/utils/http.py:_sanitize_exception_msg` | Rewrites every `RequestException.args[0]` produced by `request_safe`. Sanitised text is then routed through every WARNING/ERROR site logging `str(exc)` for a network call. |
| `src/feed/logging_safe.py:SafeFormatter.formatException` | Renders the traceback for every `log.exception(...)` call in the production feed builder. |
| `src/feed/logging_safe.py:SafeJSONFormatter.formatException` | Same drift for the structured JSON formatter; with `ensure_ascii=False` on `json.dumps`, BiDi marks are preserved as raw Unicode in the structured payload. |

### Threat model

A hostile upstream payload — VOR API response, OSM Overpass diagnostic, OEBB error body, station name in `stations.json`, malformed JSON HTTP error — embeds `‮` RLO + `‬` PDF (or `‎` LRM, ` ` LINE SEPARATOR, `؜` ALM, `​` ZWSP, `﻿` BOM, etc.). Routed through any of the five paths above, the marks reach:

1. **Forge log records** in any consumer that honours Unicode line terminators (ECMAScript-pre-2019 `JSON.parse`/`eval`, the GitHub PR-comment renderer, several YAML parsers, downstream SIEM splitters keying off Unicode whitespace) by routing ` `/` ` through `clean_message`. Even though `clean_message` collapses `\s+` to a single space (which catches ` `/` ` because Python's `\s` matches Unicode line terminators), the BiDi and zero-width family is NOT in `\s` — they slip through verbatim.
2. **Invert displayed text** (Trojan-Source / CVE-2021-42574) in any Unicode-aware terminal, GitHub Issue renderer, IDE log viewer, or SIEM dashboard so an operator triaging the public artefact misreads `user=admin drop=table` as the inverse.

### Fix

Promote the BiDi / zero-width / line-terminator family to an **unconditional** `_INVISIBLE_DANGEROUS_RE.sub("")` pre-pass in `sanitize_log_message`, independent of the `strip_control_chars` flag. The flag now gates only the ASCII control-char escape (`\n`→`\\n`, `\r`→`\\r`, `\t`→`\\t`) and the `_CONTROL_CHARS_RE` strip (which remains a defence-in-depth superset that includes the BiDi family already stripped above).

The new `_INVISIBLE_DANGEROUS_RE` covers `؜`, `​-‏`, ` -‮`, `⁦-⁩`, `﻿` — the strict subset of `_CONTROL_CHARS_RE` that has NO readability value AND is a documented log-injection / Trojan-Source primitive. Since the strip runs **before** the `if strip_control_chars:` gate, every one of the five sibling paths inherits the defence in a single cut without breaking the readable-newline contract those callers rely on for traceback formatting.

### PoC + Regression contract

`tests/test_sentinel_log_injection_bidi_gap_round2.py` (27 assertions):

- **Drift PoC** (would FAIL pre-fix, PASS post-fix): every BiDi/zero-width/line-terminator code point is stripped under `strip_control_chars=False`; `clean_message`, `_sanitize_log_detail`, `_sanitize_exception_msg`, `SafeFormatter.formatException`, `SafeJSONFormatter.formatException`, and the end-to-end `SafeFormatter.format` all neutralise hostile payloads.
- **Regression** (passes both pre-fix and post-fix): `\n`/`\r`/`\t` survive `strip_control_chars=False`; secret-redact patterns still fire under the same flag; the default `strip_control_chars=True` path keeps Round 1's `a\nb\rc\td → a\\nb\\rc\\td` escape contract intact.

## Test plan

- [x] `python -m pytest tests/test_sentinel_log_injection_bidi_gap_round2.py` — 27/27 pass post-fix; pre-fix 22/27 fail with the expected leak shapes.
- [x] `python -m pytest tests/test_sentinel_log_injection_bidi_gap.py tests/test_log_sanitization_*.py tests/test_logging_sanitize.py tests/test_ansi_sanitization.py tests/test_session_cookie_sanitization.py tests/test_url_sanitization_auth_session.py tests/test_vor_log_injection.py tests/test_sanitize_text.py tests/test_safe_json_formatter.py` — 85/85 pass.
- [x] `python -m pytest tests/test_sentinel_clear_text_logging_drift_utils.py tests/test_sentinel_json_audit_walker.py tests/test_sentinel_redaction.py tests/test_json_log_leak.py tests/test_leak_repro.py` — 19/19 pass.
- [x] `python -m pytest -x -q` — full suite 2284 passed, 3 skipped in 58s.
- [x] `python scripts/run_static_checks.py` — ruff/mypy/bandit/secret-scanner/C901 gate/pip-audit all green.

https://claude.ai/code/session_0112yf9YF6Qy5TAwXJXKMFXh

---
_Generated by [Claude Code](https://claude.ai/code/session_0112yf9YF6Qy5TAwXJXKMFXh)_