### PR TITLE
polish(stammstrecke): align source field to VOR/VAO + 30-min README cadence

### DIFF
--- a/.github/workflows/update-stammstrecke-status.yml
+++ b/.github/workflows/update-stammstrecke-status.yml
@@ -57,6 +57,23 @@ jobs:
       - name: Refresh Stammstrecke status
         run: python scripts/update_stammstrecke_status.py
 
+      # Regenerate the statistics dashboard (``docs/statistik.md``)
+      # AND patch the README ``<!-- STATS:* -->`` markers with the
+      # 30-day rolling snapshot. Runs in this same workflow so the
+      # README cadence matches the Stammstrecke observation cadence
+      # (every 30 minutes) — without this step, the README snapshot
+      # would only refresh once per day via ``generate-stats.yml``
+      # and the operator-visible "Beobachtungen (gesamt)" /
+      # "Median-Verspätung" / "Letzte Aktualisierung" cells would lag
+      # the underlying CSV ledger by up to 24 hours. The script reads
+      # only ``data/stats/*.csv`` (no network), is idempotent at the
+      # byte level (a no-data-change run re-emits identical bytes
+      # except for the timestamp cell), and writes via
+      # ``atomic_write`` so a kill-signal mid-run cannot corrupt
+      # either output.
+      - name: Refresh statistics dashboard and README snapshot
+        run: python scripts/generate_markdown_stats.py
+
       - name: Pull concurrent remote changes
         run: git pull --rebase --autostash
 
@@ -66,14 +83,16 @@ jobs:
           commit_message: 'chore: update Stammstrecke status'
           # ``cache/stammstrecke/events.json`` carries the threshold-
           # based feed events; ``data/stats/stammstrecke_<YYYY>.csv``
-          # carries the append-only median observations consumed by
-          # the nightly ``generate-stats.yml`` dashboard. Both must be
-          # committed for the README snapshot to reflect real cron
-          # data — the original workflow only committed the cache,
-          # so the CSV row was written by the script but never made
-          # it back to the repo (diagnosed 2026-05-09 in the
-          # successful-run that produced "Erfolg=2, Fehler=0" but
-          # left the working tree clean).
+          # carries the append-only median observations; ``docs/
+          # statistik.md`` and ``README.md`` carry the regenerated
+          # human-readable dashboard / snapshot. All four must be
+          # committed for the operator-visible output to stay in sync
+          # with the underlying observation cadence (every 30 min).
+          # The ``generate-stats.yml`` nightly cron remains active as
+          # a belt-and-suspenders refresh in case any 30-minute
+          # update is skipped (concurrency-group pre-emption etc.).
           file_pattern: |
             cache/stammstrecke/events.json
             data/stats/stammstrecke_*.csv
+            docs/statistik.md
+            README.md

--- a/scripts/update_stammstrecke_status.py
+++ b/scripts/update_stammstrecke_status.py
@@ -181,10 +181,17 @@ VIENNA_TZ = ZoneInfo("Europe/Vienna")
 
 OUTPUT_PATH = REPO_ROOT / "cache" / "stammstrecke" / "events.json"
 
-# Event metadata: kept verbatim from the original pyhafas-era script so
-# subscribers see the same source/category/title/link strings (i.e. the
-# RSS migration is invisible to feed readers).
-EVENT_SOURCE = "ÖBB"
+# Event metadata: ``source`` mirrors the project-standard VOR-provider
+# value (``src/providers/vor.py:1219``) because the script now polls the
+# VAO ReST ``/trip`` endpoint operated by the Verkehrsverbund Ost-Region.
+# Using ``"VOR/VAO"`` keeps the publisher attribution consistent across
+# all VAO-API-derived items in the feed and makes the data lineage
+# transparent to subscribers (who can filter by source). The pre-2026-
+# 05-09 ``"ÖBB"`` value reflected the original pyhafas/HAFAS data path
+# and was retained verbatim across the migration; this PR aligns the
+# attribution with the actual upstream now that the VAO-based pipeline
+# is producing consistently.
+EVENT_SOURCE = "VOR/VAO"
 EVENT_CATEGORY = "Störung"
 EVENT_TITLE = "S-Bahn Stammstrecke Verspätungen"
 EVENT_LINK = (

--- a/tests/scripts/test_update_stammstrecke_status.py
+++ b/tests/scripts/test_update_stammstrecke_status.py
@@ -1534,7 +1534,14 @@ def test_build_event_for_meidling_direction(_stable_now: datetime) -> None:
     }
     assert required_keys.issubset(event.keys())
     assert event["title"] == "S-Bahn Stammstrecke Verspätungen"
