### PR TITLE
feat(stammstrecke): split delay monitor by direction, align breaker with 10/h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,36 @@
 # CHANGELOG
 
 ## [Unreleased]
+* **Feat**: S-Bahn Stammstrecke Monitoring jetzt **richtungsgetrennt**.
+  `scripts/update_stammstrecke_status.py` wertet beide Fahrtrichtungen
+  (Floridsdorf → Meidling und Meidling → Floridsdorf) strikt
+  unabhängig aus und emittiert pro Richtung **separat** ein Event,
+  wenn der Median der `departure_delay`-Werte > 9 Minuten liegt
+  (Liste mit 0/1/2 Events). Eine Zusammenlegung beider Richtungen
+  hatte das Signal verfälscht — eine Störung in eine Richtung läuft
+  oft in der Gegenrichtung normal weiter. Pro Richtung eindeutige
+  `guid`/`_identity` (`stammstrecke_delay_meidling` bzw.
+  `stammstrecke_delay_floridsdorf`) damit Feed-Reader die Meldungen
+  als separate Notifications darstellen. Description-Format jetzt
+  "Durchschnittliche Verspätung von X Minuten in Richtung
+  Meidling/Floridsdorf" (Plain Text, keine HTML-Tags).
+* **Feat**: Circuit-Breaker-Konfiguration auf das documented
+  10-Requests-pro-Stunde-Budget der ÖBB-Abfragen ausgerichtet:
+  `failure_threshold=10`, `recovery_timeout=3600.0` (1 Stunde).
+  Im Normalbetrieb produziert die Pipeline 4 Calls/h
+  (Cron `*/30` × 2 Richtungen) — komfortabel unter der Schwelle;
+  im Fehlermodus deckelt der Breaker zusätzlich auf 10 Versuche/h.
 * **Feat**: S-Bahn Stammstrecke Monitoring. Neuer Workflow
   `.github/workflows/update-stammstrecke-status.yml` (Cron `*/30 * * * *`)
   ruft via `pyhafas` mit `OEBBProfile` direkte S-Bahn-Verbindungen
   Wien Floridsdorf (8100518) ↔ Wien Meidling (8100514) ab
-  (`max_changes=0`) und schreibt eine schema-konforme Meldung in
-  `cache/stammstrecke/events.json`, sobald der Median der
-  `departure_delay`-Werte über 9 Minuten liegt. Die Abfrage ist über
-  einen `CircuitBreaker` (5 Fehler / 300 s Recovery) abgesichert,
-  schreibt atomar via `atomic_write` und ist mit dem bestehenden Feed-
-  Build über `read_cache_stammstrecke()` (Provider-Flag
-  `STAMMSTRECKE_ENABLE`) integriert. Dokumentiert in
-  `docs/reference/oebb_provider_logic.md`. Tests mocken `pyhafas`
-  vollständig (`tests/scripts/test_update_stammstrecke_status.py`).
+  (`max_changes=0`) und schreibt schema-konforme Meldungen in
+  `cache/stammstrecke/events.json`. Schreibt atomar via
+  `atomic_write` und ist mit dem bestehenden Feed-Build über
+  `read_cache_stammstrecke()` (Provider-Flag `STAMMSTRECKE_ENABLE`)
+  integriert. Dokumentiert in `docs/reference/oebb_provider_logic.md`.
+  Tests mocken `pyhafas` vollständig
+  (`tests/scripts/test_update_stammstrecke_status.py`).
 * **Security**: VOR daily-quota counter is now lower-bound clamped at 0
   inside both `load_request_count` and `save_request_count` (the
   under-lock disk re-read). Pre-fix, a poisoned `data/vor_request_count.json`

--- a/docs/reference/oebb_provider_logic.md
+++ b/docs/reference/oebb_provider_logic.md
@@ -52,22 +52,29 @@ Failure-Modes haben.
 | :--- | :--- |
 | Bibliothek | [`pyhafas`](https://pypi.org/project/pyhafas/) ≥ 0.6.1 |
 | Profil | `pyhafas.profile.OEBBProfile` |
-| Origin | Wien Floridsdorf (HAFAS-ID `8100518`) |
-| Destination | Wien Meidling (HAFAS-ID `8100514`) |
+| Richtung 1 | Wien Floridsdorf (`8100518`) → Wien Meidling (`8100514`) |
+| Richtung 2 | Wien Meidling (`8100514`) → Wien Floridsdorf (`8100518`) |
 | `max_changes` | `0` (nur direkte S-Bahn-Verbindungen) |
 | `max_journeys` | 12 (≈ eine halbe Stunde Stammstrecken-Takt) |
 | Cron | `*/30 * * * *` (alle 30 Minuten) |
 
-### Filter und Aggregation
+**Beide Richtungen werden strikt getrennt ausgewertet.** Eine
+Zusammenlegung würde die Daten verfälschen — eine Störung in eine
+Richtung läuft häufig in der Gegenrichtung normal weiter, der Median
+über beide Richtungen würde das Signal verdünnen.
 
-Aus den zurückgegebenen `Journey`-Objekten werden alle `Leg`-Objekte
-ausgewählt, deren `name` dem regulären Ausdruck `^\s*S\s*\d+\s*$`
-entspricht (also reine S-Bahn-Linien wie `S 1`, `S 7`, `S 80`). Andere
-Verkehrsmittel auf den gleichen Gleisen (`REX`, `R`, `IC`, `Railjet`)
-werden verworfen — sie sind kein Stammstrecken-Produkt.
+### Filter und Aggregation (pro Richtung)
+
+Aus den zurückgegebenen `Journey`-Objekten werden pro Richtung alle
+`Leg`-Objekte ausgewählt, deren `name` dem regulären Ausdruck
+`^\s*S\s*\d+\s*$` entspricht (also reine S-Bahn-Linien wie `S 1`,
+`S 7`, `S 80`). Andere Verkehrsmittel auf den gleichen Gleisen (`REX`,
+`R`, `IC`, `Railjet`) werden verworfen — sie sind kein Stammstrecken-
+Produkt.
 
 Aus den verbleibenden Legs wird der **Median** der
-`departure_delay`-Werte (in Minuten) gebildet:
+`departure_delay`-Werte (in Minuten) gebildet — separat für jede
+Richtung:
 
 * Stornierte Legs (`leg.cancelled`) werden vom Median ausgeschlossen
   (kein Signal).
@@ -78,39 +85,82 @@ Aus den verbleibenden Legs wird der **Median** der
 
 ### Schwellenwert und Cache-Schreibverhalten
 
-Liegt der Median **strikt über 9 Minuten**, schreibt das Skript ein
-einzelnes, schema-konformes (`docs/schema/events.schema.json`) Event
-nach `cache/stammstrecke/events.json`:
+Liegt der Median für eine Richtung **strikt über 9 Minuten**, wird
+genau ein schema-konformes (`docs/schema/events.schema.json`) Event
+für diese Richtung erzeugt. Pro Cron-Tick entsteht damit eine Liste
+mit `0`, `1` oder `2` Events in `cache/stammstrecke/events.json` —
+abhängig davon, in welcher Richtung der Schwellenwert überschritten
+wurde:
 
 ```json
-{
-  "source": "ÖBB",
-  "category": "Störung",
-  "title": "S-Bahn Stammstrecke Verspätungen",
-  "description": "Auf der S-Bahn-Stammstrecke … Median: <b>X.X Minuten</b> …",
-  "link": "https://www.oebb.at/de/fahrplan/…/aktuelle-stoerungsmeldungen",
-  "guid": "<sha256(stammstrecke|median|<iso-pubDate>)>",
-  "pubDate": "2026-05-09T08:30:00+02:00",
-  "starts_at": "2026-05-09T08:30:00+02:00",
-  "ends_at": null,
-  "_identity": "stammstrecke|median|<iso-pubDate>"
-}
+[
+  {
+    "source": "ÖBB",
+    "category": "Störung",
+    "title": "S-Bahn Stammstrecke Verspätungen",
+    "description": "Durchschnittliche Verspätung von 12.5 Minuten in Richtung Meidling",
+    "link": "https://www.oebb.at/de/fahrplan/…/aktuelle-stoerungsmeldungen",
+    "guid": "<sha256(stammstrecke_delay_meidling|<iso-pubDate>)>",
+    "pubDate": "2026-05-09T08:30:00+02:00",
+    "starts_at": "2026-05-09T08:30:00+02:00",
+    "ends_at": null,
+    "_identity": "stammstrecke_delay_meidling|<iso-pubDate>"
+  },
+  {
+    "source": "ÖBB",
+    "category": "Störung",
+    "title": "S-Bahn Stammstrecke Verspätungen",
+    "description": "Durchschnittliche Verspätung von 14 Minuten in Richtung Floridsdorf",
+    "link": "https://www.oebb.at/de/fahrplan/…/aktuelle-stoerungsmeldungen",
+    "guid": "<sha256(stammstrecke_delay_floridsdorf|<iso-pubDate>)>",
+    "pubDate": "2026-05-09T08:30:00+02:00",
+    "starts_at": "2026-05-09T08:30:00+02:00",
+    "ends_at": null,
+    "_identity": "stammstrecke_delay_floridsdorf|<iso-pubDate>"
+  }
+]
 ```
 
+Die richtungsspezifischen `guid`- und `_identity`-Werte stellen
+sicher, dass Feed-Reader die beiden Meldungen als **separate**
+Notifications anzeigen.
+
 Liegt der Median ≤ 9 Minuten (oder gibt es keine S-Bahn-Legs mit
-Verspätungsdaten), schreibt das Skript stattdessen ein leeres Array
-`[]`. Die Cache-Datei ist damit zu jedem Zeitpunkt entweder eine
-gültige (möglicherweise leere) Liste — der Feed-Builder muss niemals
-einen "Datei fehlt"-Fall handhaben, sobald der erste Cron-Lauf erfolgt
-ist.
+Verspätungsdaten), wird **kein** Event für diese Richtung emittiert.
+Liegen für beide Richtungen keine Bedingungen vor, schreibt das
+Skript ein leeres Array `[]`. Die Cache-Datei ist damit zu jedem
+Zeitpunkt entweder eine gültige (möglicherweise leere) Liste — der
+Feed-Builder muss niemals einen "Datei fehlt"-Fall handhaben, sobald
+der erste Cron-Lauf erfolgt ist.
 
