### PR TITLE
security(stats-dashboard): neutralise Markdown injection at the stats-CSV → docs/statistik.md render boundary

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,166 @@
+## 2026-05-09 - Markdown Injection Sibling Drift (CWE-79 / CWE-1236-adjacent) at the Stats-Dashboard Renderer Boundary: `direction`, `provider`, `location_name` Interpolated Verbatim Into `docs/statistik.md`
+**Vulnerability:** The 2026-05-09 CSV-formula-injection round closed
+the *write* side of `data/stats/*.csv` but explicitly flagged a
+sibling-drift candidate for the next round:
+
+> Markdown rendering of the same fields
+> (`scripts/generate_markdown_stats.py:585,600,511` — Markdown table
+> cells `f"| {direction} | {count} |"` interpolate the *same*
+> upstream-influenced strings without escaping `|` / `*` / `` ` `` /
+> `<` / `>` / `[`) is a sibling drift candidate flagged here for the
+> next round: defanging at the CSV write does NOT cover the
+> markdown-injection axis when the same data is re-rendered into
+> `docs/statistik.md`.
+
+That sibling was open: four CSV-derived sinks in
+`scripts/generate_markdown_stats.py` (pre-fix) interpolated the
+operator-/upstream-influenced ``direction`` / ``provider`` /
+``location_name`` cells *verbatim* into Markdown:
+
+  ```python
+  # _format_directions_section (line 585):
+  lines.append(f"| {direction} | {count} |")          # table cell
+  # _format_providers_section (line 600):
+  lines.append(f"| {provider} | {count} |")           # table cell
+  # render_top_locations (line 491):
+  _bar_line(loc[:30], …)                              # `…` code-span label inside ``` fence
+  # render_top_locations (line 511):
+  lines.append(f"**{loc}**")                          # bold header, no fence
+  ```
+
+Four orthogonal Markdown-injection axes opened up at these sinks:
+
+  (a) **Pipe `|` in a table cell** — adds extra columns, breaks the
+      2-column table layout. A poisoned ``provider`` value
+      ``"ÖBB | INJECTED | extra"`` renders as a 4-column row that
+      mis-aligns every subsequent cell in the operator's
+      observability dashboard.
+  (b) **HTML tags in `**…**` bold context** — the bold header is
+      *outside* any code fence, so GFM-spec-compliant renderers
+      happily process inline HTML there. A poisoned
+      ``location_name`` ``"<img src=x onerror=alert(1)>"`` lands a
+      usable HTML tag in the dashboard. GitHub's own renderer
+      sanitises ``<script>`` but every operator's local IDE /
+      static-site builder has its own policy.
+  (c) **Backtick in `` `…` `` code-span label** — CommonMark code
+      spans render their interior verbatim and *backslashes are not
+      escapes inside them* — the only character that can close the
+      span is a literal backtick. A poisoned ``location_name``
+      ``"Foo`evil`bar"`` prematurely closes the inline code span,
+      leaking the bar-chart separator and glyphs as plain Markdown.
+  (d) **Embedded newlines (``\n`` / ``\r`` / U+2028 LINE SEP / U+2029
+      PARA SEP)** — `csv.reader` happily parses a quoted multi-line
+      cell. A row whose ``direction`` is ``"Foo\n## INJECTED HEADER"``
+      pre-fix split the table row at the embedded ``\n`` and the
+      second line **was rendered as a real H2 Markdown header**
+      ("## INJECTED HEADER | 1 |"), turning operator-supplied data
+      into an arbitrary new section in the public dashboard.
+
+The threat model spans three orthogonal poisoning vectors that
+already bypass the CSV-write defang:
+
+  1. **Cache-poisoning vector**: ``cache/wl/wl_baustellen.json`` and
+     ``cache/wl/events.json`` re-emit ``ev["source"]`` verbatim into
+     ``provider`` (``src/providers/wl_fetch.py:736,858``). The CSV
+     formula-prefix sanitiser strips ``=``/``+``/``-``/``@``/`\t`/`\r`
+     and C0/C1 control bytes — but PRESERVES every Markdown
+     metacharacter (`|` / `*` / `` ` `` / `<` / `>` / `[` / `]` / `(`
+     / `)` / `_` / `#` / `~` / `\\`). A poisoned cache file with
+     ``"source": "ÖBB | INJECTED"`` survives the CSV writer's
+     formula-defang untouched and lands in ``data/stats/
+     stoerungen_*.csv``, then in ``docs/statistik.md``.
+  2. **Stations-directory poisoning vector**: ``data/stations.json``
+     flows through ``display_name`` into ``direction`` (the
+     `update_stammstrecke_status` round). Same Markdown-metachar
+     residue.
+  3. **Historical-row vector**: rows committed before the
+     2026-05-09 formula-write sanitiser landed remain on disk
+     unchanged. Even if the writer were perfect for new rows, the
+     dashboard re-renders the historical CSV every cron tick — the
+     render boundary is the LAST gate.
+
+Each rendered ``docs/statistik.md`` is committed back to the
+repository (the `generate-stats.yml` workflow auto-commits) and
+becomes a public artefact: rendered by GitHub on the public repo
+browser, by every operator's local IDE / Markdown viewer, by any
+static-site builder downstream.
+
+**Fix:** Two sibling helpers in ``src/utils/text.py`` plus
+context-specific application at every sink:
+
+  1. ``normalise_markdown_text(text, *, max_len=200)`` — strips C0/C1
+     controls (except TAB/LF/CR which the whitespace-collapse step
+     replaces with a single space, preserving operator readability),
+     plus the canonical Trojan-Source / line-terminator union pinned
+     in ``src/utils/logging.py``: ALM (`؜`), ZWSP-ZWJ + LRM/RLM
+     (`​-‏`), LINE/PARA SEP + LRE/RLE/PDF/LRO/RLO
+     (` -‮`), LRI/RLI/FSI/PDI (`⁦-⁩`), and BOM
+     (`﻿`). Collapses every whitespace run to a single space and
+     caps length at ``max_len``.
+  2. ``safe_markdown_codespan(text, *, max_len=200)`` — same
+     normalisation, plus replaces literal backticks with apostrophes
+     (the project-wide convention pinned by
+     ``src.feed.reporting._sanitize_code_span``). Used wherever the
+     output flows into a `` `…` `` inline code span where backslash
+     escapes are inert by CommonMark.
+
+  At each sink in ``scripts/generate_markdown_stats.py``:
+
+  ```python
+  # _format_directions_section / _format_providers_section
+  cell = escape_markdown_cell(
+      normalise_markdown_text(direction, max_len=80)
+  )
+  lines.append(f"| {cell} | {count} |")           # \| escaped, HTML defanged
+
+  # render_top_locations bold header
+  safe_loc = escape_markdown(
+      normalise_markdown_text(loc, max_len=80)
+  )
+  lines.append(f"**{safe_loc}**")                  # <script>→&lt;script&gt;, [link]→\[link\]
+
+  # render_top_locations bar-chart label
+  bar_label = safe_markdown_codespan(
+      loc, max_len=30
+  )
+  lines.append(_bar_line(bar_label, …))            # backticks→apostrophes, \n→space
+  ```
+
+Reuses the existing pattern from ``src/feed/reporting.py`` (which
+already routes Feed-Health-report fields through
+``escape_markdown`` / ``escape_markdown_cell``) — the dashboard
+renderer was the only Markdown emitter that skipped the defence.
+
+**Tests:** Seven end-to-end PoC tests in
+``tests/scripts/test_generate_markdown_stats_md_injection.py``
+exercise each sink with a layout-breaking payload (pipe in
+direction / provider table cell, ``<script>``-tag in bold header,
+Markdown-link in bold header, backtick in code-span label,
+newline-injected H2 header, full poisoned-CSV-row → safe-Markdown
+end-to-end). All seven were verified to FAIL on the pre-fix code
+before the fix was applied. Companion unit tests in
+``tests/test_text_markdown_helpers.py`` pin the
+``normalise_markdown_text`` / ``safe_markdown_codespan`` contract
+(BiDi marks, line separators, C1 controls, ZWSP family, length
+cap, legitimate-Unicode preservation).
+
+**Learning:** When the prior round's journal entry explicitly
+flags a *named* sibling-drift candidate ("flagged here for the
+next round" + concrete file/line citations), the next Sentinel
+pass should treat it as the highest-priority hunt — the threat
+analysis is already done, only the boundary application is
+missing. Markdown rendering is the LAST sink in any text-data
+pipeline that ends in a human-readable artefact (dashboard,
+issue body, README); always treat it as a *defence boundary*
+even when an upstream sanitiser exists, because the upstream's
+threat model (formula prefixes, control bytes) is rarely the
+same as the renderer's (HTML, table cells, code spans, BiDi). A
+single ``escape_markdown`` / ``escape_markdown_cell`` /
+``safe_markdown_codespan`` triple, paired with a
+``normalise_markdown_text`` whitespace/control-byte normaliser,
+is the canonical defence shape — the Feed-Health renderer
+already used it; the dashboard's omission was pure drift.
+
 ## 2026-05-09 - CSV Formula Injection (CWE-1236) at the Stats-Writer Boundary: `provider`, `location_name`, `direction` Persisted Verbatim Into `data/stats/*.csv`
 **Vulnerability:** `append_stammstrecke_row` and
 `append_disruption_row` (`src/utils/stats.py:219-273`, pre-fix) — the

--- a/scripts/generate_markdown_stats.py
+++ b/scripts/generate_markdown_stats.py
@@ -65,6 +65,12 @@ from src.utils.stats import (  # noqa: E402
     WEEKDAY_LABELS,
     stats_path,
 )
+from src.utils.text import (  # noqa: E402
+    escape_markdown,
+    escape_markdown_cell,
+    normalise_markdown_text,
+    safe_markdown_codespan,
+)
 
 LOGGER = logging.getLogger("generate_markdown_stats")
 
@@ -83,6 +89,15 @@ MAX_CSV_BYTES: Final = 25 * 1024 * 1024
 # rendered Markdown stays comfortable even on a 96-col terminal viewer.
 MAX_BAR_WIDTH: Final = 24
 TOP_N_LOCATIONS: Final = 5
+
+# Per-cell length cap applied at every CSV-derived Markdown sink. Each
+# CSV writer in :mod:`src.utils.stats` already caps ``provider`` /
+# ``location_name`` / ``direction`` at 200 chars on persistence, but
+# the dashboard renders inside narrow Markdown table columns and
+# 30-char-label bar charts; an additional render-side cap keeps the
+# dashboard layout legible even if a future writer relaxes its own cap.
+_DASHBOARD_FIELD_MAX_LEN: Final = 80
+_DASHBOARD_BAR_LABEL_MAX_LEN: Final = 30
 
 # Visual vocabulary. Different glyphs per chart type so the eye can
 # tell them apart at a glance even when the dashboard is rendered in
@@ -487,9 +502,16 @@ def render_top_locations(
     lines: list[str] = [f"### Top {top_n} Hotspots (Anzahl Störungen)", "", "```"]
     for loc, count in items:
         suffix = f" {count}"
+        # Bar labels are wrapped in `` `…` `` inside a fenced code block.
+        # CommonMark code spans render verbatim — backslash escapes are
+        # NOT active — so the only safe defence against a CSV-derived
+        # backtick / embedded newline closing the span is replacement.
+        bar_label = safe_markdown_codespan(
+            loc, max_len=_DASHBOARD_BAR_LABEL_MAX_LEN
+        )
         lines.append(
             _bar_line(
-                loc[:30],
+                bar_label,
                 count,
                 max_value,
                 BAR_GLYPHS["location"],
@@ -504,11 +526,16 @@ def render_top_locations(
     lines.append(f"### Tageszeit-Profil der Top {top_n} Hotspots")
     lines.append("")
     for loc, _count in items:
+        # The dict lookup must use the raw ``loc`` key (which is what
+        # the aggregator stored). Only the rendered text is sanitised.
         hours = aggregate.by_location_hour.get(loc, {})
         if not hours:
             continue
         max_hour = max(hours.values()) if hours else 0
-        lines.append(f"**{loc}**")
+        safe_loc = escape_markdown(
+            normalise_markdown_text(loc, max_len=_DASHBOARD_FIELD_MAX_LEN)
+        )
+        lines.append(f"**{safe_loc}**")
         lines.append("")
         lines.append("```")
         # Show only the hours that actually carry signal — full 24-row
@@ -573,7 +600,15 @@ def _format_summary_section(
 
 
 def _format_directions_section(stammstrecke: StammstreckeAggregate) -> list[str]:
-    """Render the per-direction breakdown table."""
+    """Render the per-direction breakdown table.
+
+    Routes ``direction`` through :func:`normalise_markdown_text` +
+    :func:`escape_markdown_cell` so a CSV row whose direction field
+    contains a Markdown-meaningful character (``|`` / ``<`` / `` ` ``
+    / ``[`` / embedded newline) cannot break out of the 2-column
+    table cell. See the module-level threat model in the Sentinel
+    journal (2026-05-09 Markdown sibling drift round).
+    """
     if not stammstrecke.by_direction:
         return ["### Beobachtungen je Richtung", "", "_Keine Daten._", ""]
     items = sorted(
@@ -582,13 +617,24 @@ def _format_directions_section(stammstrecke: StammstreckeAggregate) -> list[str]
     )
     lines: list[str] = ["### Beobachtungen je Richtung", "", "| Richtung | Anzahl |", "| --- | ---: |"]
     for direction, count in items:
-        lines.append(f"| {direction} | {count} |")
+        cell = escape_markdown_cell(
+            normalise_markdown_text(direction, max_len=_DASHBOARD_FIELD_MAX_LEN)
+        )
+        lines.append(f"| {cell} | {count} |")
     lines.append("")
     return lines
 
 
 def _format_providers_section(stoerungen: StoerungAggregate) -> list[str]:
-    """Render the per-provider breakdown table."""
+    """Render the per-provider breakdown table.
+
+    See :func:`_format_directions_section` for the threat model.
+    The ``provider`` field flows from
+    :data:`cache/wl/wl_baustellen.json["source"]` (and siblings) which
+    a poisoned cache file can populate verbatim — defending the
+    rendering boundary closes that path even when the upstream cache
+    integrity check is bypassed.
+    """
     if not stoerungen.by_provider:
         return ["### Störungen je Quelle", "", "_Keine Daten._", ""]
     items = sorted(
@@ -597,7 +643,10 @@ def _format_providers_section(stoerungen: StoerungAggregate) -> list[str]:
     )
     lines: list[str] = ["### Störungen je Quelle", "", "| Quelle | Anzahl |", "| --- | ---: |"]
     for provider, count in items:
-        lines.append(f"| {provider} | {count} |")
+        cell = escape_markdown_cell(
+            normalise_markdown_text(provider, max_len=_DASHBOARD_FIELD_MAX_LEN)
+        )
+        lines.append(f"| {cell} | {count} |")
     lines.append("")
     return lines
 

--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -342,6 +342,56 @@ def html_to_text(s: str, *, collapse_newlines: bool = False) -> str:
     return txt
 
 
+# Defence-in-depth control-character allow-list for Markdown sinks. The
+# CSV writer in :mod:`src.utils.stats` already strips C0/DEL bytes at
+# the persistence boundary, but Markdown rendering is the LAST gate
+# before the value reaches a human renderer (GitHub, IDE, static-site
+# builder); historical rows, future writer-siblings, and the Unicode
+# line / paragraph / BiDi separators (which the CSV regex does not
+# cover) all need to be normalised here. The character class mirrors
+# the canonical Trojan-Source / line-terminator union pinned in
+# ``src/utils/logging.py`` minus the readable whitespace bytes that
+# the immediately-following whitespace-collapse step replaces with a
+# single space (TAB \x09, LF \x0a, CR \x0d):
+#   * \x00-\x08 + \x0b-\x0c + \x0e-\x1f — C0 controls except TAB/LF/CR.
+#   * \x7f-\x9f — DEL + C1 controls (incl. U+0085 NEXT LINE which
+#     several Markdown / SIEM splitters honour as a record terminator).
+#   * U+061C — Arabic Letter Mark (post-Unicode-6.3 BiDi control).
+#   * U+200B-U+200F — ZWSP / ZWNJ / ZWJ + LRM / RLM (CVE-2021-42574
+#     Trojan-Source first half + zero-width clutter).
+#   * U+2028-U+202E — LINE SEP / PARA SEP + LRE/RLE/PDF/LRO/RLO BiDi
+#     formatting controls.
+#   * U+2066-U+2069 — LRI / RLI / FSI / PDI BiDi isolates
+#     (CVE-2021-42574 second half).
+#   * U+FEFF — Byte Order Mark / ZWNBSP.
+_MARKDOWN_NORMALISE_UNSAFE_RE = re.compile(
+    r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069\ufeff]"
+)
+_MARKDOWN_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def normalise_markdown_text(text: str, *, max_len: int = 200) -> str:
+    """Normalise *text* before interpolating it into a Markdown sink.
+
+    Strips control bytes / BiDi marks / Unicode line separators (which
+    would otherwise either split a Markdown table row, fool a SIEM
+    splitter consuming the rendered file, or invert displayed text via
+    CVE-2021-42574-style "Trojan Source" payloads), collapses every
+    whitespace run (including embedded TAB / LF / CR) to a single
+    space, and caps length at *max_len*. The output is plain text,
+    free of layout-breaking whitespace and invisible control bytes —
+    pair with :func:`escape_markdown` (or :func:`escape_markdown_cell`
+    for table cells) to apply context-specific escaping.
+    """
+    if not text:
+        return ""
+    cleaned = _MARKDOWN_NORMALISE_UNSAFE_RE.sub("", text)
+    cleaned = _MARKDOWN_WHITESPACE_RE.sub(" ", cleaned).strip()
+    if len(cleaned) > max_len:
+        cleaned = cleaned[:max_len].rstrip()
+    return cleaned
+
+
 def escape_markdown(text: str) -> str:
     """Escape HTML and Markdown characters to prevent injection/XSS."""
     text = html.escape(text)
@@ -357,3 +407,19 @@ def escape_markdown_cell(text: str) -> str:
     escaped = escape_markdown(text)
     # Use HTML entity for pipe to be safe in tables
     return escaped.replace("|", r"\|")
+
+
+def safe_markdown_codespan(text: str, *, max_len: int = 200) -> str:
+    """Return *text* normalised for inclusion inside a `` `…` `` code span.
+
+    CommonMark code spans render their interior verbatim — backslash
+    escapes are NOT active. The only character that can break out is a
+    literal backtick, which closes the span. Replace backticks with the
+    apostrophe ``'`` (the project-wide convention — see
+    :func:`src.feed.reporting._sanitize_code_span`) and apply the same
+    control-byte / whitespace / length normalisation as
+    :func:`normalise_markdown_text` so embedded newlines cannot break
+    out of the surrounding fenced code block by smuggling a closing
+    ``\\n```\\n`` into the label.
+    """
+    return normalise_markdown_text(text, max_len=max_len).replace("`", "'")

--- a/tests/scripts/test_generate_markdown_stats_md_injection.py
+++ b/tests/scripts/test_generate_markdown_stats_md_injection.py
@@ -1,0 +1,280 @@
+"""Markdown-injection PoCs for ``scripts/generate_markdown_stats.py``.
+
+Sentinel sibling-drift round to the 2026-05-09 CSV formula injection
+fix: the dashboard renderer interpolates the same operator-/upstream-
+influenced ``direction``, ``provider``, and ``location_name`` fields
+into Markdown table cells, ``**bold**`` headers, and ``` `…` `` `` code-
+span labels with **no escaping**. Defending the CSV write boundary
+does not cover this path — the render path must defend itself.
+
+Threat model:
+
+* The ``data/stats/*.csv`` ledgers are append-only and live next to
+  every cron-run cache file. Any path-traversal / TOCTOU primitive
+  that lands a write into the repo root (the wider Sentinel audit
+  trail enumerates several rounds of these) plants a row whose
+  ``direction`` / ``provider`` / ``location_name`` is verbatim
+  attacker-controlled.
+* Historical rows committed before the 2026-05-09 formula sanitiser
+  landed remain on disk and may carry Markdown-meaningful characters
+  (``|``, ``<``, `` ` ``, ``[``, ``*``) that survive the writer-side
+  defang (which only neutralises *formula* prefixes).
+* The dashboard ``docs/statistik.md`` is rendered on every cron tick
+  and committed to the repository — it is rendered by GitHub on the
+  public repo browser and by every operator's local Markdown viewer.
+
+Each test below interpolates a payload that would either (a) break
+the table layout, (b) inject an unintended Markdown link / image, or
+(c) close the inline-code span and leak rendering control. The fix
+is to apply :func:`src.utils.text.escape_markdown_cell` /
+:func:`src.utils.text.escape_markdown` (and a backtick-stripping
+helper for the code-span sites) at every sink — exactly the pattern
+``src/feed/reporting.py`` already uses for the analogous Feed Health
+report.
+"""
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import generate_markdown_stats as script  # noqa: E402
+
+VIENNA_TZ = ZoneInfo("Europe/Vienna")
+
+
+# ---- Pipe-injection in Markdown table cells -------------------------------
+
+
+def test_directions_section_escapes_pipe_in_direction() -> None:
+    """A ``|`` in *direction* must not break out of the table cell.
+
+    Pre-fix the row rendered as ``| Foo | INJECTED | extra | 1 |`` —
+    that's *five* pipe-separated cells in a header that promises two,
+    which mis-renders the table on every Markdown engine. Post-fix the
+    pipe is backslash-escaped (``\\|``) so the row stays a 2-column row.
+    """
+    agg = script.StammstreckeAggregate(
+        by_direction={"Floridsdorf | INJECTED | extra": 1},
+        total_observations=1,
+    )
+    body = "\n".join(script._format_directions_section(agg))
+
+    # Locate the data row. The header pipes are part of the layout so
+    # we search by the (non-Markdown-meaningful) count token.
+    data_lines = [
+        line for line in body.splitlines()
+        if line.startswith("|") and "1" in line and "Anzahl" not in line and "---" not in line
+    ]
+    assert data_lines, f"could not find direction data row in body:\n{body}"
+    row = data_lines[0]
+    # Every data row in a 2-column table has *exactly* 3 unescaped pipes
+    # (start, between cells, end). More means the cell broke out.
+    pipe_count = row.count("|") - row.count(r"\|")
+    assert pipe_count == 3, (
+        f"unescaped pipes in direction cell broke the table layout: "
+        f"row={row!r}, unescaped pipe count={pipe_count}"
+    )
+
+
+def test_providers_section_escapes_pipe_in_provider() -> None:
+    """A ``|`` in *provider* must not break out of the provider table cell."""
+    agg = script.StoerungAggregate(
+        by_provider={"ÖBB | INJECTED | extra": 1},
+        total_disruptions=1,
+    )
+    body = "\n".join(script._format_providers_section(agg))
+
+    data_lines = [
+        line for line in body.splitlines()
+        if line.startswith("|") and "1" in line and "Anzahl" not in line and "---" not in line
+    ]
+    assert data_lines, f"could not find provider data row in body:\n{body}"
+    row = data_lines[0]
+    pipe_count = row.count("|") - row.count(r"\|")
+    assert pipe_count == 3, (
+        f"unescaped pipes in provider cell broke the table layout: "
+        f"row={row!r}, unescaped pipe count={pipe_count}"
+    )
+
+
+# ---- HTML / Markdown injection in **{loc}** bold header --------------------
+
+
+def test_render_top_locations_neutralises_html_in_bold_header() -> None:
+    """HTML in *location_name* must not flow unescaped into ``**…**``.
+
+    Pre-fix ``f"**{loc}**"`` interpolated ``<script>alert(1)</script>``
+    verbatim *outside* any code block — GFM happily renders inline
+    HTML in that context, turning the dashboard into an XSS-amplifier
+    on any static-site renderer that follows the spec literally
+    (GitHub's renderer additionally sanitises script tags but every
+    operator's local IDE / Markdown viewer has its own policy).
+    Post-fix ``html.escape`` turns ``<`` / ``>`` into HTML entities so
+    no tag is reconstructable in the bold-header position.
+
+    The test scopes its assertion to the bold-header lines only —
+    the bar-chart label is rendered inside `` `…` `` *inside a fenced
+    code block* where CommonMark guarantees HTML-entity encoding on
+    output, so a literal ``<script>`` substring inside that span is
+    safe by spec.
+    """
+    payload = "<script>alert(1)</script>"
+    agg = script.StoerungAggregate(
+        by_location=Counter({payload: 1}),
+        by_location_hour={payload: {7: 1}},
+        total_disruptions=1,
+    )
+    body = "\n".join(script.render_top_locations(agg, top_n=1))
+    bold_lines = [line for line in body.splitlines() if line.startswith("**") and line.endswith("**")]
+    assert bold_lines, f"expected at least one bold-header line, got body:\n{body}"
+    for line in bold_lines:
+        assert "<script>" not in line, (
+            f"<script> tag survived into bold-header line:\n{line}"
+        )
+
+
+def test_render_top_locations_neutralises_link_in_bold_header() -> None:
+    """A Markdown link in *location_name* must not become a clickable link."""
+    payload = "Karlsplatz [click](http://attacker.example/leak)"
+    agg = script.StoerungAggregate(
+        by_location=Counter({payload: 1}),
+        by_location_hour={payload: {7: 1}},
+        total_disruptions=1,
+    )
+    body = "\n".join(script.render_top_locations(agg, top_n=1))
+    # The unescaped ``[click](http://…)`` Markdown-link syntax must not
+    # appear — GitHub renders that as a hyperlink, turning the
+    # dashboard into a phishing surface.
+    assert "[click](http://attacker.example/leak)" not in body, (
+        f"unescaped Markdown link survived into bold header:\n{body}"
+    )
+
+
+# ---- Backtick in location code-span label ---------------------------------
+
+
+def test_render_top_locations_replaces_backtick_in_codespan_label() -> None:
+    """A backtick in *location_name* must not close the inline code span.
+
+    The hotspot bar chart wraps the label in `` `…` `` inside a fenced
+    code block. A literal backtick in the label closes the inline code
+    early, leaking subsequent ``│`` separators and the bar glyphs as
+    plain text. CommonMark code spans treat backslashes as literal, so
+    the only safe defence is *replacement* (apostrophe is the
+    project-wide convention — see ``src/feed/reporting.py``
+    ``_sanitize_code_span``).
+    """
+    payload = "Foo`evil`bar"
+    agg = script.StoerungAggregate(
+        by_location=Counter({payload: 1}),
+        by_location_hour={payload: {7: 1}},
+        total_disruptions=1,
+    )
+    body = "\n".join(script.render_top_locations(agg, top_n=1))
+    # Pre-fix the code-span line was `` `Foo`evil`bar               ` `` —
+    # i.e. the label contained the *literal* backtick, prematurely
+    # closing the code span. Post-fix backticks are replaced with
+    # apostrophes so the label is `` `Foo'evil'bar` `` which keeps the
+    # code span intact.
+    assert "`Foo`evil`bar" not in body, (
+        f"raw backtick survived into code-span label and broke "
+        f"out of the inline code wrapping:\n{body}"
+    )
+
+
+# ---- Newline injection breaks the table row -------------------------------
+
+
+def test_directions_section_neutralises_newline_in_direction() -> None:
+    """An embedded newline in *direction* must not split the table row.
+
+    ``csv.reader`` happily parses a quoted multi-line cell; a planted
+    row with a newline-bearing direction otherwise injects arbitrary
+    Markdown (a header, a fenced code-block fence, …) on the
+    subsequent line.
+    """
+    payload = "Foo\n## INJECTED HEADER"
+    agg = script.StammstreckeAggregate(
+        by_direction={payload: 1},
+        total_observations=1,
+    )
+    body = "\n".join(script._format_directions_section(agg))
+    # The injected ``## INJECTED HEADER`` line must not appear at the
+    # start of any rendered line — otherwise it becomes a real
+    # second-level header in the dashboard.
+    for line in body.splitlines():
+        assert not line.startswith("## INJECTED HEADER"), (
+            f"newline-injected Markdown header survived rendering:\n{body}"
+        )
+
+
+# ---- End-to-end: poisoned CSV produces safe Markdown ----------------------
+
+
+def test_render_markdown_neutralises_poisoned_csv_row(tmp_path: Path) -> None:
+    """Smoking-gun PoC: a poisoned CSV row produces a safe dashboard.
+
+    Plants a single ``stoerungen_2026.csv`` row whose ``provider``
+    field carries the cartesian-product Markdown payload and renders
+    the full dashboard. Pre-fix the rendered Markdown contains a
+    usable ``[click](…)`` link, an unescaped ``<img>`` / ``<script>``
+    HTML attribute surface, and a broken table layout. Post-fix none
+    of those substrings appear in the rendered output.
+    """
+    payload = "ÖBB | <img src=x onerror=alert(1)> | [click](http://attacker.example/leak)"
+    csv_path = tmp_path / "stoerungen_2026.csv"
+    header = ",".join(("timestamp", "weekday", "hour", "provider", "location_name"))
+    row = ",".join(
+        (
+            "2026-05-04T07:30:00+02:00",
+            "Mo",
+            "07",
+            f'"{payload}"',  # CSV-quote the field so embedded ``|`` survives intact
+            "Karlsplatz",
+        )
+    )
+    csv_path.write_text(header + "\n" + row + "\n", encoding="utf-8")
+
+    sm_rows, st_rows = script.collect_year_data(2026, stats_dir=tmp_path)
+    assert len(st_rows) == 1, "PoC fixture row should round-trip"
+    assert payload in st_rows[0].provider, "PoC: payload should reach the renderer"
+
+    md = script.render_markdown(
+        year=2026,
+        generated_at=datetime(2026, 5, 9, 8, 30, tzinfo=VIENNA_TZ),
+        stammstrecke=script.aggregate_stammstrecke(sm_rows),
+        stoerungen=script.aggregate_stoerungen(st_rows),
+    )
+
+    # 1. Markdown link syntax must not survive.
+    assert "[click](http://attacker.example/leak)" not in md, (
+        "Markdown link survived dashboard rendering"
+    )
+    # 2. HTML tags must be defanged (HTML-escape converts ``<`` / ``>``
+    #    to ``&lt;`` / ``&gt;``).
+    assert "<img " not in md, "HTML <img> tag survived dashboard rendering"
+    # 3. Pipe characters in payload must not multiply table cells —
+    #    every data row in a 2-column table has exactly 3 unescaped pipes.
+    for line in md.splitlines():
+        if not line.startswith("|"):
+            continue
+        if "Anzahl" in line or "---" in line:
+            continue
+        if "Quelle" in line:
+            continue
+        unescaped_pipes = line.count("|") - line.count(r"\|")
+        if " | " not in line:
+            continue
+        # Provider table rows: 2 columns => 3 unescaped pipes.
+        # Stammstrecke / direction rows: 2 columns => 3 unescaped pipes.
+        # Summary table rows: 2 columns => 3 unescaped pipes.
+        assert unescaped_pipes <= 3, (
+            f"poisoned CSV row broke a 2-column table layout: row={line!r}"
+        )

--- a/tests/test_text_markdown_helpers.py
+++ b/tests/test_text_markdown_helpers.py
@@ -1,0 +1,114 @@
+"""Tests for the Markdown-safety helpers in :mod:`src.utils.text`.
+
+Companion to ``tests/scripts/test_generate_markdown_stats_md_injection.py``,
+which exercises the helpers end-to-end through the dashboard renderer.
+This file pins the contract of the primitives themselves so a future
+regex regression (LRM/RLM dropped, BiDi-mark range narrowed, length
+cap removed) shows up as a focused unit-test failure rather than a
+diffuse dashboard test.
+"""
+from __future__ import annotations
+
+from src.utils.text import (
+    escape_markdown,
+    escape_markdown_cell,
+    normalise_markdown_text,
+    safe_markdown_codespan,
+)
+
+
+def test_normalise_markdown_text_strips_c0_controls() -> None:
+    """C0 controls (NUL through US, except TAB / LF / CR) must be stripped."""
+    assert normalise_markdown_text("Foo\x00Bar") == "FooBar"
+    assert normalise_markdown_text("Foo\x07Bar") == "FooBar"
+    assert normalise_markdown_text("Foo\x1fBar") == "FooBar"
+    assert normalise_markdown_text("Foo\x0bBar") == "FooBar"  # VT
+    assert normalise_markdown_text("Foo\x0cBar") == "FooBar"  # FF
+
+
+def test_normalise_markdown_text_collapses_tab_lf_cr_to_space() -> None:
+    """TAB / LF / CR survive control-byte stripping but collapse to space."""
+    assert normalise_markdown_text("Foo\tBar") == "Foo Bar"
+    assert normalise_markdown_text("Foo\nBar") == "Foo Bar"
+    assert normalise_markdown_text("Foo\rBar") == "Foo Bar"
+    assert normalise_markdown_text("Foo\r\n\tBar") == "Foo Bar"
+
+
+def test_normalise_markdown_text_strips_c1_controls_and_del() -> None:
+    """DEL + C1 range (\\x80-\\x9f) must be stripped — legacy display directives."""
+    assert normalise_markdown_text("Foo\x7fBar") == "FooBar"  # DEL
+    assert normalise_markdown_text("Foo\x80Bar") == "FooBar"
+    assert normalise_markdown_text("Foo\x9fBar") == "FooBar"
+
+
+def test_normalise_markdown_text_strips_bidi_marks() -> None:
+    """Trojan-Source BiDi marks (CVE-2021-42574) must not survive."""
+    assert normalise_markdown_text("Foo" + chr(0x202E) + "Bar") == "FooBar"  # RLO
+    assert normalise_markdown_text("Foo" + chr(0x202D) + "Bar") == "FooBar"  # LRO
+    assert normalise_markdown_text("Foo" + chr(0x200E) + "Bar") == "FooBar"  # LRM
+    assert normalise_markdown_text("Foo" + chr(0x200F) + "Bar") == "FooBar"  # RLM
+    assert normalise_markdown_text("Foo" + chr(0x061C) + "Bar") == "FooBar"  # ALM
+    assert normalise_markdown_text("Foo" + chr(0x2066) + "Bar") == "FooBar"  # LRI
+    assert normalise_markdown_text("Foo" + chr(0x2069) + "Bar") == "FooBar"  # PDI
+
+
+def test_normalise_markdown_text_strips_zero_width_chars() -> None:
+    """ZWSP / ZWNJ / ZWJ / BOM are pure invisible-clutter primitives."""
+    assert normalise_markdown_text("Foo" + chr(0x200B) + "Bar") == "FooBar"  # ZWSP
+    assert normalise_markdown_text("Foo" + chr(0x200C) + "Bar") == "FooBar"  # ZWNJ
+    assert normalise_markdown_text("Foo" + chr(0x200D) + "Bar") == "FooBar"  # ZWJ
+    assert normalise_markdown_text("Foo" + chr(0xFEFF) + "Bar") == "FooBar"  # BOM
+
+
+def test_normalise_markdown_text_strips_unicode_line_separators() -> None:
+    """U+2028 / U+2029 split log records and Markdown table rows."""
+    assert normalise_markdown_text("Foo" + chr(0x2028) + "Bar") == "FooBar"  # LINE SEP
+    assert normalise_markdown_text("Foo" + chr(0x2029) + "Bar") == "FooBar"  # PARA SEP
+
+
+def test_normalise_markdown_text_caps_length() -> None:
+    """The length cap defends against unbounded operator strings."""
+    assert normalise_markdown_text("A" * 500, max_len=80) == "A" * 80
+
+
+def test_normalise_markdown_text_handles_empty_and_whitespace() -> None:
+    assert normalise_markdown_text("") == ""
+    assert normalise_markdown_text("   ") == ""
+    assert normalise_markdown_text("\n\n\t\r") == ""
+
+
+def test_normalise_markdown_text_preserves_legitimate_unicode() -> None:
+    """Umlauts and other legitimate Unicode must NOT be stripped."""
+    assert normalise_markdown_text("Wien Floridsdorf") == "Wien Floridsdorf"
+    assert normalise_markdown_text("Karlsplatz / Oper") == "Karlsplatz / Oper"
+    assert normalise_markdown_text("ÖBB") == "ÖBB"
+    assert normalise_markdown_text("Wiener Linien") == "Wiener Linien"
+
+
+def test_safe_markdown_codespan_replaces_backticks() -> None:
+    """A backtick inside `` `…` `` closes the inline code span — replace it."""
+    assert safe_markdown_codespan("Foo`evil`bar") == "Foo'evil'bar"
+    assert safe_markdown_codespan("`leading") == "'leading"
+    assert safe_markdown_codespan("trailing`") == "trailing'"
+
+
+def test_safe_markdown_codespan_inherits_normalisation() -> None:
+    """Code-span normalisation includes control-byte / whitespace cleanup."""
+    assert safe_markdown_codespan("Foo\nbar") == "Foo bar"
+    assert safe_markdown_codespan("Foo\x00bar") == "Foobar"
+    assert safe_markdown_codespan("Foo" + chr(0x202E) + "bar") == "Foobar"
+    assert safe_markdown_codespan("A" * 500, max_len=30) == "A" * 30
+
+
+def test_escape_markdown_cell_escapes_pipe_and_html() -> None:
+    """Existing cell escape contract: pipe + Markdown + HTML defanged."""
+    assert escape_markdown_cell("Foo|Bar") == r"Foo\|Bar"
+    assert escape_markdown_cell("<b>x</b>") == "&lt;b&gt;x&lt;/b&gt;"
+    assert escape_markdown_cell("[click](http://x)") == r"\[click\]\(http://x\)"
+
+
+def test_escape_markdown_strips_dangerous_markdown_meta_chars() -> None:
+    """Existing inline escape contract: Markdown specials backslash-escaped."""
+    assert escape_markdown("**bold**") == r"\*\*bold\*\*"
+    assert escape_markdown("`code`") == r"\`code\`"
+    assert escape_markdown("@here") == r"\@here"


### PR DESCRIPTION
## Summary

Closes the sibling-drift candidate explicitly flagged in the **2026-05-09 CSV formula-injection journal entry** ("flagged here for the next round"): the stats-dashboard renderer (`scripts/generate_markdown_stats.py`) interpolated four CSV-derived operator-/upstream-influenced fields **verbatim** into Markdown.

### Vulnerability

Four sinks in `scripts/generate_markdown_stats.py` (pre-fix) interpolated `direction` / `provider` / `location_name` cells without escaping:

```python
# _format_directions_section (line 585):
lines.append(f"| {direction} | {count} |")          # table cell — pipe injection
# _format_providers_section (line 600):
lines.append(f"| {provider} | {count} |")           # table cell — pipe injection
# render_top_locations (line 491):
_bar_line(loc[:30], …)                              # `…` code-span label inside ``` fence — backtick break-out
# render_top_locations (line 511):
lines.append(f"**{loc}**")                          # bold header — HTML / Markdown-link injection
```

Four orthogonal Markdown-injection axes opened up:

1. **Pipe `|` in table cell** → adds extra columns, breaks 2-column layout.
2. **HTML in `**…**` bold header** → `<img src=x onerror=…>` lands a usable inline-HTML tag (the bold context is *outside* any code fence).
3. **Backtick in `` `…` `` code-span label** → CommonMark code spans render verbatim and backslash escapes are inert; only a literal backtick can close the span. A poisoned `Foo\`evil\`bar` location prematurely closes the inline code span.
4. **Embedded newlines (`\n` / `\r` / U+2028 LINE SEP / U+2029 PARA SEP)** → `csv.reader` happily parses a quoted multi-line cell. Pre-fix `direction = "Foo\n## INJECTED HEADER"` rendered the second line as a real H2 Markdown header in the public dashboard.

### Threat model

The CSV formula-write sanitiser (PR #1375, 2026-05-09) closed the *write* side but **only neutralises formula prefixes (`=` `+` `-` `@` TAB CR) + C0/DEL bytes**. Every Markdown metacharacter (`|` `<` `>` `[` `*` `` ` `` `_` `#` `~` `\\`) survives the writer untouched. Three orthogonal poisoning vectors bypass that defang and reach the renderer:

* **Cache-poisoning** — `cache/wl/wl_baustellen.json["source"]` re-emits verbatim into `provider` (`src/providers/wl_fetch.py:736,858`). Markdown chars survive.
* **Stations-directory poisoning** — `data/stations.json` flows through `display_name` into `direction`. Same residue.
* **Historical rows** — rows committed before 2026-05-09 remain on disk; the dashboard re-renders them every cron tick. The render boundary is the LAST gate.

`docs/statistik.md` is auto-committed by the `generate-stats.yml` workflow and rendered on the public repo browser, every operator's IDE / Markdown viewer, and any downstream static-site builder.

### Fix

Two new sibling helpers in `src/utils/text.py`:

* **`normalise_markdown_text(text, *, max_len=200)`** — strips C0/DEL + C1 controls and the canonical Trojan-Source / line-terminator union (ALM, ZWSP-ZWJ, LRM/RLM, LINE/PARA SEP, LRE/RLE/PDF/LRO/RLO, LRI/RLI/FSI/PDI, BOM) pinned in `src/utils/logging.py`, collapses every whitespace run (incl. embedded TAB/LF/CR) to a single space, caps length.
* **`safe_markdown_codespan(text, *, max_len=200)`** — same normalisation plus replaces backticks with apostrophes (CommonMark code spans render verbatim, backslash escapes are inert; project-wide convention from `src.feed.reporting._sanitize_code_span`).

Applied at every CSV-derived sink in `scripts/generate_markdown_stats.py`:

```python
# table cells
cell = escape_markdown_cell(normalise_markdown_text(direction, max_len=80))
lines.append(f"| {cell} | {count} |")

# bold header
safe_loc = escape_markdown(normalise_markdown_text(loc, max_len=80))
lines.append(f"**{safe_loc}**")

# bar-chart code-span label
bar_label = safe_markdown_codespan(loc, max_len=30)
lines.append(_bar_line(bar_label, …))
```

Reuses the existing `escape_markdown` / `escape_markdown_cell` pattern that `src/feed/reporting.py` already uses for the analogous Feed-Health Markdown report — the dashboard renderer was the only Markdown emitter that skipped the defence.

### Tests

* `tests/scripts/test_generate_markdown_stats_md_injection.py` — 7 PoC tests, one per sink axis + an end-to-end poisoned-CSV → safe-Markdown smoking gun. **Verified to FAIL on the pre-fix code** before the fix was applied.
* `tests/test_text_markdown_helpers.py` — 13 unit tests pinning the helper contract (BiDi marks, line separators, C1 controls, ZWSP family, length cap, legitimate-Unicode preservation, backtick replacement).

## Test plan

- [x] PoC tests verified to FAIL on pre-fix code (proves the vulnerability)
- [x] PoC tests verified to PASS post-fix (proves the fix)
- [x] Full pytest suite: `2484 passed, 4 skipped` (no regressions)
- [x] Mypy delta vs `main`: **0 new errors**, -2 errors fixed (the new test file's imports now resolve)
- [x] `ruff check` clean
- [x] `bandit -r src scripts -q` clean
- [x] Secret scanner clean (`Keine potentiellen Secrets gefunden`)
- [x] C901 complexity gate clean (0 new violations, no baseline change)
- [x] `pip-audit` clean (no known dependency vulns)
- [x] End-to-end manual run: poisoned CSV row → dashboard renders with `\|`-escaped pipes, `&lt;script&gt;`-defanged HTML, apostrophe-replaced backticks


---
_Generated by [Claude Code](https://claude.ai/code/session_01NX2oY1kTeNLiDoKzgwMuiZ)_