### PR TITLE
security(http): tighten validate_public_feed_url against scheme + sub-subdomain + empty-prefix drift

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,216 @@
+## 2026-05-09 - Public Feed URL Allow-List Drift: HTTP-Scheme Acceptance + `.github.io` Sub-Subdomain Wildcard + Empty / Dash-Prefixed Subdomain (Allow-List Drift Round, Validator Boundary)
+**Vulnerability:** `validate_public_feed_url`
+(`src/utils/http.py:1241-1261`, pre-fix) — the validator that pins
+every URL flowing into the published RSS feed (`<channel><link>`,
+per-item `<link>` fallback, atom `self`/`alternate` hrefs) and the
+GitHub Pages sitemap (`<urlset><url><loc>`) — accepted three orthogonal
+sub-vectors that the previous round's "Allow-List Pattern: prefer
+byte-exact equality at structural boundaries" learning explicitly
+flagged as the next drift candidate.  The validator delegated to
+`validate_http_url` for SSRF / control-character / port checks and
+then layered a host allow-list on top:
+
+  ```python
+  _PUBLIC_FEED_URL_TRUSTED_HOSTS = frozenset({"github.com"})
+  _PUBLIC_FEED_URL_TRUSTED_SUFFIXES = (".github.io",)
+  ...
+  if host in _PUBLIC_FEED_URL_TRUSTED_HOSTS:
+      return safe
+  if any(host.endswith(suffix) for suffix in
+         _PUBLIC_FEED_URL_TRUSTED_SUFFIXES):
+      return safe
+  ```
+
+That shape mapped exactly onto the three sub-vector axes the prior
+journal entry warned about — scheme-strictness, prefix-shape, and
+empty-label drift — and reproduced 12 distinct exploit shapes when
+exercised:
+
+  (a) **TLS-strip / HTTP downgrade (5 shapes)** — `validate_http_url`
+      accepts both `http` and `https` schemes by default.  The
+      public-feed pin did not constrain scheme, so every `http://`
+      variant of the trusted hosts (`http://github.com/...`,
+      `http://example.github.io/...`, etc.) passed.  An env override
+      (`FEED_LINK=http://...` / `PAGES_BASE_URL=http://...` /
+      `SITE_BASE_URL=http://...` via leaked CI env, compromised secret
+      store, intentional misconfig) lands a plaintext URL inside the
+      published RSS feed `<link>`, atom `self`/`alternate` hrefs, and
+      `sitemap.xml` `<loc>` elements.  Every subscriber's RSS reader
+      fetches the link as-written; many do not consult HSTS preload
+      lists (which `*.github.io` is on for browsers but not for most
+      RSS clients).  A MITM (corporate gateway, hostile ISP, public
+      WiFi, captive portal, ARP-spoofed LAN) downgrades the request,
+      replaces the published artefact contents — turning the entire
+      cron pipeline's published output into an attacker-controlled
+      phishing/SEO redirect amplifier on every subscriber.
+  (b) **Sub-subdomain wildcard (4 shapes)** — `host.endswith(".github.io")`
+      matches any number of labels before `.github.io` (e.g.
+      `a.b.github.io`, `attacker.victim.github.io`,
+      `nested.deep.example.github.io`).  Real GitHub Pages targets
+      are always `<single-owner>.github.io` (or
+      `<single-owner>.github.io/<repo>`); sub-subdomain shapes are
+      not Pages targets.  An attacker who flips an env override to
+      `attacker.victim.github.io/wien-oepnv` lends visual credibility
+      to a phishing destination — the `victim.github.io` substring
+      reads as the canonical project to a casual reader, and the
+      published feed item's `<link>` element carries the deception
+      verbatim into every subscriber's UI.
+  (c) **Empty / dash-prefixed subdomain (3 shapes)** —
+      `urlparse("https://.github.io/foo").hostname` returns the
+      RFC-invalid hostname `.github.io`, and
+      `".github.io".endswith(".github.io")` is True, so the validator
+      accepted a literal `.github.io` hostname.  Same shape applies to
+      `-bad.github.io` and `-.github.io`: GitHub usernames / org names
+      cannot start with a dash (RFC-1123 label rules plus GitHub's
+      stricter handle rules), so a leading-dash subdomain is not a
+      real Pages target.  The empty-prefix shape additionally
+      provides a malformed-URL primitive that some downstream
+      consumers render verbatim while others normalise — a divergent
+      rendering surface that complicates incident triage.
+
+Threat model: today the only consumers of `validate_public_feed_url`
+(`src/feed/config.py:_validated_feed_public_url`,
+`scripts/generate_sitemap.py:_is_valid_base_url`) call the validator
+with operator-supplied env overrides.  An attacker who lands an
+`http://`-scheme override, a sub-subdomain owner-impersonation
+override, or an empty-subdomain override poisons every published
+artefact for every subscriber and search-engine crawler.  The host
+pin is the LAST gate before the URL flows into RSS / sitemap / atom
+output; tightening the pin to byte-strict scheme + label shape
+matches the journal-pinned `OSMOverpassConfig` strict-equality
+pattern (Two-Site Drift Closure entry below) and collapses the
+cartesian product of sub-components into a single decision.
+
+**Fix:** Three reinforcing tightenings layered onto the existing host
+allow-list, packaged into a single PR:
+
+  (i)   **Force HTTPS scheme** — after delegating to
+        `validate_http_url`, parse the safe URL and reject any URL
+        whose `parsed.scheme.lower() != "https"`.  The validator is
+        for URLs that land in *publicly-served* artefacts; HTTP is
+        never legitimate at this boundary.
+  (ii)  **Single non-empty alphanumeric-prefix label** — replace
+        `host.endswith(suffix)` with a two-stage check: confirm the
+        suffix match, then strip the suffix and verify the remaining
+        prefix matches `^[a-z0-9][a-z0-9-]{0,62}$`
+        (`_PUBLIC_FEED_URL_GITHUB_PAGES_OWNER_RE`).  Pinned tighter
+        than RFC because GitHub usernames cannot start with a dash;
+        max length 63 follows the RFC-1123 label limit.  The
+        hostname is already lowercased by `urlparse`/NFKC
+        normalisation in `validate_http_url` before this regex is
+        consulted, so `re.IGNORECASE` is intentionally NOT used.
+  (iii) **Documentation pin** — the module-level comment block at
+        `_PUBLIC_FEED_URL_TRUSTED_HOSTS` now spells out the three
+        sub-vectors the validator closes (scheme, prefix shape,
+        empty label) so a future contributor who relaxes any of
+        them has a written-down record of the threat model rather
+        than relying on the `_PUBLIC_FEED_URL_TRUSTED_*` constant
+        names alone.
+
+**Test surface:** **+25 new pytest cases** in
+`tests/test_sentinel_public_feed_url_drift.py`:
+  * 7 cases pinning the canonical-URL regression
+    (`test_canonical_https_urls_still_accepted`) — every accepted
+    shape that landed in the pre-existing test suite plus three
+    new HTTPS-Pages variants (trailing slash, no trailing slash,
+    no path).
+  * 5 cases pinning HTTP-scheme rejection
+    (`test_http_scheme_rejected`) — every trusted host's `http://`
+    variant.
+  * 4 cases pinning sub-subdomain rejection
+    (`test_sub_subdomain_rejected`) — 2-, 3-, and 4-label prefixes
+    plus an attacker-impersonation shape.
+  * 3 cases pinning malformed-label rejection
+    (`test_invalid_label_shape_rejected`) — empty subdomain,
+    leading-dash subdomain, and just-a-dash subdomain.
+  * 6 cases pinning the pre-existing rejection contract
+    (`test_pre_existing_rejection_contract_preserved`) — every URL
+    in `test_feed_public_url_host_pinning.py`'s parametrize list
+    continues to be rejected post-fix.  Mirrors the
+    "regression-floor" pattern from
+    `test_sentinel_overpass_endpoint_strict_validation.py`.
+  Pre-fix the 12 sub-vector cases all failed (verified before
+  applying the fix); post-fix all 25 cases pass alongside the 11
+  pre-existing cases in
+  `test_feed_public_url_host_pinning.py`.
+
+**Threat-model deltas:**
+  * **TLS-strip blast radius**: pre-fix every subscriber's RSS reader
+    fetched the published `<link>` over HTTP (if env override pointed
+    HTTP), exposing the artefact contents to MITM substitution at
+    every network hop.  Post-fix: HTTPS-only, MITM is constrained to
+    TLS-protocol attacks (which are out-of-scope for this validator
+    — they are mitigated at the TLS / certificate-pinning layer).
+  * **Phishing-impersonation surface**: pre-fix
+    `attacker.victim.github.io` (any 2-label-or-deeper prefix) was
+    accepted as a "trusted GitHub host"; post-fix only
+    `<owner>.github.io` (single label matching the GitHub username
+    regex) is accepted, collapsing the impersonation surface from
+    "any sub-subdomain owner" to "any GitHub Pages owner" — an
+    attacker still needs to register a GitHub account, but cannot
+    leverage a victim's owned subdomain to lend credibility.
+  * **Malformed-URL surface**: pre-fix the validator accepted
+    RFC-invalid hostnames (`.github.io`, `-bad.github.io`); post-fix
+    the validator's output is always RFC-valid, eliminating a class
+    of divergent-rendering-surface bugs that could complicate
+    incident triage.
+
+**Learning:** The recursive meta-pattern — every time a defence
+walker / validator accepts a "wildcard match" against a structural
+component (TLD suffix, hostname suffix, scheme prefix, path prefix),
+the wildcard edge cases (empty prefix, multi-label prefix, dash-
+prefixed prefix) become the next drift surface.  Three reinforcing
+rules:
+
+  (a) **Wildcard-suffix audit rule.** Whenever a validator uses
+      `host.endswith(suffix)` (or any string-suffix wildcard), the
+      audit floor MUST verify the *prefix* shape, not just the
+      suffix match.  Concretely: `_PUBLIC_FEED_URL_GITHUB_PAGES_OWNER_RE`
+      pins a single-label allow-list shape; sibling validators that
+      use `endswith(".something")` MUST be retroactively audited for
+      the same drift.  Sibling candidates: `_UNSAFE_DOMAINS` in
+      `src/utils/http.py` (uses `endswith("." + unsafe_domain)` for
+      blocklist matching — this is the *opposite* polarity, so the
+      empty-prefix shape is favourable here, not adversarial; but
+      the multi-label prefix shape may still over-match), and any
+      future provider URL pin that uses TLD-suffix wildcarding.
+
+  (b) **Scheme-strictness rule for published-artefact validators.**
+      Every validator whose output flows into a publicly-served
+      artefact (RSS feed link, sitemap loc, atom href, OpenGraph
+      meta tag, etc.) MUST pin the scheme to `https` at the
+      validator boundary, not at the consumer boundary.  The
+      consumer-boundary pattern fails open if a future consumer
+      forgets the pin; the validator-boundary pattern is
+      structural and inherits to every consumer automatically.
+      Sibling candidates: any future `validate_atom_*` /
+      `validate_sitemap_*` helper, and the read-side of
+      `_validated_feed_public_url` (currently scheme-agnostic for
+      the env override fallback path).
+
+  (c) **Documentation pin for cartesian-product wildcards.** When
+      a validator accepts a wildcard against any structural axis
+      (host suffix, scheme prefix, path prefix), the module-level
+      docstring / comment MUST enumerate every other axis the
+      wildcard *does not* constrain — explicitly stating "this
+      validator does NOT constrain X / Y / Z" forces a future
+      contributor relaxing the wildcard to confront the entire
+      cartesian product instead of only the axis they were
+      originally tightening.  The pre-fix comment said
+      "validate_http_url only checks SSRF/DNS-rebinding properties,
+      not host identity"; the post-fix comment additionally
+      enumerates "scheme strictness" and "prefix shape" so the
+      next drift surface is named explicitly.
+
+**Prevention:** The
+`tests/test_sentinel_public_feed_url_drift.py` parametrize lists
+form the regression floor.  A future relaxation of any of the three
+sub-vector axes would require either deleting cases from the
+parametrize list or weakening the assertion — both of which fail
+loud in PR review.  Mirrors the
+`test_sentinel_overpass_endpoint_strict_validation.py` pattern from
+the Two-Site Drift Closure entry below.
+
 ## 2026-05-09 - Two-Site Drift Closure: OSMOverpassConfig Host-Only Validation + `_UNSAFE_CHARS_RE` BiDi/Zero-Width Gap (BiDi-Mark Drift Round 3 + Allow-List Drift)
 **Vulnerability:** Two structural defence-in-depth gaps closed in a
 single PR.

