### PR TITLE
fix(stammstrecke): capture VAO error body via request_safe(raise_for_status=False)

### DIFF
--- a/scripts/update_stammstrecke_status.py
+++ b/scripts/update_stammstrecke_status.py
@@ -118,7 +118,7 @@ from src.utils.circuit_breaker import (  # noqa: E402
     CircuitBreakerOpen,
 )
 from src.utils.files import atomic_write, read_capped_json  # noqa: E402
-from src.utils.http import fetch_content_safe, session_with_retries  # noqa: E402
+from src.utils.http import request_safe, session_with_retries  # noqa: E402
 from src.utils.ids import make_guid  # noqa: E402
 from src.utils.logging import sanitize_log_arg  # noqa: E402
 from src.utils.stations import canonical_name, display_name  # noqa: E402
@@ -405,9 +405,25 @@ def _query_trips(
 
     _charge_one_request(when)
 
-    content = fetch_content_safe(
+    # ``request_safe(raise_for_status=False)`` rather than the
+    # ``fetch_content_safe`` wrapper: the wrapper hardcodes
+    # ``raise_for_status=True``, which means the request_safe ``except``
+    # block runs ``r.close()`` on the response BEFORE the body is read
+    # into ``r._content`` (see ``src/utils/http.py`` lines ~2068-2073).
+    # The diagnostic helpers downstream (``_decode_error_body``,
+    # ``_describe_error_body_keys``) would then see ``response.content
+    # == b""`` and report ``body_keys=[EMPTY_BODY]`` — even though the
+    # ``Content-Length`` header confirms the body has bytes (``cl=163``
+    # in the 2026-05-09 cron run). With ``raise_for_status=False`` the
+    # body is read into ``_content`` before any exception path can
+    # close the stream. We then check status manually and synthesise
+    # the same ``HTTPError`` the wrapper would have raised, but with a
+    # response whose ``.content`` is fully populated.
+    response = request_safe(
         session,
         endpoint,
+        method="GET",
+        raise_for_status=False,
         params=params,
         # Content negotiation via Accept header instead of the
         # ``format=json`` query parameter. The trip.md curl example
@@ -417,6 +433,12 @@ def _query_trips(
         timeout=safe_timeout,
         allowed_content_types=("application/json",),
     )
+    if response.status_code >= 400:
+        raise requests.HTTPError(
+            f"VAO /trip returned HTTP {response.status_code}",
+            response=response,
+        )
+    content = response.content
 
     try:
         payload = _json_lib.loads(content)

--- a/tests/scripts/test_update_stammstrecke_status.py
+++ b/tests/scripts/test_update_stammstrecke_status.py
@@ -415,6 +415,25 @@ def test_leg_departure_delay_skips_unparseable_realtime() -> None:
 # ---- HTTPError diagnostic helpers -----------------------------------------
 
 
+def _make_response(
+    *, status_code: int = 200, body: bytes = b""
+) -> requests.Response:
+    """Construct a :class:`requests.Response` with pre-populated body.
+
+    The ``_content`` attribute is set directly so subsequent
+    ``response.content`` lookups return the bytes verbatim — mirrors
+    the post-fix shape of :func:`src.utils.http.request_safe` when
+    ``raise_for_status=False`` is passed (the helper attaches the
+    body to ``response._content`` before returning, regardless of
+    status).
+    """
+
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = body
+    return response
+
+
 def _make_http_error(
     *, status_code: int | None, body: bytes | None
 ) -> requests.HTTPError:
@@ -852,16 +871,16 @@ def test_query_trips_passes_canonical_parameters(
 
     captured: dict[str, Any] = {}
 
-    def fake_fetch(
+    def fake_request(
         session: Any, endpoint: str, *, params: dict[str, str], **kwargs: Any
-    ) -> bytes:
+    ) -> requests.Response:
         captured["endpoint"] = endpoint
         captured["params"] = dict(params)
         captured["kwargs"] = kwargs
-        return b'{"Trip": []}'
+        return _make_response(status_code=200, body=b'{"Trip": []}')
 
-    monkeypatch.setattr(script, "fetch_content_safe", fake_fetch)
-    # Bypass the quota gate — the integration of charge → fetch is
+    monkeypatch.setattr(script, "request_safe", fake_request)
+    # Bypass the quota gate — the integration of charge → request is
     # tested separately below.
     monkeypatch.setattr(script, "_charge_one_request", lambda _now: None)
 
@@ -891,8 +910,54 @@ def test_query_trips_passes_canonical_parameters(
     # Content negotiation lives entirely in the Accept header now.
     assert captured["kwargs"]["headers"]["Accept"] == "application/json"
     assert captured["kwargs"]["allowed_content_types"] == ("application/json",)
+    # CRITICAL: ``raise_for_status=False`` must be passed so the
+    # request_safe except path does not close the response stream
+    # before the body is read. See the docstring on ``_query_trips``
+    # in the script for the full root-cause analysis.
+    assert captured["kwargs"]["raise_for_status"] is False
+    assert captured["kwargs"]["method"] == "GET"
     # Timeout is bound below MAX_QUERY_TIMEOUT.
     assert captured["kwargs"]["timeout"] <= script.MAX_QUERY_TIMEOUT
+
+
+def test_query_trips_raises_http_error_with_populated_body_on_4xx(
+    monkeypatch: pytest.MonkeyPatch, _stable_now: datetime
+) -> None:
+    """A 4xx response from request_safe must produce an HTTPError whose
+    ``.response.content`` is fully populated — the diagnostic helpers
+    downstream need the body to triage the failure shape.
+
+    This is the regression-defence for the 2026-05-09 cron behaviour
+    where ``fetch_content_safe(raise_for_status=True)`` closed the
+    stream before the body was read, leaving ``response.content``
+    empty even when ``Content-Length`` confirmed bytes were sent.
+    """
+
+    body_bytes = json.dumps({"errorCode": "H890"}).encode("utf-8")
+
+    def fake_request(*args: Any, **kwargs: Any) -> requests.Response:
+        # Mirror the production path: request_safe always returns a
+        # response with ``_content`` already attached, even on 4xx,
+        # because we passed ``raise_for_status=False``.
+        return _make_response(status_code=400, body=body_bytes)
+
+    monkeypatch.setattr(script, "request_safe", fake_request)
+    monkeypatch.setattr(script, "_charge_one_request", lambda _now: None)
+
+    with pytest.raises(requests.HTTPError) as exc_info:
+        script._query_trips(
+            session=object(),
+            direction=script.DIRECTIONS[0],
+            when=_stable_now,
+        )
+    # The exception's response carries the body for downstream
+    # diagnostic-extraction.
+    assert exc_info.value.response is not None
+    assert exc_info.value.response.status_code == 400
+    assert exc_info.value.response.content == body_bytes
+    # And the body is decode-able by the same path the diagnostic
+    # helpers use.
+    assert script._extract_vao_error_code(exc_info.value) == "H890"
 
 
 def test_query_trips_normalises_single_trip_payload(
@@ -904,10 +969,13 @@ def test_query_trips_normalises_single_trip_payload(
     monkeypatch.setattr(script, "_charge_one_request", lambda _now: None)
     trip_obj = _trip(leg_name="S 1", delay_minutes=10)
 
-    def fake_fetch(*args: Any, **kwargs: Any) -> bytes:
-        return json.dumps({"Trip": trip_obj}).encode("utf-8")
+    def fake_request(*args: Any, **kwargs: Any) -> requests.Response:
+        return _make_response(
+            status_code=200,
+            body=json.dumps({"Trip": trip_obj}).encode("utf-8"),
+        )
 
-    monkeypatch.setattr(script, "fetch_content_safe", fake_fetch)
+    monkeypatch.setattr(script, "request_safe", fake_request)
 
     trips = script._query_trips(
         session=object(), direction=script.DIRECTIONS[0], when=_stable_now
@@ -923,7 +991,11 @@ def test_query_trips_raises_on_non_dict_payload(
     error-isolation branch runs."""
 
     monkeypatch.setattr(script, "_charge_one_request", lambda _now: None)
-    monkeypatch.setattr(script, "fetch_content_safe", lambda *a, **kw: b'[1,2,3]')
+    monkeypatch.setattr(
+        script,
+        "request_safe",
+        lambda *a, **kw: _make_response(status_code=200, body=b'[1,2,3]'),
+    )
 
     with pytest.raises(TypeError):
         script._query_trips(
@@ -942,12 +1014,12 @@ def test_query_trips_charges_quota_before_fetching(
     def fake_charge(_now: datetime) -> None:
         call_order.append("charge")
 
-    def fake_fetch(*args: Any, **kwargs: Any) -> bytes:
+    def fake_request(*args: Any, **kwargs: Any) -> requests.Response:
         call_order.append("fetch")
-        return b'{"Trip": []}'
+        return _make_response(status_code=200, body=b'{"Trip": []}')
 
     monkeypatch.setattr(script, "_charge_one_request", fake_charge)
-    monkeypatch.setattr(script, "fetch_content_safe", fake_fetch)
+    monkeypatch.setattr(script, "request_safe", fake_request)
 
     script._query_trips(
         session=object(), direction=script.DIRECTIONS[0], when=_stable_now
@@ -965,12 +1037,12 @@ def test_query_trips_propagates_quota_exceeded_without_fetching(
     def raising_charge(_now: datetime) -> None:
         raise script._QuotaExceeded("daily limit reached")
 
-    def fake_fetch(*args: Any, **kwargs: Any) -> bytes:
+    def fake_request(*args: Any, **kwargs: Any) -> requests.Response:
         fetched["called"] = True
-        return b""
+        return _make_response(status_code=200, body=b"")
 
     monkeypatch.setattr(script, "_charge_one_request", raising_charge)
-    monkeypatch.setattr(script, "fetch_content_safe", fake_fetch)
+    monkeypatch.setattr(script, "request_safe", fake_request)
 
     with pytest.raises(script._QuotaExceeded):
         script._query_trips(


### PR DESCRIPTION
## Summary

Vierte Iteration der HTTP-400-Triage. Diesmal **kein Hypothesen-Test** auf die Request-Form, sondern ein **chirurgischer Fix am Library-Plumbing**, der unsere Diagnostik endlich Daten liefern lässt.

### Was die letzte Diagnose offenbarte

```
HTTP 400 (errorCode=***, body_keys=[EMPTY_BODY],
         ct=application/json; charset=UTF-8, cl=163,
         server=[MISSING], www_auth=***).
```

| Diagnostic | Wert | Was es uns sagt |
| ---------- | ---- | --------------- |
| `ct=application/json; charset=UTF-8` | VAO antwortet mit echtem JSON | Kein Gateway/Proxy-Error |
| `cl=163` | 163-Byte-Body vorhanden | VAO sendet eine strukturierte Antwort |
| **`body_keys=[EMPTY_BODY]`** | Wir sehen **leeren** Body | **Library-Plumbing-Bug** |
| `errorCode=***` | Maskiert | Auch von der `[EMPTY_BODY]`-Pfad-Konsequenz, nicht vom echten Body |
| `www_auth=***` | Header enthält accessId | Hint auf Auth-Issue, aber **erst wertvoll, wenn wir den Body lesen können** |

### Root Cause: `src/utils/http.py:request_safe` Lines 2068-2073

```python
try:
    if raise_for_status:
        r.raise_for_status()        # ← feuert auf 400
    _validate_content_type(r, ...)
    content = read_response_safe(r, ...)
    r._content = content              # ← wird nie erreicht
    return r
except Exception:
    r.close()                          # ← Stream geschlossen VOR Body-Read
    raise
```

`fetch_content_safe` hardcodet `raise_for_status=True`. Der `except`-Pfad schließt den Stream BEVOR `read_response_safe` den Body in `r._content` schreibt. Unsere Diagnose-Helfer sehen `response.content == b""`, obwohl `Content-Length=163` bestätigt, dass Bytes gesendet wurden.

### Fix

Statt des Wrappers direkt `request_safe(raise_for_status=False)` aufrufen. Die Success-Path-Logik liest dann den Body **immer** in `r._content` ein. Wir prüfen `response.status_code >= 400` manuell und werfen ein synthetisches `HTTPError` mit voll populierter Response.

```python
response = request_safe(
    session, endpoint, method="GET", raise_for_status=False,  # ← key
    params=params, headers={"Accept": "application/json"},
    timeout=safe_timeout, allowed_content_types=("application/json",),
)
if response.status_code >= 400:
    raise requests.HTTPError(
        f"VAO /trip returned HTTP {response.status_code}",
        response=response,  # ← .content populated
    )
content = response.content
```

## Test-Coverage

- **Neuer Helper `_make_response`** spiegelt das Post-Fix request_safe-Verhalten (Response mit pre-populiertem `_content`)
- **5 Tests umgeschrieben** auf das neue Mock-Pattern (`script.request_safe` statt `script.fetch_content_safe`)
- **`test_query_trips_passes_canonical_parameters`** pinnt zusätzlich `raise_for_status=False` und `method="GET"` — die Regression-Defence damit ein zukünftiges Cleanup nicht still zum Wrapper zurückkehrt
- **Neuer Test `test_query_trips_raises_http_error_with_populated_body_on_4xx`** pinnt den neuen Vertrag: 400er produzieren HTTPError mit gefülltem `response.content`, und `_extract_vao_error_code` liest den canonical Code daraus

**Total: 94 passed** (war 93, +1 Body-Capture-Regression).

## Lokale Verifikation

- `pytest tests/scripts/test_update_stammstrecke_status.py` → **94 passed**
- `mypy --strict` (Script + Tests) → no issues
- `python -m src.cli checks` → ruff + mypy + bandit + secret-scan + complexity-gate alle grün

## Erwarteter Effekt

Beim nächsten Cron-Run (oder manuellem Trigger) wird das Log endlich zeigen:

```
HTTP 400 (errorCode=H890, body_keys=Message,errorCode,errorText, ...).
```

— wo `H890` (oder `SVC_LOC_INVALID`, `API_GEN`, `H730`, …) der canonical VAO-Failure-Code ist. Damit ist der Speculation-Zyklus vorbei und der nächste Fix basiert auf **echten Daten**, nicht weiteren Hypothesen.

https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr)_