-### Resilience und Sicherheit
+### Resilience und API Rate-Limit
 
-* **CircuitBreaker** (`src.utils.circuit_breaker`): 5 aufeinanderfolgende
-  Fehler trippen den Breaker; in den folgenden 300 Sekunden werden
-  weitere Calls ohne Upstream-Kontakt abgewiesen
-  (`CircuitBreakerOpen`). Damit wird Self-DDoS gegen einen
-  bekannt-defekten HAFAS-Endpoint vermieden.
+Die Circuit-Breaker-Konfiguration spiegelt das documented **API-Limit
+von 10 Requests pro Stunde** für ÖBB-Abfragen wider:
+
+* `failure_threshold = 10` — nach 10 aufeinanderfolgenden Fehlern
+  wechselt der Breaker in den OPEN-Zustand.
+* `recovery_timeout = 3600.0` (1 Stunde) — der Breaker bleibt eine
+  Stunde lang OPEN, bevor ein Probe-Call zugelassen wird.
+
+Im Normalbetrieb produziert die Pipeline durch den Cron-Plan
+(`*/30 * * * *` = 2 Ausführungen pro Stunde) und 2 Richtungen pro
+Ausführung **4 Calls pro Stunde** — komfortabel unter dem Limit.
+Im Fehlermodus deckelt der Breaker zusätzlich auf maximal 10
+Versuche pro Stunde, bevor eine ganzstündige Pause greift.
+
+Weitere Schutzmechanismen:
+
+* **CircuitBreakerOpen** kurzschließt nach erstem Auftreten innerhalb
+  einer Iteration: wenn der Breaker während der Abarbeitung der ersten
+  Richtung öffnet, wird die zweite Richtung *nicht* mehr versucht
+  (sie würde sowieso short-circuiten). Bereits gesammelte Events der
+  ersten Richtung bleiben erhalten und werden geschrieben.
+* **Per-Direction-Fehlerisolation**: ein transienter Fehler bei
+  Richtung 1 (RuntimeError, Connection Reset etc.) wirft Richtung 2
+  *nicht* weg. Der Cache wird mit den Events geschrieben, die wir
+  haben — leere Daten bei kompletter Degradation, partielle Daten bei
+  gemischtem Erfolg.
 * **Atomares Schreiben** (`src.utils.files.atomic_write`): TOCTOU-sicherer
   Pfad mit kryptographisch zufälligem Temp-Dateinamen, `os.fsync` und
   abschließendem `os.replace`. Ein Crash mitten im Write hinterlässt
@@ -146,8 +196,14 @@ verbessert.
   Standard "deutliche Stammstrecken-Beeinträchtigung").
 * **Stations-IDs**: `FLORIDSDORF_STATION_ID` / `MEIDLING_STATION_ID` —
   HAFAS-IDs aus dem ÖBB-SCOTTY-System.
+* **Richtungs-Tabelle**: `DIRECTIONS` (Tuple aus `_Direction`-Records).
+  Jede Richtung trägt Origin, Destination, das im Description-Feld
+  angezeigte Ziel-Label und den Identity-Prefix für `guid` / `_identity`.
 * **Sample-Größe**: `MAX_JOURNEYS_PER_QUERY` (default 12). Höhere
   Werte stabilisieren den Median, kosten aber mehr Pyhafas-Calls.
 * **Regex für S-Bahn-Linien**: `_S_BAHN_LINE_RE`. Erfasst alle ÖBB-
   S-Bahn-Linien (`S\d+`), inklusive zukünftiger Erweiterungen (`S 90`,
   `S 100`).
+* **Rate-Limit**: `BREAKER_FAILURE_THRESHOLD` / `BREAKER_RECOVERY_TIMEOUT`.
+  Aktuell auf 10 / 3600 s gesetzt, um das documented 10/h-API-Budget
+  unter beliebigen Failure-Modi einzuhalten.