--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -1232,10 +1232,28 @@ def validate_http_url(
 # every published item — turning the feed and sitemap into a phishing/SEO
 # redirect amplifier for every consumer (subscriber, search-engine crawler).
 # ``validate_http_url`` only checks SSRF/DNS-rebinding properties, not host
-# identity. Allowed: ``github.com`` (canonical repo URL) and any subdomain of
-# ``github.io`` (the natural GitHub Pages target for forks).
+# identity OR scheme strictness — it accepts both ``http`` and ``https``,
+# any path, and any subdomain shape that survives ``urlparse``. The
+# allow-list pin therefore must additionally constrain:
+#   * the URL scheme to ``https`` (an ``http://`` published feed link is
+#     a TLS-strip primitive against subscribers — many RSS readers do not
+#     consult HSTS preload lists, so the publisher MUST emit HTTPS-only);
+#   * the ``.github.io`` prefix to a single non-empty alphanumeric label
+#     (real GitHub Pages targets are ``<owner>.github.io`` —
+#     sub-subdomains, empty prefixes, and dash-prefixed labels are not
+#     legitimate Pages targets and are rejected at this boundary).
+# Allowed: ``github.com`` (canonical repo URL, byte-exact match) and any
+# single-label ``<owner>.github.io`` Pages target (the natural GitHub Pages
+# target for forks).
 _PUBLIC_FEED_URL_TRUSTED_HOSTS = frozenset({"github.com"})
 _PUBLIC_FEED_URL_TRUSTED_SUFFIXES = (".github.io",)
+# Single-label allow-list contract for the ``.github.io`` suffix prefix:
+# starts with [a-z0-9], optional trailing [a-z0-9-] body, max 63 chars
+# (RFC-1123 label limit). Pinned tighter than RFC because GitHub usernames
+# cannot start with a dash. The hostname is already lowercased by
+# ``urlparse``/NFKC normalisation in ``validate_http_url`` before this
+# regex is consulted, so ``re.IGNORECASE`` is intentionally NOT used.
+_PUBLIC_FEED_URL_GITHUB_PAGES_OWNER_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,62}$")
 
 
 def validate_public_feed_url(
@@ -1248,16 +1266,37 @@ def validate_public_feed_url(
     or sitemap as a redirect/phishing primitive. Use ``check_dns=False`` for
     URLs that are only embedded (never fetched), since DNS state at build
     time is irrelevant to whether the URL is a safe target for embedding.
+
+    Pins three sub-vectors that ``validate_http_url`` does not constrain:
+
+    1. **Scheme** — ``https`` only. ``http://`` published links downgrade
+       to plaintext on every subscriber's RSS reader (many do not honour
+       HSTS preload), exposing the artefact contents to MITM substitution.
+    2. **Host identity** — ``github.com`` (byte-exact) or
+       ``<owner>.github.io`` (single non-empty alphanumeric label).
+       Sub-subdomain shapes (``a.b.github.io``), empty prefixes
+       (``.github.io``), and dash-prefixed labels (``-bad.github.io``)
+       are not legitimate GitHub Pages targets and are rejected.
+    3. **Reuses every check** in ``validate_http_url`` (control chars,
+       userinfo, port whitelist, IDNA NFKC normalisation, SSRF / DNS
+       rebinding when ``check_dns=True``).
     """
 
     safe = validate_http_url(url, check_dns=check_dns)
     if not safe:
         return None
-    host = (urlparse(safe).hostname or "").lower()
+    parsed = urlparse(safe)
+    # Force HTTPS — ``http://`` is a TLS-strip primitive on subscribers.
+    if parsed.scheme.lower() != "https":
+        return None
+    host = (parsed.hostname or "").lower()
     if host in _PUBLIC_FEED_URL_TRUSTED_HOSTS:
         return safe
-    if any(host.endswith(suffix) for suffix in _PUBLIC_FEED_URL_TRUSTED_SUFFIXES):
-        return safe
+    for suffix in _PUBLIC_FEED_URL_TRUSTED_SUFFIXES:
+        if host.endswith(suffix):
+            prefix = host[: -len(suffix)]
+            if _PUBLIC_FEED_URL_GITHUB_PAGES_OWNER_RE.fullmatch(prefix):
+                return safe
     return None
 
 

--- a/tests/test_sentinel_public_feed_url_drift.py
+++ b/tests/test_sentinel_public_feed_url_drift.py
@@ -1,0 +1,211 @@
+"""Sentinel PoC: ``validate_public_feed_url`` allow-list drift sub-vectors.
+
+The 2026-05-09 Two-Site Drift Closure entry (sentinel.md, top of file)
+explicitly flagged ``validate_public_feed_url`` (``src/utils/http.py``)
+as the next allow-list-drift candidate after closing
+``OSMOverpassConfig`` host-only validation.  The validator delegates to
+``validate_http_url`` for SSRF / control-character / port checks and
+then layers a host allow-list on top:
+
+  ``_PUBLIC_FEED_URL_TRUSTED_HOSTS = frozenset({"github.com"})``
+  ``_PUBLIC_FEED_URL_TRUSTED_SUFFIXES = (".github.io",)``
+
+Three orthogonal sub-vectors slip past that pre-fix shape because
+``validate_http_url`` is intentionally lenient on scheme and the suffix
+check is byte-exact against ``.github.io`` only — not against the
+*shape* of the prefix label:
+
+  (a) **TLS-strip / HTTP downgrade** — ``http://github.com/...`` and
+      ``http://example.github.io/...`` both pass.
+      ``validate_http_url`` accepts both ``http`` and ``https`` by
+      default, so an env override (``FEED_LINK=http://...`` /
+      ``PAGES_BASE_URL=http://...`` / ``SITE_BASE_URL=http://...``)
+      lands a plaintext URL inside the published RSS feed
+      ``<link>``, atom ``self``/``alternate`` hrefs, and
+      ``sitemap.xml`` ``<loc>`` elements.  Every subscriber's RSS
+      reader fetches the link as-written; a MITM (corporate gateway,
+      hostile ISP, public WiFi) downgrades the request and replaces
+      the published artefact contents.  Many RSS readers do not
+      consult HSTS preload lists, so the upgrade-to-HTTPS that
+      browsers get for ``*.github.io`` does not save subscribers.
+
+  (b) **Sub-subdomain wildcard** — ``https://a.b.github.io/...``
+      passes because the suffix check is ``host.endswith(".github.io")``
+      with no constraint on the prefix.  A real GitHub Pages target
+      is always ``<single-owner>.github.io`` (or
+      ``<single-owner>.github.io/<repo>``); sub-subdomains are not
+      Pages targets.  An attacker who can flip an env override can
+      route the published feed link to ``attacker.victim.github.io``
+      to lend visual credibility to a phishing destination.
+
+  (c) **Empty / dash-prefixed subdomain** — ``https://.github.io/...``
+      and ``https://-bad.github.io/...`` both pass.  The empty-prefix
+      shape is RFC-invalid as a hostname but ``urlparse`` accepts it
+      and ``"".endswith(".github.io")`` is False but
+      ``".github.io".endswith(".github.io")`` is True, so the
+      validator accepts a literal ``.github.io`` hostname.  GitHub
+      usernames cannot start with a dash (RFC-1123 label rules plus
+      GitHub's stricter handle rules), so a leading-dash subdomain is
+      not a real Pages target either.
+
+Threat model (what this defence-in-depth gap closes):
+  Today the only consumers of ``validate_public_feed_url``
+  (``src/feed/config.py``, ``scripts/generate_sitemap.py``) call the
+  validator with operator-supplied env overrides
+  (``FEED_LINK``, ``PAGES_BASE_URL``, ``SITE_BASE_URL``).  An
+  attacker who lands an ``http://``-scheme override or a
+  sub-subdomain owner-impersonation override poisons every published
+  artefact for every subscriber and search-engine crawler.  The host
+  pin is the LAST gate before the URL flows into RSS / sitemap /
+  atom output; tightening the pin to **byte-strict scheme + label
+  shape** matches the journal-pinned ``OSMOverpassConfig`` strict-
+  equality pattern and collapses the cartesian product of
+  sub-components into a single decision.
+
+The fix:
+  1. Force ``https`` scheme — the validator is for URLs that land in
+     publicly-served artefacts, where HTTP is never legitimate.
+  2. Require the suffix prefix to be a single non-empty label that
+     starts with an alphanumeric character — rejects empty
+     subdomains (``.github.io``), leading-dash labels
+     (``-bad.github.io``), and sub-subdomain shapes
+     (``a.b.github.io``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils.http import validate_public_feed_url
+
+
+# ---------------------------------------------------------------------------
+# Regression: every canonical accepted URL still passes the validator.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/Origamihase/wien-oepnv",
+        "https://github.com/forker/wien-oepnv",
+        "https://origamihase.github.io/wien-oepnv",
+        "https://forker.github.io/wien-oepnv",
+        "https://example.github.io/repo",
+        "https://example.github.io/",
+        "https://example.github.io",
+    ],
+)
+def test_canonical_https_urls_still_accepted(url: str) -> None:
+    """Happy path: HTTPS canonical URLs land verbatim in the validator's
+    output.  Pre- and post-fix behaviour MUST match for the legitimate
+    deployment surfaces (default ``FEED_LINK`` / ``PAGES_BASE_URL`` /
+    ``SITE_BASE_URL`` and every fork variant)."""
+    assert validate_public_feed_url(url, check_dns=False) is not None
+
+
+# ---------------------------------------------------------------------------
+# (a) TLS-strip / HTTP downgrade — http:// must be rejected.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://github.com/Origamihase/wien-oepnv",
+        "http://github.com/forker/wien-oepnv",
+        "http://origamihase.github.io/wien-oepnv",
+        "http://forker.github.io/wien-oepnv",
+        "http://example.github.io/repo",
+    ],
+)
+def test_http_scheme_rejected(url: str) -> None:
+    """Pre-fix: every ``http://`` variant of the trusted hosts is
+    accepted because ``validate_http_url`` allows both ``http`` and
+    ``https`` schemes by default.  Post-fix: rejected because the
+    public-feed validator pins the scheme to ``https``.
+
+    Closes the TLS-strip / HTTP-downgrade vector documented at the top
+    of this module — every subscriber's RSS reader fetches the link
+    as-written, and many do not consult HSTS preload lists.
+    """
+    assert validate_public_feed_url(url, check_dns=False) is None
+
+
+# ---------------------------------------------------------------------------
+# (b) Sub-subdomain wildcard — multi-label prefixes must be rejected.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://a.b.github.io/wien-oepnv",
+        "https://a.b.c.github.io/wien-oepnv",
+        "https://attacker.victim.github.io/wien-oepnv",
+        "https://nested.deep.example.github.io/repo",
+    ],
+)
+def test_sub_subdomain_rejected(url: str) -> None:
+    """Pre-fix: every multi-label prefix on ``.github.io`` is accepted
+    because the suffix check is ``host.endswith(".github.io")`` with
+    no constraint on the prefix shape.  Post-fix: rejected because the
+    public-feed validator requires the prefix to be a single
+    non-empty label.
+
+    Closes the sub-subdomain wildcard vector — real GitHub Pages
+    targets are always ``<single-owner>.github.io``.
+    """
+    assert validate_public_feed_url(url, check_dns=False) is None
+
+
+# ---------------------------------------------------------------------------
+# (c) Empty / dash-prefixed subdomain — invalid label shapes must be
+#     rejected.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://.github.io/wien-oepnv",  # empty subdomain
+        "https://-bad.github.io/wien-oepnv",  # leading dash
+        "https://-.github.io/wien-oepnv",  # just a dash
+    ],
+)
+def test_invalid_label_shape_rejected(url: str) -> None:
+    """Pre-fix: ``.github.io`` (empty subdomain) and ``-bad.github.io``
+    (leading-dash label) both pass because ``urlparse`` accepts the
+    RFC-invalid hostnames and ``host.endswith(".github.io")`` is True
+    for the empty-prefix case.  Post-fix: rejected because the
+    public-feed validator requires the prefix to start with an
+    alphanumeric character.
+
+    Closes the malformed-label vector — GitHub usernames cannot start
+    with a dash, and an empty subdomain is not a real hostname.
+    """
+    assert validate_public_feed_url(url, check_dns=False) is None
+
+
+# ---------------------------------------------------------------------------
+# Existing rejection contract — preserved post-fix.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://evil.example.com/feed",
+        "https://gihub.com/foo/bar",  # typosquat
+        "https://github.com.evil.com/foo",  # suffix attack on github.com
+        "https://example.github.io.evil.com/foo",  # suffix attack on github.io
+        "https://evil-github.io/foo",  # missing leading dot
+        "https://github.io/foo",  # bare apex without subdomain
+    ],
+)
+def test_pre_existing_rejection_contract_preserved(url: str) -> None:
+    """Regression: every URL in the pre-existing rejection contract
+    (``test_feed_public_url_host_pinning.py``) continues to be
+    rejected post-fix.  The new tightening MUST NOT relax any
+    pre-existing security check."""
+    assert validate_public_feed_url(url, check_dns=False) is None


