### PR TITLE
fix(stammstrecke): use originExtId/destExtId; tighten errorCode regex; log body-keys

### DIFF
--- a/scripts/update_stammstrecke_status.py
+++ b/scripts/update_stammstrecke_status.py
@@ -364,10 +364,30 @@ def _query_trips(
 
     safe_timeout = max(1, min(timeout, MAX_QUERY_TIMEOUT))
 
+    # Param-naming notes for the VAO ``/trip`` endpoint (Senior-API-
+    # Integration audit, 2026-05-09):
+    #
+    # * ``originExtId`` / ``destExtId`` — the VAO ReST API distinguishes
+    #   between the HAFAS-internal location ID (``originId``, full
+    #   ``A=1@O=...@L=...`` shape returned by ``location.name``) and the
+    #   external station code (``originExtId``, the bare numeric IBNR-
+    #   style ID like ``490033400``). ``data/stations.json`` stores
+    #   ``vor_id`` in the ExtId shape, so we must use the ``ExtId``
+    #   parameter family — passing the bare numeric to ``originId``
+    #   triggers HTTP 400 with the accessId echoed in the error body
+    #   (the strict validator rejects the malformed ``originId`` and
+    #   includes the supplied accessId in its diagnostic).
+    # * ``format=json`` — VAO defaults to XML, which clashes with our
+    #   JSON-parsing code path. Both the query parameter AND the
+    #   ``Accept: application/json`` request header are sent so the
+    #   negotiation is unambiguous.
+    # * ``date`` / ``time`` — explicitly pinned to the current Vienna
+    #   wall clock so the upstream cannot drift to UTC or fail to
+    #   infer "now".
     params: dict[str, str] = {
         "format": "json",
-        "originId": direction.origin_id,
-        "destId": direction.destination_id,
+        "originExtId": direction.origin_id,
+        "destExtId": direction.destination_id,
         "date": when.strftime("%Y-%m-%d"),
         "time": when.strftime("%H:%M"),
         "numF": str(MAX_TRIPS_PER_QUERY),
@@ -388,6 +408,9 @@ def _query_trips(
         session,
         endpoint,
         params=params,
+        # Explicit content negotiation belt-and-suspenders alongside
+        # the ``format=json`` query parameter.
+        headers={"Accept": "application/json"},
         timeout=safe_timeout,
         allowed_content_types=("application/json",),
     )
@@ -818,6 +841,27 @@ _ERROR_CODE_MAX_LEN: Final = 64
 # otherwise materialise the entire (potentially huge) error body.
 _ERROR_BODY_MAX_BYTES: Final = 16 * 1024
 
+# Strict character whitelist for the rendered ``errorCode``. Real VAO
+# codes are ``[A-Za-z][A-Za-z0-9_]*`` shape (``H890``, ``H892``,
+# ``H730``, ``SVC_LOC_INVALID``, ``API_GEN``…). The 2026-05-09 cron
+# run revealed that the upstream sometimes echoes the supplied
+# ``accessId`` into the ``errorCode`` field on bad-request responses
+# (``HTTP 400`` with the accessId verbatim in the body — GitHub
+# Actions then masked the log line as ``errorCode=***``, defeating
+# the purpose of the diagnostic). The strict regex bails to
+# ``"<malformed>"`` whenever the upstream value is not a canonical
+# short code, so the diagnostic CANNOT inadvertently surface
+# user-supplied or upstream-echoed secrets even when GitHub Actions'
+# secret-masker is unavailable.
+_VAO_ERROR_CODE_RE: Final = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,31}$")
+
+# Hard cap on the rendered body-keys diagnostic. Real VAO error
+# envelopes carry ~3-5 top-level keys (``errorCode``, ``errorText``,
+# ``Message``, ``serverVersion``, ``planRtTs``); 256 chars is generous
+# headroom while bounding the worst case where a planted upstream
+# returns thousands of single-letter top-level keys.
+_BODY_KEYS_MAX_LEN: Final = 256
+
 
 def _extract_http_status(exc: requests.HTTPError) -> str:
     """Return the HTTP status code from *exc* as a stringy diagnostic.
@@ -834,27 +878,45 @@ def _extract_http_status(exc: requests.HTTPError) -> str:
     return str(status)
 
 
-def _extract_vao_error_code(exc: requests.HTTPError) -> str:
-    """Return the ``errorCode`` from a VAO error-envelope JSON body.
+def _decode_error_body(exc: requests.HTTPError) -> Mapping[str, Any] | None:
+    """Decode the response body as a top-level JSON mapping, or return ``None``.
 
-    Falls back to ``"<unknown>"`` for every failure mode (no response,
-    body too large, body not JSON, body not a mapping, errorCode field
-    absent or non-stringy). Bounded by :data:`_ERROR_BODY_MAX_BYTES` on
-    the wire and :data:`_ERROR_CODE_MAX_LEN` on the rendered string.
+    Bounded by :data:`_ERROR_BODY_MAX_BYTES` to prevent a planted
+    upstream from amplifying the diagnostic-logging branch into a
+    memory-pressure DoS.
     """
     response = getattr(exc, "response", None)
     if response is None:
-        return "<unknown>"
+        return None
     raw = getattr(response, "content", None)
     if not isinstance(raw, (bytes, bytearray)):
-        return "<unknown>"
+        return None
     if len(raw) == 0 or len(raw) > _ERROR_BODY_MAX_BYTES:
-        return "<unknown>"
+        return None
     try:
         body = _json_lib.loads(raw)
     except (ValueError, RecursionError, UnicodeDecodeError):
-        return "<unknown>"
+        return None
     if not isinstance(body, Mapping):
+        return None
+    return body
+
+
+def _extract_vao_error_code(exc: requests.HTTPError) -> str:
+    """Return the ``errorCode`` from a VAO error-envelope JSON body.
+
+    Strict-match against :data:`_VAO_ERROR_CODE_RE` (canonical short
+    HAFAS code shape) — a value that does not match (e.g. a free-form
+    error message that happens to echo upstream-controlled content,
+    including the supplied ``accessId``) collapses to ``"<malformed>"``
+    rather than risking a secret leak through the diagnostic line.
+
+    Falls back to ``"<unknown>"`` for every other failure mode (no
+    response, body too large, body not JSON, body not a mapping,
+    errorCode field absent or non-stringy).
+    """
+    body = _decode_error_body(exc)
+    if body is None:
         return "<unknown>"
     raw_code = body.get("errorCode") or body.get("error")
     if not isinstance(raw_code, str):
@@ -862,7 +924,50 @@ def _extract_vao_error_code(exc: requests.HTTPError) -> str:
     code = raw_code.strip()
     if not code:
         return "<unknown>"
+    if not _VAO_ERROR_CODE_RE.match(code):
+        # Defensive bail: the upstream value is NOT a canonical short
+        # code — most plausibly a verbose error message whose contents
+        # cannot be safely surfaced. The body-keys diagnostic from
+        # :func:`_describe_error_body_keys` will still expose enough
+        # structural shape information to triage the failure.
+        return "<malformed>"
     return code[:_ERROR_CODE_MAX_LEN]
+
+
+def _describe_error_body_keys(exc: requests.HTTPError) -> str:
+    """Return a comma-separated list of top-level keys from the JSON body.
+
+    The keys are alphabetised so the diagnostic is stable across
+    runs, capped at :data:`_BODY_KEYS_MAX_LEN` chars to bound a
+    planted-huge-key-set body, and filtered through
+    :func:`_VAO_ERROR_CODE_RE` so a top-level key whose name itself
+    smuggles upstream-controlled content (an unusual but possible
+    shape) does not slip into the log line. Keys that do NOT match
+    the canonical HAFAS field-name pattern are rendered as
+    ``"<???>"`` so the diagnostic still indicates "the body has N
+    fields" without exposing what they are.
+
+    Falls back to ``"<no-body>"`` for non-JSON / non-mapping / oversize
+    payloads, mirroring :func:`_extract_vao_error_code`.
+    """
+    body = _decode_error_body(exc)
+    if body is None:
+        return "<no-body>"
+    keys: list[str] = []
+    # ``Mapping[str, Any]`` from ``_decode_error_body`` guarantees the
+    # iteration yields ``str`` keys; we only need to gate against the
+    # canonical-shape regex.
+    for key in body.keys():
+        stripped = key.strip()
+        if _VAO_ERROR_CODE_RE.match(stripped):
+            keys.append(stripped)
+        else:
+            keys.append("<???>")
+    keys.sort()
+    rendered = ",".join(keys) or "<empty>"
+    if len(rendered) > _BODY_KEYS_MAX_LEN:
+        return rendered[:_BODY_KEYS_MAX_LEN] + "…"
+    return rendered
 
 
 def _process_direction(
@@ -910,22 +1015,25 @@ def _process_direction(
         return None, "quota_exceeded"
     except requests.HTTPError as exc:
         # Diagnostic-rich branch for non-2xx responses. Logs the HTTP
-        # status code and the VAO-supplied ``errorCode`` from the JSON
-        # body when the response is parseable. Both fields are safe to
-        # surface (no URL — therefore no ``accessId`` — and no free-form
-        # text that could echo upstream-controlled secrets). The
-        # ``errorText``/``errorMsg`` fields are deliberately NOT logged
-        # because some HAFAS peers echo the supplied ``accessId`` back
-        # into the human-readable message; the canonical ``errorCode``
-        # plus status code is sufficient to triage every documented
-        # VAO failure shape.
+        # status code, the canonical-short VAO ``errorCode`` from the
+        # JSON body when present, and the body's top-level key set.
+        # All three fields are safe to surface (no URL → no
+        # ``accessId`` leak; ``errorCode`` is regex-validated against
+        # the canonical HAFAS short-code shape; key names go through
+        # the same regex filter). The ``errorText``/``errorMsg``
+        # fields are deliberately NOT logged because some HAFAS peers
+        # echo the supplied ``accessId`` back into the human-readable
+        # message; the structured fields suffice for triage.
         status_code = _extract_http_status(exc)
         error_code = _extract_vao_error_code(exc)
+        body_keys = _describe_error_body_keys(exc)
         LOGGER.warning(
-            "Stammstrecke: Abfrage Richtung %s fehlgeschlagen: HTTP %s (errorCode=%s).",
+            "Stammstrecke: Abfrage Richtung %s fehlgeschlagen: HTTP %s "
+            "(errorCode=%s, body_keys=%s).",
             direction.target_label,
             status_code,
             sanitize_log_arg(error_code),
+            sanitize_log_arg(body_keys),
         )
         return None, "error"
     except Exception as exc:

--- a/tests/scripts/test_update_stammstrecke_status.py
+++ b/tests/scripts/test_update_stammstrecke_status.py
@@ -464,18 +464,52 @@ def test_extract_vao_error_code_falls_back_to_error_field() -> None:
     assert script._extract_vao_error_code(err) == "SVC_LOC_INVALID"
 
 
-def test_extract_vao_error_code_caps_oversize_string() -> None:
-    """A planted multi-KiB ``errorCode`` is truncated to the canonical
-    cap so a poisoned upstream cannot pollute structured logs."""
+def test_extract_vao_error_code_rejects_verbose_text_with_secrets() -> None:
+    """A verbose error message that echoes upstream-controlled content
+    (e.g. the supplied ``accessId``) MUST collapse to ``<malformed>``
+    so the diagnostic line never surfaces a secret. The 2026-05-09
+    cron run revealed VAO returning bodies whose ``errorCode`` field
+    carried free-form text that GitHub Actions then masked as
+    ``errorCode=***`` — defeating the purpose of the diagnostic."""
+
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps(
+            {"errorCode": "Invalid accessId: 0123456789abcdef"}
+        ).encode("utf-8"),
+    )
+    assert script._extract_vao_error_code(err) == "<malformed>"
+
+
+def test_extract_vao_error_code_rejects_oversize_canonical_shape() -> None:
+    """A code that exceeds the canonical 32-char short-shape collapses
+    to ``<malformed>`` rather than truncate (truncating could surface
+    a partial secret if the source field was polluted)."""
 
     huge = "X" * 5000
     err = _make_http_error(
         status_code=400,
         body=json.dumps({"errorCode": huge}).encode("utf-8"),
     )
-    code = script._extract_vao_error_code(err)
-    assert len(code) == script._ERROR_CODE_MAX_LEN
-    assert code == "X" * script._ERROR_CODE_MAX_LEN
+    assert script._extract_vao_error_code(err) == "<malformed>"
+
+
+def test_extract_vao_error_code_accepts_canonical_shapes() -> None:
+    """Codes within the canonical regex are returned verbatim."""
+
+    short = "ABC_DEF_GHI_JKL_MNO_PQR_STU"  # 27 chars — within limit
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps({"errorCode": short}).encode("utf-8"),
+    )
+    assert script._extract_vao_error_code(err) == short
+
+    over = "ABC_DEF_GHI_JKL_MNO_PQR_STU_VWXYZ"  # 33 chars — over limit
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps({"errorCode": over}).encode("utf-8"),
+    )
+    assert script._extract_vao_error_code(err) == "<malformed>"
 
 
 def test_extract_vao_error_code_caps_oversize_body() -> None:
