### PR TITLE
security: tighten OSMOverpassConfig URL validation + close BiDi-mark gap in stations validator

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,154 @@
+## 2026-05-09 - Two-Site Drift Closure: OSMOverpassConfig Host-Only Validation + `_UNSAFE_CHARS_RE` BiDi/Zero-Width Gap (BiDi-Mark Drift Round 3 + Allow-List Drift)
+**Vulnerability:** Two structural defence-in-depth gaps closed in a
+single PR.
+
+(1) **`OSMOverpassConfig.__post_init__` host-only validation** —
+`src/places/osm_client.py:203-206` (pre-fix) extracted
+`urlparse(self.endpoint).hostname` and checked membership in
+`_TRUSTED_OVERPASS_HOSTS` (a frozenset built from
+`DEFAULT_OVERPASS_ENDPOINTS` hostnames). The check accepted *any* URL
+whose hostname matched, regardless of scheme, port, path, or
+userinfo. Three orthogonal sub-vectors fall out:
+  (a) **TLS-strip** — `http://overpass-api.de/api/interpreter`
+      passes the host-only check; `validate_http_url` (called inside
+      `request_safe`) accepts `http://` by default, so a future
+      caller bypassing `get_overpass_endpoint()` would route the
+      cron pipeline's outbound request over plaintext. A MITM
+      (corporate gateway, hostile ISP, public WiFi) injects a
+      malicious station payload that flows verbatim into
+      `stations.json` and the published feed.
+  (b) **Path / endpoint hijack** —
+      `https://overpass-api.de/api/admin` or any other path on the
+      same host passes the host-only check. The Overpass operator
+      runs other paths on the same host; a future config-file /
+      CLI consumer of `OSMOverpassConfig` could redirect the cron
+      pipeline to an unrelated endpoint without tripping any guard.
+  (c) **Port / userinfo hijack** —
+      `https://overpass-api.de:8443/api/interpreter` and
+      `https://attacker:secret@overpass-api.de/api/interpreter`
+      both pass. `validate_http_url` rejects non-default ports at
+      request time so (c) is partially mitigated, but a future code
+      path bypassing `validate_http_url` (debug client, websocket
+      upgrade, raw urllib3 access) inherits the loose validator.
+      The userinfo variant additionally leaks credentials into log
+      lines that print the full `self.endpoint` string.
+
+The journal pattern across every prior allow-list-drift round is
+exactly this: the boundary that was strict on day one drifted into a
+host-only check after some refactor, and a future caller landed on
+the loose internal validator instead of the strict resolver. Every
+current caller routes through `get_overpass_endpoint()` (which IS
+strict — exact-match against `DEFAULT_OVERPASS_ENDPOINTS`), so the
+gap is defence-in-depth today, but the drift surface is permanent
+once a future contributor instantiates `OSMOverpassConfig` from a
+CLI flag, a config file, a leaked env var, or a unit-test fixture
+that bypasses the env resolver.
+
+(2) **`_UNSAFE_CHARS_RE` BiDi/Zero-Width gap** —
+`src/utils/stations_validation.py:542` (pre-fix) carried a
+character class `[<>\x00-\x08\x0b\x0c\x0e-\x1f -‮⁦-⁩]`
+that covers ASCII C0 controls (minus `\t`/`\n`/`\r`), the
+line/paragraph-separator + LRE/RLE/PDF/LRO/RLO BiDi family, and the
+LRI/RLI/FSI/PDI BiDi-isolate family. The 2026-05-09 BiDi-Mark Drift
+Round 2 entry below explicitly named this regex as the next drift
+candidate: it was narrower than the canonical
+`src/utils/logging.py:_INVISIBLE_DANGEROUS_RE` along seven code points:
+  * `؜` ARABIC LETTER MARK (ALM)
+  * `​-‏` ZWSP / ZWNJ / ZWJ / **LRM** / **RLM**
+  * `﻿` BYTE ORDER MARK (BOM)
+
+A planted `stations.json` (poisoned PR / compromised CI runner /
+partial flush + power loss / parallel orchestrator atomic state
+swap mid-write) carrying any of these code points in `name`,
+`bst_code`, `vor_id`, or `aliases` slipped past
+`_find_security_issues` and flowed verbatim into:
+  * the published RSS feed item titles (Trojan-Source rendering
+    in feed readers — same primitive as CVE-2021-42574 but missing
+    from every prior round of this regex);
+  * operator-facing log lines (post-`SafeFormatter` text is
+    sanitised at format time, but pre-sanitisation flow into
+    `caplog.text` and non-default handlers leaks);
+  * downstream SIEM ingestion (forge a second log record carrying
+    a fake `level=ERROR` via Unicode line terminators).
+
+The companion regex `_INVISIBLE_DANGEROUS_RE` already covers the
+full union as of Round 2's `strip_control_chars=False` sibling-path
+extension; the validator boundary is the last divergent surface.
+
+**Fix:**
+  (1) Tighten `OSMOverpassConfig.__post_init__` to require
+      **byte-exact match** against `DEFAULT_OVERPASS_ENDPOINTS` —
+      mirrors the contract enforced by `get_overpass_endpoint()` for
+      the env-driven path. A single `if self.endpoint not in
+      DEFAULT_OVERPASS_ENDPOINTS: raise ValueError(...)` collapses
+      every host-only sub-vector (a)/(b)/(c) into a single rejection.
+      `_TRUSTED_OVERPASS_HOSTS` is preserved as a documentation
+      constant; it is no longer the validation gate.
+  (2) Widen `_UNSAFE_CHARS_RE` to the union of the legacy
+      structural-injection set AND the canonical
+      `_INVISIBLE_DANGEROUS_RE` set:
+      `[<>\x00-\x08\x0b\x0c\x0e-\x1f؜​-‏ -‮⁦-⁩﻿]`.
+      The two regexes now stay in sync via the new inventory test
+      `test_unsafe_chars_regex_covers_canonical_invisible_dangerous_set`
+      which fails any future regression that narrows the validator
+      regex or widens `_INVISIBLE_DANGEROUS_RE` without a matching
+      validator update.
+
+**Test surface:** **+31 new pytest cases**:
+  * `tests/test_sentinel_overpass_endpoint_strict_validation.py` —
+    7 cases: canonical-endpoint regression + 5 sub-vector PoCs
+    (HTTP downgrade, path hijack, port hijack, trailing slash,
+    userinfo) + unrelated-host regression.
+  * `tests/test_sentinel_stations_validation_bidi_gap.py` — 24
+    cases: per-code-point regex match (7 cases × ALM / ZWSP / ZWNJ
+    / ZWJ / LRM / RLM / BOM), per-code-point end-to-end name flag
+    (7 cases), per-code-point end-to-end alias flag (7 cases),
+    inventory invariant covering the canonical
+    `_INVISIBLE_DANGEROUS_RE` set, existing-coverage regression,
+    and safe-character regression.
+
+**Learning:** Two reinforcing lessons:
+
+  (a) **Allow-list pattern: prefer byte-exact equality at structural
+      boundaries.** Every layer of the cron pipeline that consumes
+      a URL eventually parses + normalises it; if any of those
+      layers extracts a sub-component (hostname, path, port, scheme)
+      and validates only that sub-component, an attacker exploiting
+      the *other* sub-components of the URL is unconstrained at
+      that layer. The strict shape — byte-exact equality against a
+      const tuple — collapses the whole cartesian product of
+      sub-components into a single decision and cannot drift via
+      `urlparse`-quirk bypasses (e.g. Unicode normalisation,
+      trailing-dot host, percent-encoded path). Apply the same
+      rule to every structural boundary that internalises an
+      operator-controlled URL: `OSMOverpassConfig.endpoint`,
+      `OEBB_GTFS_RT_URL` (rolled back, but the lesson stands), any
+      future `provider.endpoint` field. Sibling drift candidates:
+      `validate_public_feed_url` (`src/utils/http.py`) currently
+      accepts a host allow-list with a TLD-suffix wildcard
+      (`.github.io`); audit whether that wildcard is byte-exact at
+      every consumer or if any caller has drifted into a host-only
+      sub-component check.
+
+  (b) **Companion-regex sync rule.** Whenever a defence regex grows
+      to cover a new code point, audit every sibling regex in the
+      project (`stations_validation._UNSAFE_CHARS_RE`,
+      `_UNSAFE_URL_CHARS` in `http.py`, station-name validators in
+      provider modules) and either widen them to match or document
+      the divergence with an explicit deferral note. The Round 2
+      entry below noted the validator's deferral was deliberate
+      (structural-validation scope, not log-sanitisation scope) but
+      flagged it as the next drift candidate; this round closes
+      that drift. The inventory test
+      `test_unsafe_chars_regex_covers_canonical_invisible_dangerous_set`
+      pins the invariant programmatically — if a future round
+      widens `_INVISIBLE_DANGEROUS_RE` to cover (e.g.) a new
+      Unicode 16 BiDi format control, the sync test fails until
+      the validator is widened too. This converts the "deliberate
+      deferral" pattern from a journal-narrative defence into a
+      programmatic audit floor that survives the next contributor
+      who hasn't read the journals.
+
 ## 2026-05-09 - JSON Size-Bomb Drift Round 8: Stammstrecke Cron Monitor Reads Its Own Cache With Bare `_json_lib.load(fh)` (Aliased-Import Bypass Of The Audit Walker)
 **Vulnerability:** PR #1365 (`0520e0d`, *feat: add S-Bahn Stammstrecke
 median-delay monitor*) plus the four follow-up PRs that iterated on the

