### PR TITLE
fix(stammstrecke): apply extId:: value-prefix; fortify HTTP 400 diagnostics

### DIFF
--- a/scripts/update_stammstrecke_status.py
+++ b/scripts/update_stammstrecke_status.py
@@ -365,29 +365,30 @@ def _query_trips(
     safe_timeout = max(1, min(timeout, MAX_QUERY_TIMEOUT))
 
     # Param-naming notes for the VAO ``/trip`` endpoint (Senior-API-
-    # Integration audit, 2026-05-09):
+    # Integration audit, 2026-05-09 — third iteration after PR #1385
+    # diagnostics + PR #1387 originExtId attempt both yielded HTTP 400):
     #
-    # * ``originExtId`` / ``destExtId`` — the VAO ReST API distinguishes
-    #   between the HAFAS-internal location ID (``originId``, full
-    #   ``A=1@O=...@L=...`` shape returned by ``location.name``) and the
-    #   external station code (``originExtId``, the bare numeric IBNR-
-    #   style ID like ``490033400``). ``data/stations.json`` stores
-    #   ``vor_id`` in the ExtId shape, so we must use the ``ExtId``
-    #   parameter family — passing the bare numeric to ``originId``
-    #   triggers HTTP 400 with the accessId echoed in the error body
-    #   (the strict validator rejects the malformed ``originId`` and
-    #   includes the supplied accessId in its diagnostic).
-    # * ``format=json`` — VAO defaults to XML, which clashes with our
-    #   JSON-parsing code path. Both the query parameter AND the
-    #   ``Accept: application/json`` request header are sent so the
-    #   negotiation is unambiguous.
+    # * **ID encoding** — VAO accepts external station IDs (bare-numeric
+    #   IBNR-style codes, e.g. ``490033400`` from ``data/stations.json``)
+    #   in two forms:
+    #     1. ``originExtId=490033400`` — DB Navigator HAFAS convention.
+    #     2. ``originId=extId::490033400`` — VAO/ÖBB convention per
+    #        Kapitel "Identifikationsarten von Ortsobjekten" (S. 19) of
+    #        the Handbuch_VAO_ReST_API_latest.pdf: the ``extId::``
+    #        prefix encodes "treat the value as an external ID". The
+    #        2026-05-09 cron runs revealed that form #1 (PR #1387)
+    #        triggered HTTP 400 with empty body on this VAO instance;
+    #        we now use form #2.
+    # * ``Accept: application/json`` header — replaces the
+    #   ``format=json`` query parameter. The trip.md curl example does
+    #   not include ``format=json``, only the Accept header; the
+    #   ``departureBoard`` endpoint is the outlier that documents both.
     # * ``date`` / ``time`` — explicitly pinned to the current Vienna
     #   wall clock so the upstream cannot drift to UTC or fail to
     #   infer "now".
     params: dict[str, str] = {
-        "format": "json",
-        "originExtId": direction.origin_id,
-        "destExtId": direction.destination_id,
+        "originId": f"extId::{direction.origin_id}",
+        "destId": f"extId::{direction.destination_id}",
         "date": when.strftime("%Y-%m-%d"),
         "time": when.strftime("%H:%M"),
         "numF": str(MAX_TRIPS_PER_QUERY),
@@ -408,8 +409,10 @@ def _query_trips(
         session,
         endpoint,
         params=params,
-        # Explicit content negotiation belt-and-suspenders alongside
-        # the ``format=json`` query parameter.
+        # Content negotiation via Accept header instead of the
+        # ``format=json`` query parameter. The trip.md curl example
+        # uses this exact pattern, and removing the query parameter
+        # eliminates one variable in the iterative HTTP 400 triage.
         headers={"Accept": "application/json"},
         timeout=safe_timeout,
         allowed_content_types=("application/json",),
@@ -863,19 +866,67 @@ _VAO_ERROR_CODE_RE: Final = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,31}$")
 _BODY_KEYS_MAX_LEN: Final = 256
 
 
+# Sentinel strings for the diagnostic logging branch.
+#
+# Why brackets-and-uppercase-words:
+# The 2026-05-09 cron run revealed that the project's ``SafeFormatter``
+# (or one of its delegated maskers) treats lowercase alphanumeric
+# tokens like ``unknown`` as "potential secret"-shaped and replaces
+# them with ``***``. The original ``<unknown>`` sentinel therefore
+# became ``***`` in the live log line, defeating the purpose of the
+# diagnostic. Switching to ``[BRACKET_TAG]``-shape tokens (uppercase,
+# underscores, hard delimiters) keeps the sentinels safely outside
+# any token-shape heuristic the masker applies.
+_DIAG_NO_RESPONSE: Final = "[NO_RESPONSE]"
+_DIAG_MISSING: Final = "[MISSING]"
+_DIAG_BAD_SHAPE: Final = "[BAD_SHAPE]"
+_DIAG_EMPTY_BODY: Final = "[EMPTY_BODY]"
+_DIAG_NO_KEYS: Final = "[NO_KEYS]"
+_DIAG_REDACTED_KEY: Final = "[REDACTED]"
+
+
 def _extract_http_status(exc: requests.HTTPError) -> str:
     """Return the HTTP status code from *exc* as a stringy diagnostic.
 
-    Falls back to ``"<no-response>"`` when the exception carries no
-    response object (network-level failure, redirect-loop break, etc.).
+    Falls back to :data:`_DIAG_NO_RESPONSE` when the exception carries
+    no response object (network-level failure, redirect-loop break,
+    etc.).
     """
     response = getattr(exc, "response", None)
     if response is None:
-        return "<no-response>"
+        return _DIAG_NO_RESPONSE
     status = getattr(response, "status_code", None)
     if not isinstance(status, int):
-        return "<unknown>"
+        return _DIAG_MISSING
     return str(status)
+
+
+def _extract_response_header(exc: requests.HTTPError, name: str) -> str:
+    """Return the value of the *name* header from *exc.response*, or a sentinel.
+
+    The headers we surface (``Content-Type``, ``Content-Length``,
+    ``Server``, ``WWW-Authenticate``) are server-set and do NOT carry
+    user-controlled content — logging them is leak-free. The value is
+    truncated at :data:`_BODY_KEYS_MAX_LEN` to bound a planted-huge-
+    header poisoning shape (an upstream that returns a multi-KiB
+    ``Server`` header would otherwise pollute the structured log
+    record).
+    """
+    response = getattr(exc, "response", None)
+    if response is None:
+        return _DIAG_NO_RESPONSE
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return _DIAG_MISSING
+    value = headers.get(name)
+    if not isinstance(value, str):
+        return _DIAG_MISSING
+    stripped = value.strip()
+    if not stripped:
+        return _DIAG_MISSING
+    if len(stripped) > _BODY_KEYS_MAX_LEN:
+        return stripped[:_BODY_KEYS_MAX_LEN] + "…"
+    return stripped
 
 
 def _decode_error_body(exc: requests.HTTPError) -> Mapping[str, Any] | None:
@@ -908,29 +959,30 @@ def _extract_vao_error_code(exc: requests.HTTPError) -> str:
     Strict-match against :data:`_VAO_ERROR_CODE_RE` (canonical short
     HAFAS code shape) — a value that does not match (e.g. a free-form
     error message that happens to echo upstream-controlled content,
-    including the supplied ``accessId``) collapses to ``"<malformed>"``
-    rather than risking a secret leak through the diagnostic line.
+    including the supplied ``accessId``) collapses to
+    :data:`_DIAG_BAD_SHAPE` rather than risking a secret leak through
+    the diagnostic line.
 
-    Falls back to ``"<unknown>"`` for every other failure mode (no
-    response, body too large, body not JSON, body not a mapping,
+    Falls back to :data:`_DIAG_MISSING` for every other failure mode
+    (no response, body too large, body not JSON, body not a mapping,
     errorCode field absent or non-stringy).
     """
     body = _decode_error_body(exc)
     if body is None:
-        return "<unknown>"
+        return _DIAG_MISSING
     raw_code = body.get("errorCode") or body.get("error")
     if not isinstance(raw_code, str):
-        return "<unknown>"
+        return _DIAG_MISSING
     code = raw_code.strip()
     if not code:
-        return "<unknown>"
+        return _DIAG_MISSING
     if not _VAO_ERROR_CODE_RE.match(code):
         # Defensive bail: the upstream value is NOT a canonical short
         # code — most plausibly a verbose error message whose contents
         # cannot be safely surfaced. The body-keys diagnostic from
         # :func:`_describe_error_body_keys` will still expose enough
         # structural shape information to triage the failure.
-        return "<malformed>"
+        return _DIAG_BAD_SHAPE
     return code[:_ERROR_CODE_MAX_LEN]
 
 
@@ -944,15 +996,15 @@ def _describe_error_body_keys(exc: requests.HTTPError) -> str:
     smuggles upstream-controlled content (an unusual but possible
     shape) does not slip into the log line. Keys that do NOT match
     the canonical HAFAS field-name pattern are rendered as
-    ``"<???>"`` so the diagnostic still indicates "the body has N
-    fields" without exposing what they are.
+    :data:`_DIAG_REDACTED_KEY` so the diagnostic still indicates
+    "the body has N fields" without exposing what they are.
 
-    Falls back to ``"<no-body>"`` for non-JSON / non-mapping / oversize
-    payloads, mirroring :func:`_extract_vao_error_code`.
+    Falls back to :data:`_DIAG_EMPTY_BODY` for non-JSON / non-mapping
+    / oversize payloads, mirroring :func:`_extract_vao_error_code`.
     """
     body = _decode_error_body(exc)
     if body is None:
-        return "<no-body>"
+        return _DIAG_EMPTY_BODY
     keys: list[str] = []
     # ``Mapping[str, Any]`` from ``_decode_error_body`` guarantees the
     # iteration yields ``str`` keys; we only need to gate against the
@@ -962,9 +1014,9 @@ def _describe_error_body_keys(exc: requests.HTTPError) -> str:
         if _VAO_ERROR_CODE_RE.match(stripped):
             keys.append(stripped)
         else:
-            keys.append("<???>")
+            keys.append(_DIAG_REDACTED_KEY)
     keys.sort()
-    rendered = ",".join(keys) or "<empty>"
+    rendered = ",".join(keys) or _DIAG_NO_KEYS
     if len(rendered) > _BODY_KEYS_MAX_LEN:
         return rendered[:_BODY_KEYS_MAX_LEN] + "…"
     return rendered
@@ -1016,24 +1068,37 @@ def _process_direction(
     except requests.HTTPError as exc:
         # Diagnostic-rich branch for non-2xx responses. Logs the HTTP
         # status code, the canonical-short VAO ``errorCode`` from the
-        # JSON body when present, and the body's top-level key set.
-        # All three fields are safe to surface (no URL → no
+        # JSON body when present, the body's top-level key set, and
+        # four server-set response headers (Content-Type,
+        # Content-Length, Server, WWW-Authenticate) so the next cron
+        # run reveals whether we are dealing with an auth rejection
+        # (401 + WWW-Authenticate set), a gateway/proxy issue (Server
+        # naming a CDN rather than the VAO origin), or a payload
+        # mismatch (Content-Type=text/html points at an HTML error
+        # page). All fields are safe to surface (no URL → no
         # ``accessId`` leak; ``errorCode`` is regex-validated against
         # the canonical HAFAS short-code shape; key names go through
-        # the same regex filter). The ``errorText``/``errorMsg``
-        # fields are deliberately NOT logged because some HAFAS peers
-        # echo the supplied ``accessId`` back into the human-readable
-        # message; the structured fields suffice for triage.
+        # the same regex filter; response headers are server-set and
+        # do not echo user-controlled content).
         status_code = _extract_http_status(exc)
         error_code = _extract_vao_error_code(exc)
         body_keys = _describe_error_body_keys(exc)
+        content_type = _extract_response_header(exc, "Content-Type")
+        content_length = _extract_response_header(exc, "Content-Length")
+        server = _extract_response_header(exc, "Server")
+        www_auth = _extract_response_header(exc, "WWW-Authenticate")
         LOGGER.warning(
             "Stammstrecke: Abfrage Richtung %s fehlgeschlagen: HTTP %s "
-            "(errorCode=%s, body_keys=%s).",
+            "(errorCode=%s, body_keys=%s, ct=%s, cl=%s, server=%s, "
+            "www_auth=%s).",
             direction.target_label,
             status_code,
             sanitize_log_arg(error_code),
             sanitize_log_arg(body_keys),
+            sanitize_log_arg(content_type),
+            sanitize_log_arg(content_length),
+            sanitize_log_arg(server),
+            sanitize_log_arg(www_auth),
         )
         return None, "error"
     except Exception as exc:

--- a/tests/scripts/test_update_stammstrecke_status.py
+++ b/tests/scripts/test_update_stammstrecke_status.py
@@ -439,7 +439,7 @@ def test_extract_http_status_returns_status_code() -> None:
 
 def test_extract_http_status_falls_back_when_no_response() -> None:
     err = requests.HTTPError("network failure", response=None)
-    assert script._extract_http_status(err) == "<no-response>"
+    assert script._extract_http_status(err) == "[NO_RESPONSE]"
 
 
 def test_extract_vao_error_code_parses_canonical_envelope() -> None:
@@ -478,7 +478,7 @@ def test_extract_vao_error_code_rejects_verbose_text_with_secrets() -> None:
             {"errorCode": "Invalid accessId: 0123456789abcdef"}
         ).encode("utf-8"),
     )
-    assert script._extract_vao_error_code(err) == "<malformed>"
+    assert script._extract_vao_error_code(err) == "[BAD_SHAPE]"
 
 
 def test_extract_vao_error_code_rejects_oversize_canonical_shape() -> None:
@@ -491,7 +491,7 @@ def test_extract_vao_error_code_rejects_oversize_canonical_shape() -> None:
         status_code=400,
         body=json.dumps({"errorCode": huge}).encode("utf-8"),
     )