@@ -503,6 +537,52 @@ def test_extract_vao_error_code_returns_unknown_for_non_dict_body() -> None:
 def test_extract_vao_error_code_returns_unknown_for_no_response() -> None:
     err = requests.HTTPError("network failure", response=None)
     assert script._extract_vao_error_code(err) == "<unknown>"
+
+
+def test_describe_error_body_keys_renders_canonical_envelope() -> None:
+    """Top-level keys are alphabetised and comma-joined for stable diagnostic
+    output across runs."""
+
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps(
+            {"errorCode": "H890", "errorText": "no journey", "Message": []}
+        ).encode("utf-8"),
+    )
+    rendered = script._describe_error_body_keys(err)
+    assert rendered == "Message,errorCode,errorText"
+
+
+def test_describe_error_body_keys_redacts_non_canonical_key_names() -> None:
+    """A top-level key whose name is itself upstream-controlled
+    (unusual but possible) is rendered as ``<???>`` so it cannot
+    smuggle a secret into the diagnostic line."""
+
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps(
+            {"errorCode": "H890", "Invalid accessId: ABC": "leak"}
+        ).encode("utf-8"),
+    )
+    rendered = script._describe_error_body_keys(err)
+    assert "<???>" in rendered
+    assert "Invalid accessId" not in rendered
+    assert "errorCode" in rendered
+
+
+def test_describe_error_body_keys_falls_back_when_no_response() -> None:
+    err = requests.HTTPError("network failure", response=None)
+    assert script._describe_error_body_keys(err) == "<no-body>"
+
+
+def test_describe_error_body_keys_falls_back_for_non_json_body() -> None:
+    err = _make_http_error(status_code=500, body=b"<html>error</html>")
+    assert script._describe_error_body_keys(err) == "<no-body>"
+
+
+def test_describe_error_body_keys_falls_back_for_empty_object() -> None:
+    err = _make_http_error(status_code=400, body=b"{}")
+    assert script._describe_error_body_keys(err) == "<empty>"
 
 
 def test_process_direction_logs_status_and_error_code_on_http_error(
@@ -537,6 +617,9 @@ def test_process_direction_logs_status_and_error_code_on_http_error(
     rendered = "\n".join(record.getMessage() for record in caplog.records)
     assert "HTTP 401" in rendered
     assert "H730" in rendered
+    # Body-keys diagnostic must surface the canonical envelope shape
+    # without leaking any value.
+    assert "body_keys=errorCode" in rendered
 
 
 def test_collect_delays_rejects_multi_ride_leg_trips() -> None:
@@ -694,7 +777,13 @@ def test_query_timeout_bound_below_max() -> None:
 def test_query_trips_passes_canonical_parameters(
     monkeypatch: pytest.MonkeyPatch, _stable_now: datetime
 ) -> None:
-    """Pin the wire-format parameters: originId/destId/numF/maxChange/rtMode."""
+    """Pin the wire-format parameters: originExtId/destExtId/numF/maxChange/rtMode.
+
+    The 2026-05-09 audit established that the bare numeric VOR Stop ID
+    must be passed via the ``ExtId`` parameter family — the
+    HAFAS-internal ``originId``/``destId`` parameters expect the full
+    ``A=1@O=...@L=...`` shape and reject bare numerics with HTTP 400.
+    """
 
     captured: dict[str, Any] = {}
 
@@ -717,13 +806,20 @@ def test_query_trips_passes_canonical_parameters(
     assert captured["endpoint"].endswith("/trip")
     params = captured["params"]
     assert params["format"] == "json"
-    assert params["originId"] == direction.origin_id
-    assert params["destId"] == direction.destination_id
+    # External-ID parameter family is mandatory — see docstring above.
+    assert params["originExtId"] == direction.origin_id
+    assert params["destExtId"] == direction.destination_id
+    assert "originId" not in params  # HAFAS-internal form not used
+    assert "destId" not in params
     assert params["numF"] == "6"  # pinned MAX_TRIPS_PER_QUERY (VAO max)
     assert params["maxChange"] == "0"  # direct-connections-only
     assert params["rtMode"] == "SERVER_DEFAULT"
     assert params["date"] == _stable_now.strftime("%Y-%m-%d")
     assert params["time"] == _stable_now.strftime("%H:%M")
+    # Explicit Accept header for content negotiation in addition to
+    # the ``format=json`` query parameter (belt-and-suspenders so the
+    # negotiation is unambiguous).
+    assert captured["kwargs"]["headers"]["Accept"] == "application/json"
     assert captured["kwargs"]["allowed_content_types"] == ("application/json",)
     # Timeout is bound below MAX_QUERY_TIMEOUT.
     assert captured["kwargs"]["timeout"] <= script.MAX_QUERY_TIMEOUT


### PR DESCRIPTION
## Summary

Senior-API-Integration-Audit der `HTTP 400 (errorCode=***)`-Diagnose hat den Root Cause identifiziert: **Parameter-Name-Mismatch**. VAO unterscheidet zwischen:

| Parameter | Erwarteter Wert |
| --------- | --------------- |
| `originId` / `destId` | HAFAS-internal Location-ID, Form `A=1@O=Wien Floridsdorf@L=490033400@` |
| **`originExtId` / `destExtId`** | **External station code, bare numeric (z.B. `490033400`)** |

`data/stations.json` speichert `vor_id` in der **ExtId-Shape**. Das Skript muss die `ExtId`-Familie verwenden. Bare Numerics an `originId`/`destId` triggern den strict validator, der den `accessId` in seine Fehlermeldung packt — den GitHub Actions dann als `***` maskiert.

## Drei Fixes

### 1. Parameter-Namen → `originExtId` / `destExtId` (CRITICAL — Root Cause)

```diff
- "originId": direction.origin_id,
- "destId": direction.destination_id,
+ "originExtId": direction.origin_id,
+ "destExtId": direction.destination_id,
```

### 2. `format=json` beibehalten + explizit `Accept: application/json`-Header

Belt-and-suspenders content negotiation — sowohl Query-Param als auch HTTP-Header. Die VAO defaultet sonst zu XML.

### 3. Strict-Shape `errorCode`-Validation + Body-Keys-Diagnostic (Defense in Depth)

`_VAO_ERROR_CODE_RE = ^[A-Za-z][A-Za-z0-9_]{0,31}$` — canonical HAFAS-Short-Code-Shape. Verbose Texte → `<malformed>`. Damit kein Secret-Leak, selbst wenn das Upstream-Backend wieder verbose Strings zurückechoet.

Plus neue `_describe_error_body_keys`-Funktion, die die **Top-Level-Keys** des JSON-Bodys leak-frei (regex-gefiltert) ins Log schreibt:

```
HTTP 400 (errorCode=H890, body_keys=Message,errorCode,errorText).
```

## Beziehung zu (geschlossenem) PR #1386

#1386 wurde geschlossen, weil sein Premise (`format=json` entfernen) auf einer Fehlinterpretation der VAO-Doku beruhte — die echte Wurzelursache war die ID-Parameter-Familie, nicht der format-Hint. Dieser PR übernimmt aber die orthogonalen Defense-in-Depth-Verbesserungen aus #1386 (strict regex + body-keys diagnostic), weil sie unabhängig von der format-Frage nützlich sind.

## Test-Coverage

| Bereich | Tests |
| ------- | ----- |
| `_query_trips` Wire-Format | originExtId/destExtId, Accept-Header, format=json bleibt |
| `_extract_vao_error_code` Strict-Shape | 4 (verbose-mit-secret, oversize, canonical-shapes) |
| `_describe_error_body_keys` | 5 (canonical, non-canonical-key, no-response, non-JSON, empty) |
| `_process_direction` Integration | body_keys diagnostic im Log |

**Total: 88 passed** (war 81, +7 strict-validation tests).

## Lokale Verifikation

- `pytest tests/scripts/test_update_stammstrecke_status.py` → **88 passed**
- `mypy --strict` (Script + Tests) → no issues
- `python -m src.cli checks` → ruff + mypy + bandit + secret-scan + complexity-gate alle grün

## Erwarteter Effekt nach Merge

Der nächste 30-Min-Cron-Tick (oder manueller `Actions → Update Stammstrecke status → Run workflow`) sollte:
- HTTP 400 verschwindet (originExtId ist die documented Param-Family für bare numeric IDs)
- Erste echte Beobachtung in `data/stats/stammstrecke_2026.csv`
- Der nächtliche `generate-stats.yml`-Run patcht die README-Snapshot-Werte

Falls die Anfrage doch failt, liefert `body_keys=...,errorCode=...` leak-freie Triage-Daten für die nächste Iteration.

https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr)_