### PR TITLE
ci(manual-full-refresh): refresh Stammstrecke status and stats dashboard

### DIFF
--- a/.github/workflows/manual-full-refresh.yml
+++ b/.github/workflows/manual-full-refresh.yml
@@ -94,7 +94,23 @@ jobs:
           # schreiben statt auf das Original-Repo zu zeigen.
           PAGES_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
 
-      # ----- 4) Aenderungen committen und pushen -----
+      # ----- 4) Stammstrecke-Status und Statistiken auffrischen -----
+      # Schreibt cache/stammstrecke/events.json und haengt eine Zeile an
+      # data/stats/stammstrecke_<YYYY>.csv an. Teilt sich die Concurrency-
+      # Gruppe ``external-api-fetch`` mit dem regulaeren 30-Minuten-Cron,
+      # sodass parallele HAFAS-Aufrufe vermieden werden.
+      - name: Refresh Stammstrecke status
+        run: python scripts/update_stammstrecke_status.py
+
+      # Regeneriert docs/statistik.md (Dashboard) und patcht zugleich die
+      # <!-- STATS:* --> Marker im README mit dem 30-Tage-Schnappschuss.
+      # Liest ausschliesslich aus data/stats/*.csv (read-only) und schreibt
+      # via atomic_write — ein Lauf ohne neue Daten patcht das README nur,
+      # wenn sich die "Letzte Aktualisierung"-Zelle aendert.
+      - name: Refresh statistics dashboard and README snapshot
+        run: python scripts/generate_markdown_stats.py
+
+      # ----- 5) Aenderungen committen und pushen -----
       - name: Pull concurrent remote changes
         run: git pull --rebase --autostash
 


### PR DESCRIPTION
## Summary

Folge zu #1379: der manuelle „alles neu"-Workflow `manual-full-refresh.yml` führt jetzt zusätzlich die beiden Stats-Schritte aus, sodass ein einmaliger manueller Trigger denselben End-Zustand wie der nächtliche `generate-stats.yml`-Cron erzeugt.

### Neue Schritte

Eingefügt zwischen `Build feed` (Section 3) und dem Commit-Step (Section 5 nach Renumbering):

1. **`Refresh Stammstrecke status`** — `python scripts/update_stammstrecke_status.py`
   - Hängt eine HAFAS-Median-Beobachtung an `data/stats/stammstrecke_<YYYY>.csv` an.
   - Schreibt `cache/stammstrecke/events.json`.
   - Teilt sich die existierende `external-api-fetch`-Concurrency-Group mit dem 30-Minuten-Cron, sodass parallele HAFAS-Aufrufe serialisiert bleiben.

2. **`Refresh statistics dashboard and README snapshot`** — `python scripts/generate_markdown_stats.py`
   - Regeneriert `docs/statistik.md` (Jahres-Dashboard).
   - Patcht die `<!-- STATS:STAMMSTRECKE:* -->` und `<!-- STATS:DISRUPTIONS:* -->` Marker im README mit dem 30-Tage-Snapshot.
   - Idempotent: wenn das gerenderte Resultat byteweise dem on-disk Stand entspricht, bleibt das README unangetastet.

### Commit-Integration

Keine Änderung am Auto-Commit-Step nötig — der existierende `add_options: -A` Modus picks die neuen Artefakte automatisch auf:
- `README.md`
- `docs/statistik.md`
- `data/stats/stammstrecke_*.csv` (bei neuer HAFAS-Beobachtung)
- `data/stats/stoerungen_*.csv` (falls der Feed-Build neue Disruption-Identitäten erkennt)
- `cache/stammstrecke/events.json`

## Test plan

- [ ] CI grün auf diesem PR (workflow-yaml-only-change → keine Test-Suite-Auswirkung).
- [ ] Manuelle Workflow-Ausführung via `Actions → Manual full refresh → Run workflow`. Erwartet: am Ende ein Commit, der u. a. das aktualisierte README mit gefüllten Stats-Tabellen und einer aktuellen `Letzte Aktualisierung`-Zelle enthält.
- [ ] Concurrency-Test: zwei `external-api-fetch`-Workflows (z. B. der 30-Minuten-Stammstrecke-Cron und ein manueller Full-Refresh) starten kurz hintereinander → der zweite wartet, statt parallel HAFAS zu treffen.

https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr)_