-    assert script._extract_vao_error_code(err) == "<malformed>"
+    assert script._extract_vao_error_code(err) == "[BAD_SHAPE]"
 
 
 def test_extract_vao_error_code_accepts_canonical_shapes() -> None:
@@ -509,7 +509,7 @@ def test_extract_vao_error_code_accepts_canonical_shapes() -> None:
         status_code=400,
         body=json.dumps({"errorCode": over}).encode("utf-8"),
     )
-    assert script._extract_vao_error_code(err) == "<malformed>"
+    assert script._extract_vao_error_code(err) == "[BAD_SHAPE]"
 
 
 def test_extract_vao_error_code_caps_oversize_body() -> None:
@@ -517,26 +517,26 @@ def test_extract_vao_error_code_caps_oversize_body() -> None:
 
     huge_body = b'{"errorCode": "H890", "padding": "' + b"X" * 65536 + b'"}'
     err = _make_http_error(status_code=400, body=huge_body)
-    assert script._extract_vao_error_code(err) == "<unknown>"
+    assert script._extract_vao_error_code(err) == "[MISSING]"
 
 
 def test_extract_vao_error_code_returns_unknown_for_non_json_body() -> None:
     err = _make_http_error(
         status_code=500, body=b"<html>internal server error</html>"
     )