### PR DESCRIPTION
## Summary

Closes the journal-flagged allow-list drift for `validate_public_feed_url`
(`src/utils/http.py`) — the validator that pins every URL flowing into the
published RSS feed (`<channel><link>`, per-item `<link>` fallback, atom
`self`/`alternate` hrefs) and the GitHub Pages sitemap
(`<urlset><url><loc>`).

The 2026-05-09 *Two-Site Drift Closure* entry in `.jules/sentinel.md`
explicitly named this validator as the next allow-list-drift candidate
after closing `OSMOverpassConfig` host-only validation. Pre-fix the
validator delegated to `validate_http_url` and then layered a host
allow-list on top:

```python
_PUBLIC_FEED_URL_TRUSTED_HOSTS = frozenset({"github.com"})
_PUBLIC_FEED_URL_TRUSTED_SUFFIXES = (".github.io",)
...
if host in _PUBLIC_FEED_URL_TRUSTED_HOSTS:
    return safe
if any(host.endswith(suffix) for suffix in _PUBLIC_FEED_URL_TRUSTED_SUFFIXES):
    return safe
```

Three orthogonal sub-vectors slipped past this shape:

### (a) TLS-strip / HTTP downgrade — 5 PoC shapes
`validate_http_url` accepts both `http` and `https` schemes by default;
the public-feed pin did not constrain scheme. So every `http://` variant
of a trusted host was accepted:
- `http://github.com/Origamihase/wien-oepnv` ✗
- `http://example.github.io/foo` ✗