--- a/scripts/update_stammstrecke_status.py
+++ b/scripts/update_stammstrecke_status.py
@@ -1,35 +1,50 @@
 #!/usr/bin/env python3
 """Monitor delays on the S-Bahn Stammstrecke (Wien Floridsdorf ↔ Wien Meidling).
 
-Queries direct S-Bahn connections via :mod:`pyhafas` (`OEBBProfile`) and
-emits a schema-compliant event into ``cache/stammstrecke/events.json``
-when the **median** ``departure_delay`` across the queried legs exceeds
-:data:`DELAY_THRESHOLD_MINUTES` minutes. Otherwise the cache is reset to
-``[]`` so the feed builder integrates a clean state.
+Queries direct S-Bahn connections via :mod:`pyhafas` (`OEBBProfile`) for
+**both directions** independently and emits up to two schema-compliant
+events into ``cache/stammstrecke/events.json``: one per direction whose
+**median** ``departure_delay`` exceeds :data:`DELAY_THRESHOLD_MINUTES`
+minutes. Directions are evaluated strictly separately because merging
+both into a single sample dilutes the signal — a station with a major
+incident in one direction often runs normally in the opposite
+direction.
 
 Design contract
 ---------------
 
+- **Two-direction split**: each cron tick runs two HAFAS calls — one
+  ``Floridsdorf → Meidling`` and one ``Meidling → Floridsdorf``. Each
+  call's medians and events are computed independently. The cache
+  output contains 0, 1, or 2 events depending on which direction(s)
+  exceeded the threshold.
 - **Resilience**: the network call to HAFAS is wrapped in
-  :class:`src.utils.circuit_breaker.CircuitBreaker`. Five consecutive
-  failures trip the breaker for 300 s, after which a single probe call
-  is admitted. Each individual call uses a hard ``QUERY_TIMEOUT`` second
-  budget (clamped to ``MAX_QUERY_TIMEOUT``) inside ``pyhafas`` itself.
+  :class:`src.utils.circuit_breaker.CircuitBreaker`. Configured at
+  ``failure_threshold=10`` and ``recovery_timeout=3600`` seconds
+  (1 hour) — semantically aligning with a documented "≤ 10 requests
+  per hour" API budget for ÖBB. After 10 consecutive failures the
+  breaker stays OPEN for one hour, capping ÖBB-bound traffic in any
+  outage scenario. Combined with the cron schedule (``*/30 * * * *``,
+  2 fires/hour × 2 directions = 4 calls/hour normally) this keeps the
+  script comfortably below the 10/h rate ceiling.
 - **Atomicity**: writes go through :func:`src.utils.files.atomic_write`
-  with restrictive 0o600 permissions; a crash mid-write cannot leave a
-  half-written cache file behind.
+  with restrictive ``0o644`` permissions; a crash mid-write cannot
+  leave a half-written cache file behind.
 - **Timezone**: GitHub Actions runs in UTC. All timestamps inside the
-  emitted event (``pubDate``, ``starts_at``) are localised to
+  emitted events (``pubDate``, ``starts_at``) are localised to
   ``Europe/Vienna`` via :mod:`zoneinfo` and serialised as ISO 8601
   strings with offset, matching ``docs/schema/events.schema.json``.
-- **Schema**: the emitted event mirrors the canonical FeedItem shape
-  every other provider produces (``source`` / ``category`` / ``title`` /
-  ``description`` / ``link`` / ``guid`` / ``pubDate`` / ``starts_at`` /
-  ``ends_at`` / ``_identity``).
+- **Schema**: each emitted event mirrors the canonical FeedItem shape
+  every other provider produces (``source`` / ``category`` / ``title``
+  / ``description`` / ``link`` / ``guid`` / ``pubDate`` / ``starts_at``
+  / ``ends_at`` / ``_identity``). Per-direction events differ in
+  ``description`` (target station name), ``guid`` and ``_identity``
+  (direction-prefixed) so feed readers treat them as separate
+  notifications.
 - **Logging**: every diagnostic message is routed through
   :func:`src.feed.logging_safe.setup_script_logging` so log injection
-  / ANSI / BiDi attacks via upstream-controlled fields are sanitised at
-  the formatter layer.
+  / ANSI / BiDi attacks via upstream-controlled fields are sanitised
+  at the formatter layer.
 
 The non-commercial nature of the project means we do not need an API
 key; ÖBB's HAFAS endpoint is queried via the publicly documented
@@ -39,8 +54,10 @@ key; ÖBB's HAFAS endpoint is queried via the publicly documented
 from __future__ import annotations
 
 import logging
+import re
 import statistics
 import sys
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -70,14 +87,15 @@ LOGGER = logging.getLogger("update_stammstrecke_status")
 FLORIDSDORF_STATION_ID = "8100518"
 MEIDLING_STATION_ID = "8100514"
 
-# Threshold above which the median delay generates a feed entry. The user-
-# facing semantics are "more than 9 minutes" — so a median of exactly
-# 9 minutes does NOT trigger the event.
+# Threshold above which the median delay of a direction generates a feed
+# entry. The user-facing semantics are "more than 9 minutes" — a median
+# of exactly 9 minutes does NOT trigger the event.
 DELAY_THRESHOLD_MINUTES = 9
 
-# Number of journeys to fetch in a single HAFAS query. Higher values give
-# a more stable median but raise the cost of a single call. 12 covers
-# roughly half an hour of S-Bahn frequency on the Stammstrecke.
+# Number of journeys to fetch per direction in a single HAFAS query.
+# Higher values give a more stable median but raise the cost of a single
+# call. 12 covers roughly half an hour of S-Bahn frequency on the
+# Stammstrecke.
 MAX_JOURNEYS_PER_QUERY = 12
 
 # Per-call HTTP budget. A pyhafas call without a timeout can hang the
@@ -86,20 +104,20 @@ MAX_JOURNEYS_PER_QUERY = 12
 QUERY_TIMEOUT = 20
 MAX_QUERY_TIMEOUT = 30
 
-# Circuit-breaker policy. Five consecutive failures (network errors,
-# upstream 5xx, parse failures) trip the breaker for 300 seconds. The
-# cron tick is every 30 minutes, so a 5-minute hold-off only ever
-# blocks at most one tick.
-BREAKER_FAILURE_THRESHOLD = 5
-BREAKER_RECOVERY_TIMEOUT = 300.0
+# Circuit-breaker policy aligned with a documented ÖBB API budget of
+# 10 requests per hour. After 10 consecutive failures the breaker
+# stays OPEN for one hour, capping ÖBB-bound traffic at 10 attempts/h
+# in any outage scenario. With the cron schedule (``*/30``, 2 fires/h)
+# and 2 directions per fire, normal operation produces only 4 calls/h —
+# well below the configured ceiling.
+BREAKER_FAILURE_THRESHOLD = 10
+BREAKER_RECOVERY_TIMEOUT = 3600.0
 
 # Pattern that identifies an S-Bahn leg. ÖBB labels Stammstrecke services
 # as ``S 1``, ``S 2``, ``S 3``, ``S 7`` etc. — the ``name`` attribute of
 # a pyhafas ``Leg`` carries this label verbatim. Anything else (REX, R,
 # IC, Railjet) is a long-distance / regional service that uses the same
 # tracks but does not represent the Stammstrecke product.
-import re  # noqa: E402
-
 _S_BAHN_LINE_RE = re.compile(r"^\s*S\s*\d+\s*$", re.IGNORECASE)
 
 VIENNA_TZ = ZoneInfo("Europe/Vienna")
@@ -112,6 +130,39 @@ EVENT_TITLE = "S-Bahn Stammstrecke Verspätungen"
 EVENT_LINK = (
     "https://www.oebb.at/de/fahrplan/fahrplanauskunft-und-stoerungsinformation/aktuelle-stoerungsmeldungen"
 )
+
+
+@dataclass(frozen=True)
+class _Direction:
+    """A single Stammstrecke query direction.
+
+    Carries the per-direction parameters (origin/destination HAFAS IDs,
+    user-facing target label for the description, identity prefix for
+    the deduplication key and GUID) so the main loop can iterate over
+    both directions without branching on direction-specific logic.
+    """
+
+    origin_id: str
+    destination_id: str
+    target_label: str
+    identity_prefix: str
+
+
+DIRECTIONS: tuple[_Direction, ...] = (
+    _Direction(
+        origin_id=FLORIDSDORF_STATION_ID,
+        destination_id=MEIDLING_STATION_ID,
+        target_label="Meidling",
+        identity_prefix="stammstrecke_delay_meidling",
+    ),
+    _Direction(
+        origin_id=MEIDLING_STATION_ID,
+        destination_id=FLORIDSDORF_STATION_ID,
+        target_label="Floridsdorf",
+        identity_prefix="stammstrecke_delay_floridsdorf",
+    ),
+)
+
 
 _BREAKER = CircuitBreaker(
     "stammstrecke-hafas",
@@ -147,11 +198,12 @@ def _build_client() -> Any:
 
 def _query_journeys(
     client: Any,
+    direction: _Direction,
     *,
     when: datetime,
     timeout: int,
 ) -> list[Journey]:
-    """Call ``client.journeys`` once and return the result list.
+    """Call ``client.journeys`` once for *direction* and return the result.
 
     The call is executed as-is; resilience (retry/back-off, breaker
     state) is provided by :data:`_BREAKER` at the call site. The
@@ -175,8 +227,8 @@ def _query_journeys(
                     pass
 
     journeys = client.journeys(
-        origin=FLORIDSDORF_STATION_ID,
-        destination=MEIDLING_STATION_ID,
+        origin=direction.origin_id,
+        destination=direction.destination_id,
         date=when,
         max_changes=0,
         max_journeys=MAX_JOURNEYS_PER_QUERY,
@@ -229,32 +281,45 @@ def _now_vienna() -> datetime:
     return datetime.now(tz=VIENNA_TZ)
 
 
+def _format_minutes(value: float) -> str:
+    """Format *value* as a German-readable minute count.
+
+    ``round(x, 1)`` followed by ``:g`` strips trailing ``.0`` so a
+    whole-minute median renders as ``"12"`` rather than ``"12.0"``,
+    while a fractional median keeps its single decimal (``"12.5"``).
+    """
+
+    rounded = round(value, 1)
+    return f"{rounded:g}"
+
+
 def _build_event(
     *,
+    direction: _Direction,
     median_delay_minutes: float,
-    sample_size: int,
     pub_date: datetime,
 ) -> dict[str, Any]:
-    """Construct the schema-compliant event dictionary.
+    """Construct a schema-compliant event dictionary for *direction*.
 
     See ``docs/schema/events.schema.json`` for the contract. ``pubDate``
     and ``starts_at`` use the same timestamp because the median is a
     point-in-time observation; ``ends_at`` is left ``null`` because the
     cause and end of the disruption are not known to this script.
+
+    Per-direction GUIDs and identity strings are derived from
+    ``direction.identity_prefix`` (e.g. ``stammstrecke_delay_meidling``)
+    so feed readers treat the two directions as separate notifications.
     """
 