-    assert script._extract_vao_error_code(err) == "<unknown>"
+    assert script._extract_vao_error_code(err) == "[MISSING]"
 
 
 def test_extract_vao_error_code_returns_unknown_for_non_dict_body() -> None:
     """A list / scalar at the top level is not a VAO error envelope."""
 
     err = _make_http_error(status_code=400, body=b'["H890"]')
-    assert script._extract_vao_error_code(err) == "<unknown>"
+    assert script._extract_vao_error_code(err) == "[MISSING]"
 
 
 def test_extract_vao_error_code_returns_unknown_for_no_response() -> None:
     err = requests.HTTPError("network failure", response=None)
-    assert script._extract_vao_error_code(err) == "<unknown>"
+    assert script._extract_vao_error_code(err) == "[MISSING]"
 
 
 def test_describe_error_body_keys_renders_canonical_envelope() -> None:
@@ -565,24 +565,68 @@ def test_describe_error_body_keys_redacts_non_canonical_key_names() -> None:
         ).encode("utf-8"),
     )
     rendered = script._describe_error_body_keys(err)
-    assert "<???>" in rendered
+    assert "[REDACTED]" in rendered
     assert "Invalid accessId" not in rendered
     assert "errorCode" in rendered
 
 
 def test_describe_error_body_keys_falls_back_when_no_response() -> None:
     err = requests.HTTPError("network failure", response=None)
