### PR TITLE
diag(stammstrecke): add err_text + req_id + code_len to HTTPError log

### DIFF
--- a/scripts/update_stammstrecke_status.py
+++ b/scripts/update_stammstrecke_status.py
@@ -1044,6 +1044,99 @@ def _describe_error_body_keys(exc: requests.HTTPError) -> str:
     return rendered
 
 
+# Hard cap on the rendered ``errorText`` diagnostic. Real VAO error
+# texts are <300 chars (1-2 sentences); 256 char ceiling is generous
+# headroom while bounding a planted-huge-text amplification shape.
+_ERROR_TEXT_MAX_LEN: Final = 256
+
+
+def _extract_vao_error_code_length(exc: requests.HTTPError) -> str:
+    """Return the length of the ``errorCode`` field as a stringy diagnostic.
+
+    The 2026-05-09 cron run revealed that VAO occasionally puts an
+    accessId-shaped value into ``errorCode``; the strict regex in
+    :func:`_extract_vao_error_code` accepts it (alphanumeric, within
+    the 32-char ceiling) and the project's SafeFormatter then masks
+    the literal value as ``***`` — defeating the diagnostic.
+
+    Logging the LENGTH is a leak-free signal: a 4-8 char value is a
+    canonical short code (``H890``, ``API_GEN``); a 16+ char value is
+    almost certainly an accessId-shaped token. The operator can then
+    distinguish "VAO returned its own short code" vs "VAO is echoing
+    our token back" without seeing the value itself.
+
+    Falls back to :data:`_DIAG_EMPTY_BODY` / :data:`_DIAG_MISSING`
+    for the same reasons as :func:`_extract_vao_error_code`.
+    """
+    body = _decode_error_body(exc)
+    if body is None:
+        return _DIAG_EMPTY_BODY
+    raw_code = body.get("errorCode") or body.get("error")
+    if not isinstance(raw_code, str):
+        return _DIAG_MISSING
+    return str(len(raw_code))
+
+
+def _extract_vao_error_text(exc: requests.HTTPError) -> str:
+    """Return the ``errorText`` field, normalised and truncated.
+
+    Unlike :func:`_extract_vao_error_code`, the errorText field is
+    intended to be human-readable diagnostic prose. A typical value is
+    e.g. ``"Invalid origin location"``, ``"Authentication failed"``,
+    ``"No journey found between A and B"``. When VAO echoes a
+    parameter value into the message, the project's SafeFormatter
+    + GitHub Actions secret-masker replace the secret with ``***``
+    while preserving the surrounding text — so an operator sees
+    ``"Invalid accessId: ***"`` rather than ``"Invalid accessId:
+    <ACCESSID>"``.
+
+    Control bytes / line-terminators / whitespace runs are
+    normalised via the project's :func:`sanitize_log_arg` (applied
+    at the call site) on top of the length cap here.
+
+    Falls back to :data:`_DIAG_EMPTY_BODY` / :data:`_DIAG_MISSING`
+    for the same reasons as :func:`_extract_vao_error_code`.
+    """
+    body = _decode_error_body(exc)
+    if body is None:
+        return _DIAG_EMPTY_BODY
+    raw_text = body.get("errorText") or body.get("errorMsg")
+    if not isinstance(raw_text, str):
+        return _DIAG_MISSING
+    text = raw_text.strip()
+    if not text:
+        return _DIAG_MISSING
+    if len(text) > _ERROR_TEXT_MAX_LEN:
+        return text[:_ERROR_TEXT_MAX_LEN] + "…"
+    return text
+
+
+def _extract_vao_request_id(exc: requests.HTTPError) -> str:
+    """Return the VAO ``requestId`` from the error body, or a sentinel.
+
+    VAO assigns each request a server-side trace ID (typically a UUID
+    or a short hex token) that VAO support can use to look up the
+    failure on their end. The value is server-set and does not echo
+    user-controlled content — safe to log fully (with the same
+    canonical-shape regex guard as :func:`_extract_vao_error_code` to
+    defend against an upstream that ever ships free-form text in this
+    field).
+    """
+    body = _decode_error_body(exc)
+    if body is None:
+        return _DIAG_EMPTY_BODY
+    raw_id = body.get("requestId") or body.get("request_id") or body.get("id")
+    if not isinstance(raw_id, str):
+        return _DIAG_MISSING
+    rid = raw_id.strip()
+    if not rid:
+        return _DIAG_MISSING
+    # Allow hex / UUID-like shapes too (digits, hyphens, underscores).
+    if not re.match(r"^[A-Za-z0-9_\-]{1,64}$", rid):
+        return _DIAG_BAD_SHAPE
+    return rid
+
+
 def _process_direction(
     session: requests.Session,
     direction: _Direction,
@@ -1088,22 +1181,29 @@ def _process_direction(
         )
         return None, "quota_exceeded"
     except requests.HTTPError as exc:
-        # Diagnostic-rich branch for non-2xx responses. Logs the HTTP
-        # status code, the canonical-short VAO ``errorCode`` from the
-        # JSON body when present, the body's top-level key set, and
-        # four server-set response headers (Content-Type,
-        # Content-Length, Server, WWW-Authenticate) so the next cron
-        # run reveals whether we are dealing with an auth rejection
-        # (401 + WWW-Authenticate set), a gateway/proxy issue (Server
-        # naming a CDN rather than the VAO origin), or a payload
-        # mismatch (Content-Type=text/html points at an HTML error
-        # page). All fields are safe to surface (no URL → no
-        # ``accessId`` leak; ``errorCode`` is regex-validated against
-        # the canonical HAFAS short-code shape; key names go through
-        # the same regex filter; response headers are server-set and
-        # do not echo user-controlled content).
+        # Diagnostic-rich branch for non-2xx responses. The previous
+        # PR (#1389) made the body readable, revealing the canonical
+        # VAO error envelope shape ``{dialectVersion, errorCode,
+        # errorText, requestId, serverVersion}``. The 2026-05-09 cron
+        # then showed ``errorCode=***`` — VAO echoes the supplied
+        # accessId into the ``errorCode`` field, which the project's
+        # SafeFormatter / GitHub Actions secret-masker then redacts
+        # entirely.
+        #
+        # This iteration adds three more leak-free diagnostics:
+        # * ``code_len`` — the length of ``errorCode`` (4-8 chars =
+        #   canonical short code; 16+ chars = accessId-shaped token);
+        # * ``err_text`` — the human-readable ``errorText`` field
+        #   with the secret-masking applied at the ``sanitize_log_arg``
+        #   layer (preserves surrounding text like "Invalid origin
+        #   location: ***");
+        # * ``req_id`` — the VAO server-side trace ID for support
+        #   triage.
         status_code = _extract_http_status(exc)
         error_code = _extract_vao_error_code(exc)
+        code_len = _extract_vao_error_code_length(exc)
+        error_text = _extract_vao_error_text(exc)
+        request_id = _extract_vao_request_id(exc)
         body_keys = _describe_error_body_keys(exc)
         content_type = _extract_response_header(exc, "Content-Type")
         content_length = _extract_response_header(exc, "Content-Length")
@@ -1111,11 +1211,14 @@ def _process_direction(
         www_auth = _extract_response_header(exc, "WWW-Authenticate")
         LOGGER.warning(
             "Stammstrecke: Abfrage Richtung %s fehlgeschlagen: HTTP %s "
-            "(errorCode=%s, body_keys=%s, ct=%s, cl=%s, server=%s, "
-            "www_auth=%s).",
+            "(errorCode=%s, code_len=%s, err_text=%s, req_id=%s, "
+            "body_keys=%s, ct=%s, cl=%s, server=%s, www_auth=%s).",
             direction.target_label,
             status_code,
             sanitize_log_arg(error_code),
+            sanitize_log_arg(code_len),
+            sanitize_log_arg(error_text),
+            sanitize_log_arg(request_id),
             sanitize_log_arg(body_keys),
             sanitize_log_arg(content_type),
             sanitize_log_arg(content_length),

--- a/tests/scripts/test_update_stammstrecke_status.py
+++ b/tests/scripts/test_update_stammstrecke_status.py
@@ -604,6 +604,127 @@ def test_describe_error_body_keys_falls_back_for_empty_object() -> None:
     assert script._describe_error_body_keys(err) == "[NO_KEYS]"
 
 
+# ---- errorCode length / errorText / requestId diagnostics -----------------
+
+
+def test_extract_vao_error_code_length_returns_string_length() -> None:
+    """Length is a leak-free signal of whether errorCode is canonical
+    (4-8 chars) or accessId-shaped (16+ chars)."""
+
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps({"errorCode": "H890"}).encode("utf-8"),
+    )
+    assert script._extract_vao_error_code_length(err) == "4"
+
+
+def test_extract_vao_error_code_length_for_token_shaped_value() -> None:
+    """A 32-char token-shape value (suspiciously accessId-sized)."""
+
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps({"errorCode": "a" * 32}).encode("utf-8"),
+    )
+    assert script._extract_vao_error_code_length(err) == "32"
+
+
+def test_extract_vao_error_code_length_falls_back_for_no_body() -> None:
+    err = _make_http_error(status_code=400, body=b"")
+    assert script._extract_vao_error_code_length(err) == "[EMPTY_BODY]"
+
+
+def test_extract_vao_error_code_length_falls_back_for_missing_field() -> None:
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps({"otherField": "x"}).encode("utf-8"),
+    )
+    assert script._extract_vao_error_code_length(err) == "[MISSING]"
+
+
+def test_extract_vao_error_text_returns_text_field() -> None:
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps(
+            {"errorCode": "H890", "errorText": "no journey found"}
+        ).encode("utf-8"),
+    )
+    assert script._extract_vao_error_text(err) == "no journey found"
+
+
+def test_extract_vao_error_text_falls_back_to_error_msg_field() -> None:
+    """Some VAO peers emit ``errorMsg`` instead of ``errorText``."""
+
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps({"errorMsg": "auth failed"}).encode("utf-8"),
+    )
+    assert script._extract_vao_error_text(err) == "auth failed"
+
+
+def test_extract_vao_error_text_truncates_oversize_value() -> None:
+    huge = "X" * 5000
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps({"errorText": huge}).encode("utf-8"),
+    )
+    rendered = script._extract_vao_error_text(err)
+    assert len(rendered) == script._ERROR_TEXT_MAX_LEN + 1  # +1 for ellipsis
+    assert rendered.endswith("…")
+
+
+def test_extract_vao_error_text_falls_back_for_empty_value() -> None:
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps({"errorText": "   "}).encode("utf-8"),
+    )
+    assert script._extract_vao_error_text(err) == "[MISSING]"
+
+
+def test_extract_vao_error_text_falls_back_for_no_body() -> None:
+    err = _make_http_error(status_code=400, body=b"")
+    assert script._extract_vao_error_text(err) == "[EMPTY_BODY]"
+
+
+def test_extract_vao_request_id_returns_uuid_shape() -> None:
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps(
+            {"requestId": "8e7f2c9b-1234-5678-90ab-cdef12345678"}
+        ).encode("utf-8"),
+    )
+    assert (
+        script._extract_vao_request_id(err)
+        == "8e7f2c9b-1234-5678-90ab-cdef12345678"
+    )
+
+
+def test_extract_vao_request_id_returns_short_hex_token() -> None:
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps({"requestId": "abc123def456"}).encode("utf-8"),
+    )
+    assert script._extract_vao_request_id(err) == "abc123def456"
+
+
+def test_extract_vao_request_id_rejects_text_with_spaces() -> None:
+    """A free-form ``requestId`` (e.g. echoing user input) collapses to
+    the bad-shape sentinel so a planted value cannot leak via this
+    diagnostic."""
+
+    err = _make_http_error(
+        status_code=400,
+        body=json.dumps(
+            {"requestId": "Invalid request from <accessId>"}
+        ).encode("utf-8"),
+    )
+    assert script._extract_vao_request_id(err) == "[BAD_SHAPE]"
+
+
+def test_extract_vao_request_id_falls_back_for_no_body() -> None:
+    err = _make_http_error(status_code=400, body=b"")
+    assert script._extract_vao_request_id(err) == "[EMPTY_BODY]"
+
+
 # ---- Response header diagnostics ------------------------------------------
 
 
