### PR TITLE
diag(stammstrecke): log HTTP status code + VAO errorCode on /trip failure

### DIFF
--- a/scripts/update_stammstrecke_status.py
+++ b/scripts/update_stammstrecke_status.py
@@ -101,7 +101,7 @@ from contextlib import ExitStack
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, TypeGuard
+from typing import Any, Final, TypeGuard
 from zoneinfo import ZoneInfo
 
 import requests
@@ -803,6 +803,68 @@ def _write_cache(payload: list[dict[str, Any]]) -> None:
         fh.write("\n")
 
 
+# Hard cap on the ``errorCode`` string length. Real VAO codes are
+# ~4-8 chars (``H890``, ``H892``, ``H730``, ``SVC_LOC_INVALID``); the
+# 64-char ceiling is generous headroom while preventing a planted
+# upstream from poisoning a structured log record with a multi-KiB
+# blob via the otherwise-trusted error-body extraction path.
+_ERROR_CODE_MAX_LEN: Final = 64
+
+# Hard cap on the JSON body we will load into memory before scanning
+# for ``errorCode``. The legitimate VAO error envelope is <1 KiB; 16
+# KiB is ~16x headroom for any plausible future evolution while still
+# preventing a planted upstream from amplifying the diagnostic-logging
+# branch into a memory-pressure DoS. ``response.content`` would
+# otherwise materialise the entire (potentially huge) error body.
+_ERROR_BODY_MAX_BYTES: Final = 16 * 1024
+
+
+def _extract_http_status(exc: requests.HTTPError) -> str:
+    """Return the HTTP status code from *exc* as a stringy diagnostic.
+
+    Falls back to ``"<no-response>"`` when the exception carries no
+    response object (network-level failure, redirect-loop break, etc.).
+    """
+    response = getattr(exc, "response", None)
+    if response is None:
+        return "<no-response>"
+    status = getattr(response, "status_code", None)
+    if not isinstance(status, int):
+        return "<unknown>"
+    return str(status)
+
+
+def _extract_vao_error_code(exc: requests.HTTPError) -> str:
+    """Return the ``errorCode`` from a VAO error-envelope JSON body.
+
+    Falls back to ``"<unknown>"`` for every failure mode (no response,
+    body too large, body not JSON, body not a mapping, errorCode field
+    absent or non-stringy). Bounded by :data:`_ERROR_BODY_MAX_BYTES` on
+    the wire and :data:`_ERROR_CODE_MAX_LEN` on the rendered string.
+    """
+    response = getattr(exc, "response", None)
+    if response is None:
+        return "<unknown>"
+    raw = getattr(response, "content", None)
+    if not isinstance(raw, (bytes, bytearray)):
+        return "<unknown>"
+    if len(raw) == 0 or len(raw) > _ERROR_BODY_MAX_BYTES:
+        return "<unknown>"
+    try:
+        body = _json_lib.loads(raw)
+    except (ValueError, RecursionError, UnicodeDecodeError):
+        return "<unknown>"
+    if not isinstance(body, Mapping):
+        return "<unknown>"
+    raw_code = body.get("errorCode") or body.get("error")
+    if not isinstance(raw_code, str):
+        return "<unknown>"
+    code = raw_code.strip()
+    if not code:
+        return "<unknown>"
+    return code[:_ERROR_CODE_MAX_LEN]
+
+
 def _process_direction(
     session: requests.Session,
     direction: _Direction,
@@ -846,6 +908,26 @@ def _process_direction(
             sanitize_log_arg(str(exc)),
         )
         return None, "quota_exceeded"
+    except requests.HTTPError as exc:
+        # Diagnostic-rich branch for non-2xx responses. Logs the HTTP
+        # status code and the VAO-supplied ``errorCode`` from the JSON
+        # body when the response is parseable. Both fields are safe to
+        # surface (no URL — therefore no ``accessId`` — and no free-form
+        # text that could echo upstream-controlled secrets). The
+        # ``errorText``/``errorMsg`` fields are deliberately NOT logged
+        # because some HAFAS peers echo the supplied ``accessId`` back
+        # into the human-readable message; the canonical ``errorCode``
+        # plus status code is sufficient to triage every documented
+        # VAO failure shape.
+        status_code = _extract_http_status(exc)
+        error_code = _extract_vao_error_code(exc)
+        LOGGER.warning(
+            "Stammstrecke: Abfrage Richtung %s fehlgeschlagen: HTTP %s (errorCode=%s).",
+            direction.target_label,
+            status_code,
+            sanitize_log_arg(error_code),
+        )
+        return None, "error"
     except Exception as exc:
         # Security: never log the full exception via ``%s`` / ``exc_info``
         # — ``VorAuth`` injected the ``accessId`` into the prepared

--- a/tests/scripts/test_update_stammstrecke_status.py
+++ b/tests/scripts/test_update_stammstrecke_status.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import requests
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -409,6 +410,133 @@ def test_leg_departure_delay_skips_unparseable_realtime() -> None:
         },
     }
     assert script._leg_departure_delay_minutes(leg) is None