-    assert script._describe_error_body_keys(err) == "<no-body>"
+    assert script._describe_error_body_keys(err) == "[EMPTY_BODY]"
 
 
 def test_describe_error_body_keys_falls_back_for_non_json_body() -> None:
     err = _make_http_error(status_code=500, body=b"<html>error</html>")
-    assert script._describe_error_body_keys(err) == "<no-body>"
+    assert script._describe_error_body_keys(err) == "[EMPTY_BODY]"
 
 
 def test_describe_error_body_keys_falls_back_for_empty_object() -> None:
     err = _make_http_error(status_code=400, body=b"{}")
-    assert script._describe_error_body_keys(err) == "<empty>"
+    assert script._describe_error_body_keys(err) == "[NO_KEYS]"
+
+
+# ---- Response header diagnostics ------------------------------------------
+
+
+def test_extract_response_header_returns_set_value() -> None:
+    err = _make_http_error(status_code=400, body=b"")
+    assert err.response is not None
+    err.response.headers["Content-Type"] = "application/json; charset=utf-8"
+    assert (
+        script._extract_response_header(err, "Content-Type")
+        == "application/json; charset=utf-8"
+    )
+
+
+def test_extract_response_header_falls_back_when_no_response() -> None:
+    err = requests.HTTPError("network failure", response=None)
+    assert script._extract_response_header(err, "Server") == "[NO_RESPONSE]"
+
+
+def test_extract_response_header_falls_back_when_header_absent() -> None:
+    err = _make_http_error(status_code=400, body=b"")
+    # No headers set — every name should fall back to the missing sentinel.
+    assert script._extract_response_header(err, "WWW-Authenticate") == "[MISSING]"
+
+
+def test_extract_response_header_caps_oversize_value() -> None:
+    """A planted huge ``Server`` header (zero-leak path: server-set, but
+    an attacker-controlled CDN could still inject a multi-KiB string)
+    is truncated at the body-keys cap with an ellipsis suffix."""
+
+    err = _make_http_error(status_code=400, body=b"")
+    assert err.response is not None
+    err.response.headers["Server"] = "A" * 5000
+    rendered = script._extract_response_header(err, "Server")
+    assert len(rendered) == script._BODY_KEYS_MAX_LEN + 1  # +1 for the ellipsis
+    assert rendered.endswith("…")
+
+
+def test_extract_response_header_strips_whitespace_only() -> None:
+    err = _make_http_error(status_code=400, body=b"")
+    assert err.response is not None
+    err.response.headers["Server"] = "   "
+    assert script._extract_response_header(err, "Server") == "[MISSING]"
 
 
 def test_process_direction_logs_status_and_error_code_on_http_error(
@@ -599,6 +643,14 @@ def test_process_direction_logs_status_and_error_code_on_http_error(
         status_code=401,
         body=json.dumps({"errorCode": "H730"}).encode("utf-8"),
     )
+
+    # Plant a few server-set headers so the new diagnostics surface the
+    # gateway/auth/payload shape that triggered the failure.
+    assert err.response is not None
+    err.response.headers["Content-Type"] = "application/json"
+    err.response.headers["Content-Length"] = "42"
+    err.response.headers["Server"] = "VAO-RestProxy/1.11.0"
+    err.response.headers["WWW-Authenticate"] = "Bearer realm=\"vao\""
 
     def boom(*args: object, **kwargs: object) -> object:
         raise err
@@ -620,6 +672,13 @@ def test_process_direction_logs_status_and_error_code_on_http_error(
     # Body-keys diagnostic must surface the canonical envelope shape
     # without leaking any value.
     assert "body_keys=errorCode" in rendered
+    # The four new server-set header diagnostics must appear so a
+    # future cron failure exposes the gateway / auth / payload shape
+    # without further code changes.
+    assert "ct=application/json" in rendered
+    assert "cl=42" in rendered
+    assert "server=VAO-RestProxy/1.11.0" in rendered
+    assert "www_auth=Bearer" in rendered
 
 
 def test_collect_delays_rejects_multi_ride_leg_trips() -> None:
@@ -777,12 +836,18 @@ def test_query_timeout_bound_below_max() -> None:
 def test_query_trips_passes_canonical_parameters(
     monkeypatch: pytest.MonkeyPatch, _stable_now: datetime
 ) -> None:
-    """Pin the wire-format parameters: originExtId/destExtId/numF/maxChange/rtMode.
+    """Pin the wire-format parameters: originId/destId with extId:: prefix
+    in value, no format= query param, Accept header for negotiation.
 
-    The 2026-05-09 audit established that the bare numeric VOR Stop ID
-    must be passed via the ``ExtId`` parameter family — the
-    HAFAS-internal ``originId``/``destId`` parameters expect the full
-    ``A=1@O=...@L=...`` shape and reject bare numerics with HTTP 400.
+    The 2026-05-09 audit (third iteration) established that VAO accepts
+    external station IDs via ``originId=extId::<bare-numeric>`` —
+    encoding the type via the value prefix per the
+    "Identifikationsarten von Ortsobjekten" chapter of the
+    Handbuch_VAO_ReST_API_latest.pdf. The previous attempts
+    (PR #1387 ``originExtId=<bare-numeric>``) yielded HTTP 400 with
+    empty body on this VAO instance; this iteration matches the
+    ``trip.md`` curl example shape exactly minus the ``extId::``
+    prefix that the manual mandates for non-OGD station IDs.
     """
 
     captured: dict[str, Any] = {}
@@ -805,20 +870,25 @@ def test_query_trips_passes_canonical_parameters(
     assert trips == []
     assert captured["endpoint"].endswith("/trip")
     params = captured["params"]
-    assert params["format"] == "json"
-    # External-ID parameter family is mandatory — see docstring above.
-    assert params["originExtId"] == direction.origin_id
-    assert params["destExtId"] == direction.destination_id
-    assert "originId" not in params  # HAFAS-internal form not used
-    assert "destId" not in params
+    # ``format=json`` is intentionally absent — content negotiation is
+    # handled exclusively via the Accept header so the request payload
+    # exactly matches the trip.md curl example shape (which lists no
+    # ``format`` parameter).
+    assert "format" not in params
+    # External-ID encoding via the ``extId::`` value prefix (NOT via a
+    # separate ``originExtId`` key). The VAO manual states that the
+    # ``extId::`` token tells the upstream to interpret the value as
+    # an external station ID rather than as a HAFAS-internal location.
+    assert params["originId"] == f"extId::{direction.origin_id}"
+    assert params["destId"] == f"extId::{direction.destination_id}"
+    assert "originExtId" not in params  # superseded by the value-prefix form
+    assert "destExtId" not in params
     assert params["numF"] == "6"  # pinned MAX_TRIPS_PER_QUERY (VAO max)
     assert params["maxChange"] == "0"  # direct-connections-only
     assert params["rtMode"] == "SERVER_DEFAULT"
     assert params["date"] == _stable_now.strftime("%Y-%m-%d")
     assert params["time"] == _stable_now.strftime("%H:%M")
-    # Explicit Accept header for content negotiation in addition to
-    # the ``format=json`` query parameter (belt-and-suspenders so the
-    # negotiation is unambiguous).
+    # Content negotiation lives entirely in the Accept header now.
     assert captured["kwargs"]["headers"]["Accept"] == "application/json"
     assert captured["kwargs"]["allowed_content_types"] == ("application/json",)
     # Timeout is bound below MAX_QUERY_TIMEOUT.


### PR DESCRIPTION
## Summary

Dritte Iteration der Stammstrecke-VAO-Triage. Zwei orthogonale Maßnahmen:

### 1. Hypothesen-Test: `originId=extId::<value>` (Geminis Vorschlag)

Per VAO-Manual Kapitel "Identifikationsarten von Ortsobjekten" (S. 19) interpretiert das Backend `originId=extId::490033400` als externe Station-ID — der `extId::`-Präfix im **Wert** kodiert den Typ, nicht der Key.

```diff
- "originExtId": direction.origin_id,
- "destExtId": direction.destination_id,
+ "originId": f"extId::{direction.origin_id}",
+ "destId": f"extId::{direction.destination_id}",
```

`format=json` wurde entfernt — das `trip.md`-Curl-Beispiel verwendet nur den Accept-Header. Eine Variable weniger im Triage-Pfad.

### 2. Fortified Diagnostics (regardless of #1's outcome)

**Problem im letzten Run:** `errorCode=***` — der SafeFormatter maskiert den literalen Sentinel `<unknown>` als `***`, weil er als token-shaped wahrgenommen wird. `<no-body>` (mit Bindestrich) wurde korrekt gerendert.

**Sentinel-Rename** (bracket-wrapped uppercase tags, bestehen den Token-Heuristik-Check):

| Alt | Neu |
| --- | --- |
| `<unknown>` | `[MISSING]` |
| `<malformed>` | `[BAD_SHAPE]` |
| `<no-body>` | `[EMPTY_BODY]` |
| `<empty>` | `[NO_KEYS]` |
| `<???>` | `[REDACTED]` |
| `<no-response>` | `[NO_RESPONSE]` |

**Vier neue Server-Set-Response-Header** (alle leak-frei — kein User-Echo möglich):
- `Content-Type` → unterscheidet JSON-Error vs. HTML-Error-Page
- `Content-Length` → bestätigt ob `response.content` lesbar war
- `Server` → enthüllt Gateway/CDN vs. VAO-Origin
- `WWW-Authenticate` → ist sofort 401-Auth-Issue erkennbar

**Beispiel-Output bei Fehler:**
```
HTTP 400 (errorCode=H890, body_keys=Message,errorCode, ct=application/json, cl=42, server=VAO-RestProxy/1.11.0, www_auth=[MISSING]).
```

## Was passiert beim nächsten Cron-Run?

| Szenario | Was wir sehen | Diagnose |
| -------- | ------------- | -------- |
| `extId::`-Hypothese korrekt | HTTP 200 (kein Log) | **Done** |
| Auth-Issue | `HTTP 401, www_auth=Bearer realm=...` | Token expired/falsche Auth-Form |
| Gateway-Block | `server=cloudflare` o.ä., `ct=text/html` | Request erreicht VAO nicht |
| Payload-Issue | `errorCode=H890`, `ct=application/json` | Echter VAO-Param-Fehler |

In jedem Fall haben wir nach diesem Run **definitive Daten** statt weiterer Speculation.

## Test-Coverage

- 93 passed (war 88, +5 Header-Diagnostics-Tests)
- mypy --strict: no issues
- ruff + bandit + secret-scan + complexity-gate: all green

https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr)_