### PR TITLE
feat(stats): zero-dependency statistics &amp; ASCII-art dashboard pipeline

### DIFF
--- a/.github/workflows/generate-stats.yml
+++ b/.github/workflows/generate-stats.yml
@@ -1,0 +1,63 @@
+name: Generate statistics dashboard
+
+on:
+  schedule:
+    # Run after the last hourly Stammstrecke / build-feed cron has settled
+    # so the daily Markdown roll-up reflects a complete previous day.
+    - cron: '15 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Stay on the same concurrency lane as the other repo-mutating jobs to
+# avoid stomping the auto-commit step. Statistics generation is idempotent;
+# a queued second run that finds nothing changed is a no-op.
+concurrency:
+  group: generate-stats-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      PYTHONPATH: src
+      PIP_CACHE_DIR: /tmp/pip-cache
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Need full history so the auto-commit action can rebase
+          # cleanly against any concurrent push to main.
+          fetch-depth: 0
+
+      - name: Ensure pip cache directory exists
+        run: mkdir -p "$PIP_CACHE_DIR"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-deps
+
+      - name: Generate Markdown statistics
+        run: python scripts/generate_markdown_stats.py
+
+      - name: Pull concurrent remote changes
+        run: git pull --rebase --autostash
+
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
+        with:
+          commit_message: 'chore: refresh statistics dashboard'
+          file_pattern: |
+            docs/statistik.md
+            data/stats/*.csv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,54 @@
 # CHANGELOG
 
 ## [Unreleased]
+* **Feat (Statistik-Dashboard)**: Komplett dependenzfreies Statistik-
+  und Logging-System für Verspätungen und Störungen — siehe Section 6
+  in [`docs/architecture.md`](docs/architecture.md). Konkret:
+  - **Append-only CSV-Ledger** unter `data/stats/`:
+    `stammstrecke_YYYY.csv` (Spalten `timestamp, weekday, hour,
+    direction, delay_minutes`) und `stoerungen_YYYY.csv` (Spalten
+    `timestamp, weekday, hour, provider, location_name`). Eine Datei
+    pro Kalenderjahr, alle Zeitstempel als ISO 8601 in
+    `Europe/Vienna`.
+  - **Producer 1**: `scripts/update_stammstrecke_status.py` schreibt
+    nach jeder erfolgreichen Median-Berechnung eine Zeile — auch
+    *unterhalb* der RSS-Trigger-Schwelle, damit das Dashboard die
+    *gesamte* Verteilung zeigt, nicht nur die Eskalationen.
+  - **Producer 2**: `src/build_feed.py` schreibt im
+    `_update_item_state`-Strict-New-Pfad eine Zeile pro *erstmals
+    gesehenem* Identity (über die `data/first_seen.json`-State-Logik
+    erkannt). Rerun-stabil: eine lange ÖBB-Streckeninformation, die
+    viele Builds überlebt, wird genau *einmal* gezählt.
+  - **Aggregator**: Neues Skript `scripts/generate_markdown_stats.py`
+    (nur Standardlibrary — `csv`, `collections`, `datetime`,
+    `statistics`, `pathlib`, `zoneinfo`, `argparse`) erzeugt
+    `docs/statistik.md` mit ASCII/Emoji-Bar-Charts: Beobachtungen je
+    Wochentag und Stunde, ⌀ Verspätung je Wochentag und Stunde,
+    Top-5-Hotspots mit Tageszeit-Profil pro Hotspot, Zusammenfassungs-
+    KPIs.
+  - **Workflow**: Neuer GitHub-Actions-Job
+    `.github/workflows/generate-stats.yml` (Cron `15 0 * * *` +
+    `workflow_dispatch`) führt den Aggregator aus und committet
+    `docs/statistik.md` plus etwaige neue CSV-Dateien via
+    `stefanzweifel/git-auto-commit-action`.
+  - **Resilienz**: Schreiber sind best-effort (jeder I/O-Fehler wird
+    geloggt + geschluckt — Statistik darf nie den Build kippen). Der
+    Aggregator routet jede CSV über `read_capped_text` + `io.StringIO`
+    (entspricht dem CSV-Size-Bomb-Sentinel) und schreibt das Dashboard
+    via `atomic_write`.
+  - **Lokationsheuristik**: `extract_location_name` versucht
+    `zwischen X und Y` → erstes Capture, dann `Wien <Stadtteil>`,
+    dann das erste großgeschriebene Multi-Wort-Token außerhalb einer
+    kleinen Stopword-Liste (Bauarbeiten, Verspätung, Linie, …).
+    Fallback `"unbekannt"`.
+  - **Tests**: 60 neue Tests
+    (`tests/scripts/test_generate_markdown_stats.py`,
+    `tests/test_utils_stats.py`) decken Bar-Skalierung, Aggregation,
+    CSV-Lesepfad inkl. oversized-file-skip, malformed-row-tolerance,
+    Tie-Breaking im Top-N-Ranking, Idempotenz, Year-Boundary-Rollover
+    und Lokations-Heuristik ab.
+  - **Quality**: Mypy-Strict 0 Fehler, Bandit 0 Issues, Ruff 0
+    Issues, alle 2 418 vorherigen Tests grün — keine Regression.
 * **Audit**: Vollständige Audit-Abnahme des S-Bahn Stammstrecke
   Monitors mit Bericht unter
   [`docs/archive/audits/oebb_stammstrecke_audit.md`](docs/archive/audits/oebb_stammstrecke_audit.md).

--- a/data/stats/README.md
+++ b/data/stats/README.md
@@ -1,0 +1,19 @@
+# `data/stats/`
+
+Append-only CSV ledgers consumed by
+[`scripts/generate_markdown_stats.py`](../../scripts/generate_markdown_stats.py).
+
+| File | Producer | Schema |
+| --- | --- | --- |
+| `stammstrecke_YYYY.csv` | [`scripts/update_stammstrecke_status.py`](../../scripts/update_stammstrecke_status.py) — appends one row per successful HAFAS median calculation | `timestamp, weekday, hour, direction, delay_minutes` |
+| `stoerungen_YYYY.csv` | [`src/build_feed.py:_update_item_state`](../../src/build_feed.py) — appends one row when a strictly new event identity is seen | `timestamp, weekday, hour, provider, location_name` |
+
+All timestamps are ISO 8601 with offset, anchored to `Europe/Vienna`.
+One file per calendar year. Files are opened in append mode; rotation
+on the year boundary is handled by the writers in
+[`src/utils/stats.py`](../../src/utils/stats.py).
+
+Files are committed automatically by the
+[`generate-stats.yml`](../../.github/workflows/generate-stats.yml)
+workflow (cron `15 0 * * *`) alongside the regenerated
+[`docs/statistik.md`](../../docs/statistik.md) dashboard.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -363,7 +363,87 @@ The relevant CLI flags / env vars:
 
 ---
 
-## 6. Cross-references
+## 6. Statistics & Dashboard Pipeline
+
+Operational metrics live entirely outside the RSS pipeline so the
+hot-path build never blocks on observability I/O. Two append-only CSV
+ledgers under `data/stats/` (one per kind, one file per calendar year)
+capture the raw observations; a daily GitHub Actions job rolls them
+into a static Markdown dashboard at `docs/statistik.md`.
+
+```mermaid
+flowchart LR
+    subgraph "Producers (every cron tick)"
+        SS[update_stammstrecke_status.py<br/><i>after median calc</i>]
+        BF[build_feed.main<br/><i>_update_item_state strict-new branch</i>]
+    end
+    subgraph "Append-only ledgers (data/stats/)"
+        SCSV[stammstrecke_YYYY.csv<br/><i>timestamp, weekday, hour, direction, delay_minutes</i>]
+        DCSV[stoerungen_YYYY.csv<br/><i>timestamp, weekday, hour, provider, location_name</i>]
+    end
+    subgraph "Aggregator (daily 00:15 UTC)"
+        AGG[generate_markdown_stats.py<br/><i>stdlib only</i>]
+    end
+    subgraph "Output"
+        MD[docs/statistik.md<br/><i>ASCII / Emoji bars</i>]
+    end
+
+    SS -- append --> SCSV
+    BF -- append --> DCSV
+    SCSV --> AGG
+    DCSV --> AGG
+    AGG --> MD
+```
+
+**Why this shape:**
+
+- **Append-only is crash-safe**: a single `write()` of one CSV row is
+  below `PIPE_BUF` on every supported platform, so concurrent appenders
+  cannot interleave bytes mid-line. No locks needed.
+- **Best-effort writes**: `src/utils/stats.py` swallows `OSError` at
+  WARNING level — full disk, permission denied, or read-only
+  filesystem cannot crash the production pipeline. Statistics are
+  observability, not core functionality.
+- **Strict-new gating**: the disruption writer is hooked into
+  `_update_item_state` *only* on the strict cache miss (no entry by
+  `_identity` *or* `guid`). A long-lived ÖBB Streckeninformation that
+  survives many feed builds is recorded once, not once per regen.
+- **Per-year files**: bounds individual file size even after years of
+  operation; the aggregator only opens the requested year's files.
+- **Zero-dependency aggregator**: `scripts/generate_markdown_stats.py`
+  uses only `csv`, `collections`, `datetime`, `statistics`,
+  `pathlib`, `zoneinfo`, `argparse`. No NumPy / Pandas / Matplotlib.
+  Keeps CI runtime small and the repo's wheel cache trivial.
+- **Bounded reads**: the aggregator routes every CSV through
+  `read_capped_text` (open + `fstat` + capped `read`) and constructs
+  `csv.reader` over an in-memory `StringIO`. Matches the project-wide
+  `tests/test_sentinel_csv_size_bomb.py` invariant against unbounded
+  CSV reads.
+- **Atomic dashboard write**: the rendered Markdown is written via
+  `atomic_write`, so a kill-signal mid-render cannot replace the
+  previous dashboard with a half-written file.
+- **Idempotent + byte-stable**: rendering twice on identical input
+  produces byte-identical Markdown (ties broken by alphabetic
+  secondary sort), so the auto-commit step in
+  `.github/workflows/generate-stats.yml` is a no-op when nothing
+  actually changed.
+
+The dashboard answers two operator questions:
+
+| Question | Section |
+|---|---|
+| **When** do Stammstrecke delays occur? | "Stammstrecke" — weekday + hour distributions of both observation count and average delay |
+| **Where** (and **when**) are disruption hotspots? | "Störungen" — per-provider table, weekday + hour distributions, top-5 hotspots with per-location hourly profile |
+
+The location heuristic in `extract_location_name` tries (in order):
+`zwischen X und Y` → first capture, then `Wien <Name>`, then the first
+capitalised multi-word token outside a small stopword set
+(Bauarbeiten, Verspätung, Linie, …). Falls back to `"unbekannt"` so
+the dashboard always renders even on adversarial provider input.
+
+---
+
+## 7. Cross-references
 
 - **Security audit history** → `.jules/sentinel.md`
 - **Performance optimisations** → `.jules/apex.md`

--- a/scripts/generate_markdown_stats.py
+++ b/scripts/generate_markdown_stats.py
@@ -1,0 +1,816 @@
+#!/usr/bin/env python3
+"""Generate the Stammstrecke + Störungen statistics dashboard.
+
+Reads the append-only CSV ledgers under ``data/stats/`` (written by
+:mod:`scripts.update_stammstrecke_status` and :mod:`src.build_feed`),
+aggregates them by weekday / hour / location, and writes a single
+Markdown report to ``docs/statistik.md``.
+
+The script is **strictly zero-dependency** — only the Python standard
+library is used (``csv``, ``collections``, ``datetime``, ``statistics``,
+``pathlib``, ``zoneinfo``, ``argparse``). No NumPy / Pandas /
+Matplotlib. ASCII / Emoji bar charts are rendered inline so the report
+is readable as plain text in a terminal as well as in any Markdown
+viewer.
+
+Design contract
+---------------
+
+* **Read-only on the inputs**: the script *never* modifies the input
+  CSVs. Corruption-tolerance is provided by skipping malformed rows
+  (logged at WARNING) instead of crashing — a single fat-fingered
+  manual edit can never break the dashboard regeneration.
+* **Idempotent on the output**: running the script twice on the same
+  data produces byte-identical Markdown. Any aggregation step that is
+  order-sensitive (top-N location ranking) breaks ties with a stable
+  secondary sort on the location name itself.
+* **Bounded read sizes**: each CSV file is capped at
+  :data:`MAX_CSV_BYTES` (~25 MiB) on read. A planted-huge file is
+  skipped with a WARNING instead of buffered into memory.
+* **Atomic write**: the dashboard is written via
+  :func:`src.utils.files.atomic_write` so a crash or kill-signal
+  mid-write cannot leave a half-rendered Markdown report on disk.
+* **Timezone**: all aggregation honours ``Europe/Vienna`` — the source
+  CSVs already store timestamps in that zone (the writers normalise
+  via :func:`src.utils.stats.to_vienna`), so the script just trusts
+  the recorded values.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import logging
+import statistics
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Final
+from zoneinfo import ZoneInfo
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.feed.logging_safe import setup_script_logging  # noqa: E402
+from src.utils.files import atomic_write, read_capped_text  # noqa: E402
+from src.utils.logging import sanitize_log_arg  # noqa: E402
+from src.utils.stats import (  # noqa: E402
+    DEFAULT_STATS_DIR,
+    STAMMSTRECKE_HEADER,
+    STOERUNGEN_HEADER,
+    WEEKDAY_LABELS,
+    stats_path,
+)
+
+LOGGER = logging.getLogger("generate_markdown_stats")
+
+VIENNA_TZ: Final = ZoneInfo("Europe/Vienna")
+
+DEFAULT_OUTPUT_PATH: Final = REPO_ROOT / "docs" / "statistik.md"
+
+# Cap each CSV at ~25 MiB on read. At ~80 bytes per row this allows
+# >300 000 rows per year — far above any realistic Stammstrecke /
+# disruption log-rate. A file that exceeds the cap is treated as
+# corrupted / planted and skipped; the dashboard still renders from
+# whatever other inputs are available.
+MAX_CSV_BYTES: Final = 25 * 1024 * 1024
+
+# Bar-chart geometry. The bar widths are intentionally short so the
+# rendered Markdown stays comfortable even on a 96-col terminal viewer.
+MAX_BAR_WIDTH: Final = 24
+TOP_N_LOCATIONS: Final = 5
+
+# Visual vocabulary. Different glyphs per chart type so the eye can
+# tell them apart at a glance even when the dashboard is rendered in
+# monochrome.
+BAR_GLYPHS: Final = {
+    "weekday": "🟦",
+    "hour": "🟧",
+    "delay_weekday": "🟥",
+    "delay_hour": "🟨",
+    "location": "🟩",
+    "location_hour": "🟪",
+}
+
+
+# ---- Data classes ----------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StammstreckeRow:
+    """One Stammstrecke median-delay observation."""
+
+    timestamp: datetime
+    weekday: str
+    hour: int
+    direction: str
+    delay_minutes: float
+
+
+@dataclass(frozen=True)
+class StoerungRow:
+    """One disruption first-seen observation."""
+
+    timestamp: datetime
+    weekday: str
+    hour: int
+    provider: str
+    location_name: str
+
+
+@dataclass
+class StammstreckeAggregate:
+    """Aggregated Stammstrecke data ready to render."""
+
+    by_weekday_count: dict[str, int] = field(default_factory=dict)
+    by_weekday_avg: dict[str, float] = field(default_factory=dict)
+    by_hour_count: dict[int, int] = field(default_factory=dict)
+    by_hour_avg: dict[int, float] = field(default_factory=dict)
+    by_direction: dict[str, int] = field(default_factory=dict)
+    total_observations: int = 0
+    threshold_exceedances: int = 0
+    threshold_minutes: float = 9.0
+
+
+@dataclass
+class StoerungAggregate:
+    """Aggregated Störungen data ready to render."""
+
+    by_weekday: dict[str, int] = field(default_factory=dict)
+    by_hour: dict[int, int] = field(default_factory=dict)
+    by_provider: dict[str, int] = field(default_factory=dict)
+    by_location: Counter[str] = field(default_factory=Counter)
+    by_location_hour: dict[str, dict[int, int]] = field(default_factory=dict)
+    total_disruptions: int = 0
+
+
+# ---- CSV reading -----------------------------------------------------------
+
+
+def _iter_csv_rows(path: Path, header: tuple[str, ...]) -> Iterator[dict[str, str]]:
+    """Yield rows from *path* as dicts, validating the header.
+
+    Routes the read through :func:`src.utils.files.read_capped_text`
+    (open + ``fstat`` + capped ``read``) and constructs
+    :class:`csv.reader` from an in-memory :class:`io.StringIO`. This
+    matches the project-wide drift-defence sentinel against unbounded
+    CSV reads — never hand a raw file handle to the csv module.
+    """
+    raw = read_capped_text(
+        path,
+        max_bytes=MAX_CSV_BYTES,
+        label="stats CSV",
+        logger=LOGGER,
+    )
+    if raw is None:
+        return
+    reader = csv.reader(io.StringIO(raw))
+    try:
+        actual_header = next(reader)
+    except StopIteration:
+        return
+    if tuple(actual_header) != header:
+        LOGGER.warning(
+            "Stats-Datei %s hat unerwarteten Header %r — überspringe.",
+            sanitize_log_arg(str(path)),
+            sanitize_log_arg(str(actual_header)),
+        )
+        return
+    for row in reader:
+        if len(row) != len(header):
+            continue
+        yield dict(zip(header, row, strict=True))
+
+
+def _parse_stammstrecke_rows(
+    raw_rows: Iterable[dict[str, str]],
+) -> list[StammstreckeRow]:
+    """Convert raw CSV dict rows to typed Stammstrecke records.
+
+    Malformed rows (unparseable timestamp, non-numeric delay) are
+    dropped silently — the aggregator's only contract is that the
+    output reflects the *parseable* data. A single bad row, possibly
+    introduced by hand-editing, must never poison the whole dashboard.
+    """
+    parsed: list[StammstreckeRow] = []
+    for row in raw_rows:
+        try:
+            ts = datetime.fromisoformat(row["timestamp"])
+        except (KeyError, ValueError, TypeError):
+            continue
+        try:
+            delay = float(row["delay_minutes"])
+        except (KeyError, ValueError, TypeError):
+            continue
+        weekday = row.get("weekday") or WEEKDAY_LABELS[ts.weekday()]
+        try:
+            hour = int(row.get("hour") or ts.hour)
+        except ValueError:
+            hour = ts.hour
+        direction = (row.get("direction") or "Unbekannt").strip() or "Unbekannt"
+        parsed.append(
+            StammstreckeRow(
+                timestamp=ts,
+                weekday=weekday,
+                hour=max(0, min(23, hour)),
+                direction=direction,
+                delay_minutes=delay,
+            )
+        )
+    return parsed
+
+
+def _parse_stoerung_rows(
+    raw_rows: Iterable[dict[str, str]],
+) -> list[StoerungRow]:
+    """Convert raw CSV dict rows to typed Störung records."""
+    parsed: list[StoerungRow] = []
+    for row in raw_rows:
+        try:
+            ts = datetime.fromisoformat(row["timestamp"])
+        except (KeyError, ValueError, TypeError):
+            continue
+        weekday = row.get("weekday") or WEEKDAY_LABELS[ts.weekday()]
+        try:
+            hour = int(row.get("hour") or ts.hour)
+        except ValueError:
+            hour = ts.hour
+        provider = (row.get("provider") or "unbekannt").strip() or "unbekannt"
+        location = (row.get("location_name") or "unbekannt").strip() or "unbekannt"
+        parsed.append(
+            StoerungRow(
+                timestamp=ts,
+                weekday=weekday,
+                hour=max(0, min(23, hour)),
+                provider=provider,
+                location_name=location,
+            )
+        )
+    return parsed
+
+
+# ---- Aggregation -----------------------------------------------------------
+
+
+def aggregate_stammstrecke(
+    rows: list[StammstreckeRow],
+    *,
+    threshold_minutes: float = 9.0,
+) -> StammstreckeAggregate:
+    """Roll *rows* up into the dimensions the dashboard needs.
+
+    *threshold_minutes* mirrors :data:`scripts.update_stammstrecke_status.
+    DELAY_THRESHOLD_MINUTES`. A "threshold exceedance" is a single
+    observation whose median delay is *strictly greater* than the
+    threshold — i.e. would have triggered an RSS event.
+    """
+    weekday_count: dict[str, int] = defaultdict(int)
+    weekday_sum: dict[str, float] = defaultdict(float)
+    hour_count: dict[int, int] = defaultdict(int)
+    hour_sum: dict[int, float] = defaultdict(float)
+    direction_count: dict[str, int] = defaultdict(int)
+    exceedances = 0
+
+    for row in rows:
+        weekday_count[row.weekday] += 1
+        weekday_sum[row.weekday] += row.delay_minutes
+        hour_count[row.hour] += 1
+        hour_sum[row.hour] += row.delay_minutes
+        direction_count[row.direction] += 1
+        if row.delay_minutes > threshold_minutes:
+            exceedances += 1
+
+    weekday_avg = {
+        wd: weekday_sum[wd] / weekday_count[wd]
+        for wd in weekday_count
+    }
+    hour_avg = {h: hour_sum[h] / hour_count[h] for h in hour_count}
+
+    return StammstreckeAggregate(
+        by_weekday_count=dict(weekday_count),
+        by_weekday_avg=weekday_avg,
+        by_hour_count=dict(hour_count),
+        by_hour_avg=hour_avg,
+        by_direction=dict(direction_count),
+        total_observations=len(rows),
+        threshold_exceedances=exceedances,
+        threshold_minutes=threshold_minutes,
+    )
+
+
+def aggregate_stoerungen(rows: list[StoerungRow]) -> StoerungAggregate:
+    """Roll *rows* up into the dimensions the dashboard needs."""
+    weekday_count: dict[str, int] = defaultdict(int)
+    hour_count: dict[int, int] = defaultdict(int)
+    provider_count: dict[str, int] = defaultdict(int)
+    location_count: Counter[str] = Counter()
+    location_hour: dict[str, dict[int, int]] = defaultdict(
+        lambda: defaultdict(int)
+    )
+
+    for row in rows:
+        weekday_count[row.weekday] += 1
+        hour_count[row.hour] += 1
+        provider_count[row.provider] += 1
+        location_count[row.location_name] += 1
+        location_hour[row.location_name][row.hour] += 1
+
+    return StoerungAggregate(
+        by_weekday=dict(weekday_count),
+        by_hour=dict(hour_count),
+        by_provider=dict(provider_count),
+        by_location=location_count,
+        by_location_hour={
+            loc: dict(hours) for loc, hours in location_hour.items()
+        },
+        total_disruptions=len(rows),
+    )
+
+
+# ---- Bar rendering ---------------------------------------------------------
+
+
+def _scale_bar(value: float, max_value: float, *, width: int = MAX_BAR_WIDTH) -> int:
+    """Return the integer block count for *value* relative to *max_value*.
+
+    A non-zero value always renders as at least one block so a faint
+    signal does not vanish entirely. Zero stays zero.
+    """
+    if max_value <= 0 or value <= 0:
+        return 0
+    raw = (value / max_value) * width
+    return max(1, min(width, int(round(raw))))
+
+
+def _bar_line(
+    label: str,
+    value: float,
+    max_value: float,
+    glyph: str,
+    *,
+    label_width: int = 12,
+    suffix: str = "",
+    width: int = MAX_BAR_WIDTH,
+) -> str:
+    """Render a single ``label │ ████░░░░ 12.3`` chart row."""
+    blocks = _scale_bar(value, max_value, width=width)
+    bar = (glyph * blocks) + ("·" * (width - blocks))
+    padded_label = label.ljust(label_width)
+    return f"`{padded_label}` │ {bar} {suffix}".rstrip()
+
+
+def render_weekday_bars(
+    counts: dict[str, int],
+    *,
+    glyph: str,
+    title: str,
+) -> list[str]:
+    """Render a Mo-So weekday chart with monotone glyphs."""
+    if not counts:
+        return [f"### {title}", "", "_Keine Daten verfügbar._", ""]
+    max_value = max(counts.values())
+    lines: list[str] = [f"### {title}", "", "```"]
+    for label in WEEKDAY_LABELS:
+        value = counts.get(label, 0)
+        suffix = f" {value}" if value else " 0"
+        lines.append(_bar_line(label, value, max_value, glyph, label_width=4, suffix=suffix))
+    lines.append("```")
+    lines.append("")
+    return lines
+
+
+def render_hour_bars(
+    counts: dict[int, int],
+    *,
+    glyph: str,
+    title: str,
+) -> list[str]:
+    """Render a 0-23 hour chart with monotone glyphs."""
+    if not counts:
+        return [f"### {title}", "", "_Keine Daten verfügbar._", ""]
+    max_value = max(counts.values())
+    lines: list[str] = [f"### {title}", "", "```"]
+    for hour in range(24):
+        value = counts.get(hour, 0)
+        suffix = f" {value}" if value else " 0"
+        lines.append(
+            _bar_line(f"{hour:02d}h", value, max_value, glyph, label_width=4, suffix=suffix)
+        )
+    lines.append("```")
+    lines.append("")
+    return lines
+
+
+def render_avg_delay_weekday(avgs: dict[str, float], glyph: str) -> list[str]:
+    """Render the weekday breakdown of *average* delay."""
+    if not avgs:
+        return [
+            "### Verspätungen ⌀ Minuten je Wochentag",
+            "",
+            "_Keine Daten verfügbar._",
+            "",
+        ]
+    max_value = max(avgs.values())
+    lines: list[str] = [
+        "### Verspätungen ⌀ Minuten je Wochentag",
+        "",
+        "```",
+    ]
+    for label in WEEKDAY_LABELS:
+        value = avgs.get(label, 0.0)
+        suffix = f" {value:5.1f} min" if value else "  0.0 min"
+        lines.append(
+            _bar_line(label, value, max_value, glyph, label_width=4, suffix=suffix)
+        )
+    lines.append("```")
+    lines.append("")
+    return lines
+
+
+def render_avg_delay_hour(avgs: dict[int, float], glyph: str) -> list[str]:
+    """Render the hour-of-day breakdown of *average* delay."""
+    if not avgs:
+        return [
+            "### Verspätungen ⌀ Minuten je Stunde",
+            "",
+            "_Keine Daten verfügbar._",
+            "",
+        ]
+    max_value = max(avgs.values())
+    lines: list[str] = [
+        "### Verspätungen ⌀ Minuten je Stunde",
+        "",
+        "```",
+    ]
+    for hour in range(24):
+        value = avgs.get(hour, 0.0)
+        suffix = f" {value:5.1f} min" if value else "  0.0 min"
+        lines.append(
+            _bar_line(
+                f"{hour:02d}h", value, max_value, glyph, label_width=4, suffix=suffix
+            )
+        )
+    lines.append("```")
+    lines.append("")
+    return lines
+
+
+def render_top_locations(
+    aggregate: StoerungAggregate,
+    *,
+    top_n: int = TOP_N_LOCATIONS,
+) -> list[str]:
+    """Render the top-N location hotspots, each with its hourly profile."""
+    if not aggregate.by_location:
+        return [
+            f"### Top {top_n} Hotspots",
+            "",
+            "_Noch keine Störungen erfasst._",
+            "",
+        ]
+
+    # ``Counter.most_common`` is stable across equal counts but ties on
+    # *count* alone are random across Python versions — fall through to
+    # an alphabetical secondary sort so dashboard regenerations are
+    # byte-deterministic for two locations with identical incident
+    # counts.
+    items = sorted(
+        aggregate.by_location.items(),
+        key=lambda pair: (-pair[1], pair[0]),
+    )[:top_n]
+    max_value = items[0][1] if items else 0
+
+    lines: list[str] = [f"### Top {top_n} Hotspots (Anzahl Störungen)", "", "```"]
+    for loc, count in items:
+        suffix = f" {count}"
+        lines.append(
+            _bar_line(
+                loc[:30],
+                count,
+                max_value,
+                BAR_GLYPHS["location"],
+                label_width=30,
+                suffix=suffix,
+                width=20,
+            )
+        )
+    lines.append("```")
+    lines.append("")
+
+    lines.append(f"### Tageszeit-Profil der Top {top_n} Hotspots")
+    lines.append("")
+    for loc, _count in items:
+        hours = aggregate.by_location_hour.get(loc, {})
+        if not hours:
+            continue
+        max_hour = max(hours.values()) if hours else 0
+        lines.append(f"**{loc}**")
+        lines.append("")
+        lines.append("```")
+        # Show only the hours that actually carry signal — full 24-row
+        # ASCII bars per hotspot dominate the dashboard for an audience
+        # that mostly cares "when does Karlsplatz break?" not "what
+        # hours are quiet?" (the latter is implicit in a missing row).
+        active_hours = sorted(h for h, v in hours.items() if v > 0)
+        for hour in active_hours:
+            value = hours[hour]
+            lines.append(
+                _bar_line(
+                    f"{hour:02d}h",
+                    value,
+                    max_hour,
+                    BAR_GLYPHS["location_hour"],
+                    label_width=4,
+                    suffix=f" {value}",
+                    width=18,
+                )
+            )
+        lines.append("```")
+        lines.append("")
+    return lines
+
+
+# ---- Markdown assembly -----------------------------------------------------
+
+
+def _format_summary_section(
+    *,
+    year: int,
+    generated_at: datetime,
+    stammstrecke: StammstreckeAggregate,
+    stoerungen: StoerungAggregate,
+) -> list[str]:
+    """Render the top-of-report key metrics block."""
+    if stammstrecke.total_observations:
+        delays = [
+            stammstrecke.by_weekday_avg[wd]
+            for wd in stammstrecke.by_weekday_avg
+        ]
+        global_avg = statistics.fmean(delays) if delays else 0.0
+    else:
+        global_avg = 0.0
+
+    return [
+        f"# Wien ÖPNV — Statistik {year}",
+        "",
+        f"_Automatisch erzeugt am {generated_at.isoformat(timespec='minutes')} (Europe/Vienna)._",
+        "",
+        "## Kennzahlen auf einen Blick",
+        "",
+        "| Kennzahl | Wert |",
+        "| --- | ---: |",
+        f"| Stammstrecke-Beobachtungen ({year}) | {stammstrecke.total_observations} |",
+        f"| Davon über {stammstrecke.threshold_minutes:g}-min-Schwelle | {stammstrecke.threshold_exceedances} |",
+        f"| ⌀ Verspätung (alle Tage) | {global_avg:.1f} min |",
+        f"| Erfasste Störungen ({year}) | {stoerungen.total_disruptions} |",
+        f"| Verschiedene Hotspots | {len(stoerungen.by_location)} |",
+        "",
+    ]
+
+
+def _format_directions_section(stammstrecke: StammstreckeAggregate) -> list[str]:
+    """Render the per-direction breakdown table."""
+    if not stammstrecke.by_direction:
+        return ["### Beobachtungen je Richtung", "", "_Keine Daten._", ""]
+    items = sorted(
+        stammstrecke.by_direction.items(),
+        key=lambda pair: (-pair[1], pair[0]),
+    )
+    lines: list[str] = ["### Beobachtungen je Richtung", "", "| Richtung | Anzahl |", "| --- | ---: |"]
+    for direction, count in items:
+        lines.append(f"| {direction} | {count} |")
+    lines.append("")
+    return lines
+
+
+def _format_providers_section(stoerungen: StoerungAggregate) -> list[str]:
+    """Render the per-provider breakdown table."""
+    if not stoerungen.by_provider:
+        return ["### Störungen je Quelle", "", "_Keine Daten._", ""]
+    items = sorted(
+        stoerungen.by_provider.items(),
+        key=lambda pair: (-pair[1], pair[0]),
+    )
+    lines: list[str] = ["### Störungen je Quelle", "", "| Quelle | Anzahl |", "| --- | ---: |"]
+    for provider, count in items:
+        lines.append(f"| {provider} | {count} |")
+    lines.append("")
+    return lines
+
+
+def render_markdown(
+    *,
+    year: int,
+    generated_at: datetime,
+    stammstrecke: StammstreckeAggregate,
+    stoerungen: StoerungAggregate,
+) -> str:
+    """Compose the full Markdown dashboard string from the aggregates."""
+    sections: list[str] = []
+    sections.extend(
+        _format_summary_section(
+            year=year,
+            generated_at=generated_at,
+            stammstrecke=stammstrecke,
+            stoerungen=stoerungen,
+        )
+    )
+
+    sections.extend(["## Stammstrecke", ""])
+    sections.extend(_format_directions_section(stammstrecke))
+    sections.extend(
+        render_weekday_bars(
+            stammstrecke.by_weekday_count,
+            glyph=BAR_GLYPHS["weekday"],
+            title="Beobachtungen je Wochentag",
+        )
+    )
+    sections.extend(
+        render_hour_bars(
+            stammstrecke.by_hour_count,
+            glyph=BAR_GLYPHS["hour"],
+            title="Beobachtungen je Stunde",
+        )
+    )
+    sections.extend(
+        render_avg_delay_weekday(
+            stammstrecke.by_weekday_avg, BAR_GLYPHS["delay_weekday"]
+        )
+    )
+    sections.extend(
+        render_avg_delay_hour(stammstrecke.by_hour_avg, BAR_GLYPHS["delay_hour"])
+    )
+
+    sections.extend(["## Störungen", ""])
+    sections.extend(_format_providers_section(stoerungen))
+    sections.extend(
+        render_weekday_bars(
+            stoerungen.by_weekday,
+            glyph=BAR_GLYPHS["weekday"],
+            title="Störungen je Wochentag",
+        )
+    )
+    sections.extend(
+        render_hour_bars(
+            stoerungen.by_hour,
+            glyph=BAR_GLYPHS["hour"],
+            title="Störungen je Stunde",
+        )
+    )
+    sections.extend(render_top_locations(stoerungen))
+
+    sections.extend(
+        [
+            "---",
+            "",
+            "_Quellen_: `data/stats/stammstrecke_*.csv`, `data/stats/stoerungen_*.csv`. "
+            "Generiert von `scripts/generate_markdown_stats.py`.",
+            "",
+        ]
+    )
+
+    return "\n".join(sections).rstrip() + "\n"
+
+
+# ---- Orchestration ---------------------------------------------------------
+
+
+def collect_year_data(
+    year: int,
+    *,
+    stats_dir: Path | None = None,
+) -> tuple[list[StammstreckeRow], list[StoerungRow]]:
+    """Load and parse all stats CSVs for *year*.
+
+    The two CSVs are read independently — a missing or malformed
+    Stammstrecke file does not prevent the Störungen file from loading,
+    and vice versa.
+    """
+    base = stats_dir if stats_dir is not None else DEFAULT_STATS_DIR
+    sm_path = stats_path("stammstrecke", year, base_dir=base)
+    st_path = stats_path("stoerungen", year, base_dir=base)
+    sm_rows = _parse_stammstrecke_rows(_iter_csv_rows(sm_path, STAMMSTRECKE_HEADER))
+    st_rows = _parse_stoerung_rows(_iter_csv_rows(st_path, STOERUNGEN_HEADER))
+    return sm_rows, st_rows
+
+
+def write_dashboard(
+    markdown: str,
+    *,
+    output_path: Path = DEFAULT_OUTPUT_PATH,
+) -> None:
+    """Atomically write *markdown* to *output_path*.
+
+    Uses :func:`src.utils.files.atomic_write` so a partially-written
+    dashboard cannot replace the previous one.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with atomic_write(output_path, mode="w", encoding="utf-8", permissions=0o644) as fh:
+        fh.write(markdown)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Returns ``0`` on success (incl. the empty-data case), ``1`` on a
+    fatal error (write failure). Parsing errors of individual CSV rows
+    are tolerated and never propagate to the exit code — the dashboard
+    is regenerated from whatever can be parsed.
+    """
+    setup_script_logging(logging.INFO)
+
+    parser = argparse.ArgumentParser(
+        description="Generate the Wien ÖPNV statistics dashboard.",
+    )
+    parser.add_argument(
+        "--year",
+        type=int,
+        default=datetime.now(VIENNA_TZ).year,
+        help="Calendar year to aggregate (default: current Vienna year).",
+    )
+    parser.add_argument(
+        "--stats-dir",
+        type=Path,
+        default=DEFAULT_STATS_DIR,
+        help=f"Directory containing the stats CSV files (default: {DEFAULT_STATS_DIR}).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help=f"Output Markdown path (default: {DEFAULT_OUTPUT_PATH}).",
+    )
+    args = parser.parse_args(argv)
+
+    sm_rows, st_rows = collect_year_data(args.year, stats_dir=args.stats_dir)
+    LOGGER.info(
+        "Stats geladen: %d Stammstrecke-Zeilen, %d Störungs-Zeilen aus %s.",
+        len(sm_rows),
+        len(st_rows),
+        sanitize_log_arg(str(args.stats_dir)),
+    )
+
+    sm_agg = aggregate_stammstrecke(sm_rows)
+    st_agg = aggregate_stoerungen(st_rows)
+
+    markdown = render_markdown(
+        year=args.year,
+        generated_at=datetime.now(VIENNA_TZ),
+        stammstrecke=sm_agg,
+        stoerungen=st_agg,
+    )
+
+    try:
+        write_dashboard(markdown, output_path=args.output)
+    except OSError as exc:
+        LOGGER.error(
+            "Konnte Dashboard nicht schreiben (%s): %s",
+            sanitize_log_arg(str(args.output)),
+            sanitize_log_arg(str(exc)),
+        )
+        return 1
+
+    LOGGER.info(
+        "Dashboard geschrieben: %s (%d Bytes).",
+        sanitize_log_arg(str(args.output)),
+        len(markdown.encode("utf-8")),
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())
+
+
+# Exposed for tests; intentionally module-private otherwise.
+__all__ = [
+    "DEFAULT_OUTPUT_PATH",
+    "MAX_CSV_BYTES",
+    "TOP_N_LOCATIONS",
+    "StammstreckeAggregate",
+    "StammstreckeRow",
+    "StoerungAggregate",
+    "StoerungRow",
+    "aggregate_stammstrecke",
+    "aggregate_stoerungen",
+    "collect_year_data",
+    "main",
+    "render_hour_bars",
+    "render_markdown",
+    "render_top_locations",
+    "render_weekday_bars",
+    "write_dashboard",
+]
+
+
+# Sanity import check: ensure the WEEKDAY_LABELS constant from
+# :mod:`src.utils.stats` matches the local one used for rendering. Drift
+# between these would silently mis-bucket weekdays.
+if tuple(WEEKDAY_LABELS) != ("Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"):  # pragma: no cover - drift guard
+    raise RuntimeError(
+        "WEEKDAY_LABELS drifted between src.utils.stats and the dashboard renderer."
+    )

--- a/scripts/update_stammstrecke_status.py
+++ b/scripts/update_stammstrecke_status.py
@@ -98,6 +98,7 @@ from src.utils.files import atomic_write, read_capped_json  # noqa: E402
 from src.utils.ids import make_guid  # noqa: E402
 from src.utils.logging import sanitize_log_arg  # noqa: E402
 from src.utils.stations import canonical_name, display_name  # noqa: E402
+from src.utils.stats import append_stammstrecke_row  # noqa: E402
 
 if TYPE_CHECKING:
     from pyhafas.types.fptf import Journey, Leg
@@ -725,6 +726,16 @@ def _process_direction(
         median_minutes,
         DELAY_THRESHOLD_MINUTES,
     )
+    # Stats: persist every successful median observation, regardless of
+    # whether it exceeds the feed-trigger threshold. The dashboard's
+    # value comes from the *full* distribution, not just the events that
+    # made it onto the RSS feed.
+    append_stammstrecke_row(
+        timestamp=when,
+        direction=direction.target_label,
+        delay_minutes=median_minutes,
+    )
+
     if median_minutes <= DELAY_THRESHOLD_MINUTES:
         return None, "no_delays"
 

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -59,6 +59,7 @@ from .utils.files import atomic_write, read_capped_json
 from .utils.http import validate_http_url
 from .utils.locking import file_lock
 from .utils.logging import sanitize_log_arg
+from .utils.stats import append_disruption_row, extract_location_name
 from .utils.text import html_to_text, truncate_html
 
 
@@ -1647,6 +1648,7 @@ def _update_item_state(it: FeedItem, now: datetime, state: dict[str, dict[str, A
     # Fallback: check guid as secondary key
     if not st and it.get("guid") and it["guid"] != ident:
         st = state.get(str(it["guid"]))
+    is_strictly_new = not st
     if not st:
         st = {"first_seen": _to_utc(now).isoformat()}
     state[ident] = st
@@ -1657,6 +1659,27 @@ def _update_item_state(it: FeedItem, now: datetime, state: dict[str, dict[str, A
         log.warning("first_seen Parsefehler: %r – fallback to now", st.get("first_seen"))
         fs_dt = _to_utc(now)
         st["first_seen"] = fs_dt.isoformat()
+
+    # Stats: log the very first observation of a disruption identity into
+    # ``data/stats/stoerungen_YYYY.csv``. We deliberately key on the
+    # *strict* state-cache miss above (i.e. neither ``ident`` nor ``guid``
+    # had a prior entry) so reruns of the same incident — a long-lived
+    # ÖBB Streckeninformation that survives many feed builds — only
+    # record a single occurrence in the dashboard. Best-effort: any
+    # I/O failure inside ``append_disruption_row`` is logged and
+    # swallowed so the feed build itself never blocks on stats I/O.
+    if is_strictly_new:
+        try:
+            append_disruption_row(
+                timestamp=_to_utc(now),
+                provider=str(it.get("source") or "unbekannt"),
+                location_name=extract_location_name(cast(dict[str, Any], it)),
+            )
+        except Exception as exc:  # pragma: no cover - defensive; writer is no-throw
+            log.warning(
+                "Disruption-Stats konnten nicht geschrieben werden: %s",
+                sanitize_log_arg(str(exc)),
+            )
     return ident, fs_dt
 
 

--- a/src/utils/stats.py
+++ b/src/utils/stats.py
@@ -1,0 +1,349 @@
+"""Append-only CSV statistics writers.
+
+The two writers exposed by this module — :func:`append_stammstrecke_row`
+and :func:`append_disruption_row` — both follow the same contract:
+
+* The target file lives under ``<repo>/data/stats/`` and is named
+  ``<kind>_YYYY.csv`` with the year derived from the supplied
+  ``timestamp`` (Europe/Vienna). One file per calendar year keeps
+  individual files small even after many years of operation.
+* The file is opened in **append mode** (``"a"``). On POSIX, a single
+  ``write()`` of a row below ``PIPE_BUF`` (4 KiB by default — our rows
+  are well below that) is atomic against concurrent appenders, so we do
+  not need a lock for typical operation.
+* The CSV header is written exactly once, when the file does not yet
+  exist. Subsequent appends only add data rows.
+* All failures (full disk, permissions, OS-level write errors, …) are
+  swallowed at WARNING level so the calling pipeline (cron job,
+  build_feed.main) never crashes because statistics could not be
+  recorded — statistics are observability, not core functionality.
+
+The module is intentionally dependency-free: only standard library
+imports plus :func:`src.utils.logging.sanitize_log_arg` for the
+WARNING-level diagnostics. Mypy-strict clean; no third-party calls.
+"""
+from __future__ import annotations
+
+import csv
+import logging
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Final
+from zoneinfo import ZoneInfo
+
+from src.utils.logging import sanitize_log_arg
+
+LOGGER = logging.getLogger("utils.stats")
+
+VIENNA_TZ: Final = ZoneInfo("Europe/Vienna")
+
+# Repository-root-relative default location. Resolved lazily so tests
+# that monkeypatch the constant pick up the override.
+DEFAULT_STATS_DIR: Final = (
+    Path(__file__).resolve().parents[2] / "data" / "stats"
+)
+
+# Header rows. Pinned constants so the aggregator and the writers cannot
+# drift apart silently — a header rename here breaks the aggregator at
+# import time, which is the desired loud-failure mode.
+STAMMSTRECKE_HEADER: Final = (
+    "timestamp",
+    "weekday",
+    "hour",
+    "direction",
+    "delay_minutes",
+)
+STOERUNGEN_HEADER: Final = (
+    "timestamp",
+    "weekday",
+    "hour",
+    "provider",
+    "location_name",
+)
+
+# German short weekday names (Mo, Di, Mi, …) keyed by ``datetime.weekday()``
+# (0 = Monday). The aggregator renders these verbatim, so any change here
+# also changes the dashboard labels.
+WEEKDAY_LABELS: Final = ("Mo", "Di", "Mi", "Do", "Fr", "Sa", "So")
+
+# Heuristic field-extraction patterns. All patterns operate on the
+# already-sanitised plain-text title/description coming out of the
+# providers — no HTML, no control bytes, no upstream-controlled
+# unbounded length (the providers cap titles at ~200 chars and
+# descriptions at a few hundred). The patterns are deliberately broad-
+# but-bounded: ``{2,80}`` upper bounds keep ReDoS off the table even on
+# pathological input.
+_BETWEEN_RE: Final = re.compile(
+    r"\bzwischen\s+([A-ZÄÖÜ][\w\.\-’']{1,80}?(?:\s+[A-ZÄÖÜ][\w\.\-’']{1,80}){0,3})"
+    r"\s+und\s+",
+    re.IGNORECASE,
+)
+_WIEN_PREFIX_RE: Final = re.compile(
+    r"\bWien\s+([A-ZÄÖÜ][\wäöüÄÖÜß\-’']{1,40}(?:\s+[A-ZÄÖÜ][\wäöüÄÖÜß\-’']{1,40})?)"
+)
+_STATION_NAME_RE: Final = re.compile(
+    r"\b([A-ZÄÖÜ][\wäöüÄÖÜß]{2,40}(?:[\-/\s][A-ZÄÖÜ][\wäöüÄÖÜß]{2,40}){0,2})\b"
+)
+# Words that pass _STATION_NAME_RE but are clearly not station names.
+# Intentionally short — only the highest-frequency false positives that
+# survive the location heuristic on real provider feeds.
+_STOPWORD_LOCATIONS: Final = frozenset(
+    {
+        "Bauarbeiten",
+        "Gleisbauarbeiten",
+        "Strassenbauarbeiten",
+        "Straßenbauarbeiten",
+        "Verkehrsunfall",
+        "Verspätung",
+        "Verspaetung",
+        "Verspätungen",
+        "Störung",
+        "Stoerung",
+        "Störungen",
+        "Stoerungen",
+        "Ersatzverkehr",
+        "Schienenersatzverkehr",
+        "Sperre",
+        "Sperrung",
+        "Aufzug",
+        "Rolltreppe",
+        "Linie",
+        "Linien",
+        "Bus",
+        "Strassenbahn",
+        "Straßenbahn",
+        "U-Bahn",
+        "S-Bahn",
+        "Achtung",
+        "Hinweis",
+        "Information",
+        "Mitteilung",
+        "Mo",
+        "Di",
+        "Mi",
+        "Do",
+        "Fr",
+        "Sa",
+        "So",
+        "Januar",
+        "Februar",
+        "März",
+        "Maerz",
+        "April",
+        "Mai",
+        "Juni",
+        "Juli",
+        "August",
+        "September",
+        "Oktober",
+        "November",
+        "Dezember",
+    }
+)
+
+
+def to_vienna(dt: datetime) -> datetime:
+    """Return *dt* localised to ``Europe/Vienna``.
+
+    A naive datetime is assumed to already be in Vienna time (we control
+    the call sites; the only naive input would be a programming error
+    in a fresh provider). A timezone-aware datetime is converted via
+    :meth:`datetime.astimezone`.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=VIENNA_TZ)
+    return dt.astimezone(VIENNA_TZ)
+
+
+def stats_path(kind: str, year: int, *, base_dir: Path | None = None) -> Path:
+    """Return the path to ``data/stats/<kind>_YYYY.csv``.
+
+    Uses :data:`DEFAULT_STATS_DIR` unless *base_dir* is supplied. Tests
+    monkeypatch ``base_dir`` via the writer-level ``stats_dir`` keyword
+    so the production constant stays read-only.
+    """
+    folder = base_dir if base_dir is not None else DEFAULT_STATS_DIR
+    return folder / f"{kind}_{year:04d}.csv"
+
+
+def _append_row(
+    path: Path,
+    header: tuple[str, ...],
+    row: tuple[str, ...],
+) -> bool:
+    """Append *row* to *path*, writing the header on first creation.
+
+    Returns ``True`` on success, ``False`` if any I/O error was caught
+    (and logged at WARNING). The boolean return makes the writers
+    individually testable without scraping log output.
+
+    Implementation note: ``newline=""`` is the canonical way to disable
+    Python's universal-newline translation on writes through
+    :mod:`csv`, which would otherwise add a stray ``\\r`` on Windows
+    and break round-tripping.
+    """
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        write_header = not path.exists() or path.stat().st_size == 0
+        with path.open("a", encoding="utf-8", newline="") as handle:
+            writer = csv.writer(handle)
+            if write_header:
+                writer.writerow(header)
+            writer.writerow(row)
+        try:
+            os.chmod(path, 0o644)
+        except OSError:
+            pass
+        return True
+    except OSError as exc:
+        LOGGER.warning(
+            "Stats append fehlgeschlagen für %s: %s",
+            sanitize_log_arg(str(path)),
+            sanitize_log_arg(str(exc)),
+        )
+        return False
+
+
+def _format_delay(delay_minutes: float) -> str:
+    """Return a stable two-decimal string representation of *delay_minutes*.
+
+    Two decimals are enough to preserve the per-second resolution that
+    HAFAS sometimes reports while keeping CSV rows compact. ``round``
+    avoids platform-specific float rendering ('11.099999999999998').
+    """
+    return f"{round(float(delay_minutes), 2):.2f}"
+
+
+def append_stammstrecke_row(
+    *,
+    timestamp: datetime,
+    direction: str,
+    delay_minutes: float,
+    stats_dir: Path | None = None,
+) -> bool:
+    """Append a single observation to ``stammstrecke_YYYY.csv``.
+
+    *direction* is the human-readable target station ("Meidling",
+    "Floridsdorf"). *delay_minutes* is the median delay over the
+    sampled S-Bahn legs for that direction.
+
+    The function is best-effort: filesystem errors are logged and
+    swallowed so the upstream cron pipeline always exits cleanly.
+    """
+    when = to_vienna(timestamp)
+    path = stats_path("stammstrecke", when.year, base_dir=stats_dir)
+    row = (
+        when.isoformat(timespec="seconds"),
+        WEEKDAY_LABELS[when.weekday()],
+        f"{when.hour:02d}",
+        direction,
+        _format_delay(delay_minutes),
+    )
+    return _append_row(path, STAMMSTRECKE_HEADER, row)
+
+
+def append_disruption_row(
+    *,
+    timestamp: datetime,
+    provider: str,
+    location_name: str,
+    stats_dir: Path | None = None,
+) -> bool:
+    """Append a single freshly-detected disruption to ``stoerungen_YYYY.csv``.
+
+    The caller is responsible for ensuring that *timestamp* corresponds
+    to the moment the event was first observed (``first_seen``), not
+    some derivative timestamp from the event payload itself — this
+    keeps the dashboard's time-of-day binning aligned with operator
+    observation times rather than upstream-supplied event metadata.
+
+    Best-effort; never raises.
+    """
+    when = to_vienna(timestamp)
+    path = stats_path("stoerungen", when.year, base_dir=stats_dir)
+    row = (
+        when.isoformat(timespec="seconds"),
+        WEEKDAY_LABELS[when.weekday()],
+        f"{when.hour:02d}",
+        provider.strip() or "unbekannt",
+        location_name.strip() or "unbekannt",
+    )
+    return _append_row(path, STOERUNGEN_HEADER, row)
+
+
+def extract_location_name(item: dict[str, Any]) -> str:
+    """Best-effort heuristic to pick a representative location for *item*.
+
+    Tries — in order — the most signal-rich shapes seen in the
+    providers' real payloads:
+
+    1. ``zwischen X und Y`` — the X side (canonical ÖBB phrasing for a
+       between-stations disruption).
+    2. ``Wien <Stadtteil>`` — the prefix is the strongest "this is a
+       station name" signal in the corpus.
+    3. The first capitalised multi-word token longer than two letters
+       that is not in :data:`_STOPWORD_LOCATIONS`. Captures e.g.
+       ``Karlsplatz``, ``Floridsdorf``, ``Praterstern``.
+
+    Falls back to ``"unbekannt"`` if nothing matches. The function
+    never raises — a malformed item just returns the fallback string.
+    """
+    title = str(item.get("title") or "")
+    description = str(item.get("description") or "")
+    haystack = " ".join(part for part in (title, description) if part)
+    if not haystack:
+        return "unbekannt"
+
+    # Bound the search window: providers cap descriptions at a few
+    # hundred chars but a defensive cap also keeps the regex engine
+    # bounded on adversarial inputs.
+    haystack = haystack[:1024]
+
+    between = _BETWEEN_RE.search(haystack)
+    if between:
+        candidate = between.group(1).strip()
+        if candidate:
+            return _normalise_location(candidate)
+
+    wien = _WIEN_PREFIX_RE.search(haystack)
+    if wien:
+        suffix = wien.group(1).strip()
+        if suffix:
+            return f"Wien {suffix}"
+
+    for match in _STATION_NAME_RE.finditer(haystack):
+        candidate = _normalise_location(match.group(1))
+        if not candidate:
+            continue
+        first_word = candidate.split(maxsplit=1)[0]
+        if first_word in _STOPWORD_LOCATIONS:
+            continue
+        if len(candidate) < 3:
+            continue
+        return candidate
+
+    return "unbekannt"
+
+
+def _normalise_location(value: str) -> str:
+    """Trim, collapse whitespace, and cap *value* at a sensible length."""
+    cleaned = " ".join(value.split())
+    if len(cleaned) > 80:
+        cleaned = cleaned[:80].rstrip()
+    return cleaned
+
+
+__all__ = [
+    "STAMMSTRECKE_HEADER",
+    "STOERUNGEN_HEADER",
+    "WEEKDAY_LABELS",
+    "DEFAULT_STATS_DIR",
+    "VIENNA_TZ",
+    "append_stammstrecke_row",
+    "append_disruption_row",
+    "extract_location_name",
+    "stats_path",
+    "to_vienna",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,6 +237,30 @@ def reset_build_feed_state() -> None:
     reset_registry(with_defaults=True)
 
 
+@pytest.fixture(autouse=True)
+def isolate_stats_writes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Redirect ``src.utils.stats`` CSV appends to a per-test tmp directory.
+
+    The production writers default to ``data/stats/`` under the repo
+    root. Without this guard, any test that exercises a hot-path which
+    transitively records stats (build_feed.update_item_state's
+    strict-new branch, scripts/update_stammstrecke_status._process_direction)
+    would write into the real on-disk ledger and contaminate the
+    committed history with synthetic test rows.
+
+    The override is monkeypatched on the module attribute, so call
+    sites that did not pass an explicit ``stats_dir`` keyword (which
+    is the common case in production) pick up the test path. Tests
+    that *do* explicitly target a different ``stats_dir`` (e.g.
+    ``test_utils_stats.py``) are unaffected because the explicit
+    keyword wins inside ``stats_path``.
+    """
+    from src.utils import stats as stats_utils
+
+    monkeypatch.setattr(stats_utils, "DEFAULT_STATS_DIR", tmp_path / "stats")
+    yield
+
+
 # ---------------------------------------------------------------------------
 # CircuitBreaker test-isolation fixture
 #

--- a/tests/scripts/test_generate_markdown_stats.py
+++ b/tests/scripts/test_generate_markdown_stats.py
@@ -1,0 +1,432 @@
+"""Tests for ``scripts/generate_markdown_stats.py``.
+
+The aggregator is exercised end-to-end through CSV files written into a
+``tmp_path`` directory — that mirrors the production read path exactly
+(``csv.reader`` on real on-disk bytes) without coupling tests to any
+mock-CSV abstraction. Where helpful, individual rendering helpers are
+also called directly so a single regression in scaling logic shows up
+as a focused failure rather than a giant whole-dashboard diff.
+"""
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import generate_markdown_stats as script  # noqa: E402
+from src.utils import stats as stats_utils  # noqa: E402
+
+VIENNA_TZ = ZoneInfo("Europe/Vienna")
+
+
+# ---- Helpers ---------------------------------------------------------------
+
+
+def _write_csv(path: Path, header: tuple[str, ...], rows: list[tuple[str, ...]]) -> None:
+    """Helper that writes a small CSV the same way the production writer does."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [",".join(header)]
+    for row in rows:
+        lines.append(",".join(row))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _stammstrecke_csv(tmp_path: Path, year: int = 2026) -> Path:
+    return tmp_path / f"stammstrecke_{year}.csv"
+
+
+def _stoerungen_csv(tmp_path: Path, year: int = 2026) -> Path:
+    return tmp_path / f"stoerungen_{year}.csv"
+
+
+# ---- Bar-rendering primitives ---------------------------------------------
+
+
+def test_scale_bar_returns_zero_for_zero_value() -> None:
+    assert script._scale_bar(0.0, 10.0) == 0
+
+
+def test_scale_bar_returns_at_least_one_block_for_nonzero() -> None:
+    """A non-zero value must always render as at least one block.
+
+    Otherwise faint-but-present signals would visually disappear from
+    the dashboard, defeating the purpose of the chart.
+    """
+    assert script._scale_bar(0.001, 10.0, width=24) == 1
+
+
+def test_scale_bar_caps_at_width_for_value_at_max() -> None:
+    assert script._scale_bar(10.0, 10.0, width=24) == 24
+
+
+def test_scale_bar_handles_zero_max_safely() -> None:
+    assert script._scale_bar(5.0, 0.0) == 0
+
+
+def test_render_weekday_bars_includes_all_seven_days_even_when_empty_input(
+) -> None:
+    out = script.render_weekday_bars(
+        {"Mo": 5, "Di": 0},
+        glyph="🟦",
+        title="Test",
+    )
+    body = "\n".join(out)
+    for label in stats_utils.WEEKDAY_LABELS:
+        assert label in body, f"weekday label {label} missing from rendered chart"
+    assert "Test" in body
+
+
+def test_render_hour_bars_renders_24_rows_for_nonempty_input() -> None:
+    out = script.render_hour_bars({0: 1, 7: 5, 23: 2}, glyph="🟧", title="Stunden")
+    body = "\n".join(out)
+    for hour in (0, 7, 12, 23):
+        assert f"{hour:02d}h" in body
+
+
+def test_render_weekday_bars_handles_empty_data() -> None:
+    out = script.render_weekday_bars({}, glyph="🟦", title="leer")
+    body = "\n".join(out)
+    assert "_Keine Daten verfügbar._" in body
+
+
+# ---- Aggregation -----------------------------------------------------------
+
+
+def test_aggregate_stammstrecke_counts_observations_and_threshold() -> None:
+    rows = [
+        script.StammstreckeRow(
+            timestamp=datetime(2026, 5, 4, 7, 0, tzinfo=VIENNA_TZ),
+            weekday="Mo",
+            hour=7,
+            direction="Meidling",
+            delay_minutes=4.0,
+        ),
+        script.StammstreckeRow(
+            timestamp=datetime(2026, 5, 4, 8, 0, tzinfo=VIENNA_TZ),
+            weekday="Mo",
+            hour=8,
+            direction="Meidling",
+            delay_minutes=12.0,  # over threshold
+        ),
+        script.StammstreckeRow(
+            timestamp=datetime(2026, 5, 5, 8, 0, tzinfo=VIENNA_TZ),
+            weekday="Di",
+            hour=8,
+            direction="Floridsdorf",
+            delay_minutes=11.0,  # over threshold
+        ),
+    ]
+    agg = script.aggregate_stammstrecke(rows, threshold_minutes=9.0)
+    assert agg.total_observations == 3
+    assert agg.threshold_exceedances == 2
+    assert agg.by_weekday_count == {"Mo": 2, "Di": 1}
+    assert agg.by_hour_count == {7: 1, 8: 2}
+    # average for Mo is (4 + 12) / 2 = 8
+    assert agg.by_weekday_avg["Mo"] == pytest.approx(8.0)
+    assert agg.by_direction == {"Meidling": 2, "Floridsdorf": 1}
+
+
+def test_aggregate_stoerungen_counts_per_dimension() -> None:
+    rows = [
+        script.StoerungRow(
+            timestamp=datetime(2026, 5, 4, 7, 0, tzinfo=VIENNA_TZ),
+            weekday="Mo",
+            hour=7,
+            provider="ÖBB",
+            location_name="Wien Floridsdorf",
+        ),
+        script.StoerungRow(
+            timestamp=datetime(2026, 5, 4, 14, 0, tzinfo=VIENNA_TZ),
+            weekday="Mo",
+            hour=14,
+            provider="Wiener Linien",
+            location_name="Karlsplatz",
+        ),
+        script.StoerungRow(
+            timestamp=datetime(2026, 5, 5, 14, 0, tzinfo=VIENNA_TZ),
+            weekday="Di",
+            hour=14,
+            provider="ÖBB",
+            location_name="Wien Floridsdorf",
+        ),
+    ]
+    agg = script.aggregate_stoerungen(rows)
+    assert agg.total_disruptions == 3
+    assert agg.by_provider == {"ÖBB": 2, "Wiener Linien": 1}
+    assert agg.by_location["Wien Floridsdorf"] == 2
+    assert agg.by_location["Karlsplatz"] == 1
+    assert agg.by_location_hour["Wien Floridsdorf"] == {7: 1, 14: 1}
+
+
+# ---- CSV reading -----------------------------------------------------------
+
+
+def test_collect_year_data_reads_well_formed_files(tmp_path: Path) -> None:
+    _write_csv(
+        _stammstrecke_csv(tmp_path),
+        stats_utils.STAMMSTRECKE_HEADER,
+        [
+            ("2026-05-04T07:30:00+02:00", "Mo", "07", "Meidling", "5.50"),
+            ("2026-05-04T08:00:00+02:00", "Mo", "08", "Meidling", "12.00"),
+        ],
+    )
+    _write_csv(
+        _stoerungen_csv(tmp_path),
+        stats_utils.STOERUNGEN_HEADER,
+        [
+            ("2026-05-04T07:30:00+02:00", "Mo", "07", "ÖBB", "Wien Floridsdorf"),
+            ("2026-05-04T08:00:00+02:00", "Mo", "08", "Wiener Linien", "Karlsplatz"),
+        ],
+    )
+    sm, st = script.collect_year_data(2026, stats_dir=tmp_path)
+    assert len(sm) == 2
+    assert len(st) == 2
+    assert sm[0].direction == "Meidling"
+    assert st[0].location_name == "Wien Floridsdorf"
+
+
+def test_collect_year_data_returns_empty_when_files_missing(tmp_path: Path) -> None:
+    sm, st = script.collect_year_data(2026, stats_dir=tmp_path / "nope")
+    assert sm == []
+    assert st == []
+
+
+def test_collect_year_data_skips_oversized_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A planted-huge CSV must be skipped, not buffered into memory."""
+    monkeypatch.setattr(script, "MAX_CSV_BYTES", 64)
+    payload_rows = [
+        ("2026-05-04T07:30:00+02:00", "Mo", "07", "Meidling", "5.50"),
+    ] * 10
+    _write_csv(_stammstrecke_csv(tmp_path), stats_utils.STAMMSTRECKE_HEADER, payload_rows)
+    sm, _ = script.collect_year_data(2026, stats_dir=tmp_path)
+    assert sm == []
+
+
+def test_collect_year_data_rejects_unexpected_header(tmp_path: Path) -> None:
+    _write_csv(
+        _stammstrecke_csv(tmp_path),
+        ("not", "the", "expected", "header", "row"),
+        [("a", "b", "c", "d", "e")],
+    )
+    sm, _ = script.collect_year_data(2026, stats_dir=tmp_path)
+    assert sm == []
+
+
+def test_parse_stammstrecke_rows_skips_malformed_rows() -> None:
+    raw = [
+        # Bad timestamp.
+        {
+            "timestamp": "not-a-timestamp",
+            "weekday": "Mo",
+            "hour": "07",
+            "direction": "Meidling",
+            "delay_minutes": "5.0",
+        },
+        # Bad delay value.
+        {
+            "timestamp": "2026-05-04T07:30:00+02:00",
+            "weekday": "Mo",
+            "hour": "07",
+            "direction": "Meidling",
+            "delay_minutes": "not-a-number",
+        },
+        # Good row — the survivor.
+        {
+            "timestamp": "2026-05-04T07:30:00+02:00",
+            "weekday": "Mo",
+            "hour": "07",
+            "direction": "Meidling",
+            "delay_minutes": "5.0",
+        },
+    ]
+    rows = script._parse_stammstrecke_rows(raw)
+    assert len(rows) == 1
+    assert rows[0].direction == "Meidling"
+
+
+def test_parse_stoerung_rows_uses_fallbacks_for_missing_fields() -> None:
+    raw = [
+        {
+            "timestamp": "2026-05-04T07:30:00+02:00",
+            "weekday": "",
+            "hour": "",
+            "provider": "",
+            "location_name": "",
+        },
+    ]
+    rows = script._parse_stoerung_rows(raw)
+    assert len(rows) == 1
+    assert rows[0].provider == "unbekannt"
+    assert rows[0].location_name == "unbekannt"
+    assert rows[0].weekday == "Mo"  # 2026-05-04 is a Monday
+    assert rows[0].hour == 7
+
+
+# ---- Top-N location rendering ---------------------------------------------
+
+
+def test_render_top_locations_breaks_ties_alphabetically() -> None:
+    agg = script.StoerungAggregate(
+        by_location=Counter({"Bbb": 3, "Aaa": 3, "Ccc": 1}),
+        by_location_hour={
+            "Bbb": {7: 3},
+            "Aaa": {8: 3},
+            "Ccc": {14: 1},
+        },
+        total_disruptions=7,
+    )
+    out = script.render_top_locations(agg, top_n=3)
+    body = "\n".join(out)
+    aaa_idx = body.index("Aaa")
+    bbb_idx = body.index("Bbb")
+    assert aaa_idx < bbb_idx, "ties on count must break alphabetically"
+
+
+def test_render_top_locations_handles_empty_aggregate() -> None:
+    out = script.render_top_locations(script.StoerungAggregate(), top_n=5)
+    body = "\n".join(out)
+    assert "Noch keine Störungen erfasst" in body
+
+
+# ---- Full markdown rendering ----------------------------------------------
+
+
+def test_render_markdown_includes_summary_table_and_sections() -> None:
+    sm_agg = script.StammstreckeAggregate(
+        by_weekday_count={"Mo": 1},
+        by_weekday_avg={"Mo": 5.0},
+        by_hour_count={7: 1},
+        by_hour_avg={7: 5.0},
+        by_direction={"Meidling": 1},
+        total_observations=1,
+        threshold_exceedances=0,
+        threshold_minutes=9.0,
+    )
+    st_agg = script.StoerungAggregate(
+        by_weekday={"Mo": 1},
+        by_hour={7: 1},
+        by_provider={"ÖBB": 1},
+        by_location=Counter({"Wien Floridsdorf": 1}),
+        by_location_hour={"Wien Floridsdorf": {7: 1}},
+        total_disruptions=1,
+    )
+    md = script.render_markdown(
+        year=2026,
+        generated_at=datetime(2026, 5, 9, 8, 30, tzinfo=VIENNA_TZ),
+        stammstrecke=sm_agg,
+        stoerungen=st_agg,
+    )
+    assert md.startswith("# Wien ÖPNV — Statistik 2026")
+    assert "## Stammstrecke" in md
+    assert "## Störungen" in md
+    assert "Top 5 Hotspots" in md
+    assert "Wien Floridsdorf" in md
+    assert "ÖBB" in md
+    assert md.endswith("\n")
+
+
+def test_render_markdown_is_byte_stable_across_repeat_calls() -> None:
+    """Two invocations on the same inputs must produce identical bytes.
+
+    The auto-commit step in the workflow only commits when the output
+    actually changed, so non-determinism here would create churn in
+    the git history.
+    """
+    sm_agg = script.StammstreckeAggregate(
+        by_weekday_count={"Mo": 2, "Di": 2},
+        by_weekday_avg={"Mo": 6.0, "Di": 7.0},
+        by_hour_count={7: 2, 8: 2},
+        by_hour_avg={7: 6.0, 8: 7.0},
+        by_direction={"Meidling": 2, "Floridsdorf": 2},
+        total_observations=4,
+        threshold_exceedances=1,
+    )
+    st_agg = script.StoerungAggregate(
+        by_weekday={"Mo": 2, "Di": 1},
+        by_hour={7: 1, 8: 2},
+        by_provider={"ÖBB": 2, "Wiener Linien": 1},
+        by_location=Counter({"A": 2, "B": 1}),
+        by_location_hour={"A": {7: 1, 8: 1}, "B": {8: 1}},
+        total_disruptions=3,
+    )
+    when = datetime(2026, 5, 9, 8, 30, tzinfo=VIENNA_TZ)
+    a = script.render_markdown(year=2026, generated_at=when, stammstrecke=sm_agg, stoerungen=st_agg)
+    b = script.render_markdown(year=2026, generated_at=when, stammstrecke=sm_agg, stoerungen=st_agg)
+    assert a == b
+
+
+def test_render_markdown_handles_empty_aggregates_gracefully() -> None:
+    md = script.render_markdown(
+        year=2026,
+        generated_at=datetime(2026, 5, 9, 8, 30, tzinfo=VIENNA_TZ),
+        stammstrecke=script.StammstreckeAggregate(),
+        stoerungen=script.StoerungAggregate(),
+    )
+    assert "_Keine Daten verfügbar._" in md
+
+
+# ---- write_dashboard ------------------------------------------------------
+
+
+def test_write_dashboard_produces_atomic_output(tmp_path: Path) -> None:
+    out = tmp_path / "subdir" / "statistik.md"
+    script.write_dashboard("# hi\n", output_path=out)
+    assert out.read_text(encoding="utf-8") == "# hi\n"
+
+
+# ---- main(): integration --------------------------------------------------
+
+
+def test_main_writes_dashboard_for_well_formed_inputs(tmp_path: Path) -> None:
+    _write_csv(
+        _stammstrecke_csv(tmp_path),
+        stats_utils.STAMMSTRECKE_HEADER,
+        [
+            ("2026-05-04T07:30:00+02:00", "Mo", "07", "Meidling", "5.50"),
+            ("2026-05-04T08:00:00+02:00", "Mo", "08", "Floridsdorf", "11.00"),
+        ],
+    )
+    _write_csv(
+        _stoerungen_csv(tmp_path),
+        stats_utils.STOERUNGEN_HEADER,
+        [
+            ("2026-05-04T07:30:00+02:00", "Mo", "07", "ÖBB", "Wien Floridsdorf"),
+        ],
+    )
+    output = tmp_path / "statistik.md"
+    rc = script.main(
+        [
+            "--year", "2026",
+            "--stats-dir", str(tmp_path),
+            "--output", str(output),
+        ]
+    )
+    assert rc == 0
+    body = output.read_text(encoding="utf-8")
+    assert "Stammstrecke" in body
+    assert "Wien Floridsdorf" in body
+    assert "Meidling" in body
+
+
+def test_main_returns_zero_with_no_input_files(tmp_path: Path) -> None:
+    output = tmp_path / "statistik.md"
+    rc = script.main(
+        [
+            "--year", "2026",
+            "--stats-dir", str(tmp_path / "missing"),
+            "--output", str(output),
+        ]
+    )
+    assert rc == 0
+    body = output.read_text(encoding="utf-8")
+    assert "Keine Daten verfügbar" in body

--- a/tests/scripts/test_generate_markdown_stats.py
+++ b/tests/scripts/test_generate_markdown_stats.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import sys
 from collections import Counter
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -30,8 +31,18 @@ VIENNA_TZ = ZoneInfo("Europe/Vienna")
 # ---- Helpers ---------------------------------------------------------------
 
 
-def _write_csv(path: Path, header: tuple[str, ...], rows: list[tuple[str, ...]]) -> None:
-    """Helper that writes a small CSV the same way the production writer does."""
+def _write_csv(
+    path: Path,
+    header: tuple[str, ...],
+    rows: Sequence[tuple[str, ...]],
+) -> None:
+    """Helper that writes a small CSV the same way the production writer does.
+
+    *rows* is typed as :class:`Sequence` rather than :class:`list` so
+    callers can pass concrete tuple element types (e.g.
+    ``list[tuple[str, str, str, str, str]]``) without tripping the
+    list-invariance rule mypy enforces under ``--strict``.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     lines = [",".join(header)]
     for row in rows:

--- a/tests/test_utils_stats.py
+++ b/tests/test_utils_stats.py
@@ -1,0 +1,215 @@
+"""Tests for ``src.utils.stats``.
+
+Covers the append-only CSV writers and the location-name extraction
+heuristic. The writers are exercised against ``tmp_path`` so the
+production CSV path is never touched.
+"""
+from __future__ import annotations
+
+import csv
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.utils import stats as stats_utils  # noqa: E402
+
+VIENNA_TZ = ZoneInfo("Europe/Vienna")
+
+
+def _read_csv(path: Path) -> tuple[list[str], list[list[str]]]:
+    """Return ``(header, data_rows)`` from a CSV path."""
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.reader(handle))
+    if not rows:
+        return [], []
+    return rows[0], rows[1:]
+
+
+# ---- to_vienna ------------------------------------------------------------
+
+
+def test_to_vienna_passes_through_aware_vienna_datetime() -> None:
+    when = datetime(2026, 5, 4, 12, 0, tzinfo=VIENNA_TZ)
+    assert stats_utils.to_vienna(when) == when
+
+
+def test_to_vienna_converts_utc_to_vienna() -> None:
+    when_utc = datetime(2026, 5, 4, 10, 0, tzinfo=UTC)
+    converted = stats_utils.to_vienna(when_utc)
+    assert converted.tzinfo is not None
+    # In May, Vienna is UTC+02:00 → 10:00 UTC = 12:00 Vienna
+    assert converted.hour == 12
+
+
+def test_to_vienna_localises_naive_datetime() -> None:
+    naive = datetime(2026, 5, 4, 12, 0)
+    converted = stats_utils.to_vienna(naive)
+    assert converted.tzinfo is not None
+    assert converted.year == 2026
+
+
+# ---- Stammstrecke writer --------------------------------------------------
+
+
+def test_append_stammstrecke_row_writes_header_on_first_call(tmp_path: Path) -> None:
+    when = datetime(2026, 5, 4, 7, 30, tzinfo=VIENNA_TZ)
+    ok = stats_utils.append_stammstrecke_row(
+        timestamp=when,
+        direction="Meidling",
+        delay_minutes=5.5,
+        stats_dir=tmp_path,
+    )
+    assert ok is True
+    path = tmp_path / "stammstrecke_2026.csv"
+    header, rows = _read_csv(path)
+    assert tuple(header) == stats_utils.STAMMSTRECKE_HEADER
+    assert rows == [["2026-05-04T07:30:00+02:00", "Mo", "07", "Meidling", "5.50"]]
+
+
+def test_append_stammstrecke_row_appends_without_rewriting_header(tmp_path: Path) -> None:
+    when = datetime(2026, 5, 4, 7, 30, tzinfo=VIENNA_TZ)
+    stats_utils.append_stammstrecke_row(
+        timestamp=when, direction="Meidling", delay_minutes=5.5, stats_dir=tmp_path
+    )
+    stats_utils.append_stammstrecke_row(
+        timestamp=when, direction="Floridsdorf", delay_minutes=12.0, stats_dir=tmp_path
+    )
+    path = tmp_path / "stammstrecke_2026.csv"
+    header, rows = _read_csv(path)
+    assert tuple(header) == stats_utils.STAMMSTRECKE_HEADER
+    assert len(rows) == 2
+    assert rows[0][3] == "Meidling"
+    assert rows[1][3] == "Floridsdorf"
+
+
+def test_append_stammstrecke_row_rolls_over_at_year_boundary(tmp_path: Path) -> None:
+    """A timestamp in 2027 must land in ``stammstrecke_2027.csv``."""
+    a = datetime(2026, 12, 31, 23, 59, tzinfo=VIENNA_TZ)
+    b = datetime(2027, 1, 1, 0, 5, tzinfo=VIENNA_TZ)
+    stats_utils.append_stammstrecke_row(
+        timestamp=a, direction="Meidling", delay_minutes=1.0, stats_dir=tmp_path
+    )
+    stats_utils.append_stammstrecke_row(
+        timestamp=b, direction="Meidling", delay_minutes=2.0, stats_dir=tmp_path
+    )
+    assert (tmp_path / "stammstrecke_2026.csv").exists()
+    assert (tmp_path / "stammstrecke_2027.csv").exists()
+
+
+def test_append_stammstrecke_row_returns_false_on_io_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A simulated OSError must be swallowed (returns False), not raised."""
+
+    def _raise(*args: object, **kwargs: object) -> None:
+        raise OSError("disk on fire")
+
+    monkeypatch.setattr(Path, "mkdir", _raise)
+    ok = stats_utils.append_stammstrecke_row(
+        timestamp=datetime(2026, 5, 4, 7, 30, tzinfo=VIENNA_TZ),
+        direction="Meidling",
+        delay_minutes=5.0,
+        stats_dir=tmp_path / "nope",
+    )
+    assert ok is False
+
+
+# ---- Disruption writer ----------------------------------------------------
+
+
+def test_append_disruption_row_persists_provider_and_location(tmp_path: Path) -> None:
+    when = datetime(2026, 5, 4, 7, 30, tzinfo=VIENNA_TZ)
+    ok = stats_utils.append_disruption_row(
+        timestamp=when,
+        provider="ÖBB",
+        location_name="Wien Floridsdorf",
+        stats_dir=tmp_path,
+    )
+    assert ok is True
+    header, rows = _read_csv(tmp_path / "stoerungen_2026.csv")
+    assert tuple(header) == stats_utils.STOERUNGEN_HEADER
+    assert rows == [
+        ["2026-05-04T07:30:00+02:00", "Mo", "07", "ÖBB", "Wien Floridsdorf"]
+    ]
+
+
+def test_append_disruption_row_normalises_blank_fields(tmp_path: Path) -> None:
+    when = datetime(2026, 5, 4, 7, 30, tzinfo=VIENNA_TZ)
+    stats_utils.append_disruption_row(
+        timestamp=when,
+        provider="   ",
+        location_name="",
+        stats_dir=tmp_path,
+    )
+    _, rows = _read_csv(tmp_path / "stoerungen_2026.csv")
+    assert rows[0][3] == "unbekannt"
+    assert rows[0][4] == "unbekannt"
+
+
+# ---- Location heuristic ---------------------------------------------------
+
+
+def test_extract_location_name_uses_zwischen_pattern() -> None:
+    item = {
+        "title": "S 7: Verspätung",
+        "description": "Verspätungen zwischen Floridsdorf und Praterstern wegen Bauarbeiten.",
+    }
+    assert stats_utils.extract_location_name(item) == "Floridsdorf"
+
+
+def test_extract_location_name_falls_back_to_wien_prefix() -> None:
+    item = {
+        "title": "ÖBB: Information",
+        "description": "Streckensperre rund um Wien Meidling bis Vormittag.",
+    }
+    assert stats_utils.extract_location_name(item) == "Wien Meidling"
+
+
+def test_extract_location_name_returns_unbekannt_when_nothing_matches() -> None:
+    item = {"title": "", "description": ""}
+    assert stats_utils.extract_location_name(item) == "unbekannt"
+
+
+def test_extract_location_name_skips_stopwords_like_bauarbeiten() -> None:
+    item = {
+        "title": "Bauarbeiten",
+        "description": "Bauarbeiten heute, Karlsplatz betroffen.",
+    }
+    extracted = stats_utils.extract_location_name(item)
+    assert extracted != "Bauarbeiten"
+    assert "Karlsplatz" in extracted
+
+
+def test_extract_location_name_caps_overly_long_strings() -> None:
+    item = {
+        "title": "X" * 5000,
+        "description": "Wien " + ("a" * 200),
+    }
+    out = stats_utils.extract_location_name(item)
+    assert len(out) <= 90  # 80-char location cap + small "Wien " prefix slack
+
+
+def test_extract_location_name_handles_non_string_inputs_safely() -> None:
+    item: dict[str, object] = {"title": None, "description": 12345}
+    assert stats_utils.extract_location_name(item) == "unbekannt"
+
+
+# ---- Path helper ----------------------------------------------------------
+
+
+def test_stats_path_uses_default_dir_when_unspecified() -> None:
+    path = stats_utils.stats_path("stammstrecke", 2026)
+    assert path.name == "stammstrecke_2026.csv"
+    assert path.parent == stats_utils.DEFAULT_STATS_DIR
+
+
+def test_stats_path_honours_base_dir_override(tmp_path: Path) -> None:
+    path = stats_utils.stats_path("stoerungen", 2027, base_dir=tmp_path)
+    assert path == tmp_path / "stoerungen_2027.csv"


### PR DESCRIPTION
## Summary

Adds a **strictly zero-dependency** statistics & logging pipeline that
tracks Stammstrecke delays and disruption events, persists them as
append-only CSV ledgers, and renders a static ASCII/emoji-bar Markdown
dashboard at `docs/statistik.md`.

- **Producer 1** — `scripts/update_stammstrecke_status.py` appends one
  row per HAFAS median calculation into
  `data/stats/stammstrecke_YYYY.csv` (also for medians *below* the
  RSS threshold, so the dashboard shows the full distribution, not
  just escalations).
- **Producer 2** — `src/build_feed.py:_update_item_state` appends one
  row per *strictly new* event identity (state-cache miss on both
  `_identity` and `guid`) into `data/stats/stoerungen_YYYY.csv`.
  Long-lived items survive across many builds without being
  double-counted.
- **Aggregator** — `scripts/generate_markdown_stats.py` reads the
  current year's CSVs (stdlib only: `csv`, `collections`, `datetime`,
  `statistics`, `pathlib`, `zoneinfo`, `argparse`) and renders
  `docs/statistik.md`. Output answers: when do Stammstrecke delays
  occur (weekday + hour breakdowns of count and ⌀ delay), and which
  locations are top-5 hotspots (with per-location hourly profile).
- **Workflow** — `.github/workflows/generate-stats.yml` runs daily at
  `00:15 UTC` (and on `workflow_dispatch`), commits the regenerated
  dashboard plus any new CSV files via `git-auto-commit-action`.

## Architecture

| Concern | Decision |
| --- | --- |
| Concurrency-safe writes | Append mode (POSIX guarantees single-line atomicity below `PIPE_BUF`) |
| File rotation | One file per calendar year, picked from the row's `Europe/Vienna` timestamp |
| Crash safety | Writers swallow `OSError` (best-effort observability), aggregator uses `atomic_write` |
| Bounded reads | Aggregator routes every CSV through `read_capped_text` + `io.StringIO` (matches the project-wide `tests/test_sentinel_csv_size_bomb.py` invariant) |
| Idempotency | Two runs on identical input produce byte-identical Markdown (ties broken by alphabetic secondary sort) |
| Test isolation | Autouse `isolate_stats_writes` fixture in `tests/conftest.py` redirects `DEFAULT_STATS_DIR` to `tmp_path` so test runs cannot contaminate the real ledger |

## Quality gates

- ✅ `mypy --strict`: 0 errors across 44 source files
- ✅ `bandit -r src scripts`: 0 issues
- ✅ `ruff check src scripts tests`: 0 issues
- ✅ `pytest`: **2 478 passed, 4 skipped** (60 net-new tests, 2 418 prior tests still green)
- ✅ Complexity gate: 0 new C901 violations

## Test plan

- [ ] Confirm `docs/statistik.md` renders correctly when GitHub displays it (emoji bar charts inside fenced code blocks)
- [ ] Trigger `workflow_dispatch` once to verify the auto-commit step works
- [ ] Watch the next `update-stammstrecke-status.yml` run — confirm a row is appended to `data/stats/stammstrecke_2026.csv`
- [ ] Watch the next `build-feed.yml` run with at least one new disruption — confirm a row is appended to `data/stats/stoerungen_2026.csv`

https://claude.ai/code/session_019qSHFJbSAgNphUqaUGKthk

---
_Generated by [Claude Code](https://claude.ai/code/session_019qSHFJbSAgNphUqaUGKthk)_