### PR TITLE
ci(stammstrecke): commit data/stats CSV alongside the events cache

### DIFF
--- a/.github/workflows/update-stammstrecke-status.yml
+++ b/.github/workflows/update-stammstrecke-status.yml
@@ -64,4 +64,16 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: 'chore: update Stammstrecke status'
-          file_pattern: 'cache/stammstrecke/events.json'
+          # ``cache/stammstrecke/events.json`` carries the threshold-
+          # based feed events; ``data/stats/stammstrecke_<YYYY>.csv``
+          # carries the append-only median observations consumed by
+          # the nightly ``generate-stats.yml`` dashboard. Both must be
+          # committed for the README snapshot to reflect real cron
+          # data — the original workflow only committed the cache,
+          # so the CSV row was written by the script but never made
+          # it back to the repo (diagnosed 2026-05-09 in the
+          # successful-run that produced "Erfolg=2, Fehler=0" but
+          # left the working tree clean).
+          file_pattern: |
+            cache/stammstrecke/events.json
+            data/stats/stammstrecke_*.csv


### PR DESCRIPTION
## Summary

🎉 **Der vorherige Cron-Run war ein voller Erfolg** (PR #1392 Effect):

```
Stammstrecke: Richtung Meidling — 3 S-Bahn-Legs aus 6 Trips analysiert.
Stammstrecke: Richtung Meidling — Median: 0.00 Minuten (Schwelle: 9).
Stammstrecke: Richtung Floridsdorf — 0 S-Bahn-Legs aus 6 Trips analysiert.
Stammstrecke: Cache mit 0 Event(s) aktualisiert (Erfolg=2, Fehler=0).
```

**Aber: ein letzter Bug in der Workflow-Konfiguration** — `Working tree clean. Nothing to commit.`

## Wurzelursache

`update-stammstrecke-status.yml` `file_pattern` war zu eng:

```yaml
file_pattern: 'cache/stammstrecke/events.json'   # ← nur das Cache-File
```

Der Script-Output:
- ✅ `cache/stammstrecke/events.json` → bleibt `[]` (Median ≤ 9 min, no event) → Auto-Commit-Action sieht keine Änderung
- ❌ `data/stats/stammstrecke_2026.csv` → bekommt eine neue Zeile **aber wird nicht committet**

Folge: die Median-Observation existiert lokal im CI-Runner, aber landet nie im Repo. Der nächtliche `generate-stats.yml`-Run findet keine neuen Daten und der README-Snapshot bleibt stehen.

## Fix

```diff
- file_pattern: 'cache/stammstrecke/events.json'
+ file_pattern: |
+   cache/stammstrecke/events.json
+   data/stats/stammstrecke_*.csv
```

Mirrors die `generate-stats.yml`-Konfiguration (die bereits beide `docs/statistik.md` UND `data/stats/*.csv` committet) — beide Files gehören zur selben "Stammstrecke status" Responsibility:

| File | Rolle | Schreibrhythmus |
| ---- | ----- | --------------- |
| `cache/stammstrecke/events.json` | Feed-Event-Cache | Jeder Run (idempotent — bleibt `[]` solange kein Threshold-Breach) |
| `data/stats/stammstrecke_<YYYY>.csv` | Append-only Median-Observation-Ledger | Jeder Run mit erfolgreicher HAFAS-Median-Berechnung |

## Erwartete Wirkung

Beim nächsten Cron-Tick (`*/30`):
- 30-Min-Median-Observation wird committet
- `generate-stats.yml` (cron 00:15 UTC) aggregiert die akkumulierten CSV-Rows
- README-Snapshot zeigt **echte** Werte ("Beobachtungen (gesamt) = N>1, Median-Verspätung in Echtzeit, etc.")

## Lessons Learned — Triage Recap (alle 8 PRs)

| PR | Beitrag |
| -- | ------- |
| #1382 | Migration pyhafas → VOR `/trip` |
| #1385 | HTTP-Status-Code Diagnostic |
| #1387 | Versuchter `originExtId`-Fix (war falsch — accessId fehlte) |
| #1389 | `request_safe(raise_for_status=False)` → Body wieder lesbar |
| #1390 | `errorText`/`requestId`/`code_len`-Diagnostics |
| #1391 | **Root Cause #1**: VOR-Secrets in Workflow exportiert |
| #1392 | **Root Cause #2**: `extId::`-Präfix → bare numeric IDs |
| **#1393** | **Root Cause #3**: CSV mit committen statt nur Cache |

Die fortified Diagnostic-Stack war **essential** — ohne sie wären wir bei "HTTPError" stecken geblieben. Auch dieser file_pattern-Fix wurde durch Logs lokalisiert (`Working tree clean. Nothing to commit.`).

https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr)_