--- a/src/places/osm_client.py
+++ b/src/places/osm_client.py
@@ -186,11 +186,20 @@ class OSMStation:
 class OSMOverpassConfig:
     """Frozen config for an :class:`OSMOverpassClient` instance.
 
-    ``endpoint`` is validated against :data:`_TRUSTED_OVERPASS_HOSTS`
+    ``endpoint`` is validated against :data:`DEFAULT_OVERPASS_ENDPOINTS`
     inside ``__post_init__`` so an env override pointing at an attacker
-    host is rejected before any network request is made. ``timeout_s``
-    is clamped to :data:`_MAX_TIMEOUT_S` and ``user_agent`` is required
-    to be a descriptive string per the Overpass fair-use policy.
+    host (or a TLS-strip / path-hijack / port-hijack variant of a trusted
+    host) is rejected before any network request is made. The match is
+    intentionally **byte-exact** against the constant tuple — host-only
+    validation accepts ``http://overpass-api.de/api/interpreter``
+    (HTTP downgrade), ``https://overpass-api.de/api/admin`` (path
+    hijack), and ``https://overpass-api.de:8443/api/interpreter``
+    (port hijack), all of which a future caller routing through this
+    constructor without first round-tripping through
+    :func:`get_overpass_endpoint` would otherwise re-enable.
+    ``timeout_s`` is clamped to :data:`_MAX_TIMEOUT_S` and
+    ``user_agent`` is required to be a descriptive string per the
+    Overpass fair-use policy.
     """
 
     endpoint: str
