### PR TITLE
fix(stammstrecke): export VOR_ACCESS_ID secret to the cron workflow

### DIFF
--- a/.github/workflows/update-stammstrecke-status.yml
+++ b/.github/workflows/update-stammstrecke-status.yml
@@ -23,6 +23,20 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
       PIP_CACHE_DIR: /tmp/pip-cache
+      # VOR/VAO API credentials — required by ``scripts/update_stammstrecke_
+      # status.py`` since the 2026-05-09 migration from pyhafas to the
+      # VOR ``/trip`` endpoint. Without these env vars,
+      # ``vor_provider.read_secret("VOR_ACCESS_ID")`` returns an empty
+      # string, ``VorAuth.access_id`` is ``""``, the per-request
+      # ``if self.access_id:`` gate skips the injection, and VAO
+      # rejects every request with ``HTTP 400 (errorText="Missing
+      # value for required param accessId")`` — diagnosed in the
+      # 2026-05-09 cron-log triage. Mirrors the env block in
+      # ``update-vor-cache.yml`` and ``manual-full-refresh.yml``.
+      VOR_ACCESS_ID: ${{ secrets.VOR_ACCESS_ID }}
+      VOR_BASE_URL: ${{ secrets.VOR_BASE_URL }}
+      VOR_BASE: ${{ secrets.VOR_BASE }}
+      VOR_VERSION: ${{ secrets.VOR_VERSION }}
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## ROOT CAUSE GEFUNDEN — nach 6 Iterationen Diagnose-Aufbau

Die letzte Cron-Ausgabe zeigte den entscheidenden Hinweis:

```
HTTP 400 (errorCode=***, code_len=9,
          err_text=Missing value for required param accessId,
          req_id=default-request-id, ...)
```

**`err_text`** — exponiert durch PR #1390 — sagt es klar: **VAO empfängt keinen `accessId`-Query-Parameter**.

## Warum?

`update-stammstrecke-status.yml` exportiert die VOR/VAO-Secrets **nicht** als env vars. Vergleich:

```diff
  env:
    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
    PYTHONPATH: src
    PIP_CACHE_DIR: /tmp/pip-cache
+   VOR_ACCESS_ID: ${{ secrets.VOR_ACCESS_ID }}
+   VOR_BASE_URL: ${{ secrets.VOR_BASE_URL }}
+   VOR_BASE: ${{ secrets.VOR_BASE }}
+   VOR_VERSION: ${{ secrets.VOR_VERSION }}
```

Folge-Kette:
1. `read_secret("VOR_ACCESS_ID")` → `""` (env var nicht gesetzt)
2. `VorAuth.access_id = ""`
3. Per-Request-Gate `if self.access_id:` → False → kein accessId injiziert
4. VAO rejects mit `Missing value for required param accessId`

Die Migration von pyhafas zu VOR (PR #1382) hat die ursprüngliche Workflow-Form geerbt, die nie VOR-Secrets exportierte (weil pyhafas einen unauthentifizierten mgate.exe-Endpunkt nutzte). Der post-migration Script BRAUCHT die accessId, aber der Workflow wurde nie aktualisiert.

## Fix

Die vier `VOR_*` env vars im Workflow ergänzen — exakt analog zu `update-vor-cache.yml` und `manual-full-refresh.yml`. **Keine Script-Änderung nötig.** Der existierende Loader handelt den Empty-Secret-Fall bereits sauber (er produziert einfach keine Auth, was wir auch beobachtet haben).

## Diagnostik-Lessons

Die 6-PR-Iterationen waren nicht umsonst: **die finale Diagnostik (`err_text=...`) war notwendig**, um diesen Bug zu finden. Ohne sie hätten wir nur `HTTPError` gesehen — und ein Workflow-Config-Bug ist von einer bare `HTTPError`-Klasse aus unmöglich zu finden:

| PR | Was es exponierte |
| -- | ----------------- |
| #1385 | HTTP-Status (400 statt 401/429/500) → "Bad Request, nicht Auth, nicht Quota" |
| #1387/#1388 | Response-Header (`ct=application/json`) → "VAO antwortet, kein Gateway-Error" |
| #1389 | Body lesbar (`request_safe(raise_for_status=False)`) → entdeckte Stream-Close-Race |
| #1390 | `err_text` field → entdeckte das fehlende `accessId` |
| **#1391** | **Die one-line Workflow-Config-Fix** |

## Erwartete Wirkung

Beim nächsten Cron-Tick (`*/30`) sollte:
- `accessId`-Query-Param injiziert werden
- VAO `/trip` HTTP 200 zurückgeben mit den nächsten 6 S-Bahn-Verbindungen
- Median nach `data/stats/stammstrecke_2026.csv` appendet
- Der nächtliche `generate-stats.yml`-Run patcht den README-Snapshot mit echten Werten

## Test plan

- [ ] CI grün auf diesem PR (workflow-yaml-only-change → keine Test-Auswirkung).
- [ ] Manueller Workflow-Trigger nach Merge: `Actions → Update Stammstrecke status → Run workflow`. Erwartet: kein HTTP 400 mehr im Log; cache/stammstrecke/events.json wird mit der heutigen Beobachtung committed.

https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr)_