An env override (`FEED_LINK=http://...` / `PAGES_BASE_URL=http://...` /
`SITE_BASE_URL=http://...` via leaked CI env, compromised secret store)
lands a plaintext URL inside published artefacts. Subscribers' RSS
readers fetch the link as-written; many do not consult HSTS preload
(which `*.github.io` is on for browsers but not most RSS clients). MITM
downgrades the request and replaces the artefact contents.

### (b) Sub-subdomain wildcard — 4 PoC shapes
`host.endswith(".github.io")` matched any number of labels before
`.github.io`:
- `https://a.b.github.io/foo` ✗
- `https://attacker.victim.github.io/foo` ✗

Real GitHub Pages targets are always `<single-owner>.github.io`. An
attacker who flips an env override to `attacker.victim.github.io` lends
visual credibility to a phishing destination — the `victim.github.io`
substring reads as the canonical project to a casual reader.

### (c) Empty / dash-prefixed subdomain — 3 PoC shapes
`urlparse("https://.github.io/foo").hostname` returns the RFC-invalid
hostname `.github.io`, and `".github.io".endswith(".github.io")` is
True:
- `https://.github.io/foo` ✗
- `https://-bad.github.io/foo` ✗
- `https://-.github.io/foo` ✗

GitHub usernames cannot start with a dash, so these are not real Pages
targets either.