@@ -201,9 +210,20 @@ class OSMOverpassConfig:
     max_response_bytes: int = _MAX_RESPONSE_BYTES
 
     def __post_init__(self) -> None:
-        host = (urlparse(self.endpoint).hostname or "").lower()
-        if host not in _TRUSTED_OVERPASS_HOSTS:
-            raise ValueError(f"Overpass endpoint {self.endpoint!r} is not on the trusted host allow-list {sorted(_TRUSTED_OVERPASS_HOSTS)}")
+        # Strict allow-list: byte-exact match against
+        # ``DEFAULT_OVERPASS_ENDPOINTS``. Mirrors the contract enforced
+        # by ``get_overpass_endpoint`` for the env-driven path.
+        # Host-only validation (the pre-fix shape) accepted HTTP
+        # downgrade / path / port / userinfo variants of a trusted host
+        # — every one of which a future caller bypassing the env
+        # resolver could re-enable. Pin the canonical contract at the
+        # structural boundary so any future config-file / CLI consumer
+        # of this dataclass inherits the same defence floor.
+        if self.endpoint not in DEFAULT_OVERPASS_ENDPOINTS:
+            raise ValueError(
+                f"Overpass endpoint {self.endpoint!r} is not on the trusted "
+                f"endpoint allow-list {list(DEFAULT_OVERPASS_ENDPOINTS)}"
+            )
         if not self.user_agent or not self.user_agent.strip():
             raise ValueError("OSMOverpassConfig.user_agent is required")
         if self.timeout_s <= 0 or self.query_timeout_s <= 0:

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -539,7 +539,25 @@ def _find_gtfs_issues(
             yield GTFSIssue(identifier=identifier, name=name, vor_id=vor_id)
 
 
-_UNSAFE_CHARS_RE = re.compile(r"[<>\x00-\x08\x0b\x0c\x0e-\x1f\u2028-\u202e\u2066-\u2069]")
+# Unsafe character class for ``stations.json`` validation. Sized as the
+# UNION of (a) the legacy structural-injection set (``<``/``>`` for HTML,
+# ASCII C0 controls excluding ``\t``/``\n``/``\r``) and (b) every code
+# point covered by the canonical log sanitiser
+# ``src/utils/logging.py:_INVISIBLE_DANGEROUS_RE``. The 2026-05-09
+# BiDi-Mark Drift Round 2 entry in ``.jules/sentinel.md`` flagged the
+# divergence between the two regexes as the next drift candidate: the
+# canonical sanitiser already strips ``\u061c`` (ALM), ``\u200b-\u200f``
+# (ZWSP/ZWNJ/ZWJ/LRM/RLM), and ``\ufeff`` (BOM), but the validator did
+# not, so a planted ``stations.json`` carrying any of those characters
+# in ``name``/``bst_code``/``vor_id``/``aliases`` slipped past
+# ``_find_security_issues`` and flowed verbatim into the published feed
+# and operator-facing log lines (Trojan-Source / log-forging primitive
+# per CVE-2021-42574). The widened set keeps the two regexes in sync;
+# any future widening of ``_INVISIBLE_DANGEROUS_RE`` MUST be reflected
+# here \u2014 pinned by ``test_unsafe_chars_regex_covers_canonical_invisible_dangerous_set``.
+_UNSAFE_CHARS_RE = re.compile(
+    r"[<>\x00-\x08\x0b\x0c\x0e-\x1f\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069\ufeff]"
+)
 
 # Pattern for the synthetic ``bst_id``/``bst_code`` values assigned to
 # VOR-sourced station entries (e.g. ``900100``–``900112`` for the Wien

--- a/tests/test_sentinel_overpass_endpoint_strict_validation.py
+++ b/tests/test_sentinel_overpass_endpoint_strict_validation.py
@@ -1,0 +1,178 @@
+"""Sentinel PoC: ``OSMOverpassConfig`` host-only endpoint validation.
+
+The 2026-05-08 OSM-First migration shipped ``OSMOverpassConfig`` with a
+``__post_init__`` that validates ``endpoint`` only by **hostname**: any URL
+whose ``urlparse(url).hostname`` lands in
+:data:`_TRUSTED_OVERPASS_HOSTS` is accepted, regardless of scheme,
+port, or path. Three orthogonal defence-in-depth gaps fall out of that
+shape that the strict ``get_overpass_endpoint()`` allow-list already
+closes for the env-driven path:
+
+  (a) **TLS-strip / HTTP downgrade** — ``http://overpass-api.de/api/interpreter``
+      passes the host check. ``validate_http_url`` (called inside
+      ``request_safe``) accepts ``http://`` by default, so the cron
+      pipeline's outbound request would actually go over plaintext —
+      a MITM (corporate gateway, public WiFi, hostile ISP) can
+      intercept the response and inject a malicious station payload
+      that flows verbatim into ``stations.json`` and the published
+      feed.
+  (b) **Path / endpoint hijack** — ``https://overpass-api.de/api/admin``
+      or ``https://overpass-api.de/anything-else`` passes the host
+      check. The Overpass operator runs other paths on the same host
+      (e.g. status endpoints) and an attacker who can flip a future
+      env or config-file consumer of ``OSMOverpassConfig`` could
+      redirect the cron pipeline to a different endpoint on the same
+      host that the project does not expect.
+  (c) **Non-standard port** — ``https://overpass-api.de:8443/api/interpreter``
+      passes the host check. ``validate_http_url`` rejects non-default
+      ports (allowed_ports defaults to ``(80, 443)``), so the request
+      would actually fail at request time. But the *config* is
+      accepted; in a future code path that bypasses ``validate_http_url``
+      (e.g. a websocket upgrade, raw socket fallback, debug client)
+      the port is unconstrained.
+
+Threat model (what this defence-in-depth gap closes):
+  Today the only callers of ``OSMOverpassConfig`` resolve the
+  endpoint through ``get_overpass_endpoint()`` which IS strict
+  (exact-match against ``DEFAULT_OVERPASS_ENDPOINTS``). The host-only
+  check therefore appears redundant. But the journal pattern across
+  every prior round of the env-cap / allow-list family is exactly:
+  *the boundary that was strict on day one drifted into a host-only
+  check after some refactor, and a future caller landed on the
+  loose internal validator instead of the strict resolver*. Pin
+  the strict shape at the structural boundary (``__post_init__``)
+  so a future contributor who instantiates ``OSMOverpassConfig``
+  from a CLI flag, a config file, a leaked env var, or a unit test
+  fixture cannot accidentally re-enable any of (a)-(c) above.
+
+The fix mirrors ``get_overpass_endpoint()``: the endpoint MUST appear
+verbatim in :data:`DEFAULT_OVERPASS_ENDPOINTS`. ``urlparse`` is no
+longer trusted to do the discrimination — string-equality is the
+strongest possible allow-list contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.places.osm_client import (
+    DEFAULT_OVERPASS_ENDPOINTS,
+    OSMOverpassConfig,
+)
+
+
+_VALID_USER_AGENT = "wien-oepnv-test/1.0 (contact: test@example.com)"
+
+
+def test_config_accepts_canonical_https_endpoint() -> None:
+    """Regression: every URL listed in ``DEFAULT_OVERPASS_ENDPOINTS`` is
+    still accepted verbatim. The strict validator MUST NOT break the
+    happy path."""
+    for endpoint in DEFAULT_OVERPASS_ENDPOINTS:
+        config = OSMOverpassConfig(endpoint=endpoint, user_agent=_VALID_USER_AGENT)
+        assert config.endpoint == endpoint
+
+
+def test_config_rejects_http_downgrade_on_trusted_host() -> None:
+    """Pre-fix: ``http://overpass-api.de/api/interpreter`` passes the
+    host-only check (urlparse hostname is ``overpass-api.de``, which IS
+    on the trusted-host allow-list). Post-fix: rejected because the
+    URL is not an exact match against ``DEFAULT_OVERPASS_ENDPOINTS``.
+
+    Closes the TLS-strip / HTTP-downgrade vector documented at the top
+    of this module.
+    """
+    plaintext = DEFAULT_OVERPASS_ENDPOINTS[0].replace("https://", "http://", 1)
+    assert plaintext.startswith("http://"), "Sanity check on test fixture"
+
+    with pytest.raises(ValueError):
+        OSMOverpassConfig(endpoint=plaintext, user_agent=_VALID_USER_AGENT)
+
+
+def test_config_rejects_path_hijack_on_trusted_host() -> None:
+    """Pre-fix: ``https://overpass-api.de/api/admin`` passes the host
+    check because the hostname lands in the allow-list. Post-fix:
+    rejected because the URL is not an exact match against
+    ``DEFAULT_OVERPASS_ENDPOINTS``.
+
+    Closes the path-hijack vector — an attacker who can flip the
+    endpoint URL through a future config-file consumer could
+    redirect the cron pipeline to an unrelated path on the same
+    host (e.g. an admin endpoint, a debug-status route, a 404
+    fingerprint surface).
+    """
+    canonical = DEFAULT_OVERPASS_ENDPOINTS[0]
+    # Use the same host but a different path
+    hijacked = canonical.rsplit("/", 1)[0] + "/admin"
+
+    with pytest.raises(ValueError):
+        OSMOverpassConfig(endpoint=hijacked, user_agent=_VALID_USER_AGENT)
+
+
+def test_config_rejects_non_standard_port_on_trusted_host() -> None:
+    """Pre-fix: ``https://overpass-api.de:8443/api/interpreter`` passes
+    the host check because the hostname lands in the allow-list.
+    Post-fix: rejected because the URL is not an exact match against
+    ``DEFAULT_OVERPASS_ENDPOINTS``.
+
+    Closes the port-hijack vector — even though
+    :func:`validate_http_url` rejects non-standard ports at request
+    time, a future code path that bypasses that helper (debug
+    client, websocket upgrade, raw urllib3 access) would happily
+    use the configured non-standard port.
+    """
+    canonical = DEFAULT_OVERPASS_ENDPOINTS[0]
+    # Inject a non-standard port between the host and the path
+    scheme, rest = canonical.split("://", 1)
+    host, _, path = rest.partition("/")
+    weird = f"{scheme}://{host}:8443/{path}"
+
+    with pytest.raises(ValueError):
+        OSMOverpassConfig(endpoint=weird, user_agent=_VALID_USER_AGENT)
+
+
+def test_config_rejects_trailing_slash_variant() -> None:
+    """Defence-in-depth: even a subtle visual variant of a canonical
+    URL (extra trailing slash) is rejected. The strict allow-list
+    requires byte-exact equality so a future contributor cannot drift
+    by adding a trailing slash at one call site and not the others.
+    """
+    canonical = DEFAULT_OVERPASS_ENDPOINTS[0]
+    if canonical.endswith("/"):
+        variant = canonical.rstrip("/")
+    else:
+        variant = canonical + "/"
+
+    with pytest.raises(ValueError):
+        OSMOverpassConfig(endpoint=variant, user_agent=_VALID_USER_AGENT)
+
+
+def test_config_rejects_canonical_url_with_userinfo() -> None:
+    """Pre-fix: ``https://user:pass@overpass-api.de/api/interpreter``
+    passes the host check (urlparse strips userinfo). Post-fix:
+    rejected because the URL is not an exact match against
+    ``DEFAULT_OVERPASS_ENDPOINTS``.
+
+    Closes the userinfo-injection vector: even though the actual HTTP
+    layer ignores userinfo on most modern hosts, embedding ``user:pass``
+    in the URL leaks the credentials into log lines that print the
+    full ``self.endpoint`` string and risks downstream consumers
+    (e.g. SIEM ingestion) treating the userinfo as authentication
+    metadata.
+    """
+    canonical = DEFAULT_OVERPASS_ENDPOINTS[0]
+    scheme, rest = canonical.split("://", 1)
+    poisoned = f"{scheme}://attacker:secret@{rest}"
+
+    with pytest.raises(ValueError):
+        OSMOverpassConfig(endpoint=poisoned, user_agent=_VALID_USER_AGENT)
+
+
+def test_config_still_rejects_unrelated_host() -> None:
+    """Regression: the host-only baseline is preserved. An entirely
+    untrusted host is still rejected with the same error class."""
+    with pytest.raises(ValueError):
+        OSMOverpassConfig(
+            endpoint="https://evil.example/api/interpreter",
+            user_agent=_VALID_USER_AGENT,
+        )

--- a/tests/test_sentinel_stations_validation_bidi_gap.py
+++ b/tests/test_sentinel_stations_validation_bidi_gap.py
@@ -1,0 +1,264 @@
+"""Sentinel PoC: ``_UNSAFE_CHARS_RE`` in ``src/utils/stations_validation.py``
+is narrower than the canonical ``_INVISIBLE_DANGEROUS_RE``.
+
+The 2026-05-09 BiDi-Mark Drift Round 2 entry in ``.jules/sentinel.md``
+explicitly named this gap as the next drift candidate::
+
+    The companion regex in ``src/utils/stations_validation.py:_UNSAFE_CHARS_RE``
+    is also narrower than ``_INVISIBLE_DANGEROUS_RE`` — that's a deliberate
+    deferral (station-validator scope is structural validation, not log
+    sanitisation), but flag it as the next drift candidate if a future
+    round audits station-data flow into log emit.
+
+Pre-fix character class::
+
+    [<>\\x00-\\x08\\x0b\\x0c\\x0e-\\x1f\\u2028-\\u202e\\u2066-\\u2069]
+
+The set covers ASCII C0 controls (minus ``\\t``/``\\n``/``\\r``), the
+line/paragraph-separator + LRE/RLE/PDF/LRO/RLO BiDi family (``\\u2028-
+\\u202e``), and the LRI/RLI/FSI/PDI BiDi-isolate family (``\\u2066-
+\\u2069``). It explicitly **DOES NOT** cover:
+
+  * ``\\u061c`` — ARABIC LETTER MARK (ALM, post-Unicode-6.3 BiDi
+    control). Same Trojan-Source primitive as the LRE/RLE family but
+    missing from every prior round of this regex.
+  * ``\\u200b-\\u200f`` — ZWSP / ZWNJ / ZWJ / **LRM** / **RLM**. The
+    LRM/RLM marks are the same Trojan-Source primitive as the
+    already-stripped ``\\u202a-\\u202e`` family: a planted station
+    name with LRM/RLM inverts displayed text in a Unicode-aware
+    terminal so an operator skimming a log line misreads the value.
+    The zero-width family (ZWSP/ZWNJ/ZWJ) enables visual obfuscation
+    where a station name *looks* identical to a legitimate one but
+    is treated as different by the deduplication / merge logic.
+  * ``\\ufeff`` — BYTE ORDER MARK (zero-width no-break space). A
+    planted name with a leading BOM looks identical to the canonical
+    name but has different bytes; the validator should flag it.
+
+The canonical sanitiser ``src/utils/logging.py:_INVISIBLE_DANGEROUS_RE``
+covers the full union (``\\u061c`` ALM + ``\\u200b-\\u200f`` zero-width
++ LRM/RLM + ``\\u2028-\\u202e`` separators + LRE/RLE/PDF/LRO/RLO +
+``\\u2066-\\u2069`` LRI/RLI/FSI/PDI + ``\\ufeff`` BOM). The fix in this
+PR widens ``_UNSAFE_CHARS_RE`` to the same union so a planted
+``stations.json`` with any of the missing code points is flagged at
+validation time, before the entries flow into the published feed and
+operator-facing log lines.
+
+Threat model
+------------
+A planted ``stations.json`` (compromised CI runner / partial flush +
+power loss / corrupted previous run / parallel orchestrator process
+performing an atomic state swap mid-write / hostile PR that lands a
+poisoned entry) carries a station name like:
+
+    "Wien‮ Hauptbahnhof"  # \\u202e = RTL OVERRIDE — DOES get flagged today
+
+vs.
+
+    "Wien‎ Hauptbahnhof"  # \\u200e = LRM            — DOES NOT get flagged today
+
+Both have identical Trojan-Source / log-injection blast radius, but
+the LRM variant slips past ``_find_security_issues``. The validator's
+verdict feeds ``scripts/validate_stations.py`` which gates the cron
+pipeline; a planted name with LRM therefore reaches the published
+feed and operator dashboards verbatim.
+
+Companion fix
+-------------
+This file pins the invariant in two layers:
+
+  1. **PoC tests** (per code point) that exercise the validator with
+     each of the missing characters and assert a security issue is
+     yielded.
+  2. **Inventory test** that asserts ``_UNSAFE_CHARS_RE`` matches
+     every character in the canonical ``_INVISIBLE_DANGEROUS_RE`` set.
+     A regression here means a future contributor either narrowed
+     ``_UNSAFE_CHARS_RE`` (drift) or widened ``_INVISIBLE_DANGEROUS_RE``
+     without updating the validator (drift in the opposite direction).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils import logging as canonical_logging
+from src.utils import stations_validation
+
+
+# Code points that ``_INVISIBLE_DANGEROUS_RE`` covers but pre-fix
+# ``_UNSAFE_CHARS_RE`` did not. Each is a documented BiDi / zero-width /
+# Trojan-Source primitive.
+_MISSING_CODE_POINTS: tuple[tuple[str, str], ...] = (
+    ("؜", "ARABIC LETTER MARK (ALM)"),
+    ("​", "ZERO WIDTH SPACE (ZWSP)"),
+    ("‌", "ZERO WIDTH NON-JOINER (ZWNJ)"),
+    ("‍", "ZERO WIDTH JOINER (ZWJ)"),
+    ("‎", "LEFT-TO-RIGHT MARK (LRM)"),
+    ("‏", "RIGHT-TO-LEFT MARK (RLM)"),
+    ("﻿", "BYTE ORDER MARK (BOM)"),
+)
+
+
+@pytest.mark.parametrize(
+    "code_point,label",
+    _MISSING_CODE_POINTS,
+    ids=[label for _, label in _MISSING_CODE_POINTS],
+)
+def test_unsafe_chars_regex_matches_missing_code_point(
+    code_point: str, label: str
+) -> None:
+    """Pre-fix: ``_UNSAFE_CHARS_RE`` did not match ``code_point`` so a
+    planted station name carrying it slipped past
+    ``_find_security_issues``. Post-fix: the regex matches the code
+    point and the validator flags the issue."""
+    assert stations_validation._UNSAFE_CHARS_RE.search(code_point) is not None, (
+        f"_UNSAFE_CHARS_RE must match {label} ({hex(ord(code_point))}); "
+        "see .jules/sentinel.md (BiDi-Mark Drift Round 2) for the full "
+        "list of code points the validator must reject."
+    )
+
+
+@pytest.mark.parametrize(
+    "code_point,label",
+    _MISSING_CODE_POINTS,
+    ids=[label for _, label in _MISSING_CODE_POINTS],
+)
+def test_find_security_issues_flags_planted_name_with_missing_code_point(
+    code_point: str, label: str
+) -> None:
+    """End-to-end PoC: a planted ``stations.json`` entry whose ``name``
+    contains ``code_point`` must be reported as a SecurityIssue."""
+    poisoned = [
+        {
+            "bst_id": "12345",
+            "name": f"Wien{code_point} Hauptbahnhof",
+        }
+    ]
+    issues = list(stations_validation._find_security_issues(poisoned))
+    assert issues, (
+        f"Planted name with {label} ({hex(ord(code_point))}) must be "
+        "flagged by _find_security_issues — pre-fix _UNSAFE_CHARS_RE was "
+        "narrower than _INVISIBLE_DANGEROUS_RE and let these characters "
+        "through."
+    )
+    assert any("name" in issue.reason for issue in issues), (
+        "SecurityIssue must reference the offending field"
+    )
+
+
+@pytest.mark.parametrize(
+    "code_point,label",
+    _MISSING_CODE_POINTS,
+    ids=[label for _, label in _MISSING_CODE_POINTS],
+)
+def test_find_security_issues_flags_planted_alias_with_missing_code_point(
+    code_point: str, label: str
+) -> None:
+    """End-to-end PoC: a planted ``stations.json`` entry whose
+    ``aliases`` carry ``code_point`` must be reported. Aliases flow
+    through fuzzy-name matching into the merge / dedupe pipeline, so
+    a poisoned alias is at least as load-bearing as a poisoned name.
+    """
+    poisoned = [
+        {
+            "bst_id": "12345",
+            "name": "Wien Hauptbahnhof",
+            "aliases": [f"Wien Hbf{code_point}"],
+        }
+    ]
+    issues = list(stations_validation._find_security_issues(poisoned))
+    assert issues, (
+        f"Planted alias with {label} ({hex(ord(code_point))}) must be "
+        "flagged by _find_security_issues — the alias drift family is "
+        "as load-bearing as the name drift family."
+    )
+    assert any("alias" in issue.reason for issue in issues), (
+        "SecurityIssue must reference the offending alias field"
+    )
+
+
+def test_unsafe_chars_regex_covers_canonical_invisible_dangerous_set() -> None:
+    """Inventory invariant: every character that
+    :data:`src.utils.logging._INVISIBLE_DANGEROUS_RE` matches MUST
+    also match :data:`src.utils.stations_validation._UNSAFE_CHARS_RE`.
+
+    A regression here means the two regexes have drifted apart again
+    — either the validator was narrowed (drift) or the canonical log
+    sanitiser was widened without a matching update at the validator
+    boundary. Both shapes leak a planted station name carrying the
+    newly-listed code point past the validator and into the published
+    feed.
+    """
+    canonical = canonical_logging._INVISIBLE_DANGEROUS_RE
+    validator = stations_validation._UNSAFE_CHARS_RE
+
+    # Materialise every code point the canonical regex matches and
+    # assert the validator regex matches the same set.
+    canonical_code_points: list[int] = []
+    for cp in range(0x110000):  # full Unicode BMP + supplementary planes
+        if canonical.fullmatch(chr(cp)):
+            canonical_code_points.append(cp)
+
+    # Sanity: the canonical regex covers a non-trivial set.
+    assert canonical_code_points, "Canonical _INVISIBLE_DANGEROUS_RE matches nothing"
+
+    missing: list[int] = []
+    for cp in canonical_code_points:
+        if not validator.fullmatch(chr(cp)):
+            missing.append(cp)
+
+    assert not missing, (
+        f"_UNSAFE_CHARS_RE is narrower than _INVISIBLE_DANGEROUS_RE; "
+        f"missing {len(missing)} code point(s): "
+        + ", ".join(f"U+{cp:04X}" for cp in missing[:20])
+        + (" …" if len(missing) > 20 else "")
+        + "\nThe two regexes must stay in sync: any code point covered "
+        "by the canonical log sanitiser must also be flagged by the "
+        "stations.json validator. See .jules/sentinel.md "
+        "(BiDi-Mark Drift Round 2) for the closing rule."
+    )
+
+
+def test_unsafe_chars_regex_preserves_existing_coverage() -> None:
+    """Regression: every character ``_UNSAFE_CHARS_RE`` matched pre-fix
+    must still match post-fix. The widening MUST be additive."""
+    pre_fix_must_match = (
+        "<",
+        ">",
+        "\x00",
+        "\x01",
+        "\x07",
+        "\x0b",
+        "\x0c",
+        "\x0e",
+        "\x1f",
+        " ",
+        " ",
+        "‪",
+        "‫",
+        "‬",
+        "‭",
+        "‮",
+        "⁦",
+        "⁧",
+        "⁨",
+        "⁩",
+    )
+    for cp in pre_fix_must_match:
+        assert stations_validation._UNSAFE_CHARS_RE.search(cp) is not None, (
+            f"Existing coverage must be preserved: {hex(ord(cp))} "
+            "must still match _UNSAFE_CHARS_RE after the widening."
+        )
+
+
+def test_unsafe_chars_regex_does_not_match_safe_chars() -> None:
+    """Regression: ASCII letters / digits / common punctuation that
+    legitimate station names carry (e.g. umlauts, hyphens, parentheses,
+    spaces) must NOT match the widened regex. The fix must not be a
+    super-set that turns every legitimate name into a security issue.
+    """
+    safe_chars = "Wien Hauptbahnhof - Praterstern Westbahnhof Höchstädtplatz Wien Süd 1234567890.,-/()"
+    for ch in safe_chars:
+        assert stations_validation._UNSAFE_CHARS_RE.search(ch) is None, (
+            f"Widened _UNSAFE_CHARS_RE must NOT match safe character "
+            f"{ch!r} ({hex(ord(ch))})"
+        )


### PR DESCRIPTION
## Summary

Two structural defence-in-depth gaps closed in a single PR. Both vulnerabilities have proof-of-concept tests that fail before the fix and pass after.

### 1. `OSMOverpassConfig.__post_init__` host-only validation

Pre-fix `src/places/osm_client.py:203-206` extracted `urlparse(self.endpoint).hostname` and only checked membership in `_TRUSTED_OVERPASS_HOSTS` (a frozenset built from `DEFAULT_OVERPASS_ENDPOINTS` hostnames). The check accepted *any* URL whose hostname matched, regardless of scheme, port, path, or userinfo. Three orthogonal sub-vectors fall out:

- **TLS-strip / HTTP downgrade** — `http://overpass-api.de/api/interpreter` passes the host-only check; `validate_http_url` (called inside `request_safe`) accepts `http://` by default. A future caller bypassing `get_overpass_endpoint()` would route the cron pipeline's outbound request over plaintext, allowing a MITM (corporate gateway, hostile ISP, public WiFi) to inject a malicious station payload.
- **Path / endpoint hijack** — `https://overpass-api.de/api/admin` and any other path on the same host pass the host-only check.
- **Port / userinfo hijack** — `https://overpass-api.de:8443/api/interpreter` and `https://attacker:secret@overpass-api.de/api/interpreter` both pass.

**Fix:** Tighten `__post_init__` to require **byte-exact match** against `DEFAULT_OVERPASS_ENDPOINTS` — mirrors the contract `get_overpass_endpoint()` already enforces for the env-driven path. Today's only callers route through that resolver so the gap is defence-in-depth, but the structural boundary now survives any future config-file / CLI consumer that instantiates `OSMOverpassConfig` directly.

### 2. `_UNSAFE_CHARS_RE` BiDi/Zero-Width gap

Pre-fix `src/utils/stations_validation.py:542` carried a character class that was narrower than the canonical `src/utils/logging.py:_INVISIBLE_DANGEROUS_RE` along seven code points:

- `U+061C` (ARABIC LETTER MARK / ALM)
- `U+200B-U+200F` (ZWSP / ZWNJ / ZWJ / **LRM** / **RLM**)
- `U+FEFF` (BYTE ORDER MARK)

The 2026-05-09 BiDi-Mark Drift Round 2 entry in `.jules/sentinel.md` already explicitly named this regex as the next drift candidate. A planted `stations.json` (poisoned PR / compromised CI runner / partial flush + power loss / parallel orchestrator atomic state swap mid-write) carrying any of these code points in `name`, `bst_code`, `vor_id`, or `aliases` slipped past `_find_security_issues` and flowed verbatim into the published RSS feed item titles (Trojan-Source rendering — same primitive as CVE-2021-42574) and operator-facing log lines.

**Fix:** Widen `_UNSAFE_CHARS_RE` to the union of the legacy structural-injection set AND the canonical `_INVISIBLE_DANGEROUS_RE` set. The two regexes now stay in sync via a new inventory test that fails any future regression that narrows the validator regex or widens `_INVISIBLE_DANGEROUS_RE` without a matching validator update.

### Test surface

- `tests/test_sentinel_overpass_endpoint_strict_validation.py` — 7 cases: canonical-endpoint regression + 5 sub-vector PoCs (HTTP downgrade, path hijack, port hijack, trailing slash, userinfo) + unrelated-host regression.
- `tests/test_sentinel_stations_validation_bidi_gap.py` — 24 cases: per-code-point regex match (7 cases × ALM / ZWSP / ZWNJ / ZWJ / LRM / RLM / BOM), per-code-point end-to-end name flag (7 cases), per-code-point end-to-end alias flag (7 cases), inventory invariant covering the canonical `_INVISIBLE_DANGEROUS_RE` set, existing-coverage regression, and safe-character regression.

## Test plan

- [x] `python -m pytest tests/test_sentinel_overpass_endpoint_strict_validation.py tests/test_sentinel_stations_validation_bidi_gap.py` — 31 new tests pass
- [x] `python -m pytest --timeout=60` — full suite: 2378 passed, 4 skipped, no regressions
- [x] `python scripts/run_static_checks.py` — ruff, mypy --strict (0 errors with CI-pinned mypy 1.10.1), bandit, secret scanner, C901 gate, pip-audit all clean
- [x] Journal entry added to `.jules/sentinel.md` documenting the threat model + fix shape + companion-regex sync rule for future contributors

https://claude.ai/code/session_01A9o4TgzjhJGZjJbpzyVB9q

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9o4TgzjhJGZjJbpzyVB9q)_