### PR TITLE
docs: refine Stammstrecke &amp; statistics docs after PR #1372

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,54 +1,49 @@
-# CHANGELOG
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
-* **Feat (Statistik-Dashboard)**: Komplett dependenzfreies Statistik-
-  und Logging-System für Verspätungen und Störungen — siehe Section 6
-  in [`docs/architecture.md`](docs/architecture.md). Konkret:
-  - **Append-only CSV-Ledger** unter `data/stats/`:
-    `stammstrecke_YYYY.csv` (Spalten `timestamp, weekday, hour,
-    direction, delay_minutes`) und `stoerungen_YYYY.csv` (Spalten
-    `timestamp, weekday, hour, provider, location_name`). Eine Datei
-    pro Kalenderjahr, alle Zeitstempel als ISO 8601 in
-    `Europe/Vienna`.
-  - **Producer 1**: `scripts/update_stammstrecke_status.py` schreibt
-    nach jeder erfolgreichen Median-Berechnung eine Zeile — auch
-    *unterhalb* der RSS-Trigger-Schwelle, damit das Dashboard die
-    *gesamte* Verteilung zeigt, nicht nur die Eskalationen.
-  - **Producer 2**: `src/build_feed.py` schreibt im
-    `_update_item_state`-Strict-New-Pfad eine Zeile pro *erstmals
-    gesehenem* Identity (über die `data/first_seen.json`-State-Logik
-    erkannt). Rerun-stabil: eine lange ÖBB-Streckeninformation, die
-    viele Builds überlebt, wird genau *einmal* gezählt.
-  - **Aggregator**: Neues Skript `scripts/generate_markdown_stats.py`
-    (nur Standardlibrary — `csv`, `collections`, `datetime`,
-    `statistics`, `pathlib`, `zoneinfo`, `argparse`) erzeugt
-    `docs/statistik.md` mit ASCII/Emoji-Bar-Charts: Beobachtungen je
-    Wochentag und Stunde, ⌀ Verspätung je Wochentag und Stunde,
-    Top-5-Hotspots mit Tageszeit-Profil pro Hotspot, Zusammenfassungs-
-    KPIs.
-  - **Workflow**: Neuer GitHub-Actions-Job
-    `.github/workflows/generate-stats.yml` (Cron `15 0 * * *` +
-    `workflow_dispatch`) führt den Aggregator aus und committet
-    `docs/statistik.md` plus etwaige neue CSV-Dateien via
-    `stefanzweifel/git-auto-commit-action`.
-  - **Resilienz**: Schreiber sind best-effort (jeder I/O-Fehler wird
-    geloggt + geschluckt — Statistik darf nie den Build kippen). Der
-    Aggregator routet jede CSV über `read_capped_text` + `io.StringIO`
-    (entspricht dem CSV-Size-Bomb-Sentinel) und schreibt das Dashboard
-    via `atomic_write`.
-  - **Lokationsheuristik**: `extract_location_name` versucht
-    `zwischen X und Y` → erstes Capture, dann `Wien <Stadtteil>`,
-    dann das erste großgeschriebene Multi-Wort-Token außerhalb einer
-    kleinen Stopword-Liste (Bauarbeiten, Verspätung, Linie, …).
-    Fallback `"unbekannt"`.
-  - **Tests**: 60 neue Tests
-    (`tests/scripts/test_generate_markdown_stats.py`,
-    `tests/test_utils_stats.py`) decken Bar-Skalierung, Aggregation,
-    CSV-Lesepfad inkl. oversized-file-skip, malformed-row-tolerance,
-    Tie-Breaking im Top-N-Ranking, Idempotenz, Year-Boundary-Rollover
-    und Lokations-Heuristik ab.
-  - **Quality**: Mypy-Strict 0 Fehler, Bandit 0 Issues, Ruff 0
-    Issues, alle 2 418 vorherigen Tests grün — keine Regression.
+* **Added (Statistik-Dashboard)**: Zero-dependency Append-only-CSV-
+  Pipeline und Markdown-Dashboard — Architektur-Kontext in
+  [`docs/architecture.md` § 6](docs/architecture.md).
+  - Producer — `scripts/update_stammstrecke_status.py` hängt nach
+    jeder Median-Berechnung eine Zeile an
+    `data/stats/stammstrecke_YYYY.csv` an (auch unterhalb der
+    RSS-Schwelle, damit das Dashboard die *gesamte* Verteilung
+    abbildet).
+  - Producer — `src/build_feed.py:_update_item_state` schreibt im
+    Strict-New-Pfad (Cache-Miss auf `_identity` *und* `guid`) eine
+    Zeile in `data/stats/stoerungen_YYYY.csv`. Lange Streckeninformationen
+    werden genau einmal gezählt.
+  - Aggregator — `scripts/generate_markdown_stats.py` (Standardlib
+    only: `csv`, `collections`, `datetime`, `statistics`, `pathlib`,
+    `zoneinfo`, `argparse`) rendert `docs/statistik.md` mit
+    ASCII/Emoji-Bars: Verteilung je Wochentag/Stunde, ⌀ Verspätung,
+    Top-5-Hotspots mit Tageszeit-Profil.
+  - Workflow — `.github/workflows/generate-stats.yml`
+    (Cron `15 0 * * *` + `workflow_dispatch`) committet das Dashboard
+    plus neue CSV-Dateien via `stefanzweifel/git-auto-commit-action`.
+* **Added (Test-Isolation)**: Autouse-Fixture `isolate_stats_writes`
+  in `tests/conftest.py` monkeypatcht `src.utils.stats.DEFAULT_STATS_DIR`
+  pro Test auf `tmp_path` — verhindert, dass Suite-Läufe synthetische
+  Zeilen ins committete Ledger schreiben (PR #1372).
+* **Security (Bounded CSV reads)**: Aggregator routet jede CSV durch
+  `read_capped_text` + `io.StringIO` (entspricht dem
+  `tests/test_sentinel_csv_size_bomb.py`-Sentinel) und schreibt das
+  Dashboard atomar via `atomic_write`. Producer-Writer sind best-effort
+  (jeder `OSError` wird auf WARNING-Level geschluckt) — Statistik
+  kann den Build nie kippen.
+* **Changed (Audit-Report)**: Addendum (§ 14) zum bestehenden
+  [`docs/archive/audits/oebb_stammstrecke_audit.md`](docs/archive/audits/oebb_stammstrecke_audit.md)
+  dokumentiert die Statistik-Pipeline-Integration und bestätigt, dass
+  die Audit-Befunde der Sections 1–13 unverändert bestehen
+  (Verdict bleibt **0 Findings**, production-ready).
+* **Changed (Reference-Doku)**: `docs/reference/oebb_provider_logic.md`
+  korrigiert auf `MAX_JOURNEYS_PER_QUERY = 5` (vormals stale `12`)
+  und enthält jetzt einen Abschnitt zur Statistik-Logging-Integration
+  des Stammstrecke-Skripts.
 * **Audit**: Vollständige Audit-Abnahme des S-Bahn Stammstrecke
   Monitors mit Bericht unter
   [`docs/archive/audits/oebb_stammstrecke_audit.md`](docs/archive/audits/oebb_stammstrecke_audit.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -365,11 +365,12 @@ The relevant CLI flags / env vars:
 
 ## 6. Statistics & Dashboard Pipeline
 
-Operational metrics live entirely outside the RSS pipeline so the
-hot-path build never blocks on observability I/O. Two append-only CSV
-ledgers under `data/stats/` (one per kind, one file per calendar year)
-capture the raw observations; a daily GitHub Actions job rolls them
-into a static Markdown dashboard at `docs/statistik.md`.
+Operational metrics live entirely outside the RSS pipeline. Two
+append-only CSV ledgers under `data/stats/` capture every relevant
+observation as it happens; a separate daily GitHub Actions job
+aggregates them into a static Markdown dashboard at
+`docs/statistik.md`. The hot-path build never blocks on
+observability I/O.
 
 ```mermaid
 flowchart LR
@@ -395,51 +396,69 @@ flowchart LR
     AGG --> MD
 ```
 
-**Why this shape:**
+### Architectural goals
 
-- **Append-only is crash-safe**: a single `write()` of one CSV row is
-  below `PIPE_BUF` on every supported platform, so concurrent appenders
-  cannot interleave bytes mid-line. No locks needed.
-- **Best-effort writes**: `src/utils/stats.py` swallows `OSError` at
-  WARNING level — full disk, permission denied, or read-only
-  filesystem cannot crash the production pipeline. Statistics are
-  observability, not core functionality.
-- **Strict-new gating**: the disruption writer is hooked into
-  `_update_item_state` *only* on the strict cache miss (no entry by
-  `_identity` *or* `guid`). A long-lived ÖBB Streckeninformation that
-  survives many feed builds is recorded once, not once per regen.
-- **Per-year files**: bounds individual file size even after years of
-  operation; the aggregator only opens the requested year's files.
-- **Zero-dependency aggregator**: `scripts/generate_markdown_stats.py`
-  uses only `csv`, `collections`, `datetime`, `statistics`,
-  `pathlib`, `zoneinfo`, `argparse`. No NumPy / Pandas / Matplotlib.
-  Keeps CI runtime small and the repo's wheel cache trivial.
-- **Bounded reads**: the aggregator routes every CSV through
-  `read_capped_text` (open + `fstat` + capped `read`) and constructs
-  `csv.reader` over an in-memory `StringIO`. Matches the project-wide
-  `tests/test_sentinel_csv_size_bomb.py` invariant against unbounded
-  CSV reads.
-- **Atomic dashboard write**: the rendered Markdown is written via
-  `atomic_write`, so a kill-signal mid-render cannot replace the
-  previous dashboard with a half-written file.
-- **Idempotent + byte-stable**: rendering twice on identical input
-  produces byte-identical Markdown (ties broken by alphabetic
-  secondary sort), so the auto-commit step in
-  `.github/workflows/generate-stats.yml` is a no-op when nothing
-  actually changed.
+| Goal | Embodied by |
+| --- | --- |
+| **CI/CD decoupling** — the daily aggregator job runs on its own cron, never blocks `build-feed.yml` | `.github/workflows/generate-stats.yml` (cron `15 0 * * *`, `concurrency: generate-stats-${{ github.ref }}`) |
+| **Strictly zero data-science dependencies** — no `numpy`, `pandas`, `matplotlib`; CI install stays sub-second | `scripts/generate_markdown_stats.py` imports only `csv`, `collections`, `datetime`, `statistics`, `pathlib`, `zoneinfo`, `argparse` |
+| **Append-only, lock-free producers** — single-line writes on POSIX are atomic below `PIPE_BUF` (4 KiB), so concurrent cron ticks cannot interleave bytes mid-line | `src/utils/stats.py:_append_row` (mode `"a"`, no `flock`) |
+| **Strict-new gating for disruptions** — long-lived events recorded once, not once per build | `src/build_feed.py:_update_item_state` records only on the *strict* state-cache miss (neither `_identity` nor `guid` had a prior entry) |
+| **Idempotent, byte-stable output** — re-running the aggregator on identical input produces byte-identical Markdown so `git-auto-commit-action` is a no-op when nothing changed | Stable secondary sort (alphabetical) breaks every tie in `render_top_locations`; renderer never reads `now()` outside the timestamp shown in the header |
+| **Per-year file rotation** — individual ledger size stays bounded even over multi-year operation | Filename derived from the row's Vienna-local `timestamp.year`, not process clock |
 
-The dashboard answers two operator questions:
+### Resiliency layers
 
-| Question | Section |
+The producers are observability, not core functionality, so every
+failure path is **best-effort, no-throw**: any `OSError` from the
+writer is logged at WARNING and swallowed. Production pipelines never
+crash because the disk filled up.
+
+The aggregator, by contrast, is the choke point that has to read
+*untrusted* on-disk bytes (a planted-huge CSV from a compromised CI
+runner is the canonical threat model). Three layered defences cover
+it:
+
+1. **Bounded reads** — every CSV is loaded through
+   `read_capped_text` (open + `fstat` on the open fd + capped
+   `read(MAX_CSV_BYTES + 1)`) and parsed via `csv.reader` over an
+   in-memory `io.StringIO`. The "no bare `csv.reader(handle)` in
+   `src/` or `scripts/`" invariant is enforced by
+   `tests/test_sentinel_csv_size_bomb.py`.
+2. **Malformed-row tolerance** — `_parse_stammstrecke_rows` /
+   `_parse_stoerung_rows` skip individual rows that fail
+   `fromisoformat` or `float()`. A single fat-fingered manual edit
+   never corrupts the entire dashboard.
+3. **Atomic dashboard write** — the rendered Markdown lands on disk
+   through `src.utils.files.atomic_write`. A kill-signal mid-render
+   cannot replace the previous dashboard with a half-written file.
+
+### Test isolation
+
+The production writers default to `<repo>/data/stats/` via
+`src.utils.stats.DEFAULT_STATS_DIR`. An autouse fixture
+`isolate_stats_writes` in `tests/conftest.py` monkey-patches that
+constant to a per-test `tmp_path` for **every** test in the suite, so
+any test that transitively exercises a hot path which records stats
+(the `_update_item_state` strict-new branch, the Stammstrecke
+processing loop) cannot pollute the committed CSV ledger. Tests that
+explicitly target a different `stats_dir` (the dedicated unit tests in
+`tests/test_utils_stats.py`) are unaffected because the explicit
+keyword always wins inside `stats_path`.
+
+### What the dashboard answers
+
+| Question | Section in `docs/statistik.md` |
 |---|---|
 | **When** do Stammstrecke delays occur? | "Stammstrecke" — weekday + hour distributions of both observation count and average delay |
 | **Where** (and **when**) are disruption hotspots? | "Störungen" — per-provider table, weekday + hour distributions, top-5 hotspots with per-location hourly profile |
 
-The location heuristic in `extract_location_name` tries (in order):
-`zwischen X und Y` → first capture, then `Wien <Name>`, then the first
-capitalised multi-word token outside a small stopword set
-(Bauarbeiten, Verspätung, Linie, …). Falls back to `"unbekannt"` so
-the dashboard always renders even on adversarial provider input.
+The location heuristic in `extract_location_name` tries — in order —
+`zwischen X und Y` (capture group 1), then `Wien <Name>`, then the
+first capitalised multi-word token outside a small stopword set
+(`Bauarbeiten`, `Verspätung`, `Linie`, …). Falls back to
+`"unbekannt"` so the dashboard always renders, even on adversarial
+provider input.
 
 ---
 

--- a/docs/archive/audits/oebb_stammstrecke_audit.md
+++ b/docs/archive/audits/oebb_stammstrecke_audit.md
@@ -632,3 +632,122 @@ geprüften Kriterien:
 Das Feature ist **production-ready**.
 
 — Audit durchgeführt am 2026-05-09 im Rahmen der Stammstrecke-PR-Serie.
+
+---
+
+## 14. Addendum (2026-05-09 evening): Statistics-Pipeline Integration
+
+Nach Abnahme dieses Audits wurde der Stammstrecke-Monitor um einen
+**append-only Statistics-Sink** erweitert (PR #1372). Das Addendum
+dokumentiert die Änderungen und bestätigt, dass die in den Sections 1–13
+geprüften Sicherheits-, Resilienz- und Typisierungs-Befunde unverändert
+bestehen.
+
+### 14.1 Scope der Erweiterung
+
+* `scripts/update_stammstrecke_status.py:_process_direction` ruft nach
+  jeder erfolgreichen Median-Berechnung
+  `src.utils.stats.append_stammstrecke_row(timestamp, direction,
+  delay_minutes)` auf. Eine Zeile wird *unabhängig* davon geschrieben,
+  ob die `DELAY_THRESHOLD_MINUTES`-Schwelle überschritten ist — der
+  Statistik-Sink reflektiert die *vollständige* Verspätungsverteilung,
+  nicht nur die Eskalationen, die als RSS-Event emittiert werden.
+* Neuer Aggregator `scripts/generate_markdown_stats.py` (stdlib-only)
+  rendert das Markdown-Dashboard `docs/statistik.md` aus den
+  CSV-Ledgern unter `data/stats/`. Architektur-Diagramm und
+  Kontext: [`docs/architecture.md` § 6](../../architecture.md).
+
+### 14.2 Sicherheitseigenschaften des CSV-Writers
+
+| Eigenschaft | Wie erfüllt |
+| :--- | :--- |
+| **Best-effort, no-throw** | `_append_row` umfasst die gesamte Schreib-Logik in `try / except OSError` — Disk-Full, Read-Only-Mount, Permission-Denied loggen WARNING und liefern `False`. Die Cron-Pipeline crasht nie, weil die Statistik nicht geschrieben werden konnte. |
+| **Atomare Zeilen-Writes** | Nur `mode="a"`-Append unter `PIPE_BUF` (4 KiB) — POSIX garantiert byteweise Atomarität, keine Locks erforderlich. |
+| **Kein Sensitive Data** | Schema enthält ausschließlich Median-Verspätung, Richtung, Provider-Name, Lokation. Keine Secrets, keine Identitäten, keine HAFAS-Antworten verbatim. |
+| **TOCTOU-sicheres Verzeichnis-Setup** | `path.parent.mkdir(parents=True, exist_ok=True)` — Race mit gleichzeitigem `mkdir` führt zum erwarteten `exist_ok=True`-Pfad. |
+| **Permission-Hardening** | `os.chmod(path, 0o644)` nach jedem erfolgreichen Append — die Datei ist publish-friendly (kein Geheimnis), aber owner-write-only. |
+
+### 14.3 Test-Isolation: `isolate_stats_writes`
+
+Die Produktions-Writer schreiben per Default in
+`<repo>/data/stats/` via `src.utils.stats.DEFAULT_STATS_DIR`. Ohne
+zusätzliche Sicherung würde **jeder** Test, der einen Hot-Path
+exerciert, der transitiv Statistik schreibt (z. B. `_update_item_state`
+im `build_feed`-Flow oder `_process_direction` im
+Stammstrecke-Skript), Zeilen in das **echte** CSV-Ledger schreiben
+und die Git-Historie mit synthetischen Test-Daten kontaminieren.
+
+Schutz: ein **autouse**-Fixture `isolate_stats_writes` in
+`tests/conftest.py` monkeypatcht `DEFAULT_STATS_DIR` für **jeden**
+Test im gesamten Suite-Lauf auf einen per-Test `tmp_path`:
+
+```python
+@pytest.fixture(autouse=True)
+def isolate_stats_writes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    from src.utils import stats as stats_utils
+    monkeypatch.setattr(stats_utils, "DEFAULT_STATS_DIR", tmp_path / "stats")
+    yield
+```
+
+Tests, die explizit ein anderes `stats_dir` ansteuern (die fokussierten
+Unit-Tests in `tests/test_utils_stats.py`), bleiben unbeeinflusst:
+das explizite Keyword gewinnt im `stats_path`-Resolver vor
+`DEFAULT_STATS_DIR`. Die Fixture verhindert insbesondere folgende
+ansonsten invasive Failure-Modi:
+
+* Jeder Lauf von `pytest` würde `data/stats/stammstrecke_<year>.csv`
+  und `data/stats/stoerungen_<year>.csv` erzeugen oder erweitern.
+* Pre-commit-Hooks hätten neue, synthetische Daten als unstaged
+  Changes identifiziert und CI-Runs unter Umständen gekippt.
+* Test-erzeugte Lokationsnamen ("Title Just", "Title Line", …)
+  hätten das Dashboard mit verzerrten Hotspot-Daten bestückt, sobald
+  ein Aggregator-Run sie aufnimmt.
+
+Ein während der Implementierung beobachteter Vorfall (Test-Run schrieb
+`stoerungen_2023.csv` … `stoerungen_2026.csv` mit Mock-Titeln in das
+Repository-Verzeichnis) wurde durch genau dieses Fixture präventiv
+geschlossen, bevor der erste Commit den Branch verließ.
+
+### 14.4 Aggregator-Hardening (zur Vollständigkeit)
+
+`scripts/generate_markdown_stats.py` parsiert *untrusted* On-Disk-Bytes
+(eine geplante-große CSV vom kompromittierten CI-Runner ist das
+kanonische Bedrohungsmodell). Drei geschichtete Verteidigungen:
+
+1. **Bounded Reads** — jede CSV läuft durch `read_capped_text`
+   (open + `fstat` + capped `read(MAX_CSV_BYTES + 1)`) und wird
+   *anschließend* per `csv.reader` über `io.StringIO` geparst.
+   Die Invariante „kein nacktes `csv.reader(handle)` in `src/` oder
+   `scripts/`" ist durch
+   `tests/test_sentinel_csv_size_bomb.py::test_no_unbounded_csv_dictreader_in_src_or_scripts`
+   gesichert.
+2. **Malformed-Row-Toleranz** — `_parse_*_rows` skippen einzelne
+   Zeilen mit kaputtem `fromisoformat` oder nicht-numerischem
+   Delay. Eine handgepflegte fehlerhafte Zeile zerstört nicht das
+   gesamte Dashboard.
+3. **Atomares Dashboard-Write** — `atomic_write` schreibt in
+   einen kryptografisch zufällig benannten Temp-Pfad und renamed
+   am Ende per `os.replace`. Ein Kill-Signal mitten im Render-Run
+   kann das Dashboard nicht durch eine halbgeschriebene Datei
+   ersetzen.
+
+### 14.5 Quality-Gates des Addendums
+
+| Gate | Status |
+| :--- | :--- |
+| Mypy `--strict` (`src/` + `tests/`) | ✅ 0 neue Fehler (CI-pinned mypy 1.10.1) |
+| Bandit | ✅ 0 Issues |
+| Ruff (E, F, S, B, UP) | ✅ clean |
+| Pytest (Voll-Suite) | ✅ +60 neue Tests, 2 478 grün, keine Regression |
+| C901 Complexity Gate | ✅ 0 neue Verstöße |
+
+### 14.6 Rückwirkung auf die Findings
+
+**Keine.** Die Erweiterung ist *additiv* — sie hängt einen
+best-effort-Statistik-Sink an die bestehende Median-Logik an, ohne
+eine der in Sections 1–13 verifizierten Eigenschaften (Typisierung,
+Security, Resilienz, Self-Healing, Schema-Compliance, Zeitzonen-
+Konsistenz) zu verändern. Der Audit-Verdict („**0 Findings**,
+production-ready") bleibt unverändert.
+
+— Addendum hinzugefügt am 2026-05-09 nach Merge von PR #1372.

--- a/docs/reference/oebb_provider_logic.md
+++ b/docs/reference/oebb_provider_logic.md
@@ -55,7 +55,7 @@ Failure-Modes haben.
 | Richtung 1 | Wien Floridsdorf (`8100518`) → Wien Meidling (`8100514`) |
 | Richtung 2 | Wien Meidling (`8100514`) → Wien Floridsdorf (`8100518`) |
 | `max_changes` | `0` (nur direkte S-Bahn-Verbindungen) |
-| `max_journeys` | 12 (≈ eine halbe Stunde Stammstrecken-Takt) |
+| `max_journeys` | `5` (die unmittelbar nächsten 5 S-Bahnen je Richtung — 10 Journey-Objekte pro Cron-Tick gesamt) |
 | Cron | `*/30 * * * *` (alle 30 Minuten) |
 
 **Beide Richtungen werden strikt getrennt ausgewertet.** Eine
@@ -267,6 +267,21 @@ ab:
    `data/stations.json`): exception swallowing + Strip.
 3. `display_name` liefert leer: ebenfalls Seed mit Strip.
 
+### Statistik-Logging (Append-Only CSV)
+
+Nach jeder erfolgreichen Median-Berechnung — *unabhängig* davon, ob
+die Schwelle überschritten wird oder nicht — schreibt das Skript eine
+Zeile in `data/stats/stammstrecke_YYYY.csv` (Spalten `timestamp,
+weekday, hour, direction, delay_minutes`, ISO 8601 `Europe/Vienna`).
+Damit reflektiert das Dashboard (`docs/statistik.md`, regeneriert
+durch `scripts/generate_markdown_stats.py`) die *gesamte* Verteilung
+der Verspätungen und nicht nur die Eskalationen, die als RSS-Event
+emittiert wurden. Der Writer (`src.utils.stats.append_stammstrecke_row`)
+ist **best-effort**: jeder I/O-Fehler wird auf WARNING-Level geloggt
+und geschluckt, damit eine fehlgeschlagene Statistik niemals den
+Cron-Lauf kippt. Architektur-Kontext und Diagramm: siehe Section 6 in
+[`docs/architecture.md`](../architecture.md).
+
 ### Feed-Integration
 
 Der Feed-Builder lädt die Datei beim Build über
@@ -297,8 +312,14 @@ verbessert.
   `MAX_QUERY_TIMEOUT` (oberer Clamp). Wird durch
   `_patch_session_timeout` als Default in `session.request`
   injiziert.
-* **Sample-Größe**: `MAX_JOURNEYS_PER_QUERY` (default 12). Höhere
-  Werte stabilisieren den Median, kosten aber mehr Pyhafas-Calls.
+* **Sample-Größe**: `MAX_JOURNEYS_PER_QUERY` (aktuell `5`). Liefert
+  den Median über die *unmittelbar nächsten 5* anstehenden S-Bahnen
+  pro Richtung — eine ungerade Sample-Größe macht den Median exakt
+  zum mittleren Element (statt Mittel zweier Werte) und liefert
+  dadurch eine Aussage robust gegen Ausreißer und nahe an der
+  Operator-Erwartung „wie ist es *jetzt*?". Höhere Werte glätten,
+  vergrößern aber die HAFAS-Payload und entkoppeln den Median vom
+  aktuellen Betriebszustand.
 * **Regex für S-Bahn-Linien**: `_S_BAHN_LINE_RE`. Erfasst alle ÖBB-
   S-Bahn-Linien (`S\d+`), inklusive zukünftiger Erweiterungen (`S 90`,
   `S 100`).


### PR DESCRIPTION
## Summary

Documentation-only follow-up to merged PR #1372. Acts on a senior-tech-writer review of the four files most affected by the Stammstrecke + statistics work.

### `docs/architecture.md` § 6 — Statistics & Dashboard Pipeline
- Restructured into two crisp tables: **Architectural goals** (CI/CD decoupling, zero data-science dependencies, lock-free append, strict-new gating, idempotent output, per-year rotation) and **Resiliency layers** (bounded reads via `read_capped_text` + `io.StringIO`, malformed-row tolerance, atomic dashboard write).
- Added a dedicated **Test isolation** subsection covering the autouse `isolate_stats_writes` fixture.
- Tightened prose; made the *no `numpy` / `pandas` / `matplotlib`* constraint and the memory-safety refactor first-class items rather than buried bullets.

### `docs/reference/oebb_provider_logic.md`
- **Bug fix:** `max_journeys` was documented as `12` in two places; actual value is `5` (since PR #1369). Updated the parameter table and the Erweiterungs-Punkte rationale (odd sample size → exact-middle median; smaller HAFAS payload; operator-expectation alignment).
- **New:** "Statistik-Logging (Append-Only CSV)" subsection documenting that the script now writes one row per median calculation into `data/stats/stammstrecke_YYYY.csv` (best-effort) and cross-links to architecture.md § 6.

### `docs/archive/audits/oebb_stammstrecke_audit.md`
- **Added § 14 Addendum** (post-merge of PR #1372). Documents the stats-pipeline integration, the CSV writer's security properties (no-throw, atomic line writes, no sensitive data, TOCTOU-safe directory setup, permission hardening), and the `isolate_stats_writes` test-isolation fixture in detail (including the real-world incident it prevented during implementation). Confirms the original audit verdict (**0 Findings**, production-ready) is unchanged.

### `CHANGELOG.md`
- Added the standard **Keep a Changelog** header at the top.
- Condensed the previous 50-line `**Feat (Statistik-Dashboard)**` entry into a tightly-categorised set of bullets using the project's existing inline-tag convention (`**Added (...)**:`, `**Changed (...)**:`, `**Security (...)**:`).

## Quality gates

- ✅ `mypy --strict` (CI-pinned 1.10.1): 0 errors across 418 source files
- ✅ `ruff check src scripts tests`: 0 issues
- ✅ Documentation only — no production code changed; full test suite untouched

## Test plan

- [ ] Render `docs/architecture.md` § 6 on GitHub and confirm the Mermaid diagram + tables display correctly
- [ ] Render `docs/archive/audits/oebb_stammstrecke_audit.md` § 14 and confirm the Python code block formats cleanly
- [ ] Confirm internal links resolve: `docs/architecture.md` ↔ `docs/reference/oebb_provider_logic.md` ↔ `docs/archive/audits/oebb_stammstrecke_audit.md`

https://claude.ai/code/session_019qSHFJbSAgNphUqaUGKthk

---
_Generated by [Claude Code](https://claude.ai/code/session_019qSHFJbSAgNphUqaUGKthk)_