+
+
+# ---- HTTPError diagnostic helpers -----------------------------------------
+
+
+def _make_http_error(
+    *, status_code: int | None, body: bytes | None
+) -> requests.HTTPError:
+    """Construct a :class:`requests.HTTPError` whose ``response`` carries
+    *status_code* and *body*. Used to exercise the diagnostic-extraction
+    helpers without standing up a real HTTP roundtrip.
+    """
+
+    response = requests.Response()
+    if status_code is not None:
+        response.status_code = status_code
+    if body is not None:
+        response._content = body
+    err = requests.HTTPError("simulated", response=response)
+    return err
+
+
+def test_extract_http_status_returns_status_code() -> None:
+    err = _make_http_error(status_code=429, body=b"")
+    assert script._extract_http_status(err) == "429"
+
+
+def test_extract_http_status_falls_back_when_no_response() -> None:
+    err = requests.HTTPError("network failure", response=None)
+    assert script._extract_http_status(err) == "<no-response>"
+
+
+def test_extract_vao_error_code_parses_canonical_envelope() -> None:
+    """A documented VAO error envelope is rendered as its ``errorCode``."""
+
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps(
+            {"errorCode": "H890", "errorText": "no journey found"}
+        ).encode("utf-8"),
+    )
+    assert script._extract_vao_error_code(err) == "H890"
+
+
+def test_extract_vao_error_code_falls_back_to_error_field() -> None:
+    """Some VAO peers use ``error`` instead of ``errorCode``."""
+
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps({"error": "SVC_LOC_INVALID"}).encode("utf-8"),
+    )
+    assert script._extract_vao_error_code(err) == "SVC_LOC_INVALID"
+
+
+def test_extract_vao_error_code_caps_oversize_string() -> None:
+    """A planted multi-KiB ``errorCode`` is truncated to the canonical
+    cap so a poisoned upstream cannot pollute structured logs."""
+
+    huge = "X" * 5000
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps({"errorCode": huge}).encode("utf-8"),
+    )
+    code = script._extract_vao_error_code(err)
+    assert len(code) == script._ERROR_CODE_MAX_LEN
+    assert code == "X" * script._ERROR_CODE_MAX_LEN
+
+
+def test_extract_vao_error_code_caps_oversize_body() -> None:
+    """A planted multi-MiB body is rejected before JSON parsing."""
+
+    huge_body = b'{"errorCode": "H890", "padding": "' + b"X" * 65536 + b'"}'
+    err = _make_http_error(status_code=400, body=huge_body)
+    assert script._extract_vao_error_code(err) == "<unknown>"
+
+
+def test_extract_vao_error_code_returns_unknown_for_non_json_body() -> None:
+    err = _make_http_error(
+        status_code=500, body=b"<html>internal server error</html>"
+    )
+    assert script._extract_vao_error_code(err) == "<unknown>"
+
+
+def test_extract_vao_error_code_returns_unknown_for_non_dict_body() -> None:
+    """A list / scalar at the top level is not a VAO error envelope."""
+
+    err = _make_http_error(status_code=400, body=b'["H890"]')
+    assert script._extract_vao_error_code(err) == "<unknown>"
+
+
+def test_extract_vao_error_code_returns_unknown_for_no_response() -> None:
+    err = requests.HTTPError("network failure", response=None)
+    assert script._extract_vao_error_code(err) == "<unknown>"
+
+
+def test_process_direction_logs_status_and_error_code_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    _stable_now: datetime,
+) -> None:
+    """The new HTTPError branch in :func:`_process_direction` must surface
+    BOTH the HTTP status code and the VAO ``errorCode`` so the next
+    workflow run reveals which failure mode tripped the request without
+    leaking the post-VorAuth URL."""
+
+    err = _make_http_error(
+        status_code=401,
+        body=json.dumps({"errorCode": "H730"}).encode("utf-8"),
+    )
+
+    def boom(*args: object, **kwargs: object) -> object:
+        raise err
+
+    monkeypatch.setattr(script, "_query_trips", boom)
+
+    with caplog.at_level(logging.WARNING, logger="update_stammstrecke_status"):
+        event, status = script._process_direction(
+            session=requests.Session(),
+            direction=script.DIRECTIONS[0],
+            when=_stable_now,
+            previous_first_seen={},
+        )
+    assert event is None
+    assert status == "error"
+    rendered = "\n".join(record.getMessage() for record in caplog.records)
+    assert "HTTP 401" in rendered
+    assert "H730" in rendered
 
 
 def test_collect_delays_rejects_multi_ride_leg_trips() -> None:


### PR DESCRIPTION
## Summary

Production-Cron beobachtet jetzt nach der pyhafas→VOR-Migration zwei aufeinanderfolgende `HTTPError`s pro Stammstrecke-Lauf:

```
WARNING: Stammstrecke: Abfrage Richtung Meidling fehlgeschlagen: HTTPError.
WARNING: Stammstrecke: Abfrage Richtung Floridsdorf fehlgeschlagen: HTTPError.
```

Der bare Klassenname reicht nicht für eine Diagnose — Auth-Problem? Quota? Falsche Parameter? Endpoint-Mismatch? Die existierende Logging-Logik unterdrückt diese Info bewusst, weil `RequestException.__str__` die Post-`VorAuth`-URL inklusive `accessId` enthalten kann.

Dieser PR fügt eine **diagnose-reiche `except requests.HTTPError`-Branch** hinzu, die zwei sichere Fields exponiert:

1. **HTTP-Status-Code** aus `response.status_code` (Integer, niemals user-controlled).
2. **VAO-`errorCode`** aus dem JSON-Body (z. B. `H890`, `H730`, `SVC_LOC_INVALID`).

Was bleibt unsichtbar:
- Die URL → kein `accessId`-Leak.
- `errorText`/`errorMsg` → manche HAFAS-Peers echoen den `accessId` in human-readable Texten zurück.

### Sicherheitshärtung der neuen Helpers

| Cap | Wert | Schutz vor |
| --- | ---- | ---------- |
| `_ERROR_BODY_MAX_BYTES` | 16 KiB | Multi-MiB-Body → Memory-DoS via diagnostic-logging |
| `_ERROR_CODE_MAX_LEN` | 64 Zeichen | Multi-KiB-`errorCode` → Log-Record-Poisoning |

Alle Failure-Modi (kein Response, Body zu groß, kein JSON, keine Mapping, fehlende Field) → Sentinel `"<unknown>"`. Die Diagnose-Branch ist selbst crash-frei.

### Test-Coverage (10 neue Tests)

| Test | Zweck |
| ---- | ----- |
| `test_extract_http_status_returns_status_code` | Glücksfall: 429 → "429" |
| `test_extract_http_status_falls_back_when_no_response` | Network-Failure ohne Response |
| `test_extract_vao_error_code_parses_canonical_envelope` | `{"errorCode": "H890"}` |
| `test_extract_vao_error_code_falls_back_to_error_field` | `{"error": "..."}` Variante |
| `test_extract_vao_error_code_caps_oversize_string` | 5000-char `errorCode` → 64 chars |
| `test_extract_vao_error_code_caps_oversize_body` | 64 KiB Body → "<unknown>" |
| `test_extract_vao_error_code_returns_unknown_for_non_json_body` | HTML-Body |
| `test_extract_vao_error_code_returns_unknown_for_non_dict_body` | Top-Level Liste |
| `test_extract_vao_error_code_returns_unknown_for_no_response` | exc.response is None |
| `test_process_direction_logs_status_and_error_code_on_http_error` | End-to-End: HTTP 401 + H730 → beide im Log |

### Bewusste Nicht-Änderungen

Dieser PR **ändert die Request-Payload nicht** (numF, maxChange, format). Das Ziel ist, **erst** genug Diagnose zu exponieren, **dann** den nächsten Cron-Run zu beobachten, **danach** einen gezielten Fix zu landen. Speculative parameter changes ohne Beweis würden riskieren, das echte Problem zu kaschieren.

### Nächste Schritte (nach Merge)

1. Warten auf den nächsten 30-Min-Cron-Tick (oder manueller `Actions → Update Stammstrecke status → Run workflow`).
2. Logs anschauen: erwarteter Output etwa `HTTP 401 (errorCode=H730)` (Auth-Fehler) oder `HTTP 400 (errorCode=H890)` (kein Trip gefunden) oder `HTTP 429 (errorCode=...)` (Rate-Limit).
3. Auf Basis des Status+Code einen gezielten Fix-PR landen.

## Verifikation lokal

- `pytest tests/scripts/test_update_stammstrecke_status.py` → **81 passed** (war 71, +10)
- `mypy --strict --explicit-package-bases scripts/ tests/scripts/` → no issues
- `python -m src.cli checks` → ruff + mypy + bandit + secret-scan + complexity-gate alle grün

https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr)_