-    rounded = round(median_delay_minutes, 1)
     description = (
-        f"Auf der S-Bahn-Stammstrecke (Wien Floridsdorf ↔ Wien Meidling) wurden "
-        f"erhöhte Verspätungen erkannt. Median der Abfahrtsverspätungen über "
-        f"die letzten {sample_size} S-Bahn-Verbindungen: "
-        f"<b>{rounded:.1f} Minuten</b> (Schwellenwert: "
-        f"{DELAY_THRESHOLD_MINUTES} Minuten). Quelle: ÖBB HAFAS via pyhafas."
+        f"Durchschnittliche Verspätung von "
+        f"{_format_minutes(median_delay_minutes)} Minuten "
+        f"in Richtung {direction.target_label}"
     )
 
     iso_pub = pub_date.isoformat()
-    identity = f"stammstrecke|median|{iso_pub}"
-    guid = make_guid("stammstrecke", "median", iso_pub)
+    identity = f"{direction.identity_prefix}|{iso_pub}"
+    guid = make_guid(direction.identity_prefix, iso_pub)
 
     return {
         "source": EVENT_SOURCE,
@@ -291,12 +356,99 @@ def _write_cache(payload: list[dict[str, Any]]) -> None:
         fh.write("\n")
 
 
+def _process_direction(
+    client: Any,
+    direction: _Direction,
+    *,
+    when: datetime,
+    timeout: int,
+) -> tuple[dict[str, Any] | None, str]:
+    """Query ``direction`` once and return ``(event_or_none, status)``.
+
+    The return tuple's second element is one of:
+
+    * ``"event"`` — direction exceeded threshold, event was built;
+    * ``"no_delays"`` — direction succeeded but emitted no S-Bahn legs
+      with delay data, or median ≤ threshold;
+    * ``"error"`` — pyhafas raised an exception (already logged).
+
+    The ``CircuitBreakerOpen`` case is *not* handled here — the caller
+    catches it so it can break out of the per-direction loop instead
+    of consuming further breaker-protected slots.
+    """
+
+    LOGGER.info(
+        "Stammstrecke: Abfrage Wien %s → Wien %s um %s.",
+        "Floridsdorf" if direction.origin_id == FLORIDSDORF_STATION_ID else "Meidling",
+        direction.target_label,
+        when.isoformat(),
+    )
+    try:
+        journeys = _BREAKER.call(
+            _query_journeys, client, direction, when=when, timeout=timeout
+        )
+    except CircuitBreakerOpen:
+        # Re-raise so main() can break out of the loop without re-trying
+        # the next direction (the breaker would short-circuit it anyway).
+        raise
+    except Exception as exc:
+        LOGGER.warning(
+            "Stammstrecke: Abfrage Richtung %s fehlgeschlagen: %s: %s.",
+            direction.target_label,
+            type(exc).__name__,
+            sanitize_log_arg(str(exc)),
+        )
+        return None, "error"
+
+    delays = _collect_sbahn_delays_minutes(journeys)
+    LOGGER.info(
+        "Stammstrecke: Richtung %s — %d S-Bahn-Legs aus %d Journeys analysiert.",
+        direction.target_label,
+        len(delays),
+        len(journeys),
+    )
+    if not delays:
+        return None, "no_delays"
+
+    median_minutes = float(statistics.median(delays))
+    LOGGER.info(
+        "Stammstrecke: Richtung %s — Median: %.2f Minuten (Schwelle: %d).",
+        direction.target_label,
+        median_minutes,
+        DELAY_THRESHOLD_MINUTES,
+    )
+    if median_minutes <= DELAY_THRESHOLD_MINUTES:
+        return None, "no_delays"
+
+    event = _build_event(
+        direction=direction,
+        median_delay_minutes=median_minutes,
+        pub_date=when,
+    )
+    LOGGER.info(
+        "Stammstrecke: Richtung %s — Median %.2f > %d → Event erzeugt (guid=%s).",
+        direction.target_label,
+        median_minutes,
+        DELAY_THRESHOLD_MINUTES,
+        event["guid"][:12],
+    )
+    return event, "event"
+
+
 def main() -> int:
-    """Entry point. Returns ``0`` on success, ``1`` on a controlled error.
+    """Entry point. Returns ``0`` on success (incl. partial), ``1`` on full failure.
 
     The script never raises an unhandled exception out of ``main`` — the
     cron pipeline relies on a clean exit so other cache updates run on
     schedule even when this provider is degraded.
+
+    Per-direction error handling is intentionally permissive: a transient
+    failure on one direction does NOT discard data already collected
+    from the other. ``CircuitBreakerOpen`` is the only exception that
+    short-circuits the loop, because its semantics are "stop hitting
+    the upstream" — the breaker would short-circuit the second call
+    anyway, and an empty events list is the appropriate signal until
+    the recovery window has elapsed.
     """
 
     configure_logging()
@@ -322,74 +474,43 @@ def main() -> int:
         return 1
 
     when = _now_vienna()
+    events: list[dict[str, Any]] = []
+    successes = 0
+    errors = 0
+
+    for direction in DIRECTIONS:
+        try:
+            event, status = _process_direction(
+                client, direction, when=when, timeout=timeout
+            )
+        except CircuitBreakerOpen:
+            LOGGER.warning(
+                "Stammstrecke: Circuit breaker offen (%d aufeinanderfolgende Fehler) — "
+                "überspringe verbleibende Richtungen für diese Tick.",
+                _BREAKER.consecutive_failures,
+            )
+            break
+
+        if status == "error":
+            errors += 1
+            continue
+        successes += 1
+        if event is not None:
+            events.append(event)
+
+    _write_cache(events)
     LOGGER.info(
-        "Stammstrecke: Abfrage Wien Floridsdorf → Wien Meidling um %s (max_changes=0, max_journeys=%d).",
-        when.isoformat(),
-        MAX_JOURNEYS_PER_QUERY,
+        "Stammstrecke: Cache mit %d Event(s) aktualisiert (Erfolg=%d, Fehler=%d).",
+        len(events),
+        successes,
+        errors,
     )
 
-    try:
-        journeys = _BREAKER.call(_query_journeys, client, when=when, timeout=timeout)
-    except CircuitBreakerOpen:
-        LOGGER.warning(
-            "Stammstrecke: Circuit breaker offen (%d aufeinanderfolgende Fehler) — "
-            "schreibe leere Cache-Datei und überspringe diese Tick.",
-            _BREAKER.consecutive_failures,
-        )
-        _write_cache([])
-        return 0
-    except Exception as exc:
-        # Keep the cache file in a known-good state instead of leaving a
-        # stale entry from the previous run when HAFAS is degraded.
-        LOGGER.warning(
-            "Stammstrecke: Abfrage fehlgeschlagen: %s: %s — schreibe leere Cache-Datei.",
-            type(exc).__name__,
-            sanitize_log_arg(str(exc)),
-        )
-        _write_cache([])
+    # Exit 1 only if every direction failed AND at least one was attempted —
+    # a CircuitBreakerOpen-only run (errors=0, successes=0) is intentional
+    # short-circuiting and exits 0.
+    if successes == 0 and errors > 0:
         return 1
-
-    delays = _collect_sbahn_delays_minutes(journeys)
-    LOGGER.info(
-        "Stammstrecke: %d S-Bahn-Legs aus %d Journeys analysiert.",
-        len(delays),
-        len(journeys),
-    )
-
-    if not delays:
-        LOGGER.info(
-            "Stammstrecke: Keine S-Bahn-Legs mit Verspätungsdaten gefunden — schreibe leere Cache-Datei."
-        )
-        _write_cache([])
-        return 0
-
-    median_minutes = float(statistics.median(delays))
-    LOGGER.info(
-        "Stammstrecke: Median der Abfahrtsverspätungen: %.2f Minuten (Schwelle: %d).",
-        median_minutes,
-        DELAY_THRESHOLD_MINUTES,
-    )
-
-    if median_minutes <= DELAY_THRESHOLD_MINUTES:
-        _write_cache([])
-        LOGGER.info(
-            "Stammstrecke: Median ≤ %d Minuten — keine Meldung, Cache geleert.",
-            DELAY_THRESHOLD_MINUTES,
-        )
-        return 0
-
-    event = _build_event(
-        median_delay_minutes=median_minutes,
-        sample_size=len(delays),
-        pub_date=when,
-    )
-    _write_cache([event])
-    LOGGER.info(
-        "Stammstrecke: Median %.2f Min > %d Min — Meldung in Cache geschrieben (guid=%s).",
-        median_minutes,
-        DELAY_THRESHOLD_MINUTES,
-        event["guid"][:12],
-    )
     return 0
 
 

--- a/tests/scripts/test_update_stammstrecke_status.py
+++ b/tests/scripts/test_update_stammstrecke_status.py
@@ -4,7 +4,8 @@ The pyhafas client is mocked end-to-end so the test suite never reaches
 the live ÖBB HAFAS endpoint. Each test exercises a single, isolated
 branch of the script's decision tree: import-time failure, transport
 error, circuit-breaker open, median-below-threshold, median-above-
-threshold, no S-Bahn legs found.
+threshold, no S-Bahn legs found — for each of the **two** Stammstrecke
+directions independently.
 """
 from __future__ import annotations
 
@@ -31,6 +32,9 @@ from src.utils.circuit_breaker import CircuitBreaker  # noqa: E402
 VIENNA_TZ = ZoneInfo("Europe/Vienna")
 
 
+# ---- Fixtures --------------------------------------------------------------
+
+
 @pytest.fixture(autouse=True)
 def _isolated_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
     """Redirect cache writes to a per-test directory."""
@@ -42,7 +46,11 @@ def _isolated_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterato
 
 @pytest.fixture(autouse=True)
 def _fresh_breaker(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Replace the module-level breaker so tests don't share state."""
+    """Replace the module-level breaker so tests don't share state.
+
+    Uses the production breaker config (10 / 3600 s) so the threshold-
+    based behavioural tests reflect what runs in CI.
+    """
 
     monkeypatch.setattr(
         script,
@@ -65,6 +73,9 @@ def _stable_now(monkeypatch: pytest.MonkeyPatch) -> Iterator[datetime]:
     yield pinned
 
 
+# ---- Helpers ---------------------------------------------------------------
+
+
 def _leg(*, name: str, delay_minutes: float | None, cancelled: bool = False) -> Any:
     """Return a duck-typed leg mock matching pyhafas FPTF Leg."""
 
@@ -81,6 +92,45 @@ def _read_output(path: Path) -> list[dict[str, Any]]:
     payload = json.loads(raw)
     assert isinstance(payload, list)
     return payload
+
+
+def _make_directional_client(
+    floridsdorf_to_meidling: list[Any] | Exception,
+    meidling_to_floridsdorf: list[Any] | Exception,
+) -> Any:
+    """Build a fake HafasClient that returns per-direction mock data.
+
+    Each direction can also be an :class:`Exception` instance to
+    simulate a per-direction transport error without affecting the
+    other direction's outcome.
+    """
+
+    def journeys(**kwargs: Any) -> list[Any]:
+        origin = kwargs.get("origin")
+        destination = kwargs.get("destination")
+        if (
+            origin == script.FLORIDSDORF_STATION_ID
+            and destination == script.MEIDLING_STATION_ID
+        ):
+            payload = floridsdorf_to_meidling
+        elif (
+            origin == script.MEIDLING_STATION_ID
+            and destination == script.FLORIDSDORF_STATION_ID
+        ):
+            payload = meidling_to_floridsdorf
+        else:  # pragma: no cover - defensive: unexpected origin/dest pair
+            raise AssertionError(
+                f"Unexpected origin/destination pair: {origin!r} → {destination!r}"
+            )
+        if isinstance(payload, Exception):
+            raise payload
+        return payload
+
+    return SimpleNamespace(profile=SimpleNamespace(), journeys=journeys)
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, client: Any) -> None:
+    monkeypatch.setattr(script, "_build_client", lambda: client)
 
 
 # ---- Helper-level unit tests -----------------------------------------------
@@ -122,10 +172,52 @@ def test_collect_delays_includes_only_sbahn_with_delay() -> None:
     assert delays == [4.0, 10.0]
 
 
-def test_build_event_matches_schema_required_fields(_stable_now: datetime) -> None:
+def test_collect_delays_handles_missing_legs_attribute() -> None:
+    """A misbehaving HAFAS peer might emit journeys without a ``legs`` attr."""
+
+    journeys = [SimpleNamespace()]  # no legs attribute at all
+    assert script._collect_sbahn_delays_minutes(journeys) == []
+
+
+def test_collect_delays_handles_legs_set_to_none() -> None:
+    journeys = [SimpleNamespace(legs=None)]
+    assert script._collect_sbahn_delays_minutes(journeys) == []
+
+
+def test_format_minutes_strips_trailing_zero() -> None:
+    assert script._format_minutes(12.0) == "12"
+    assert script._format_minutes(12.5) == "12.5"
+    assert script._format_minutes(11.04) == "11"  # rounds to 11.0
+    assert script._format_minutes(11.05) == "11.1"
+
+
+def test_directions_table_covers_both_targets() -> None:
+    """Sanity: DIRECTIONS contains exactly the two Stammstrecke directions."""
+
+    targets = {d.target_label for d in script.DIRECTIONS}
+    prefixes = {d.identity_prefix for d in script.DIRECTIONS}
+    assert targets == {"Meidling", "Floridsdorf"}
+    assert prefixes == {
+        "stammstrecke_delay_meidling",
+        "stammstrecke_delay_floridsdorf",
+    }
+
+
+def test_breaker_config_aligns_with_10_per_hour_budget() -> None:
+    """Pin the rate-limit-aligned breaker constants documented in the script."""
+
+    assert script.BREAKER_FAILURE_THRESHOLD == 10
+    assert script.BREAKER_RECOVERY_TIMEOUT == 3600.0
+
+
+# ---- _build_event tests ----------------------------------------------------
+
+
+def test_build_event_for_meidling_direction(_stable_now: datetime) -> None:
+    direction = next(d for d in script.DIRECTIONS if d.target_label == "Meidling")
     event = script._build_event(
+        direction=direction,
         median_delay_minutes=12.5,
-        sample_size=8,
         pub_date=_stable_now,
     )
     required_keys = {
@@ -142,66 +234,148 @@ def test_build_event_matches_schema_required_fields(_stable_now: datetime) -> No
     assert event["title"] == "S-Bahn Stammstrecke Verspätungen"
     assert event["source"] == "ÖBB"
     assert event["category"] == "Störung"
+    assert (
+        event["description"]
+        == "Durchschnittliche Verspätung von 12.5 Minuten in Richtung Meidling"
+    )
     # Timestamps must be ISO-8601 strings with offset (Europe/Vienna).
     assert event["pubDate"] == _stable_now.isoformat()
     assert event["starts_at"] == _stable_now.isoformat()
     assert event["pubDate"].endswith(("+02:00", "+01:00"))
     assert event["ends_at"] is None
-    # GUID must be deterministic for the same timestamp.
-    again = script._build_event(
-        median_delay_minutes=12.5, sample_size=8, pub_date=_stable_now
+    assert event["_identity"].startswith("stammstrecke_delay_meidling|")
+
+
+def test_build_event_for_floridsdorf_direction(_stable_now: datetime) -> None:
+    direction = next(d for d in script.DIRECTIONS if d.target_label == "Floridsdorf")
+    event = script._build_event(
+        direction=direction,
+        median_delay_minutes=15.0,
+        pub_date=_stable_now,
     )
-    assert event["guid"] == again["guid"]
-
-
-# ---- main() integration tests ----------------------------------------------
-
-
-def test_main_writes_event_when_median_above_threshold(
-    monkeypatch: pytest.MonkeyPatch, _isolated_output: Path, _stable_now: datetime
-) -> None:
-    fake_client = SimpleNamespace(
-        profile=SimpleNamespace(),
-        journeys=lambda **kwargs: [
-            _journey(legs=[_leg(name="S 1", delay_minutes=11)]),
-            _journey(legs=[_leg(name="S 2", delay_minutes=10)]),
-            _journey(legs=[_leg(name="S 3", delay_minutes=9)]),
-            _journey(legs=[_leg(name="S 7", delay_minutes=12)]),
-            _journey(legs=[_leg(name="S 80", delay_minutes=15)]),
-        ],
-    )
-    monkeypatch.setattr(script, "_build_client", lambda: fake_client)
-
-    exit_code = script.main()
-    assert exit_code == 0
-
-    payload = _read_output(_isolated_output)
-    assert len(payload) == 1
-    event = payload[0]
     assert event["title"] == "S-Bahn Stammstrecke Verspätungen"
-    assert event["pubDate"] == _stable_now.isoformat()
-    assert "11.0 Minuten" in event["description"]
+    # 15.0 must render as "15" (no trailing zero) per ``_format_minutes``.
+    assert (
+        event["description"]
+        == "Durchschnittliche Verspätung von 15 Minuten in Richtung Floridsdorf"
+    )
+    assert event["_identity"].startswith("stammstrecke_delay_floridsdorf|")
 
 
-def test_main_writes_empty_when_median_below_threshold(
+def test_build_event_guids_differ_per_direction(_stable_now: datetime) -> None:
+    """Each direction must produce a distinct GUID for the same timestamp.
+
+    The user-facing contract is that feed readers treat the two
+    direction events as separate notifications. That requires distinct
+    ``guid`` values even when the underlying timestamps coincide.
+    """
+
+    meidling = next(d for d in script.DIRECTIONS if d.target_label == "Meidling")
+    floridsdorf = next(d for d in script.DIRECTIONS if d.target_label == "Floridsdorf")
+    event_a = script._build_event(
+        direction=meidling, median_delay_minutes=12.5, pub_date=_stable_now
+    )
+    event_b = script._build_event(
+        direction=floridsdorf, median_delay_minutes=12.5, pub_date=_stable_now
+    )
+    assert event_a["guid"] != event_b["guid"]
+    assert event_a["_identity"] != event_b["_identity"]
+
+
+def test_build_event_guid_is_deterministic(_stable_now: datetime) -> None:
+    direction = script.DIRECTIONS[0]
+    event_a = script._build_event(
+        direction=direction, median_delay_minutes=12.5, pub_date=_stable_now
+    )
+    event_b = script._build_event(
+        direction=direction, median_delay_minutes=12.5, pub_date=_stable_now
+    )
+    assert event_a["guid"] == event_b["guid"]
+
+
+# ---- main() integration tests ---------------------------------------------
+
+
+def test_main_writes_two_events_when_both_directions_above_threshold(
     monkeypatch: pytest.MonkeyPatch, _isolated_output: Path
 ) -> None:
-    fake_client = SimpleNamespace(
-        profile=SimpleNamespace(),
-        journeys=lambda **kwargs: [
-            _journey(legs=[_leg(name="S 1", delay_minutes=2)]),
-            _journey(legs=[_leg(name="S 2", delay_minutes=4)]),
-            _journey(legs=[_leg(name="S 3", delay_minutes=9)]),
-            _journey(legs=[_leg(name="S 7", delay_minutes=3)]),
-        ],
-    )
-    monkeypatch.setattr(script, "_build_client", lambda: fake_client)
+    """Both directions exceed the threshold → one event per direction."""
 
-    exit_code = script.main()
-    assert exit_code == 0
+    fwd = [
+        _journey(legs=[_leg(name="S 1", delay_minutes=11)]),
+        _journey(legs=[_leg(name="S 2", delay_minutes=10)]),
+        _journey(legs=[_leg(name="S 3", delay_minutes=12)]),
+    ]
+    bwd = [
+        _journey(legs=[_leg(name="S 7", delay_minutes=14)]),
+        _journey(legs=[_leg(name="S 80", delay_minutes=15)]),
+        _journey(legs=[_leg(name="S 1", delay_minutes=13)]),
+    ]
+    _patch_client(monkeypatch, _make_directional_client(fwd, bwd))
 
+    assert script.main() == 0
     payload = _read_output(_isolated_output)
-    assert payload == []
+    assert len(payload) == 2
+    descriptions = {event["description"] for event in payload}
+    assert (
+        "Durchschnittliche Verspätung von 11 Minuten in Richtung Meidling"
+        in descriptions
+    )
+    assert (
+        "Durchschnittliche Verspätung von 14 Minuten in Richtung Floridsdorf"
+        in descriptions
+    )
+    # Both events must have distinct GUIDs.
+    guids = {event["guid"] for event in payload}
+    assert len(guids) == 2
+
+
+def test_main_writes_only_meidling_event_when_only_forward_above_threshold(
+    monkeypatch: pytest.MonkeyPatch, _isolated_output: Path
+) -> None:
+    fwd = [
+        _journey(legs=[_leg(name="S 1", delay_minutes=14)]),
+        _journey(legs=[_leg(name="S 2", delay_minutes=13)]),
+    ]
+    bwd = [
+        _journey(legs=[_leg(name="S 7", delay_minutes=2)]),
+        _journey(legs=[_leg(name="S 80", delay_minutes=4)]),
+    ]
+    _patch_client(monkeypatch, _make_directional_client(fwd, bwd))
+
+    assert script.main() == 0
+    payload = _read_output(_isolated_output)
+    assert len(payload) == 1
+    assert "in Richtung Meidling" in payload[0]["description"]
+    assert payload[0]["_identity"].startswith("stammstrecke_delay_meidling|")
+
+
+def test_main_writes_only_floridsdorf_event_when_only_backward_above_threshold(
+    monkeypatch: pytest.MonkeyPatch, _isolated_output: Path
+) -> None:
+    fwd = [_journey(legs=[_leg(name="S 1", delay_minutes=2)])]
+    bwd = [
+        _journey(legs=[_leg(name="S 7", delay_minutes=11)]),
+        _journey(legs=[_leg(name="S 80", delay_minutes=12)]),
+    ]
+    _patch_client(monkeypatch, _make_directional_client(fwd, bwd))
+
+    assert script.main() == 0
+    payload = _read_output(_isolated_output)
+    assert len(payload) == 1
+    assert "in Richtung Floridsdorf" in payload[0]["description"]
+    assert payload[0]["_identity"].startswith("stammstrecke_delay_floridsdorf|")
+
+
+def test_main_writes_empty_when_both_directions_below_threshold(
+    monkeypatch: pytest.MonkeyPatch, _isolated_output: Path
+) -> None:
+    fwd = [_journey(legs=[_leg(name="S 1", delay_minutes=2)])]
+    bwd = [_journey(legs=[_leg(name="S 7", delay_minutes=4)])]
+    _patch_client(monkeypatch, _make_directional_client(fwd, bwd))
+
+    assert script.main() == 0
+    assert _read_output(_isolated_output) == []
 
 
 def test_main_writes_empty_when_median_equals_threshold(
@@ -209,15 +383,11 @@ def test_main_writes_empty_when_median_equals_threshold(
 ) -> None:
     """Median exactly equal to threshold must NOT trigger the event."""
 
-    fake_client = SimpleNamespace(
-        profile=SimpleNamespace(),
-        journeys=lambda **kwargs: [
-            _journey(legs=[_leg(name="S 1", delay_minutes=9)]),
-            _journey(legs=[_leg(name="S 2", delay_minutes=9)]),
-            _journey(legs=[_leg(name="S 3", delay_minutes=9)]),
-        ],
-    )
-    monkeypatch.setattr(script, "_build_client", lambda: fake_client)
+    nine = [
+        _journey(legs=[_leg(name="S 1", delay_minutes=9)]),
+        _journey(legs=[_leg(name="S 2", delay_minutes=9)]),
+    ]
+    _patch_client(monkeypatch, _make_directional_client(nine, nine))
 
     assert script.main() == 0
     assert _read_output(_isolated_output) == []
@@ -226,21 +396,62 @@ def test_main_writes_empty_when_median_equals_threshold(
 def test_main_writes_empty_when_no_sbahn_legs(
     monkeypatch: pytest.MonkeyPatch, _isolated_output: Path
 ) -> None:
-    fake_client = SimpleNamespace(
-        profile=SimpleNamespace(),
-        journeys=lambda **kwargs: [
-            _journey(legs=[_leg(name="REX 7", delay_minutes=20)]),
-            _journey(legs=[_leg(name="IC 533", delay_minutes=15)]),
-        ],
-    )
-    monkeypatch.setattr(script, "_build_client", lambda: fake_client)
+    """Only non-S-Bahn legs in either direction → empty cache, exit 0."""
+
+    fwd = [_journey(legs=[_leg(name="REX 7", delay_minutes=20)])]
+    bwd = [_journey(legs=[_leg(name="IC 533", delay_minutes=15)])]
+    _patch_client(monkeypatch, _make_directional_client(fwd, bwd))
 
     assert script.main() == 0
     assert _read_output(_isolated_output) == []
 
 
+def test_main_partial_failure_keeps_other_direction_event(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolated_output: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Direction 1 raises but direction 2 succeeds with a high median.
+
+    The event for the surviving direction must still be persisted —
+    discarding direction 2's data because direction 1 had a transient
+    error would degrade the feed for no reason.
+    """
+
+    fwd_error = RuntimeError("transient connection reset")
+    bwd_high = [
+        _journey(legs=[_leg(name="S 7", delay_minutes=12)]),
+        _journey(legs=[_leg(name="S 80", delay_minutes=14)]),
+    ]
+    _patch_client(monkeypatch, _make_directional_client(fwd_error, bwd_high))
+
+    caplog.set_level(logging.WARNING, logger=script.LOGGER.name)
+    # Exit code 0 because at least one direction succeeded.
+    assert script.main() == 0
+
+    payload = _read_output(_isolated_output)
+    assert len(payload) == 1
+    assert "in Richtung Floridsdorf" in payload[0]["description"]
+    assert any("Richtung Meidling" in r.getMessage() for r in caplog.records)
+
+
+def test_main_returns_1_when_all_directions_fail(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolated_output: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    err1 = RuntimeError("connection reset 1")
+    err2 = RuntimeError("connection reset 2")
+    _patch_client(monkeypatch, _make_directional_client(err1, err2))
+
+    caplog.set_level(logging.WARNING, logger=script.LOGGER.name)
+    assert script.main() == 1
+    assert _read_output(_isolated_output) == []
+
+
 def test_main_writes_empty_on_import_error(
-    monkeypatch: pytest.MonkeyPatch, _isolated_output: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _isolated_output: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     def raise_import_error() -> Any:
@@ -254,27 +465,17 @@ def test_main_writes_empty_on_import_error(
     assert any("nicht verfügbar" in r.getMessage() for r in caplog.records)
 
 
-def test_main_writes_empty_on_query_failure(
-    monkeypatch: pytest.MonkeyPatch, _isolated_output: Path,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    def boom(**kwargs: Any) -> list[Any]:
-        raise RuntimeError("connection reset by peer")
-
-    fake_client = SimpleNamespace(profile=SimpleNamespace(), journeys=boom)
-    monkeypatch.setattr(script, "_build_client", lambda: fake_client)
-
-    caplog.set_level(logging.WARNING, logger=script.LOGGER.name)
-    assert script.main() == 1
-    assert _read_output(_isolated_output) == []
-    assert any("fehlgeschlagen" in r.getMessage() for r in caplog.records)
-
-
 def test_main_short_circuits_when_breaker_is_open(
-    monkeypatch: pytest.MonkeyPatch, _isolated_output: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _isolated_output: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Pre-tripping the breaker forces main() onto its short-circuit path."""
+    """Pre-tripping the breaker forces main() onto its short-circuit path.
+
+    When the breaker is OPEN, the first direction's call raises
+    ``CircuitBreakerOpen``. main() must break out of the loop without
+    invoking the upstream for the second direction either.
+    """
 
     breaker = CircuitBreaker(
         "stammstrecke-hafas-pretrip",
@@ -285,47 +486,58 @@ def test_main_short_circuits_when_breaker_is_open(
     breaker.record_failure()
     monkeypatch.setattr(script, "_BREAKER", breaker)
 
-    upstream_called = False
+    upstream_calls: list[tuple[str | None, str | None]] = []
 
     def must_not_be_called(**kwargs: Any) -> list[Any]:
-        nonlocal upstream_called
-        upstream_called = True
+        upstream_calls.append((kwargs.get("origin"), kwargs.get("destination")))
         return []
 
     fake_client = SimpleNamespace(
         profile=SimpleNamespace(), journeys=must_not_be_called
     )
-    monkeypatch.setattr(script, "_build_client", lambda: fake_client)
+    _patch_client(monkeypatch, fake_client)
 
     caplog.set_level(logging.WARNING, logger=script.LOGGER.name)
+    # Exit 0 — breaker-open is intentional short-circuiting, not a failure.
     assert script.main() == 0
     assert _read_output(_isolated_output) == []
-    assert upstream_called is False
+    assert upstream_calls == []
     assert any("breaker" in r.getMessage().lower() for r in caplog.records)
 
 
 def test_main_handles_non_list_payload(
-    monkeypatch: pytest.MonkeyPatch, _isolated_output: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _isolated_output: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    fake_client = SimpleNamespace(
-        profile=SimpleNamespace(),
-        journeys=lambda **kwargs: "not-a-list",
-    )
-    monkeypatch.setattr(script, "_build_client", lambda: fake_client)
+    """Both directions return a non-list value → both fail, exit 1."""
+
+    def journeys(**kwargs: Any) -> Any:
+        return "not-a-list"
+
+    fake_client = SimpleNamespace(profile=SimpleNamespace(), journeys=journeys)
+    _patch_client(monkeypatch, fake_client)
 
     caplog.set_level(logging.WARNING, logger=script.LOGGER.name)
     assert script.main() == 1
     assert _read_output(_isolated_output) == []
 
 
-def test_collect_delays_handles_missing_legs_attribute() -> None:
-    """A misbehaving HAFAS peer might emit journeys without a ``legs`` attr."""
+def test_main_emits_iso8601_with_vienna_offset(
+    monkeypatch: pytest.MonkeyPatch,
+    _isolated_output: Path,
+    _stable_now: datetime,
+) -> None:
+    """Verify the timezone contract: pubDate is Europe/Vienna, ISO 8601."""
 
-    journeys = [SimpleNamespace()]  # no legs attribute at all
-    assert script._collect_sbahn_delays_minutes(journeys) == []
+    fwd = [_journey(legs=[_leg(name="S 1", delay_minutes=12)])]
+    bwd = [_journey(legs=[_leg(name="S 7", delay_minutes=12)])]
+    _patch_client(monkeypatch, _make_directional_client(fwd, bwd))
 
-
-def test_collect_delays_handles_legs_set_to_none() -> None:
-    journeys = [SimpleNamespace(legs=None)]
-    assert script._collect_sbahn_delays_minutes(journeys) == []
+    assert script.main() == 0
+    payload = _read_output(_isolated_output)
+    assert len(payload) == 2
+    for event in payload:
+        assert event["pubDate"] == _stable_now.isoformat()
+        # Either summer (+02:00) or winter (+01:00) — date is in May → +02:00.
+        assert event["pubDate"].endswith("+02:00")


### PR DESCRIPTION
## Summary

Folge-PR zu #1365: Drei zielgerichtete Anpassungen am Stammstrecke-Monitor, damit die emittierten Daten die tatsächliche Verkehrslage korrekt abbilden.

### 1. Richtungen strikt getrennt auswerten

Bisher wurde nur eine Richtung (Floridsdorf → Meidling) abgefragt — was bei einseitigen Störungen das Median-Signal verfälscht. Der Monitor fragt jetzt **beide Richtungen separat** ab und emittiert pro Richtung **unabhängig** ein Event:

| Richtung | Origin → Destination | Event-Identity-Prefix |
| :--- | :--- | :--- |
| Richtung 1 | Floridsdorf (`8100518`) → Meidling (`8100514`) | `stammstrecke_delay_meidling` |
| Richtung 2 | Meidling (`8100514`) → Floridsdorf (`8100518`) | `stammstrecke_delay_floridsdorf` |

`cache/stammstrecke/events.json` enthält damit **0, 1 oder 2 Events** — abhängig davon, in welcher Richtung der Median > 9 Minuten überschritten wird.

### 2. Event-Schema (Titel & Beschreibung)

Plain-Text-Description, identity- und guid-Werte richtungsspezifisch, damit Feed-Reader die zwei Meldungen als separate Notifications darstellen:

```json
{
  "title": "S-Bahn Stammstrecke Verspätungen",
  "description": "Durchschnittliche Verspätung von 12.5 Minuten in Richtung Meidling",
  "guid": "<sha256(stammstrecke_delay_meidling|<iso-pubDate>)>",
  "_identity": "stammstrecke_delay_meidling|<iso-pubDate>",
  ...
}
```

`_format_minutes(...)` strippt trailing `.0` (`12.0` → `"12"`, `12.5` → `"12.5"`) für lesbare deutsche Ausgabe.

### 3. Circuit-Breaker auf 10 req/h ausgerichtet

`BREAKER_FAILURE_THRESHOLD = 10` und `BREAKER_RECOVERY_TIMEOUT = 3600.0` (1 Stunde). Normaler Betrieb: 4 Calls/h (cron `*/30` × 2 Richtungen). Im Fehlermodus deckelt der Breaker zusätzlich auf max. 10 Versuche/h vor einer einstündigen Pause.

### Failure-Isolation

Eine transiente Störung bei Richtung 1 verwirft Richtung 2 nicht mehr; nur `CircuitBreakerOpen` short-circuitet die Schleife (die zweite Richtung würde sowieso short-circuiten).

## Quality Gates

- ✅ `mypy --strict src tests` — 0 Fehler
- ✅ `ruff check .` — clean
- ✅ `bandit -r scripts/update_stammstrecke_status.py` — 0 Issues
- ✅ `pytest tests/scripts/test_update_stammstrecke_status.py` — **25/25 passed**
- ✅ Komplexitäts-Gate (C901) — 0 neue Verstöße

## Test plan

- [x] Mypy strict in src + tests ohne neue Fehler
- [x] Ruff & Bandit clean
- [x] Neue Unit-Tests (25) grün, decken alle Pfade ab:
  - 2 Events bei beiden Richtungen über Schwelle
  - 1 Event nur Meidling-Richtung
  - 1 Event nur Floridsdorf-Richtung
  - 0 Events bei beiden unter Schwelle
  - Median = Schwelle → 0 Events
  - Partial Failure (Richtung 1 RuntimeError, Richtung 2 hoch) → 1 Event
  - Beide Richtungen scheitern → 0 Events, exit 1
  - Circuit-Breaker offen → 0 Calls, 0 Events, exit 0
  - ImportError pyhafas → leerer Cache, exit 0
  - Pinning der Richtungs-Konfiguration und Breaker-Konstanten
- [ ] Manueller `workflow_dispatch`-Lauf des Workflows
- [ ] Feed-Build-Lauf mit Real-Daten verifizieren

## Dokumentation

- `docs/reference/oebb_provider_logic.md` — Abschnitt vollständig auf das Zwei-Richtungs-Modell umgeschrieben (Datenquelle-Tabelle, Filter pro Richtung, Cache-Schreibverhalten mit JSON-Beispiel, Resilience + 10/h-Rate-Limit, Erweiterungs-Punkte).
- `CHANGELOG.md` — zwei neue `[Unreleased]`-Einträge für die Richtungstrennung und die Breaker-Anpassung.

https://claude.ai/code/session_01L2YzrDMfNGYPHUzdqHQnBJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2YzrDMfNGYPHUzdqHQnBJ)_