@@ -660,14 +781,20 @@ def test_process_direction_logs_status_and_error_code_on_http_error(
 
     err = _make_http_error(
         status_code=401,
-        body=json.dumps({"errorCode": "H730"}).encode("utf-8"),
+        body=json.dumps(
+            {
+                "errorCode": "H730",
+                "errorText": "Authentication failed",
+                "requestId": "8e7f2c9b-1234-5678-90ab-cdef12345678",
+            }
+        ).encode("utf-8"),
     )
 
     # Plant a few server-set headers so the new diagnostics surface the
     # gateway/auth/payload shape that triggered the failure.
     assert err.response is not None
     err.response.headers["Content-Type"] = "application/json"
-    err.response.headers["Content-Length"] = "42"
+    err.response.headers["Content-Length"] = "92"
     err.response.headers["Server"] = "VAO-RestProxy/1.11.0"
     err.response.headers["WWW-Authenticate"] = "Bearer realm=\"vao\""
 
@@ -691,13 +818,20 @@ def test_process_direction_logs_status_and_error_code_on_http_error(
     # Body-keys diagnostic must surface the canonical envelope shape
     # without leaking any value.
     assert "body_keys=errorCode" in rendered
-    # The four new server-set header diagnostics must appear so a
-    # future cron failure exposes the gateway / auth / payload shape
+    # The four server-set header diagnostics must appear so a future
+    # cron failure exposes the gateway / auth / payload shape
     # without further code changes.
     assert "ct=application/json" in rendered
-    assert "cl=42" in rendered
+    assert "cl=92" in rendered
     assert "server=VAO-RestProxy/1.11.0" in rendered
     assert "www_auth=Bearer" in rendered
+    # The three new error-body diagnostics from the 2026-05-09
+    # accessId-echoing audit must also appear: errorCode-length
+    # (length-only fingerprint), errorText (human-readable diagnostic
+    # string), and requestId (server-side trace ID for support).
+    assert "code_len=4" in rendered  # H730 is 4 chars
+    assert "err_text=Authentication failed" in rendered
+    assert "req_id=8e7f2c9b-1234-5678-90ab-cdef12345678" in rendered
 
 
 def test_collect_delays_rejects_multi_ride_leg_trips() -> None:

--- a/tests/test_update_baustellen_cache.py
+++ b/tests/test_update_baustellen_cache.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import socket
+import sys
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -8,6 +10,68 @@ from typing import Any
 import pytest
 
 from scripts import update_baustellen_cache
+
+
+def _patch_http_layer_bypass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Monkeypatch the SSRF / DNS / IP-verification layer so a
+    ``responses``-mocked URL can be consumed without hitting the real
+    network.
+
+    Three layers need to be patched in concert; missing any one leaks
+    through to a real network call:
+
+    * ``validate_http_url`` — patched on the **caller's namespace**
+      (``update_baustellen_cache``) because the script does
+      ``from utils.http import validate_http_url`` at import time, so
+      patching only ``sys.modules['utils.http'].validate_http_url``
+      would leave the script's local binding pointing at the
+      original function.
+
+    * ``verify_response_ip`` — patched on the **provider module**
+      because it is called by the request machinery at the HTTP-layer
+      level, not from the script.
+
+    * ``_resolve_hostname_safe`` — patched on the **provider module**
+      with a fake resolver that returns ``127.0.0.1`` so the request
+      layer never times out on DNS even when the runner's namespace
+      forbids name resolution (the 2026-05-09 cron flake —
+      ``responses`` intercepts at the HTTP layer, but our HTTP
+      utility resolves DNS BEFORE handing off to the requests
+      library, so the mock cannot prevent the timeout). The fake
+      mirrors the :func:`socket.getaddrinfo`-shaped tuple the
+      production helper returns so downstream consumers never need
+      an ``isinstance`` check.
+    """
+    # The fake IP must NOT be one of the SSRF-rejected ranges
+    # (loopback, RFC1918, link-local, multicast, etc.) — the
+    # request layer post-validates each resolved IP via
+    # ``is_ip_safe`` and raises "No safe IP resolved" when every
+    # entry fails. ``8.8.8.8`` (Google Public DNS) is a documented-
+    # safe public IPv4 that survives every gate. We additionally
+    # patch ``is_ip_safe`` to ``True`` as a belt-and-suspenders so
+    # a future tightening of the safe-IP allowlist cannot
+    # silently re-break this fixture.
+    fake_addrinfo: list[tuple[Any, ...]] = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 0)),
+    ]
+    # 1) The caller's local binding (the script imports the name
+    # directly, so the module-attribute patch below cannot reach it).
+    monkeypatch.setattr(
+        update_baustellen_cache, "validate_http_url", lambda url, **_kw: url
+    )
+    # 2) The provider-module attributes — these are looked up at call
+    # time by the HTTP machinery itself, so patching the module
+    # attribute is sufficient.
+    for module_name in ("src.utils.http", "utils.http"):
+        if module_name not in sys.modules:
+            continue
+        module = sys.modules[module_name]
+        monkeypatch.setattr(module, "validate_http_url", lambda url, **kw: url)
+        monkeypatch.setattr(module, "verify_response_ip", lambda _: None)
+        monkeypatch.setattr(
+            module, "_resolve_hostname_safe", lambda _hostname: fake_addrinfo
+        )
+        monkeypatch.setattr(module, "is_ip_safe", lambda _ip, **_kw: True)
 
 
 SAMPLE_PATH = Path(__file__).resolve().parents[1] / "data" / "samples" / "baustellen_sample.geojson"
@@ -224,17 +288,9 @@ def test_fetch_remote_rejects_unexpected_content_type(
     memory and handed to ``json.loads``, which works only by accident."""
     import logging
     import responses
-    import sys
 
     # Bypass DNS / IP checks (we're testing content-type filtering, not SSRF).
-    for module_name in ("src.utils.http", "utils.http"):
-        if module_name in sys.modules:
-            monkeypatch.setattr(
-                sys.modules[module_name], "validate_http_url", lambda url, **kw: url
-            )
-            monkeypatch.setattr(
-                sys.modules[module_name], "verify_response_ip", lambda _: None
-            )
+    _patch_http_layer_bypass(monkeypatch)
 
     @responses.activate
     def run() -> None:
@@ -288,16 +344,8 @@ def test_fetch_remote_accepts_geojson_variants(
     responses — overshooting (rejecting a legitimate variant) would put the
     feed into permanent fallback mode."""
     import responses
-    import sys
 
-    for module_name in ("src.utils.http", "utils.http"):
-        if module_name in sys.modules:
-            monkeypatch.setattr(
-                sys.modules[module_name], "validate_http_url", lambda url, **kw: url
-            )
-            monkeypatch.setattr(
-                sys.modules[module_name], "verify_response_ip", lambda _: None
-            )
+    _patch_http_layer_bypass(monkeypatch)
 
     @responses.activate
     def run() -> None:


### PR DESCRIPTION
## Summary

PR #1389 hat den Body endlich lesbar gemacht. Die letzte Cron-Diagnose:

```
HTTP 400 (errorCode=***, body_keys=dialectVersion,errorCode,
          errorText,requestId,serverVersion,
          ct=application/json; charset=UTF-8, cl=163, server=[MISSING], www_auth=***)
```

**Bestätigt:** das ist die canonical VAO-Error-Envelope. Aber `errorCode=***` zeigt: **VAO echoet den supplied `accessId` in das `errorCode`-Feld**. Der String matcht meine strict regex (alphanumerisch, ≤32 chars), wird verbatim returnt, und der GitHub-Actions-Masker maskiert ihn.

Wir haben jetzt eine strukturell-valide VAO-Antwort, aber keine actionable Info.

## Drei neue Diagnostiken — leak-frei

| Field | Bedeutung | Leak-Risk |
| ----- | --------- | --------- |
| **`code_len`** | Länge des `errorCode`-Werts | Zero-Leak. 4-15 = canonical Code (`H890`, `SVC_LOC_INVALID`); 16+ = accessId-shaped Token |
| **`err_text`** | Human-readable `errorText`-Feld | Substring-masked: `"Authentication failed: ***"` zeigt Failure-Kategorie auch wenn Wert maskiert |
| **`req_id`** | Server-side `requestId` (UUID / hex token) | Zero-Leak — server-set, nicht user-echoed; VAO-Support kann damit lookup machen |

### Neue Log-Zeile (Beispiel)

```
HTTP 401 (errorCode=H730, code_len=4, err_text=Authentication failed,
          req_id=8e7f2c9b-1234-5678-90ab-cdef12345678, body_keys=...,
          ct=..., cl=..., server=..., www_auth=...).
```

Damit ist sofort sichtbar:
- **Auth-Issue** — wenn `err_text` von Credential-Problem spricht
- **Param-Issue** — wenn `err_text` einen Parameter-Namen nennt
- **Upstream-Issue** — `req_id` für VAO-Support-Ticket

## Test-Coverage

| Bereich | Tests |
| ------- | ----- |
| `_extract_vao_error_code_length` | 4 (canonical, token-shape, no-body, missing) |
| `_extract_vao_error_text` | 5 (text, errorMsg-Fallback, oversize, empty, no-body) |
| `_extract_vao_request_id` | 4 (UUID, hex, free-form-rejection, no-body) |
| Integration | erweitert: alle drei neuen Fields im Log assertet |

**Total: 107 passed** (war 94, +13).

## Lokale Verifikation

- `pytest tests/scripts/test_update_stammstrecke_status.py` → **107 passed**
- `mypy --strict` (Script + Tests) → no issues
- `python -m src.cli checks` → ruff + mypy + bandit + secret-scan + complexity-gate alle grün

## Erwartete Wirkung

Der nächste Cron-Run liefert genug Info für eine **definitive nächste Aktion** — entweder einen gezielten Fix (basierend auf `err_text`) oder ein VAO-Support-Ticket mit der `req_id`. Speculation-Zyklus endet.

https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr)_