## Fix

Three reinforcing tightenings layered onto the existing host allow-list:

1. **Force HTTPS scheme** — after delegating to `validate_http_url`,
   parse the safe URL and reject any URL whose
   `parsed.scheme.lower() != "https"`.
2. **Single non-empty alphanumeric-prefix label** — replace
   `host.endswith(suffix)` with a two-stage check that strips the suffix
   and verifies the remaining prefix matches
   `^[a-z0-9][a-z0-9-]{0,62}$` (`_PUBLIC_FEED_URL_GITHUB_PAGES_OWNER_RE`).
   Pinned tighter than RFC because GitHub usernames cannot start with a
   dash; max length 63 follows the RFC-1123 label limit.
3. **Documentation pin** — module-level comment block enumerates the
   three sub-vectors closed (scheme, prefix shape, empty label) so a
   future contributor relaxing any axis confronts the threat model in
   writing.

## Test plan

- [x] **+25 cases** in `tests/test_sentinel_public_feed_url_drift.py`:
  - 7 cases: `test_canonical_https_urls_still_accepted` regression for
    every accepted shape.
  - 5 cases: `test_http_scheme_rejected` — every trusted host's `http://`
    variant.
  - 4 cases: `test_sub_subdomain_rejected` — 2-, 3-, 4-label prefixes
    plus impersonation shape.
  - 3 cases: `test_invalid_label_shape_rejected` — empty / leading-dash /
    just-a-dash subdomains.
  - 6 cases: `test_pre_existing_rejection_contract_preserved` — every
    URL in `test_feed_public_url_host_pinning.py`'s parametrize list
    continues to reject.
  - **Pre-fix verification**: 12 of 25 cases failed against the old
    validator; post-fix all 25 pass.
- [x] `tests/test_feed_public_url_host_pinning.py` (11 pre-existing
  cases) continues to pass unchanged — happy path, fallback paths, and
  fork-acceptance regressions all preserved.
- [x] Full local pytest suite: **2443 passed, 4 skipped, 0 failed** in
  ~82s.
- [x] `python scripts/run_static_checks.py` — ruff ✓, mypy ✓
  (44 source files, no new errors), bandit ✓, secret scanner ✓,
  C901 complexity gate ✓ (0 new violations), pip-audit ✓.

Journal entry added to `.jules/sentinel.md` documenting the threat
model, fix, and three reinforcing prevention rules
(wildcard-suffix audit, scheme-strictness rule for published-artefact
validators, documentation pin for cartesian-product wildcards).

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8zRPuwdPHWkfMemuhH7k2)_