### PR TITLE
security(stations_validation): neutralise Markdown injection at to_markdown() boundary

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,228 @@
+## 2026-05-09 - Markdown Injection Drift Round 3: Eight Bullet-Body Sinks at the `ValidationReport.to_markdown()` Boundary — Stations-Directory Sister of the Feed-Health / Stats-Dashboard Renderer Drifts
+**Vulnerability:** The 2026-05-09 Markdown-injection rounds closed the
+renderer boundary in `scripts/generate_markdown_stats.py` (stats
+dashboard) and `src/feed/reporting.py` (Feed-Health report + GitHub
+Issue body) but their threat-model paragraph on "Markdown rendering is
+the LAST sink in any text-data pipeline that ends in a human-readable
+artefact (dashboard, **issue body**, **README**); always treat it as
+a *defence boundary* even when an upstream sanitiser exists" *implicitly*
+opened a sibling drift round: the third Markdown-emitting renderer in
+the project — `ValidationReport.to_markdown()` in
+`src/utils/stations_validation.py` — interpolated up to fifteen
+operator-controlled string fields (across eight issue-category
+sections) directly into Markdown bullet bodies *without any
+escaping at all*.
+
+The renderer is consumed by the CLI subcommand
+``python -m src.cli stations validate --output
+docs/stations_validation_report.md`` (driven by
+``.github/workflows/update-stations.yml`` on a monthly cron and
+``.github/workflows/manual-full-refresh.yml`` on workflow_dispatch).
+Both workflows then auto-commit the rendered Markdown via
+``stefanzweifel/git-auto-commit-action`` so the file is *publicly
+published* on github.com (and any GitHub Pages site mirroring
+``docs/``). The repo's ``docs/sitemap.xml`` even points to
+``stations_validation_report.html`` — the file is a public,
+search-indexed artefact.
+
+Pre-fix sinks (eight orthogonal Markdown-rendering bullet lines, each
+interpolating two-to-five operator-controlled fields):
+
+  ```python
+  # src/utils/stations_validation.py:to_markdown (pre-fix):
+  # 1. Security warnings:
+  f"- {sec_issue.identifier} ({sec_issue.name}): {sec_issue.reason}"
+  # 2. Provider issues:
+  f"- {provider_issue.identifier} ({provider_issue.name}): {provider_issue.reason}"
+  # 3. Cross station ID issues (FIVE operator-controlled fields):
+  f"- {cross_issue.identifier} ({cross_issue.name}): alias {cross_issue.alias!r} "
+  f"collides with {cross_issue.colliding_field} of "
+  f"{cross_issue.colliding_identifier} ({cross_issue.colliding_name})"
+  # 4. Geographic duplicates (joined identifier list):
+  f"- ({group.latitude:.5f}, {group.longitude:.5f}) → " + ", ".join(group.identifiers)
+  # 5. Alias issues:
+  f"- {alias_issue.identifier} ({alias_issue.name}): {alias_issue.reason}"
+  # 6. Coordinate anomalies:
+  f"- {coordinate_issue.identifier} ({coordinate_issue.name}): {coordinate_issue.reason}"
+  # 7. GTFS mismatches (vor_id is operator-controlled):
+  f"- {gtfs_issue.identifier} ({gtfs_issue.name}) → missing stop_id {gtfs_issue.vor_id}"
+  # 8. Naming issues:
+  f"- {naming_issue.identifier} ({naming_issue.name}): {naming_issue.reason}"
+  ```
+
+Four orthogonal Markdown-injection axes opened up at these sinks:
+
+  (a) **Backtick inline-code-span break-out** — a name like
+      ``Wien Hbf \`<img src=x onerror=alert(1)>\``` opens a CommonMark
+      inline code span that lets the embedded HTML render as a live
+      ``<img>`` tag in the public ``docs/stations_validation_report.md``
+      artefact. CommonMark code spans render their interior verbatim
+      and ``escape_markdown`` is the only defence (backslash-escaping
+      the backtick collapses the code-span entirely).
+
+  (b) **Markdown-link phishing** — a payload like
+      ``[click here](javascript:alert(1))`` or
+      ``[click here](https://evil.example)`` renders as a clickable
+      Markdown link in the published report. An operator skimming the
+      report on github.com sees a normal-looking link that points to
+      an attacker-controlled destination — a usable phishing primitive
+      against every repo watcher.
+
+  (c) **Asterisk emphasis spoof** — ``*spoofed-bold*`` injects italic
+      / bold emphasis the operator did not author. While individually
+      low-impact, combined with semantic injection (e.g. ``*RESOLVED*``,
+      ``*CRITICAL*``) it lets an upstream forge operator-facing
+      visual signals.
+
+  (d) **HTML angle-bracket injection** — although
+      ``_UNSAFE_CHARS_RE`` in ``_find_security_issues`` flags
+      ``<``/``>`` and ``_collect_blocking_issues`` in
+      ``scripts/update_all_stations.py`` aborts the commit when those
+      fire, that gate is **only active in the orchestrator script**.
+      The standalone CLI invocation (``python -m src.cli stations
+      validate``) and the ``manual-full-refresh.yml`` workflow's
+      regenerate-step both bypass the gate entirely — a hostile
+      ``stations.json`` produced by any of those paths flows
+      verbatim into the renderer.
+
+The threat surface at every sink is operator-controlled-but-
+upstream-influenced:
+
+  1. **`stations.json` is populated by cron-driven scripts** —
+     ``scripts/update_all_stations.py`` orchestrates
+     ``update_vor_stations.py`` / ``update_wl_stations.py`` /
+     ``update_oebb_cache.py`` / ``fetch_google_places_stations.py`` /
+     ``enrich_station_aliases.py`` — every one fans out to external
+     API surfaces (VOR / OEBB / Wiener Linien / Google Places /
+     OSM Overpass). A compromised upstream / DNS-hijack / MITM that
+     returns a station with a hostile ``name`` field lands the
+     payload in ``stations.json`` even when the per-fetch SSRF /
+     DNS-rebinding / size-cap defences hold.
+  2. **Cross-cutting** — every prior round's threat-model surface
+     for cron-pipeline poisoning (leaked CI env, compromised
+     secret store, intentional misconfig, partial flush + power
+     loss on cache write) carries here.
+
+The defence-in-depth contract collapses the cartesian product of
+(upstream source × upstream-gate bypass × backtick / link / asterisk
+/ angle-bracket axis × eight renderer sinks) into a single sanitiser
+at the last gate before rendering.
+
+**Fix:** A single canonical defence helper applied per-sink:
+
+  ```python
+  # src/utils/stations_validation.py — module-level helper:
+  def _safe_md(text: object) -> str:
+      """Compose normalise_markdown_text + escape_markdown for the
+      stations validation report renderer."""
+      return escape_markdown(
+          normalise_markdown_text(str(text), max_len=_REPORT_FIELD_MAX_LEN)
+      )
+
+  # to_markdown — every text interpolation routed through _safe_md:
+  f"- {_safe_md(sec.identifier)} ({_safe_md(sec.name)}): {_safe_md(sec.reason)}"
+  # ... 14 more interpolations across the seven other sections
+  ```
+
+The helper is module-level (NOT nested inside ``to_markdown``) so it
+adds zero to the C901 complexity counter — the function stays at its
+baselined 18. The ``_REPORT_FIELD_MAX_LEN = 400`` cap is sized
+generously enough for the longest legitimate ``reason`` (the alias-
+issue ``f"missing required aliases: {…}"`` join can carry several
+station names) while still bounding a planted-huge-field
+amplification shape.
+
+For the cross-station-id alias sink, the legacy ``{alias!r}`` (Python
+repr — quotes the value but does NOT escape Markdown chars) is
+replaced with explicit single-quote wrapping ``'{_safe_md(alias)}'``.
+This preserves the rendered ``'Mitte'`` shape that
+``test_markdown_rendering_contains_cross_station_id_section`` pins
+while ensuring that hostile aliases like ``"Mitte`xss`"`` get the
+backtick backslash-escaped.
+
+For the geographic-duplicates sink, the joined identifier list uses
+a generator expression (``", ".join(_safe_md(ident) for ident in
+group.identifiers)``) so each element is sanitised independently —
+catches a hostile identifier even when other identifiers in the
+group are clean.
+
+The lat/longitude formatting (``:.5f``) is not sanitised because
+``DuplicateGroup.latitude`` / ``longitude`` are typed ``float`` and
+validated by ``_extract_float`` (rejects NaN / inf / non-numeric)
+on construction — numeric formatting is safe by construction.
+
+**Tests:** Ten end-to-end PoC tests in
+``tests/test_sentinel_stations_validation_markdown_injection.py``
+exercise every sink with a layout-breaking payload:
+  * Six per-issue-category backtick / link / emphasis tests
+    (``test_security_issue_backtick_in_name_does_not_break_out_to_html``,
+    ``test_alias_issue_backtick_in_reason_does_not_break_out_to_html``,
+    ``test_naming_issue_markdown_link_in_reason_does_not_render_as_link``,
+    ``test_provider_issue_markdown_link_in_name_does_not_render_as_link``,
+    ``test_coordinate_issue_asterisk_emphasis_does_not_render_as_bold``,
+    ``test_cross_station_id_issue_backtick_in_alias_does_not_break_out``).
+  * Two list-and-aggregate tests
+    (``test_duplicate_group_backtick_in_identifier_does_not_break_out``,
+    ``test_gtfs_issue_backtick_in_vor_id_does_not_break_out``).
+  * One end-to-end test
+    (``test_end_to_end_hostile_stations_json_does_not_inject_markdown``)
+    that builds a real ``stations.json`` with a hostile name, runs
+    the full ``validate_stations`` pipeline, and asserts the rendered
+    output contains no Markdown / HTML break-out primitives.
+  * One inventory invariant
+    (``test_to_markdown_sink_inventory_is_pinned``) that scans the
+    source for the canonical pre-fix interpolation patterns and
+    fails when ANY of the seven text-bearing sinks is reintroduced
+    without the ``_safe_md`` wrapper.
+
+All ten were verified to FAIL on the pre-fix code (the first one
+caught the literal ``\`<img`` substring in the rendered output) and
+to PASS on the post-fix code. The existing
+``test_markdown_rendering_contains_cross_station_id_section`` was
+updated to assert on ``"bst\\_code"`` (the underscore-escaped
+form) rather than the raw ``"bst_code"`` to reflect the new
+escaping contract.
+
+**Learning:** Three reinforcing lessons:
+
+  (a) **Every Markdown-emitting renderer in a project is a
+      sister sink to every other Markdown-emitting renderer.** The
+      2026-05-09 stats-dashboard round closed
+      `scripts/generate_markdown_stats.py`. The 2026-05-09 Round 2
+      closed `src/feed/reporting.py`. This Round 3 closed
+      `src/utils/stations_validation.py`. The drift family is
+      defined by the *output medium* (Markdown rendered on
+      github.com / GitHub Pages / IDE viewers), not by the *source
+      file*. A future round MUST treat any new ``to_markdown``-
+      shaped function as a sister sink and audit the full chain
+      from data source → renderer → published artefact in one
+      sweep, not one renderer at a time.
+
+  (b) **Upstream gates do not substitute for renderer-boundary
+      defences.** ``_collect_blocking_issues`` in
+      ``scripts/update_all_stations.py`` aborts the commit when
+      ``_UNSAFE_CHARS_RE`` fires — a useful belt-and-suspenders
+      check for the orchestrator's *write* path. But the renderer
+      is invoked from THREE other code paths (standalone CLI,
+      ``manual-full-refresh.yml`` regenerate step, any future
+      direct caller) that bypass the gate entirely. The renderer
+      MUST defend itself even when the typical caller has its own
+      defences — the cartesian product of (caller bypass × payload
+      shape) is too large to enumerate at every call site.
+
+  (c) **`!r` repr-formatting is NOT a Markdown sanitiser.**
+      ``f"alias {alias!r}"`` adds quotes around the value (useful
+      for delimiting the alias text) but does not escape Markdown
+      characters. A hostile ``alias = "Mitte\`xss\`"`` renders as
+      ``alias 'Mitte\`xss\`'`` — the backtick still breaks out of
+      any surrounding inline code span. The replacement pattern
+      ``f"alias '{escape_markdown(alias)}'"`` preserves the visual
+      delimiter while applying the canonical defence. The
+      project-wide convention pinned by this round: NEVER use
+      ``!r`` to "safe-quote" a string in a Markdown context;
+      always use explicit quote-wrapping plus ``escape_markdown``
+      (or ``safe_markdown_codespan`` for inline-code-span sinks).
+
 ## 2026-05-09 - Markdown Injection Drift Round 2: Inline-Code-Span and Fenced-Code-Block Break-Out at the Feed-Health / GitHub-Issue Renderer (`feed_path`, `error_log_path`, Diagnostics) — Env-Override Path-Boundary Sibling
 **Vulnerability:** The 2026-05-09 stats-dashboard Markdown-injection
 round (entry below) closed the renderer boundary in

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -20,6 +20,7 @@ from collections.abc import Iterable, Iterator, Mapping, Sequence
 
 from src.utils.files import read_capped_text
 from src.utils.stations import MAX_STATIONS_FILE_BYTES, _normalize_token
+from src.utils.text import escape_markdown, normalise_markdown_text
 
 # Security: per-loader byte cap for the GTFS ``stops.txt`` CSV consumed
 # by ``_load_gtfs_stop_ids``. Sized at 50 MiB to comfortably cover
@@ -110,6 +111,32 @@ class NamingIssue:
     reason: str
 
 
+# Per-cell length cap applied at every ``stations.json``-derived
+# Markdown sink in :meth:`ValidationReport.to_markdown`. Mirrors the
+# canonical ``_DASHBOARD_FIELD_MAX_LEN`` constant in
+# ``scripts/generate_markdown_stats.py``: the report renders bullet
+# lines that already include identifier + name + reason from the same
+# row; an additional render-side cap keeps the layout legible even if
+# a future writer persists multi-KiB blobs to the source field.
+_REPORT_FIELD_MAX_LEN = 400
+
+
+def _safe_md(text: object) -> str:
+    """Render ``text`` for inclusion as bullet body in the validation report.
+
+    Composes :func:`normalise_markdown_text` (strips C0/C1 controls +
+    Trojan-Source / line-terminator union + ZWSP family + BiDi marks,
+    collapses whitespace, caps length) with :func:`escape_markdown`
+    (HTML-escapes + backslash-escapes the CommonMark structural set
+    ``[]()*_`@<>``). Mirrors the canonical defence pattern applied at
+    every other Markdown-renderer boundary in the project — see the
+    module-level threat model in :meth:`ValidationReport.to_markdown`.
+    """
+    return escape_markdown(
+        normalise_markdown_text(str(text), max_len=_REPORT_FIELD_MAX_LEN)
+    )
+
+
 @dataclass(frozen=True)
 class ValidationReport:
     """Summary returned by :func:`validate_stations`."""
@@ -139,6 +166,37 @@ class ValidationReport:
         )
 
     def to_markdown(self) -> str:
+        # Security (Markdown injection at the public-artefact renderer
+        # boundary): every text field interpolated below carries
+        # operator-controlled data sourced from ``stations.json`` — which
+        # is in turn populated by cron-driven scripts that fan out to
+        # external API surfaces (VOR/OEBB/Wiener Linien/Google Places/
+        # OSM Overpass). A compromised upstream / DNS-hijack / MITM (or
+        # any future fetch path that does not pin the host) injects
+        # arbitrary ``name`` / ``bst_code`` / ``vor_id`` / ``alias``
+        # bytes that flow VERBATIM into ``docs/stations_validation_
+        # report.md`` — auto-committed by the ``update-stations.yml``
+        # cron workflow and the ``manual-full-refresh.yml`` workflow,
+        # then rendered on github.com (and every operator's IDE /
+        # Markdown viewer / GitHub Pages mirror). The canonical
+        # ``escape_markdown`` + ``normalise_markdown_text`` defence pair
+        # mirrors the renderer-boundary pattern applied in
+        # ``scripts/generate_markdown_stats.py`` and
+        # ``src/feed/reporting.py`` (2026-05-09 Markdown Injection Drift
+        # rounds). ``_safe_md`` (module-level helper) strips C0/C1 controls
+        # + Trojan-Source / line-terminator union + ZWSP family + BiDi
+        # marks (via ``normalise_markdown_text``), then backslash-
+        # escapes the CommonMark structural set ``[]()*_\`@<>`` and
+        # HTML-escapes ``&<>"'`` (via ``escape_markdown``). Layered
+        # defence: the upstream ``_collect_blocking_issues`` gate aborts
+        # the ``update_all_stations.py`` commit when ``_UNSAFE_CHARS_RE``
+        # fires on ``<>`` / ASCII C0 / BiDi, but that gate is ONLY
+        # active in the orchestrator script — the standalone CLI
+        # invocation (``python -m src.cli stations validate``), the
+        # ``manual-full-refresh.yml`` workflow's regenerate-step, and
+        # any future direct ``to_markdown()`` caller bypass it
+        # entirely. Sanitising at THIS boundary closes every code path
+        # in one cut.
         lines = ["# Stations Validation Report", ""]
         lines.append(f"*Total stations analysed*: {self.total_stations}")
         lines.append(f"*GTFS stops loaded*: {self.gtfs_stop_count}")
@@ -154,67 +212,70 @@ class ValidationReport:
 
         if self.security_issues:
             lines.append("## Security warnings (potential XSS/Injection)")
-            for sec_issue in self.security_issues:
+            for sec in self.security_issues:
                 lines.append(
-                    f"- {sec_issue.identifier} ({sec_issue.name}): {sec_issue.reason}"
+                    f"- {_safe_md(sec.identifier)} ({_safe_md(sec.name)}): {_safe_md(sec.reason)}"
                 )
             lines.append("")
 
         if self.provider_issues:
             lines.append("## Provider issues (VOR/OEBB)")
-            for provider_issue in self.provider_issues:
+            for prov in self.provider_issues:
                 lines.append(
-                    f"- {provider_issue.identifier} ({provider_issue.name}): {provider_issue.reason}"
+                    f"- {_safe_md(prov.identifier)} ({_safe_md(prov.name)}): {_safe_md(prov.reason)}"
                 )
             lines.append("")
 
         if self.cross_station_id_issues:
             lines.append("## Cross station ID issues")
-            for cross_issue in self.cross_station_id_issues:
+            for cross in self.cross_station_id_issues:
                 lines.append(
-                    f"- {cross_issue.identifier} ({cross_issue.name}): alias {cross_issue.alias!r} collides with "
-                    f"{cross_issue.colliding_field} of {cross_issue.colliding_identifier} ({cross_issue.colliding_name})"
+                    f"- {_safe_md(cross.identifier)} ({_safe_md(cross.name)}): "
+                    f"alias '{_safe_md(cross.alias)}' collides with "
+                    f"{_safe_md(cross.colliding_field)} of "
+                    f"{_safe_md(cross.colliding_identifier)} ({_safe_md(cross.colliding_name)})"
                 )
             lines.append("")
 
         if self.duplicates:
             lines.append("## Geographic duplicates")
             for group in self.duplicates:
+                joined_ids = ", ".join(_safe_md(ident) for ident in group.identifiers)
                 lines.append(
-                    f"- ({group.latitude:.5f}, {group.longitude:.5f}) → "
-                    + ", ".join(group.identifiers)
+                    f"- ({group.latitude:.5f}, {group.longitude:.5f}) → {joined_ids}"
                 )
             lines.append("")
 
         if self.alias_issues:
             lines.append("## Alias issues")
-            for alias_issue in self.alias_issues:
+            for ali in self.alias_issues:
                 lines.append(
-                    f"- {alias_issue.identifier} ({alias_issue.name}): {alias_issue.reason}"
+                    f"- {_safe_md(ali.identifier)} ({_safe_md(ali.name)}): {_safe_md(ali.reason)}"
                 )
             lines.append("")
 
         if self.coordinate_issues:
             lines.append("## Coordinate anomalies")
-            for coordinate_issue in self.coordinate_issues:
+            for coord in self.coordinate_issues:
                 lines.append(
-                    f"- {coordinate_issue.identifier} ({coordinate_issue.name}): {coordinate_issue.reason}"
+                    f"- {_safe_md(coord.identifier)} ({_safe_md(coord.name)}): {_safe_md(coord.reason)}"
                 )
             lines.append("")
 
         if self.gtfs_issues:
             lines.append("## GTFS mismatches")
-            for gtfs_issue in self.gtfs_issues:
+            for gtfs in self.gtfs_issues:
                 lines.append(
-                    f"- {gtfs_issue.identifier} ({gtfs_issue.name}) → missing stop_id {gtfs_issue.vor_id}"
+                    f"- {_safe_md(gtfs.identifier)} ({_safe_md(gtfs.name)}) → "
+                    f"missing stop_id {_safe_md(gtfs.vor_id)}"
                 )
             lines.append("")
 
         if self.naming_issues:
             lines.append("## Naming issues")
-            for naming_issue in self.naming_issues:
+            for naming in self.naming_issues:
                 lines.append(
-                    f"- {naming_issue.identifier} ({naming_issue.name}): {naming_issue.reason}"
+                    f"- {_safe_md(naming.identifier)} ({_safe_md(naming.name)}): {_safe_md(naming.reason)}"
                 )
             lines.append("")
 

--- a/tests/test_sentinel_stations_validation_markdown_injection.py
+++ b/tests/test_sentinel_stations_validation_markdown_injection.py
@@ -1,0 +1,376 @@
+"""Sentinel: Markdown injection at the ValidationReport.to_markdown() boundary.
+
+The CLI subcommand ``python -m src.cli stations validate --output
+docs/stations_validation_report.md`` (driven by the
+``update-stations.yml`` cron workflow and the ``manual-full-refresh.yml``
+workflow) regenerates the public ``docs/stations_validation_report.md``
+artefact from ``data/stations.json``. The same workflow then
+auto-commits the file via ``stefanzweifel/git-auto-commit-action`` so the
+report is *publicly published* on github.com (and any GitHub Pages site
+mirroring ``docs/``).
+
+The data that flows into the report is fed by the cron-driven
+``scripts/update_all_stations.py`` orchestrator, which fans out to the
+external API surface of VOR / OEBB / Wiener Linien / Google Places /
+OSM Overpass. A compromised upstream / DNS-hijack / MITM (or a
+sufficiently lax fetch path that does not pin the host) can therefore
+inject arbitrary ``name`` / ``bst_code`` / ``vor_id`` / ``alias``
+strings into ``stations.json`` — which then flow VERBATIM into
+``ValidationReport.to_markdown()``.
+
+The pre-fix ``to_markdown()`` interpolates these strings into eight
+distinct Markdown sinks (security warnings, provider issues, cross
+station ID issues, geographic duplicates, alias issues, coordinate
+anomalies, GTFS mismatches, naming issues) without any escaping. The
+following CommonMark primitives all break out:
+
+* **Backtick-in-bullet-text** — a ```xss``` token closes any inline
+  code span the operator would otherwise see and lets ``<img
+  src=x onerror=alert(1)>`` render as live HTML in the public artefact.
+* **Square-bracket Markdown link** — ``[click here](javascript:alert(1))``
+  renders as a clickable phishing link in the published report.
+* **Asterisk emphasis** — ``*spoofed*`` injects bold/italic emphasis
+  that the operator did not author.
+* **HTML angle brackets** — although ``_UNSAFE_CHARS_RE`` in
+  ``_find_security_issues`` flags angle brackets and the upstream
+  ``_collect_blocking_issues`` gate aborts the commit when it does, that
+  gate is ONLY active in ``scripts/update_all_stations.py``. The
+  standalone CLI invocation (``python -m src.cli stations validate``)
+  and any future code path that calls ``to_markdown()`` directly skips
+  the gate entirely.
+
+This sister round closes the renderer boundary in
+``ValidationReport.to_markdown()`` with the same canonical
+``escape_markdown(normalise_markdown_text(...))`` defence pattern that
+``scripts/generate_markdown_stats.py`` and ``src/feed/reporting.py``
+already apply at their renderer boundaries (see the 2026-05-09
+"Markdown Injection Drift Round 2" sentinel journal entry).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.utils.stations_validation import (
+    AliasIssue,
+    CoordinateIssue,
+    CrossStationIDIssue,
+    DuplicateGroup,
+    GTFSIssue,
+    NamingIssue,
+    ProviderIssue,
+    SecurityIssue,
+    ValidationReport,
+    validate_stations,
+)
+
+
+def _build_report(**overrides: object) -> ValidationReport:
+    """Helper: empty ValidationReport with one issue category populated."""
+    defaults: dict[str, object] = {
+        "total_stations": 1,
+        "duplicates": (),
+        "alias_issues": (),
+        "coordinate_issues": (),
+        "gtfs_issues": (),
+        "security_issues": (),
+        "cross_station_id_issues": (),
+        "provider_issues": (),
+        "naming_issues": (),
+        "gtfs_stop_count": 0,
+    }
+    defaults.update(overrides)
+    return ValidationReport(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Backtick-in-bullet-text break-out
+# ---------------------------------------------------------------------------
+
+
+def test_security_issue_backtick_in_name_does_not_break_out_to_html() -> None:
+    """A ``\\``…``\\``` token in ``name`` must not surface as a live inline
+    code span (which would let an embedded ``<img>`` render as live HTML).
+
+    Pre-fix the rendered Markdown contained an unescaped backtick.
+    Post-fix the canonical ``escape_markdown`` helper backslash-escapes
+    it so the bullet line carries a literal ``\\``` rather than opening
+    an inline code span.
+    """
+    issue = SecurityIssue(
+        identifier="bst:1",
+        name="Wien Hbf `<img src=x onerror=alert(1)>`",
+        reason="injected",
+    )
+    markdown = _build_report(security_issues=(issue,)).to_markdown()
+    # The hostile backtick must be backslash-escaped (canonical
+    # ``escape_markdown`` output). A bare backtick in the name field
+    # would let GitHub's CommonMark renderer treat the embedded HTML as
+    # an inline code span; the escape neutralises that.
+    assert "`<img" not in markdown, (
+        "Markdown injection: bare backtick survived in security-issue "
+        "bullet — letting <img> render as live HTML in the public "
+        "docs/stations_validation_report.md artefact"
+    )
+
+
+def test_alias_issue_backtick_in_reason_does_not_break_out_to_html() -> None:
+    """The ``reason`` field on AliasIssue is the f-string output of
+    ``f"missing required aliases: {missing_text}"`` where ``missing_text``
+    is comma-joined from ``name``/``bst_code``/``vor_id``. A backtick in
+    any of those source fields propagates into the rendered bullet.
+    """
+    issue = AliasIssue(
+        identifier="bst:42",
+        name="Normal",
+        reason="missing required aliases: `xss`",
+    )
+    markdown = _build_report(alias_issues=(issue,)).to_markdown()
+    assert "`xss`" not in markdown, (
+        "Markdown injection: bare backtick survived in alias-issue "
+        "reason field — letting embedded HTML render in the public "
+        "docs/stations_validation_report.md artefact"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Markdown-link injection (phishing via [text](url))
+# ---------------------------------------------------------------------------
+
+
+def test_naming_issue_markdown_link_in_reason_does_not_render_as_link() -> None:
+    """A ``[text](url)`` payload in the reason field would render as a
+    clickable Markdown link in the public artefact — a usable phishing
+    primitive against any operator skimming the report on github.com.
+    """
+    issue = NamingIssue(
+        identifier="bst:7",
+        name="Wien",
+        reason="canonical name 'X' is not unique (also used by [click](https://evil.example))",
+    )
+    markdown = _build_report(naming_issues=(issue,)).to_markdown()
+    # Post-fix the square brackets must be backslash-escaped so GitHub's
+    # CommonMark renderer treats them as literal text.
+    assert "[click](https://evil.example)" not in markdown, (
+        "Markdown injection: bare [link](url) survived in naming-issue "
+        "reason — letting a phishing link render in the public report"
+    )
+
+
+def test_provider_issue_markdown_link_in_name_does_not_render_as_link() -> None:
+    """The ``name`` interpolated into the provider-issues bullet must
+    not surface a ``[text](url)`` payload as a clickable link."""
+    issue = ProviderIssue(
+        identifier="bst:9",
+        name="Wien [phish](https://evil.example)",
+        reason="Need at least two VOR entries",
+    )
+    markdown = _build_report(provider_issues=(issue,)).to_markdown()
+    assert "[phish](https://evil.example)" not in markdown, (
+        "Markdown injection: bare [link](url) survived in provider-issue "
+        "name — letting a phishing link render in the public report"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Asterisk emphasis (spoofed bold/italic)
+# ---------------------------------------------------------------------------
+
+
+def test_coordinate_issue_asterisk_emphasis_does_not_render_as_bold() -> None:
+    """A ``*text*`` payload in any text field would render as italics in
+    the public artefact, letting an upstream forge operator-facing
+    emphasis it did not author."""
+    issue = CoordinateIssue(
+        identifier="bst:3",
+        name="Wien *spoofed-bold*",
+        reason="missing latitude",
+    )
+    markdown = _build_report(coordinate_issues=(issue,)).to_markdown()
+    # Post-fix the asterisks must be backslash-escaped.
+    assert "*spoofed-bold*" not in markdown, (
+        "Markdown injection: bare asterisks survived in coordinate-issue "
+        "name — spoofed bold/italic renders in the public report"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-station ID issue: alias / colliding identifier / colliding name
+# ---------------------------------------------------------------------------
+
+
+def test_cross_station_id_issue_backtick_in_alias_does_not_break_out() -> None:
+    """The cross-station-ID line interpolates four user-controlled fields:
+    ``identifier``, ``name``, ``alias``, ``colliding_identifier``,
+    ``colliding_name`` — every one is a Markdown injection sink.
+    """
+    issue = CrossStationIDIssue(
+        identifier="bst:1",
+        name="Wien Mitte",
+        alias="Mitte `xss`",
+        colliding_identifier="bst:2",
+        colliding_name="Praterstern",
+        colliding_field="bst_code",
+    )
+    markdown = _build_report(cross_station_id_issues=(issue,)).to_markdown()
+    assert "Mitte `xss`" not in markdown, (
+        "Markdown injection: bare backtick survived in cross-station-id "
+        "alias — letting embedded HTML render in the public report"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Geographic duplicates: identifiers list joined with comma
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_group_backtick_in_identifier_does_not_break_out() -> None:
+    """The duplicates section joins ``identifiers`` with ``", "`` and
+    interpolates the joined string verbatim. A backtick in any identifier
+    breaks out of any surrounding inline code span the operator would
+    otherwise read as a single grouped identifier list."""
+    group = DuplicateGroup(
+        latitude=48.2,
+        longitude=16.4,
+        identifiers=("bst:1", "code:`xss`"),
+        names=("A", "B"),
+    )
+    markdown = _build_report(duplicates=(group,)).to_markdown()
+    assert "code:`xss`" not in markdown, (
+        "Markdown injection: bare backtick survived in geographic-"
+        "duplicates identifier list — letting embedded HTML render"
+    )
+
+
+# ---------------------------------------------------------------------------
+# GTFS mismatch: vor_id field
+# ---------------------------------------------------------------------------
+
+
+def test_gtfs_issue_backtick_in_vor_id_does_not_break_out() -> None:
+    """The GTFS-mismatch line surfaces ``vor_id`` verbatim. A backtick in
+    that field (legitimate VOR ids are 9 digits — anything else is an
+    upstream-injection signal) breaks out of any surrounding inline
+    code span."""
+    issue = GTFSIssue(
+        identifier="bst:5",
+        name="Normal",
+        vor_id="12345`xss`",
+    )
+    markdown = _build_report(gtfs_issues=(issue,)).to_markdown()
+    assert "12345`xss`" not in markdown, (
+        "Markdown injection: bare backtick survived in GTFS-issue "
+        "vor_id — letting embedded HTML render in the public report"
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: validate_stations on a stations.json with hostile entries
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_hostile_stations_json_does_not_inject_markdown(
+    tmp_path: Path,
+) -> None:
+    """A stations.json crafted by a compromised upstream (or a
+    sufficiently lax fetch path) carries a hostile name. After running
+    ``validate_stations`` and rendering ``to_markdown()`` the published
+    report MUST not contain raw Markdown / HTML break-out primitives.
+
+    The test stations have intentional duplicate coordinates so the
+    duplicate-group section fires and embeds the hostile name. (The
+    ``_find_security_issues`` gate would also fire on the angle brackets
+    in the payload — which is fine; the test is checking the renderer
+    boundary, not the upstream gate.)
+    """
+    stations = [
+        {
+            "bst_id": 1,
+            "bst_code": "A1",
+            "name": "Wien `<img src=x onerror=alert(1)>`",
+            "aliases": ["Wien `<img src=x onerror=alert(1)>`", "A1"],
+            "latitude": 48.2,
+            "longitude": 16.4,
+            "source": "oebb",
+            "in_vienna": True,
+            "pendler": False,
+        },
+        {
+            "bst_id": 2,
+            "bst_code": "B2",
+            "name": "Wien Normal",
+            "aliases": ["Wien Normal", "B2"],
+            "latitude": 48.2,
+            "longitude": 16.4,
+            "source": "wl",
+            "in_vienna": True,
+            "pendler": False,
+        },
+    ]
+    stations_file = tmp_path / "stations.json"
+    stations_file.write_text(json.dumps(stations), encoding="utf-8")
+
+    report = validate_stations(stations_file)
+    markdown = report.to_markdown()
+
+    # The raw payload must NOT appear unescaped in the rendered Markdown.
+    # The backtick is the load-bearing primitive (it opens an inline code
+    # span that would render the embedded ``<img onerror>`` as live HTML
+    # on github.com / GitHub Pages).
+    assert "`<img" not in markdown, (
+        "End-to-end Markdown injection: a hostile name in stations.json "
+        "surfaced as a live inline code span in the rendered report"
+    )
+    # Defence-in-depth: HTML angle brackets must also be escaped (the
+    # canonical ``escape_markdown`` chains html.escape first).
+    assert "<img src=x onerror=alert(1)>" not in markdown, (
+        "End-to-end HTML injection: angle brackets in stations.json "
+        "surfaced as raw HTML in the rendered report"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inventory invariant: pin every text-interpolation sink in to_markdown()
+# ---------------------------------------------------------------------------
+
+
+def test_to_markdown_sink_inventory_is_pinned() -> None:
+    """Inventory invariant: a future refactor that adds a NEW
+    text-interpolation sink to ``to_markdown()`` without going through
+    the canonical ``escape_markdown`` re-opens this Markdown-injection
+    family. The test counts the literal sink count today; bumping it
+    requires explicitly re-validating that the new sink is sanitised.
+    """
+    src = Path(__file__).resolve().parents[1] / "src" / "utils" / "stations_validation.py"
+    text = src.read_text(encoding="utf-8")
+    # Each of the eight issue categories renders one bullet line with
+    # f-string interpolation of issue fields. The exact count is not
+    # the security gate (escape_markdown is); the count is the audit
+    # trip-wire that catches a NEW sink added without escaping.
+    # The lat/longitude geographic-duplicates sink is excluded from the
+    # inventory: ``DuplicateGroup.latitude`` / ``longitude`` are typed
+    # ``float`` and validated by ``_extract_float`` (rejects NaN / inf /
+    # non-numeric), so numeric formatting via ``:.5f`` is safe by
+    # construction. Only the ``identifiers`` sublist on that line carries
+    # operator-controlled text and is sanitised via ``_safe`` per element.
+    sink_markers = (
+        "f\"- {sec_issue.identifier}",
+        "f\"- {provider_issue.identifier}",
+        "f\"- {cross_issue.identifier}",
+        "f\"- {alias_issue.identifier}",
+        "f\"- {coordinate_issue.identifier}",
+        "f\"- {gtfs_issue.identifier}",
+        "f\"- {naming_issue.identifier}",
+    )
+    found = [m for m in sink_markers if m in text]
+    # Post-fix, every legacy raw-interpolation marker has been replaced
+    # by a sanitised variant — none should remain. A future refactor
+    # that re-introduces one of these patterns trips this invariant.
+    assert not found, (
+        "to_markdown() inventory regression: found unsanitised raw "
+        "interpolation sink(s): "
+        + ", ".join(found)
+        + ". Wrap operator-controlled fields with escape_markdown() + "
+        "normalise_markdown_text() before interpolation."
+    )

--- a/tests/test_station_validation.py
+++ b/tests/test_station_validation.py
@@ -248,7 +248,12 @@ def test_markdown_rendering_contains_cross_station_id_section() -> None:
     assert "## Cross station ID issues" in markdown
     assert "bst:1234" in markdown
     assert "'Mitte'" in markdown
-    assert "bst_code" in markdown
+    # Underscore is a Markdown emphasis primitive; the canonical
+    # ``escape_markdown`` defence at the renderer boundary backslash-
+    # escapes it so the field name renders literally on github.com.
+    # Rendered output is unchanged (``\\_`` → ``_`` after CommonMark
+    # escape resolution); only the raw Markdown text differs.
+    assert "bst\\_code" in markdown
     assert "bst:5678" in markdown
     assert "No issues detected." not in markdown
 


### PR DESCRIPTION
## Summary

**Markdown Injection Drift Round 3** — sister sink to:
- 2026-05-09 Round 1 (stats dashboard, `scripts/generate_markdown_stats.py`)
- 2026-05-09 Round 2 (feed-health report + GitHub Issue body, `src/feed/reporting.py`)

`ValidationReport.to_markdown()` in `src/utils/stations_validation.py` interpolated up to fifteen operator-controlled string fields (across eight issue-category sections) directly into Markdown bullet bodies **without any escaping**. The rendered output is auto-committed to `docs/stations_validation_report.md` by the `update-stations.yml` cron workflow and the `manual-full-refresh.yml` workflow — making it a publicly-published artefact on github.com (and any GitHub Pages site mirroring `docs/`; the repo's `docs/sitemap.xml` even points to `stations_validation_report.html`).

## Threat model

`stations.json` is populated by cron-driven scripts that fan out to external API surfaces (VOR / OEBB / Wiener Linien / Google Places / OSM Overpass). A compromised upstream / DNS-hijack / MITM that returns a station with a hostile `name` field lands the payload in `stations.json` — and from there flows VERBATIM into the rendered report.

Four orthogonal break-out axes opened up at every sink:
- **Backtick inline-code-span** — `` `<img src=x onerror=alert(1)>` `` renders as live HTML.
- **Markdown link** — `[click](https://evil.example)` renders as a clickable phishing link.
- **Asterisk emphasis** — `*spoofed-bold*` injects emphasis the operator did not author.
- **HTML angle brackets** — although `_UNSAFE_CHARS_RE` flags `<>` upstream, the `_collect_blocking_issues` gate is **only active in `update_all_stations.py`**. The standalone CLI (`python -m src.cli stations validate`), the `manual-full-refresh.yml` regenerate step, and any future direct `to_markdown()` caller bypass it entirely.

## Fix

- Module-level `_safe_md` helper composes `normalise_markdown_text` + `escape_markdown` (mirrors the canonical pattern from `scripts/generate_markdown_stats.py`).
- Every text interpolation in `to_markdown()` — across all eight issue categories — routed through `_safe_md`.
- The cross-station-id alias sink replaces `{alias!r}` (Python repr — quotes but does NOT escape Markdown chars) with explicit single-quote wrapping plus `_safe_md`.
- The geographic-duplicates joined identifier list uses a generator expression so each element is sanitised independently.
- Helper kept module-level to add zero to the C901 complexity counter (`to_markdown` stays at its baselined 18).

## Test plan

- [x] 10 new PoC tests in `tests/test_sentinel_stations_validation_markdown_injection.py` covering:
  - Six per-issue-category backtick / link / asterisk break-out tests
  - Two list-and-aggregate tests (duplicates identifier list, GTFS `vor_id`)
  - One end-to-end test that builds a real `stations.json` with a hostile name, runs `validate_stations`, and asserts no break-out primitives in the rendered output
  - One inventory invariant pinning the seven text-bearing sinks against future raw-interpolation regressions
- [x] All 10 new tests verified to **FAIL on pre-fix** code and **PASS post-fix**.
- [x] Existing `test_markdown_rendering_contains_cross_station_id_section` updated to assert on `"bst\_code"` (the underscore-escaped form) reflecting the new escaping contract.
- [x] All 2,590 tests pass locally.
- [x] Static checks clean (ruff + bandit + secret scanner + C901 + pip-audit). Mypy: only pre-existing `src/utils/http.py` errors unchanged from baseline.

🛡️ Sentinel

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTbwxgDBJDJ9idyLZQBQ8F)_