### PR TITLE
security(reporting): neutralise Markdown injection at Feed-Health / GitHub-Issue inline-code-span and fenced-code-block boundaries

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,225 @@
+## 2026-05-09 - Markdown Injection Drift Round 2: Inline-Code-Span and Fenced-Code-Block Break-Out at the Feed-Health / GitHub-Issue Renderer (`feed_path`, `error_log_path`, Diagnostics) — Env-Override Path-Boundary Sibling
+**Vulnerability:** The 2026-05-09 stats-dashboard Markdown-injection
+round (entry below) closed the renderer boundary in
+`scripts/generate_markdown_stats.py` but its threat-model paragraph
+on "Markdown rendering is the LAST sink in any text-data pipeline
+that ends in a human-readable artefact (dashboard, **issue body**,
+README); always treat it as a *defence boundary* even when an
+upstream sanitiser exists" implicitly opened a sibling drift round:
+the *next* Markdown-emitting modules in the project — `render_feed_
+health_markdown` and `_GithubIssueReporter._build_body` in
+`src/feed/reporting.py` — interpolate two operator-controlled file
+paths *verbatim* inside ``\`…\``` inline code spans plus a
+``\`\`\`text … \`\`\``` fenced code block.
+
+Pre-fix sinks (five orthogonal break-out axes across two renderers
+and one issue-body builder):
+
+  ```python
+  # src/feed/reporting.py:render_feed_health_markdown (line 531):
+  lines.append(f"- **RSS-Datei:** `{report.feed_path}`")
+  # src/feed/reporting.py:_GithubIssueReporter._build_body (line 1012):
+  lines.append(f"- **Feed-Datei:** `{report.feed_path}`")
+  # src/feed/reporting.py:_GithubIssueReporter._build_body (line 1063):
+  lines.append(f"Weitere Details finden sich in der Logdatei "
+               f"`{error_log_path}`.")
+  # src/feed/reporting.py:_GithubIssueReporter._build_body (line 1057-1059):
+  lines.append("```text")
+  lines.append(diagnostics)         # ← contains f"Feed={feed_path}"
+  lines.append("```")
+  ```
+
+Three orthogonal Markdown-injection axes opened up at these sinks:
+
+  (a) **Backtick-in-inline-code-span** — CommonMark inline code spans
+      render their interior verbatim and *backslashes are not
+      escapes inside them* — the only character that closes the
+      span is a literal backtick. ``feed_path = "docs/feed`<img src=x
+      onerror=alert(1)>`.xml"`` closes the inline span at line 531 /
+      1012 and lets ``<img src=x onerror=alert(1)>`` render as a
+      live HTML tag in (i) the public ``docs/feed_health.md``
+      artefact (auto-committed by the workflow, rendered by GitHub
+      on the public repo browser, by every operator's IDE / Markdown
+      viewer, by any static-site builder downstream) and (ii) the
+      auto-submitted GitHub Issue body (visible to every repo
+      watcher; the issue is opened on every failed feed run, so
+      every reader of the project's notifications channel sees it).
+      Same primitive at line 1063 with ``error_log_path``.
+  (b) **Newline-injection in inline code span** — embedded ``\n`` /
+      ``\r`` / U+2028 LINE SEP / U+2029 PARA SEP in ``feed_path``
+      split the bullet-list item across multiple lines. A path
+      ``"docs/foo\n## INJECTED HEADER\n.xml"`` rendered the second
+      line as a real Markdown ATX H2 header in the public Feed-
+      Health report — turning operator-supplied path bytes into an
+      arbitrary new section in the dashboard.
+  (c) **Triple-backtick fence-break inside the diagnostics fenced
+      code block** — the ``\`\`\`text … \`\`\``` block at line 1057-
+      1059 wraps `diagnostics_message()` which contains
+      ``f"Feed={self.feed_path}"`` without sanitation. A payload
+      ``feed_path = "docs/feed.xml\n\`\`\`\n# INJECTED H1\n\`\`\`"``
+      lands a ``\`\`\``` on its own line *inside* the fence; CommonMark
+      closes the fence there and the H1 header escapes the block
+      into the public GitHub Issue body. Multi-line + triple-
+      backtick is the canonical CommonMark fence-break primitive.
+
+The threat surface at every sink is operator-controlled:
+
+  1. **`OUT_PATH` env override → `report.feed_path`** —
+     ``out_path = validate_path(Path(feed_config.OUT_PATH), "OUT_PATH")``
+     in `src/build_feed.py:2380` resolves the env-driven path; the
+     resolver only checks the *first path component* against
+     ``ALLOWED_ROOTS = {"docs", "data", "log"}`` (line 36 of
+     `src/feed/config.py`). Backticks, newlines, BiDi marks, and
+     line/paragraph separators in the *rest* of the path survive
+     the validator unchanged. ``OUT_PATH=docs/feed\`xss\`.xml``
+     passes ``validate_path`` and lands in ``RunReport.finish(...)``
+     verbatim via ``out_path.as_posix()``.
+  2. **`LOG_DIR` env override → `error_log_path`** —
+     ``LOG_DIR_PATH = resolve_env_path("LOG_DIR", Path("log"),
+     allow_fallback=True)`` (line 326 of `src/feed/config.py`)
+     applies the same first-component validator; a poisoned
+     ``LOG_DIR=log\`xss\`/sub`` lands in ``error_log_path`` after
+     ``error_log_path = Path(LOG_DIR) / "errors.log"``.
+  3. **Cross-cutting** — every prior round's threat-model surface
+     for env overrides (leaked CI env, compromised secret store,
+     intentional misconfig, partial flush + power loss on `.env`
+     write) carries here. The defence-in-depth contract collapses
+     the cartesian product of (env source × path-validator
+     bypass × backtick / newline / BiDi axis × renderer sink) into
+     a single sanitiser at the last gate before rendering.
+
+The Feed-Health report and the auto-submitted GitHub Issue are the
+project's two highest-visibility human-facing renderers: the
+report is committed back to `docs/` (a public artefact mirrored on
+the GitHub Pages site), and the issue is opened on every failed
+feed run (visible to every repo watcher). Each renderer was missing
+the canonical ``escape_markdown`` / ``safe_markdown_codespan``
+defence the prior round pinned for the stats dashboard.
+
+**Fix:** Five context-specific applications of the canonical
+``safe_markdown_codespan`` helper from
+``src/utils/text.py:412-425`` (the same helper introduced by the
+2026-05-09 Markdown-injection round, which composes
+``normalise_markdown_text`` — strips C0/C1 controls + Trojan-Source
+/ line-terminator union + ZWSP family + BiDi marks, collapses
+whitespace to a single space — and replaces every literal backtick
+with the project-wide apostrophe convention pinned by
+``_sanitize_code_span``):
+
+  ```python
+  # render_feed_health_markdown (line 531):
+  lines.append(
+      f"- **RSS-Datei:** `{safe_markdown_codespan(report.feed_path)}`"
+  )
+
+  # _build_body (line 1012):
+  lines.append(
+      f"- **Feed-Datei:** `{safe_markdown_codespan(report.feed_path)}`"
+  )
+
+  # _build_body fenced code block (line 1057-1059):
+  lines.append("```text")
+  # 50 000-char cap is well above any realistic diagnostics size and
+  # well below _MAX_GITHUB_BODY_LENGTH = 60 000 which the downstream
+  # _bounded_github_body call enforces on the rendered body.
+  lines.append(safe_markdown_codespan(diagnostics, max_len=50_000))
+  lines.append("```")
+
+  # _build_body (line 1063):
+  lines.append(
+      "Weitere Details finden sich in der Logdatei "
+      f"`{safe_markdown_codespan(str(error_log_path))}`."
+  )
+  ```
+
+The helper is applied per-sink (matching the project's existing
+``escape_markdown_cell`` / ``escape_markdown`` / ``_sanitize_code_
+span`` per-sink convention) so a future code path that bypasses
+``RunReport.finish`` (debug fixture, alternate logger handler,
+unit-test stub) inherits the defence at the renderer boundary
+rather than at the boundary that captured the path.
+
+For the fenced code block, the cap is raised from the helper's
+default ``max_len=200`` to ``max_len=50_000`` — well above the
+realistic diagnostics size (each warning capped at 2000 chars,
+100 warnings max) and well below
+``_MAX_REPORT_MESSAGE_LENGTH * _MAX_REPORT_MESSAGE_COUNT`` worst-
+case. The downstream ``_bounded_github_body`` (60 000-char cap with
+line-boundary truncation) already enforces the GitHub Issue API
+limit, so the fenced-code-block sanitiser is layered between the
+diagnostics aggregator and the body cap.
+
+**Tests:** Seven end-to-end PoC tests in
+``tests/test_sentinel_reporting_codespan_injection.py`` exercise
+each sink with a layout-breaking payload:
+  * `test_feed_health_markdown_feed_path_backtick_breaks_inline_code_span`
+    — backtick + ``<script>`` payload in ``feed_path`` → must stay
+    inside one inline code span (exactly two backticks on the
+    bullet line, post-fix).
+  * `test_feed_health_markdown_feed_path_newline_breaks_layout` —
+    newline + ATX H2 payload → must not surface as a real H2.
+  * `test_feed_health_markdown_feed_path_bidi_marks_stripped` —
+    LRO + ZWSP + BOM → must be stripped.
+  * `test_github_issue_body_feed_path_backtick_breaks_inline_code_span`
+    — same backtick primitive at the GitHub Issue sink.
+  * `test_github_issue_body_error_log_path_backtick_breaks_inline_code_span`
+    — same backtick primitive at the ``error_log_path`` sink (uses
+    `monkeypatch.setattr` on the imported reference because
+    ``LOG_DIR`` is captured at module load time).
+  * `test_github_issue_body_feed_path_fence_break_via_newline` —
+    ``\n\`\`\`\n`` payload in ``feed_path`` → fenced code block
+    keeps exactly two ``\`\`\``` fences, no escaped H1.
+  * `test_inline_code_span_sinks_inventory_pinned` — inventory
+    invariant: a future refactor that introduces a fourth ``\`…\```
+    inline code span sourced from an env-controlled string without
+    going through ``safe_markdown_codespan`` re-opens this
+    Markdown-injection vector and trips the inventory test.
+
+All seven were verified to FAIL on the pre-fix code before the fix
+was applied, and to PASS on the post-fix code. The `responses`-
+mocked GitHub Issue submission pattern mirrors the existing
+``test_reporting_github.py`` fixture (monkeypatched SSRF guard +
+single registered POST URL + body capture from `responses.calls[0]`).
+
+**Learning:** Two reinforcing lessons:
+
+  (a) **Inline code spans and fenced code blocks are *separate*
+      defence boundaries from "raw HTML / Markdown links / table
+      cells" — and they require separate defences.** The 2026-05-09
+      stats-dashboard round pinned ``escape_markdown`` /
+      ``escape_markdown_cell`` for the bold-header / table-cell
+      sinks; this round pins ``safe_markdown_codespan`` for the
+      inline-code-span / fenced-code-block sinks. CommonMark's
+      "backslash escapes are not active inside code spans / code
+      blocks" rule means the canonical ``escape_markdown``
+      sanitiser does *nothing* useful inside backticks — a
+      sanitised value still surfaces its embedded backtick and
+      closes the span. The helper-pair canonicalised in
+      ``src/utils/text.py`` (``escape_markdown`` /
+      ``escape_markdown_cell`` / ``safe_markdown_codespan`` /
+      ``normalise_markdown_text``) maps 1-to-1 onto the four
+      Markdown sink contexts (raw text, table cell, inline code,
+      fenced code). Audit every f-string interpolation against the
+      sink's specific defence — the wrong sanitiser is as bad as
+      no sanitiser.
+
+  (b) **The path-validator-only-checks-first-component pattern is
+      a recurring drift surface.** ``validate_path``
+      (`src/feed/config.py:208-224`) checks
+      ``rel.parts[0] in ALLOWED_ROOTS`` — every byte AFTER the
+      first component is unconstrained. This is the right shape
+      for filesystem-traversal defence (it pins the path inside
+      the repo) but the *wrong* shape for Markdown / log /
+      shell-quoting defence at downstream consumers. Every public
+      string that flows out of an env-controlled path consumer —
+      ``OUT_PATH``, ``LOG_DIR``, ``FEED_HEALTH_PATH``,
+      ``FEED_HEALTH_JSON_PATH``, ``STATE_FILE``, future env-driven
+      paths — must be sanitised at every sink that interprets the
+      value as anything other than a filesystem path. The
+      inventory test pins the audited sinks programmatically;
+      future drift trips on the test instead of waiting for the
+      next Sentinel pass.
+
 ## 2026-05-09 - Markdown Injection Sibling Drift (CWE-79 / CWE-1236-adjacent) at the Stats-Dashboard Renderer Boundary: `direction`, `provider`, `location_name` Interpolated Verbatim Into `docs/statistik.md`
 **Vulnerability:** The 2026-05-09 CSV-formula-injection round closed
 the *write* side of `data/stats/*.csv` but explicitly flagged a

--- a/src/feed/reporting.py
+++ b/src/feed/reporting.py
@@ -23,7 +23,7 @@ from ..utils.env import get_bool_env, read_secret
 from ..utils.files import atomic_write
 from ..utils.http import request_safe, session_with_retries, validate_http_url
 from ..utils.logging import sanitize_log_arg, sanitize_log_message
-from ..utils.text import escape_markdown, escape_markdown_cell
+from ..utils.text import escape_markdown, escape_markdown_cell, safe_markdown_codespan
 
 log = logging.getLogger("build_feed")
 
@@ -528,7 +528,19 @@ def render_feed_health_markdown(
     lines.append(f"- **Start:** {_format_timestamp(report.started_at)}")
     lines.append(f"- **Ende:** {_format_timestamp(report.finished_at)}")
     if report.feed_path:
-        lines.append(f"- **RSS-Datei:** `{report.feed_path}`")
+        # Security (Markdown injection at inline-code-span boundary): the
+        # ``feed_path`` string is the POSIX form of ``OUT_PATH`` resolved by
+        # ``src.feed.config.resolve_env_path`` — env-controlled (leaked CI
+        # env, compromised secret store, intentional misconfig). A literal
+        # backtick inside the value closes the inline code span and lets
+        # attacker-controlled Markdown / HTML render in the public
+        # ``docs/feed_health.md`` artefact. ``safe_markdown_codespan``
+        # replaces backticks with apostrophes and strips C0/C1 controls +
+        # Trojan-Source BiDi marks + line / paragraph separators that
+        # would otherwise split the bullet item or smuggle a fake header.
+        lines.append(
+            f"- **RSS-Datei:** `{safe_markdown_codespan(report.feed_path)}`"
+        )
     lines.append("")
 
     lines.append("## Pipeline-Kennzahlen")
@@ -1009,7 +1021,16 @@ class _GithubIssueReporter:
         lines.append(f"- **Start:** {started}")
         lines.append(f"- **Ende:** {finished}")
         if report.feed_path:
-            lines.append(f"- **Feed-Datei:** `{report.feed_path}`")
+            # Security (Markdown injection at inline-code-span boundary):
+            # see ``render_feed_health_markdown`` for the threat model. The
+            # GitHub Issue body is rendered as Markdown by the GitHub web UI
+            # and is visible to every repo watcher, so an env-controlled
+            # backtick lands a usable HTML tag (``<img onerror>`` / ``[link]
+            # (...)``) in a public artefact. ``safe_markdown_codespan``
+            # neutralises every backtick / control byte / BiDi mark.
+            lines.append(
+                f"- **Feed-Datei:** `{safe_markdown_codespan(report.feed_path)}`"
+            )
         if report.raw_item_count is not None:
             lines.append(f"- **Items (roh):** {report.raw_item_count}")
         if report.final_item_count is not None:
@@ -1055,12 +1076,32 @@ class _GithubIssueReporter:
             lines.append("## Diagnosedaten")
             lines.append("")
             lines.append("```text")
-            lines.append(diagnostics)
+            # Security (fenced-code-block break-out): ``diagnostics`` carries
+            # ``feed_path`` (env-controlled via ``OUT_PATH``) verbatim. A
+            # ``\n```\n`` payload in the path would close the open fence
+            # mid-block and let arbitrary Markdown render after the break
+            # in the public GitHub Issue body. ``safe_markdown_codespan``
+            # collapses every whitespace run (including embedded newlines)
+            # to a single space so no triple-backtick can land on its own
+            # line, and replaces backticks with apostrophes as a second
+            # layer of defence. The 50 000-char cap is well above any
+            # realistic diagnostics size and well below ``_MAX_GITHUB_BODY_
+            # LENGTH = 60 000`` which a downstream call to
+            # ``_bounded_github_body`` enforces on the rendered body.
+            lines.append(safe_markdown_codespan(diagnostics, max_len=50_000))
             lines.append("```")
             lines.append("")
 
+        # Security (Markdown injection at inline-code-span boundary):
+        # ``error_log_path`` is ``Path(LOG_DIR) / "errors.log"``;
+        # ``LOG_DIR`` is env-controlled via ``src.feed.config.resolve_env_
+        # path``. A literal backtick in ``LOG_DIR`` closes the inline code
+        # span and lets attacker-controlled Markdown render in the public
+        # GitHub Issue body. ``safe_markdown_codespan`` neutralises every
+        # backtick / control byte / BiDi mark.
         lines.append(
-            f"Weitere Details finden sich in der Logdatei `{error_log_path}`."
+            "Weitere Details finden sich in der Logdatei "
+            f"`{safe_markdown_codespan(str(error_log_path))}`."
         )
 
         return "\n".join(lines).strip() + "\n"

--- a/tests/test_sentinel_reporting_codespan_injection.py
+++ b/tests/test_sentinel_reporting_codespan_injection.py
@@ -1,0 +1,321 @@
+"""Sentinel PoC: Markdown-injection at the Feed-Health / GitHub-Issue
+inline-code-span and fenced-code-block sinks in
+``src/feed/reporting.py``.
+
+Threat model
+------------
+
+``report.feed_path`` is the POSIX form of ``OUT_PATH`` (env-controlled
+via ``src.feed.config.resolve_env_path``); ``error_log_path`` is the
+POSIX form of ``LOG_DIR`` / ``errors.log`` (env-controlled via the
+same resolver). Both flow into the published artefacts:
+
+  * ``docs/feed_health.md`` (a public artefact rendered by GitHub on
+    the public repo browser).
+  * The auto-submitted GitHub Issue body (visible to every repo
+    watcher; the issue is opened on every failed feed run).
+
+Pre-fix ``render_feed_health_markdown`` (line 531) and
+``_GithubIssueReporter._build_body`` (lines 1012, 1063) interpolated
+those env-controlled paths *verbatim* inside ``\\`…\\``` inline code
+spans. A poisoned env override (leaked CI env, compromised secret
+store, intentional misconfig) carrying a literal backtick in
+``OUT_PATH`` / ``LOG_DIR`` closes the inline code span and lets the
+remainder render as arbitrary Markdown / HTML.
+
+Pre-fix ``_build_body`` (lines 1057-1059) wrapped
+``RunReport.diagnostics_message()`` inside a ``\\`\\`\\`text … \\`\\`\\```
+fenced code block. The diagnostics text contains ``f"Feed={feed_path}"``
+without sanitation; a payload carrying ``\\n\\`\\`\\`\\n`` in
+``OUT_PATH`` closes the fence mid-block and lets the remainder render
+as Markdown.
+
+The fix is to route ``feed_path`` and ``error_log_path`` (every
+inline-code-span sink) through :func:`src.utils.text.safe_markdown_codespan`,
+and to route the diagnostics text (the fenced-code-block sink) through
+the same helper with a higher length cap. The helper:
+
+  1. Strips C0/C1 controls + the canonical Trojan-Source / line-
+     terminator union (BiDi marks, ZWSP family, line/paragraph
+     separators, BOM).
+  2. Collapses whitespace to a single space (eliminates embedded
+     newlines that could break a fenced code block).
+  3. Replaces literal backticks with apostrophes (the project-wide
+     convention pinned by ``_sanitize_code_span``).
+  4. Caps length.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import responses
+
+from src.feed.reporting import (
+    FeedHealthMetrics,
+    RunReport,
+    render_feed_health_markdown,
+)
+
+
+# ---- Shared fixtures -------------------------------------------------------
+
+
+def _empty_metrics() -> FeedHealthMetrics:
+    return FeedHealthMetrics(
+        raw_items=0,
+        filtered_items=0,
+        deduped_items=0,
+        new_items=0,
+        duplicate_count=0,
+        duplicates=(),
+    )
+
+
+def _make_report(feed_path: str | None = None) -> RunReport:
+    report = RunReport(statuses=[("wl", True)])
+    report.provider_success("wl", items=0)
+    if feed_path is None:
+        report.finish(build_successful=True)
+    else:
+        report.finish(build_successful=True, feed_path=Path(feed_path))
+    return report
+
+
+# ---- render_feed_health_markdown — feed_path inline-code-span --------------
+
+
+def test_feed_health_markdown_feed_path_backtick_breaks_inline_code_span() -> None:
+    """A backtick in ``feed_path`` MUST NOT break out of the inline code
+    span at line 531. Pre-fix the literal backtick closed the span and
+    let attacker-controlled Markdown render verbatim.
+    """
+    payload = "docs/feed`<script>alert(1)</script>`.xml"
+    report = _make_report(feed_path=payload)
+    markdown = render_feed_health_markdown(report, _empty_metrics())
+
+    # Locate the bullet line that interpolates feed_path.
+    bullet_line = next(
+        line for line in markdown.splitlines() if "RSS-Datei" in line
+    )
+    # Post-fix: the backtick is replaced with an apostrophe so the
+    # only ``\\``` characters left on the line are the opening and
+    # closing fence of the inline code span (exactly two).
+    assert bullet_line.count("`") == 2, (
+        f"Inline code span MUST contain exactly two backticks "
+        f"(opening + closing). Pre-fix the embedded backtick made it "
+        f"four. Got: {bullet_line!r}"
+    )
+    # The safe form replaces backticks with apostrophes so the whole
+    # literal stays inside one inline code span.
+    assert "feed'<script>alert(1)</script>'.xml" in bullet_line
+
+
+def test_feed_health_markdown_feed_path_newline_breaks_layout() -> None:
+    """A newline in ``feed_path`` MUST NOT split the bullet-list item
+    or smuggle a fake Markdown header.
+    """
+    payload = "docs/foo\n## INJECTED HEADER\n.xml"
+    report = _make_report(feed_path=payload)
+    markdown = render_feed_health_markdown(report, _empty_metrics())
+
+    # Post-fix: the newline is whitespace-collapsed so the ``##`` can
+    # never start a fresh line as a Markdown ATX header.
+    assert re.search(r"^## INJECTED HEADER", markdown, re.MULTILINE) is None, (
+        "Newline + ``##`` in feed_path landed an attacker-controlled H2 "
+        "header in the rendered Markdown."
+    )
+    # The literal payload-with-newline MUST NOT survive; the value
+    # collapses to a single line.
+    assert payload not in markdown
+    bullet_line = next(
+        line for line in markdown.splitlines() if "RSS-Datei" in line
+    )
+    assert "\n" not in bullet_line
+
+
+def test_feed_health_markdown_feed_path_bidi_marks_stripped() -> None:
+    """Trojan-Source BiDi marks in ``feed_path`` MUST be stripped so
+    the rendered Markdown cannot invert displayed text in feed-health
+    viewers.
+    """
+    # U+202E RIGHT-TO-LEFT OVERRIDE — the canonical CVE-2021-42574
+    # primitive. U+200B ZWSP. U+FEFF BOM.
+    payload = "docs/feed‮​﻿.xml"
+    report = _make_report(feed_path=payload)
+    markdown = render_feed_health_markdown(report, _empty_metrics())
+
+    assert "‮" not in markdown
+    assert "​" not in markdown
+    assert "﻿" not in markdown
+
+
+# ---- _GithubIssueReporter._build_body — feed_path inline-code-span ---------
+
+
+def _post_issue_capture_body(
+    monkeypatch: pytest.MonkeyPatch,
+    report: RunReport,
+) -> str:
+    """Stand up the auto-issue submitter and return the captured body.
+
+    Mirrors the existing pattern from ``test_reporting_github.py`` —
+    monkeypatches the SSRF guard, registers a responses URL, and
+    triggers ``report.log_results()`` (which calls ``_submit_github_issue``).
+    """
+    monkeypatch.setenv("FEED_GITHUB_CREATE_ISSUES", "1")
+    monkeypatch.setenv("FEED_GITHUB_REPOSITORY", "demo/repo")
+    monkeypatch.setenv("FEED_GITHUB_TOKEN", "secret-token")
+    monkeypatch.setattr("src.utils.http.validate_http_url", lambda url, **kw: url)
+
+    import sys
+    for module_name in ["src.utils.http", "utils.http"]:
+        if module_name in sys.modules:
+            monkeypatch.setattr(sys.modules[module_name], "verify_response_ip", lambda _: None)
+
+    responses.post(
+        "https://api.github.com/repos/demo/repo/issues",
+        json={"html_url": "https://github.com/demo/repo/issues/1"},
+        status=201,
+    )
+    report.log_results()
+    assert len(responses.calls) == 1, "expected exactly one POST to GitHub"
+    payload = json.loads(responses.calls[0].request.body)
+    return str(payload["body"])
+
+
+@responses.activate
+def test_github_issue_body_feed_path_backtick_breaks_inline_code_span(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backtick in ``feed_path`` MUST NOT break out of the inline
+    code span at ``_build_body`` line 1012.
+    """
+    payload = "docs/feed`<img src=x onerror=alert(1)>`.xml"
+    report = _make_report(feed_path=payload)
+    # Force log_results to submit by recording an error.
+    report.add_error_message("test error to trigger issue submission")
+
+    body = _post_issue_capture_body(monkeypatch, report)
+
+    feed_line = next(
+        line for line in body.splitlines() if "Feed-Datei" in line
+    )
+    # Post-fix the inline code span has exactly two backticks (open + close).
+    assert feed_line.count("`") == 2, (
+        f"GitHub Issue body Feed-Datei line MUST keep its inline code "
+        f"span intact (exactly two backticks). Got: {feed_line!r}"
+    )
+    assert "feed'<img src=x onerror=alert(1)>'.xml" in feed_line
+
+
+@responses.activate
+def test_github_issue_body_error_log_path_backtick_breaks_inline_code_span(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backtick in ``error_log_path`` (env-controlled via ``LOG_DIR``)
+    MUST NOT break out of the inline code span at ``_build_body``
+    line 1063.
+    """
+    # We cannot simply set LOG_DIR via env here because the path is
+    # imported at module load time. Instead we monkeypatch the imported
+    # reference inside reporting so the test exercises the real sink.
+    poisoned_path = Path("log`<script>alert('xss')</script>`/errors.log")
+    import src.feed.reporting as reporting_module
+    monkeypatch.setattr(reporting_module, "error_log_path", poisoned_path)
+
+    report = _make_report()
+    report.add_error_message("test error to trigger issue submission")
+
+    body = _post_issue_capture_body(monkeypatch, report)
+
+    log_line = next(
+        line for line in body.splitlines() if "Logdatei" in line
+    )
+    # Post-fix the inline code span has exactly two backticks
+    # (the opening + closing fence) — no embedded backtick from the
+    # poisoned path closes the span early.
+    assert log_line.count("`") == 2, (
+        f"GitHub Issue body Logdatei line MUST keep its inline code "
+        f"span intact. Got: {log_line!r}"
+    )
+    assert "<script>alert('xss')</script>" in log_line, (
+        "Sanity check: the safe form preserves the literal text inside "
+        "the inline code span (rendered as code, not as HTML)."
+    )
+    # The two backticks belong to the inline code span; no markdown
+    # link / bold / header escapes the span.
+    assert "**" not in log_line.replace("**Logdatei**", "")
+
+
+@responses.activate
+def test_github_issue_body_feed_path_fence_break_via_newline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A newline + triple-backtick in ``feed_path`` MUST NOT close the
+    diagnostics fenced code block at ``_build_body`` lines 1057-1059.
+    """
+    # Newline + ``` on its own line → CommonMark closes the open
+    # fence. Anything after renders as Markdown.
+    payload = "docs/feed.xml\n```\n# INJECTED H1\n```"
+    report = _make_report(feed_path=payload)
+    report.add_error_message("test error to trigger issue submission")
+
+    body = _post_issue_capture_body(monkeypatch, report)
+
+    # Post-fix: the diagnostics block is wrapped in ``\\``\\``\\``text`` /
+    # ``\\``\\``\\``` and contains a single line of (collapsed-whitespace
+    # + apostrophe-replaced) text. No ``\\``\\``\\``` sits on its own line
+    # *inside* the fence, so the fence stays open until the explicit
+    # closing fence emitted by ``_build_body``.
+    fence_count = body.count("```")
+    assert fence_count == 2, (
+        f"Diagnostics fenced code block MUST emit exactly two ``\\``\\``\\``` "
+        f"fences (open + close). Pre-fix the newline+triple-backtick in "
+        f"feed_path injected extra fences. Got fence_count={fence_count}."
+    )
+    # No fresh-line H1 / H2 may appear; payload's ``# INJECTED H1`` MUST
+    # be on the SAME line as the surrounding diagnostics text.
+    for line in body.splitlines():
+        # A standalone ATX-H1 header from the payload is the failure
+        # signature.
+        assert not line.lstrip().startswith("# INJECTED H1"), (
+            f"Standalone H1 escaped the diagnostics fence: {line!r}"
+        )
+
+
+# ---- Inventory invariant ---------------------------------------------------
+
+
+def test_inline_code_span_sinks_inventory_pinned() -> None:
+    """Inventory invariant: the three operator-controlled inline-code-
+    span sinks in ``src/feed/reporting.py`` MUST route through a
+    backtick-stripping sanitiser.
+
+    A future refactor that introduces a fourth ``\\`…\\``` inline code
+    span sourced from an env-controlled string (``OUT_PATH``,
+    ``LOG_DIR``, ``FEED_HEALTH_PATH``, …) without going through
+    :func:`src.utils.text.safe_markdown_codespan` re-opens the
+    Markdown-injection vector. This test fails on any drift away from
+    the canonical helper for the audited sinks.
+    """
+    reporting_src = Path("src/feed/reporting.py").read_text(encoding="utf-8")
+
+    # The three audited sinks must reference safe_markdown_codespan
+    # in their immediate textual neighbourhood.
+    assert "safe_markdown_codespan(report.feed_path" in reporting_src or \
+        "safe_markdown_codespan(\n            report.feed_path" in reporting_src or \
+        "safe_markdown_codespan(_path)" in reporting_src or \
+        "safe_path = safe_markdown_codespan" in reporting_src, (
+        "feed_path inline-code-span sinks must route through "
+        "safe_markdown_codespan."
+    )
+    assert "safe_markdown_codespan(str(error_log_path)" in reporting_src or \
+        "safe_markdown_codespan(error_log" in reporting_src or \
+        "safe_log_path = safe_markdown_codespan" in reporting_src, (
+        "error_log_path inline-code-span sink must route through "
+        "safe_markdown_codespan."
+    )


### PR DESCRIPTION
## Summary

`render_feed_health_markdown` (line 531) and `_GithubIssueReporter._build_body` (lines 1012, 1057-1059, 1063) interpolated two **env-controlled** paths — `report.feed_path` (POSIX form of `OUT_PATH`) and `error_log_path` (POSIX form of `LOG_DIR`/`errors.log`) — verbatim inside inline `` `…` `` code spans and a ```` ```text … ``` ```` fenced code block. `validate_path` only constrains the first path component against `ALLOWED_ROOTS = {"docs", "data", "log"}`; backticks, newlines, BiDi marks, and line/paragraph separators in the rest of the path survive into the renderers.

### Threat

The rendered Markdown lands in two highest-visibility human-facing artefacts:

1. **`docs/feed_health.md`** — auto-committed by the workflow, rendered by GitHub on the public repo browser, by every operator's IDE / Markdown viewer, by any static-site builder downstream.
2. **The auto-submitted GitHub Issue body** — opened on every failed feed run, visible to every repo watcher.

Three orthogonal Markdown break-out axes:

| # | Primitive | Effect |
|---|-----------|--------|
| (a) | Backtick in `feed_path` / `error_log_path` | Closes the inline code span; lands a usable HTML tag (`<img onerror>`, `<script>`) or Markdown link in the public artefact |
| (b) | Newline + `## Header` in `feed_path` | Splits the bullet item; surfaces an attacker-controlled ATX header in the Feed-Health report |
| (c) | Newline + ```` ``` ```` in `feed_path` | Closes the diagnostics fenced code block mid-content; arbitrary Markdown / HTML renders after the fence break inside the GitHub Issue body |

Threat sources mirror every prior env-override round (leaked CI env, compromised secret store, intentional misconfig, partial flush + power loss on `.env` write).

### Fix

Five context-specific applications of the canonical `safe_markdown_codespan` helper from `src/utils/text.py:412-425` (the helper introduced by the 2026-05-09 stats-dashboard Markdown-injection round):

- `render_feed_health_markdown` line 531: `feed_path` inline code span.
- `_build_body` line 1012: `feed_path` inline code span.
- `_build_body` line 1057-1059: diagnostics fenced code block (`max_len=50_000` — well above realistic diagnostics size, well below `_MAX_GITHUB_BODY_LENGTH = 60_000`).
- `_build_body` line 1063: `error_log_path` inline code span.

`safe_markdown_codespan` strips C0/C1 controls + Trojan-Source / line-terminator union (BiDi marks, ZWSP family, line/paragraph separators, BOM) via `normalise_markdown_text`, collapses every whitespace run to a single space, and replaces literal backticks with the project-wide apostrophe convention pinned by `_sanitize_code_span`.

### Tests (+7 new pytest cases)

`tests/test_sentinel_reporting_codespan_injection.py`:

- `test_feed_health_markdown_feed_path_backtick_breaks_inline_code_span`
- `test_feed_health_markdown_feed_path_newline_breaks_layout`
- `test_feed_health_markdown_feed_path_bidi_marks_stripped`
- `test_github_issue_body_feed_path_backtick_breaks_inline_code_span`
- `test_github_issue_body_error_log_path_backtick_breaks_inline_code_span`
- `test_github_issue_body_feed_path_fence_break_via_newline`
- `test_inline_code_span_sinks_inventory_pinned` — pins the canonical helper at every audited sink so future drift trips on the inventory test instead of waiting for the next Sentinel pass.

All seven verified to **fail** on the pre-fix code and **pass** on the post-fix code. Full local pytest run: **2521 passed, 4 skipped**. `python scripts/run_static_checks.py` mypy / ruff / bandit / scan_secrets / C901 / pip-audit gates pass at the project-pinned versions.

## Test plan

- [x] Run `python -m pytest tests/test_sentinel_reporting_codespan_injection.py -v` — 7/7 PASS post-fix
- [x] Run full `python -m pytest -q` — 2521 passed, 4 skipped, no regressions
- [x] Run `python scripts/run_static_checks.py` — ruff / mypy (1.10) / bandit / secret-scan / C901 / pip-audit all green
- [ ] CI green (waiting on this PR's checks)

🛡️ Sentinel auto-generated security PR.

https://claude.ai/code/session_016W7m3vQf1PqMxwFjWp6rcG

---
_Generated by [Claude Code](https://claude.ai/code/session_016W7m3vQf1PqMxwFjWp6rcG)_