-    assert event["source"] == "ÖBB"
+    # ``source`` is the project-standard VOR-provider value
+    # (``src/providers/vor.py:1219``) since the 2026-05-09 migration
+    # to the VAO ReST ``/trip`` endpoint. The pre-migration ``"ÖBB"``
+    # value reflected the pyhafas/HAFAS data path and was retained
+    # verbatim during the migration; aligning to ``"VOR/VAO"`` keeps
+    # the publisher attribution consistent with every other
+    # VAO-API-derived item in the feed.
+    assert event["source"] == "VOR/VAO"
     assert event["category"] == "Störung"
     assert (
         event["description"]


### PR DESCRIPTION
## Summary

Zwei post-migration Polish-Items basierend auf User-Audit-Review:

### 1. `EVENT_SOURCE = "VOR/VAO"` (war `"ÖBB"`)

Der Migration-Plan hat den `source`-String absichtlich unverändert gelassen, damit die Migration für Subscribers unsichtbar bleibt. Jetzt — nach erfolgreicher End-to-End-Verifikation — sollte die Attribution mit der Realität übereinstimmen:

- **Project-Standard:** `src/providers/vor.py:1219` setzt `"source": "VOR/VAO"` für alle VAO-API-derived Items
- **Konsistenz:** Subscribers, die nach `source` filtern, sehen Stammstrecke-Items zusammen mit dem regulären VOR-Disruption-Feed
- **Kein guid-Impact:** `_build_event` baut den guid aus `(identity_prefix, iso_first_seen)` — Active Episodes bleiben stabil

```diff
- EVENT_SOURCE = "ÖBB"
+ EVENT_SOURCE = "VOR/VAO"
```

### 2. README-Snapshot alle 30 Minuten (war: 1× pro Tag)

`generate_markdown_stats.py` wird jetzt direkt nach `update_stammstrecke_status.py` im selben Workflow ausgeführt:

```diff
  - name: Refresh Stammstrecke status
    run: python scripts/update_stammstrecke_status.py

+ - name: Refresh statistics dashboard and README snapshot
+   run: python scripts/generate_markdown_stats.py

  - name: Pull concurrent remote changes
    run: git pull --rebase --autostash
```

Plus `file_pattern` erweitert um `docs/statistik.md` und `README.md`. Damit werden alle vier Artefakte konsistent committet:

| File | Cadence pre-PR | Cadence post-PR |
| ---- | -------------- | --------------- |
| `cache/stammstrecke/events.json` | 30 min ✓ | 30 min ✓ |
| `data/stats/stammstrecke_*.csv` | 30 min ✓ | 30 min ✓ |
| `docs/statistik.md` | **24 h** ❌ | **30 min** ✓ |
| `README.md` (STATS-Marker) | **24 h** ❌ | **30 min** ✓ |

Die `generate-stats.yml`-Nightly-Cron bleibt als Belt-and-Suspenders aktiv, falls ein 30-Min-Tick durch Concurrency-Pre-Emption ausfällt.

### Idempotenz / Commit-Churn

`patch_readme_stats` ist byte-equality-aware (PR #1389) — wenn die zu schreibenden Bytes identisch sind, wird der File-Write übersprungen. Pro 30-Min-Tick ändert sich:
- `data/stats/stammstrecke_*.csv` — bekommt eine neue Zeile (immer geänderter Diff)
- `cache/stammstrecke/events.json` — meist `[]` (Median ≤ 9 min), bei Stau ändert sich der Inhalt
- `README.md` / `docs/statistik.md` — `Letzte Aktualisierung`-Zelle ändert sich (1-Zeilen-Diff)

→ 48 Commits/Tag mit echten Datenupdates. Kein noise — jeder Commit reflektiert eine echte Beobachtung.

## Test-Coverage

| Test | Status |
| ---- | ------ |
| `test_build_event_for_meidling_direction` (`event["source"] == "VOR/VAO"`) | ✓ aktualisiert |
| `test_main_clears_cache_when_breaker_is_open` (stale fixture mit `source="ÖBB"`) | unverändert — das ist semantisch korrekt: pre-migration cache wird gelöscht |

**Total: 115 passed**.

## Lokale Verifikation

- `pytest tests/scripts/test_update_stammstrecke_status.py` → **115 passed**
- `mypy --strict` (Script + Tests) → no issues
- `python -m src.cli checks` → ruff + mypy + bandit + secret-scan + complexity-gate alle grün
- YAML-Strukturverifikation: 8 Steps in korrekter Reihenfolge, file_pattern komplett

## Erwarteter Effekt

Beim nächsten Cron-Tick (`*/30`) sollte:
- `event["source"]` im Feed den Wert `"VOR/VAO"` zeigen
- README "Letzte Aktualisierung" auf den 30-Min-Tick-Timestamp aktualisiert werden
- `generate-stats.yml`-Nightly bleibt als Backup aktiv

https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr)_