### PR TITLE
fix(stats): catalogue-anchored location extraction; drop free-form regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ Die S-Bahn-Stammstrecke ist das Rückgrat des Pendlerverkehrs. Wir erfassen und 
 
 | Kennzahl | Wert |
 | -------- | ---- |
-| Beobachtungen (gesamt) | 1 |
-| Median-Verspätung | 2.0 min |
-| Kritische Verspätungen (> 9 min) | 0 |
-| Letzte Aktualisierung | 2026-05-09 16:47 CEST |
+| Beobachtungen (gesamt) | _wird berechnet…_ |
+| Median-Verspätung | _wird berechnet…_ |
+| Kritische Verspätungen (> 9 min) | _wird berechnet…_ |
+| Letzte Aktualisierung | 2026-05-09 20:46 CEST |
 <!-- STATS:STAMMSTRECKE:END -->
 
 ### Häufigste Störungsorte
@@ -58,9 +58,9 @@ Die S-Bahn-Stammstrecke ist das Rückgrat des Pendlerverkehrs. Wir erfassen und 
 
 | Rang | Station / Ort | Vorfälle |
 | ---- | ------------- | -------- |
-| 1. | Demonstration Linie | 2 |
-| 2. | Fremder Verkehrsunfall Linie | 2 |
-| 3. | Fahrtbehinderung Falschparker Linie | 1 |
+| 1. | _wird berechnet…_ | – |
+| 2. | _wird berechnet…_ | – |
+| 3. | _wird berechnet…_ | – |
 <!-- STATS:DISRUPTIONS:END -->
 
 > **Hinweis:** Die zugrunde liegenden Roh-Ledger im CSV-Format liegen unter [`data/stats/`](data/stats/) (Zeitstempel in `Europe/Vienna`).

--- a/data/stats/stoerungen_2026.csv
+++ b/data/stats/stoerungen_2026.csv
@@ -1,11 +1,11 @@
 timestamp,weekday,hour,provider,location_name
-2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,Rettungseinsatz Linie
-2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,Fahrtbehinderung Falschparker Linie
-2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,Demonstration Linie
-2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,Demonstration Linie
-2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,Feuerwehreinsatz Linie
-2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,Fahrtbehinderung Fremder Verkehrsunfall
-2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,Fremder Verkehrsunfall Linie
-2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,Fremder Verkehrsunfall Linie
-2026-05-09T16:47:21+02:00,Sa,16,Wiener Linien,Signalstörung Linie
-2026-05-09T16:47:21+02:00,Sa,16,Wiener Linien,Polizeieinsatz Linie
+2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,unbekannt
+2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,unbekannt
+2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,unbekannt
+2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,unbekannt
+2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,unbekannt
+2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,unbekannt
+2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,unbekannt
+2026-05-09T15:02:37+02:00,Sa,15,Wiener Linien,unbekannt
+2026-05-09T16:47:21+02:00,Sa,16,Wiener Linien,unbekannt
+2026-05-09T16:47:21+02:00,Sa,16,Wiener Linien,unbekannt

--- a/docs/statistik.md
+++ b/docs/statistik.md
@@ -1,6 +1,6 @@
 # Wien ÖPNV — Statistik 2026
 
-_Automatisch erzeugt am 2026-05-09T16:47+02:00 (Europe/Vienna)._
+_Automatisch erzeugt am 2026-05-09T20:45+02:00 (Europe/Vienna)._
 
 ## Kennzahlen auf einen Blick
 
@@ -10,7 +10,7 @@ _Automatisch erzeugt am 2026-05-09T16:47+02:00 (Europe/Vienna)._
 | Davon über 9-min-Schwelle | 0 |
 | ⌀ Verspätung (alle Tage) | 2.0 min |
 | Erfasste Störungen (2026) | 10 |
-| Verschiedene Hotspots | 8 |
+| Verschiedene Hotspots | 0 |
 
 ## Stammstrecke
 
@@ -151,47 +151,9 @@ _Automatisch erzeugt am 2026-05-09T16:47+02:00 (Europe/Vienna)._
 `23h ` │ ························  0
 ```
 
-### Top 5 Hotspots (Anzahl Störungen)
+### Top 5 Hotspots
 
-```
-`Demonstration Linie           ` │ 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩  2
-`Fremder Verkehrsunfall Linie  ` │ 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩  2
-`Fahrtbehinderung Falschparker ` │ 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩··········  1
-`Fahrtbehinderung Fremder Verke` │ 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩··········  1
-`Feuerwehreinsatz Linie        ` │ 🟩🟩🟩🟩🟩🟩🟩🟩🟩🟩··········  1
-```
-
-### Tageszeit-Profil der Top 5 Hotspots
-
-**Demonstration Linie**
-
-```
-`15h ` │ 🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪  2
-```
-
-**Fremder Verkehrsunfall Linie**
-
-```
-`15h ` │ 🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪  2
-```
-
-**Fahrtbehinderung Falschparker Linie**
-
-```
-`15h ` │ 🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪  1
-```
-
-**Fahrtbehinderung Fremder Verkehrsunfall**
-
-```
-`15h ` │ 🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪  1
-```
-
-**Feuerwehreinsatz Linie**
-
-```
-`15h ` │ 🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪🟪  1
-```
+_Noch keine Störungen mit Stationszuordnung erfasst._
 
 ---
 

--- a/scripts/generate_markdown_stats.py
+++ b/scripts/generate_markdown_stats.py
@@ -101,6 +101,18 @@ README_DISRUPTIONS_TOP_N: Final = 3
 STAMMSTRECKE_THRESHOLD_MINUTES: Final = 9.0
 README_PENDING_PLACEHOLDER: Final = "_wird berechnet…_"
 
+# Sentinel emitted by :func:`src.utils.stats.extract_location_name` when
+# no directory-anchored station can be identified for a disruption (the
+# upstream title/description simply doesn't mention a station name we
+# recognise). The Top-N "Häufigste Störungsorte" / "Hotspots" rankings
+# explicitly skip this bucket — without the filter, every period in
+# which most disruptions are line-only mentions ("Demonstration auf
+# Linie 5") would surface ``unbekannt`` as the #1 hotspot, which is not
+# useful operator information. The bucket is still counted in the
+# overall "Erfasste Störungen" total and in the weekday / hour
+# distributions so the temporal signal is preserved.
+LOCATION_UNKNOWN: Final = "unbekannt"
+
 # Bar-chart geometry. The bar widths are intentionally short so the
 # rendered Markdown stays comfortable even on a 96-col terminal viewer.
 MAX_BAR_WIDTH: Final = 24
@@ -503,6 +515,24 @@ def render_top_locations(
             "_Noch keine Störungen erfasst._",
             "",
         ]
+    # Drop the ``unbekannt`` bucket from the ranking so periods dominated
+    # by line-only disruption mentions ("Demonstration auf Linie 5",
+    # "Polizeieinsatz Linie 13A") do not surface the sentinel as the #1
+    # hotspot. The bucket stays in the underlying aggregate so the
+    # totals and temporal distributions in the rest of the dashboard
+    # are unaffected.
+    ranked_locations = {
+        loc: count
+        for loc, count in aggregate.by_location.items()
+        if loc != LOCATION_UNKNOWN
+    }
+    if not ranked_locations:
+        return [
+            f"### Top {top_n} Hotspots",
+            "",
+            "_Noch keine Störungen mit Stationszuordnung erfasst._",
+            "",
+        ]
 
     # ``Counter.most_common`` is stable across equal counts but ties on
     # *count* alone are random across Python versions — fall through to
@@ -510,7 +540,7 @@ def render_top_locations(
     # byte-deterministic for two locations with identical incident
     # counts.
     items = sorted(
-        aggregate.by_location.items(),
+        ranked_locations.items(),
         key=lambda pair: (-pair[1], pair[0]),
     )[:top_n]
     max_value = items[0][1] if items else 0
@@ -610,7 +640,13 @@ def _format_summary_section(
         f"| Davon über {stammstrecke.threshold_minutes:g}-min-Schwelle | {stammstrecke.threshold_exceedances} |",
         f"| ⌀ Verspätung (alle Tage) | {global_avg:.1f} min |",
         f"| Erfasste Störungen ({year}) | {stoerungen.total_disruptions} |",
-        f"| Verschiedene Hotspots | {len(stoerungen.by_location)} |",
+        # Count distinct *known* hotspots only — the ``unbekannt``
+        # bucket aggregates every disruption whose upstream
+        # title/description didn't mention a directory-known station,
+        # so including it here would inflate the "Verschiedene
+        # Hotspots" cell by exactly +1 (the sentinel) regardless of
+        # how many real station mentions are in the ledger.
+        f"| Verschiedene Hotspots | {sum(1 for loc in stoerungen.by_location if loc != LOCATION_UNKNOWN)} |",
         "",
     ]
 
@@ -860,8 +896,15 @@ def render_readme_disruptions_block(
         for rank in range(1, top_n + 1):
             body_lines.append(f"| {rank}. | {README_PENDING_PLACEHOLDER} | – |")
         return header + "\n".join(body_lines) + "\n"
+    # Skip the ``unbekannt`` bucket so periods dominated by line-only
+    # disruption mentions ("Demonstration auf Linie 5") don't surface
+    # the sentinel as the #1 hotspot in the README. The bucket is still
+    # counted in the dashboard's overall total / temporal distribution
+    # — this filter only affects the operator-visible top-N ranking.
     counter: Counter[str] = Counter()
     for row in rows:
+        if row.location_name == LOCATION_UNKNOWN:
+            continue
         counter[row.location_name] += 1
     ranked = sorted(
         counter.items(),
@@ -1192,6 +1235,7 @@ __all__ = [
     "DEFAULT_OUTPUT_PATH",
     "DEFAULT_README_PATH",
     "DEFAULT_README_WINDOW_DAYS",
+    "LOCATION_UNKNOWN",
     "MAX_CSV_BYTES",
     "README_DISRUPTIONS_TOP_N",
     "README_MAX_BYTES",

--- a/src/utils/stats.py
+++ b/src/utils/stats.py
@@ -34,6 +34,7 @@ from typing import Any, Final
 from zoneinfo import ZoneInfo
 
 from src.utils.logging import sanitize_log_arg
+from src.utils.stations import display_name, station_info
 
 LOGGER = logging.getLogger("utils.stats")
 
@@ -88,7 +89,7 @@ WEEKDAY_LABELS: Final = ("Mo", "Di", "Mi", "Do", "Fr", "Sa", "So")
 # ``provider`` — see ``src/providers/wl_fetch.py`` lines 736 and 858),
 # a poisoned station directory (``data/stations.json`` flows through
 # ``display_name`` into ``direction``), or a future loosening of
-# :func:`extract_location_name`'s anchored-uppercase regex set. The
+# :func:`extract_location_name`'s directory-anchored gate. The
 # OWASP-recommended neutralisation is a leading single quote ``'``,
 # which spreadsheets render as plain text (the apostrophe itself is
 # hidden in display) — defanged but still visible to operators
@@ -145,6 +146,30 @@ def _sanitize_csv_text_field(value: str) -> str:
     return cleaned
 
 
+# Structured-signal patterns. Each captures a *labelled* location segment
+# that the providers already serialise into ``description`` (or ``title``)
+# in a deterministic shape — these are the cleanest signals because the
+# field came out of a curated upstream API field (WL ``relatedStops`` /
+# attrs.station / attrs.location) or out of our own VOR ``in Richtung``
+# render. The capture group is then passed through
+# :func:`_resolve_via_directory`, which only returns a value when
+# :func:`station_info` recognises it — so a poisoned upstream string can
+# never silently land as a "location" cell on the dashboard.
+#
+# All upper bounds are explicit (``{1,80}``) to keep the regex engine
+# bounded on adversarial inputs (ReDoS hardening).
+_HALTESTELLE_RE: Final = re.compile(
+    r"\|\s*Haltestelle:\s*([^|]{1,200})",
+    re.IGNORECASE,
+)
+_LABELED_LOCATION_RE: Final = re.compile(
+    r"\|\s*(?:Station|Location)\s*:\s*([^|]{1,200})",
+    re.IGNORECASE,
+)
+_RICHTUNG_RE: Final = re.compile(
+    r"\bin\s+Richtung\s+([^,\.\[\|]{1,80})",
+    re.IGNORECASE,
+)
 _BETWEEN_RE: Final = re.compile(
     r"\bzwischen\s+([A-ZÄÖÜ][\w\.\-’']{1,80}?(?:\s+[A-ZÄÖÜ][\w\.\-’']{1,80}){0,3})"
     r"\s+und\s+",
@@ -153,63 +178,44 @@ _BETWEEN_RE: Final = re.compile(
 _WIEN_PREFIX_RE: Final = re.compile(
     r"\bWien\s+([A-ZÄÖÜ][\wäöüÄÖÜß\-’']{1,40}(?:\s+[A-ZÄÖÜ][\wäöüÄÖÜß\-’']{1,40})?)"
 )
-_STATION_NAME_RE: Final = re.compile(
-    r"\b([A-ZÄÖÜ][\wäöüÄÖÜß]{2,40}(?:[\-/\s][A-ZÄÖÜ][\wäöüÄÖÜß]{2,40}){0,2})\b"
-)
-# Words that pass _STATION_NAME_RE but are clearly not station names.
-# Intentionally short — only the highest-frequency false positives that
-# survive the location heuristic on real provider feeds.
-_STOPWORD_LOCATIONS: Final = frozenset(
+
+# Sliding-window scan parameters. ``_MAX_STATION_WINDOW`` mirrors the
+# value used in :mod:`src.providers.oebb._find_stations_in_text` so the
+# two scans behave consistently — a station name that resolves there
+# also resolves here. The token-split character class strips arrow /
+# slash / dash punctuation that appears in route titles
+# (``"A ↔ B"`` / ``"A / B"``) and would otherwise corrupt window joins.
+_MAX_STATION_WINDOW: Final = 4
+_TOKEN_SPLIT_RE: Final = re.compile(r"[\s/]+")
+_NOISE_TOKEN_RE: Final = re.compile(r"^[↔→←↗↘↙↖<>=–—\-«»‹›]+$")
+# Single-token chunks that the directory's alias-expansion rules would
+# silently collapse into flagship stations. ``Hbf`` aliases to
+# ``Wien Hauptbahnhof`` even when the surrounding text is talking about
+# a different station ("Verbindungen zum Hbf umgeleitet"); ``Bahnhof`` /
+# ``Bf`` likewise; ``Wien`` alone aliases on its own (and would land
+# every Vienna-related disruption under the same node). Mirrors the
+# ``oebb._GENERIC_STATION_TOKENS`` filter to keep the two scans in sync.
+_GENERIC_DIRECTORY_TOKENS: Final = frozenset(
     {
-        "Bauarbeiten",
-        "Gleisbauarbeiten",
-        "Strassenbauarbeiten",
-        "Straßenbauarbeiten",
-        "Verkehrsunfall",
-        "Verspätung",
-        "Verspaetung",
-        "Verspätungen",
-        "Störung",
-        "Stoerung",
-        "Störungen",
-        "Stoerungen",
-        "Ersatzverkehr",
-        "Schienenersatzverkehr",
-        "Sperre",
-        "Sperrung",
-        "Aufzug",
-        "Rolltreppe",
-        "Linie",
-        "Linien",
-        "Bus",
-        "Strassenbahn",
-        "Straßenbahn",
-        "U-Bahn",
-        "S-Bahn",
-        "Achtung",
-        "Hinweis",
-        "Information",
-        "Mitteilung",
-        "Mo",
-        "Di",
-        "Mi",
-        "Do",
-        "Fr",
-        "Sa",
-        "So",
-        "Januar",
-        "Februar",
-        "März",
-        "Maerz",
-        "April",
-        "Mai",
-        "Juni",
-        "Juli",
-        "August",
-        "September",
-        "Oktober",
-        "November",
-        "Dezember",
+        "hbf",
+        "bhf",
+        "bf",
+        "bahnhof",
+        "bahnhst",
+        "hauptbahnhof",
+        "westbahnhof",
+        "westbf",
+        "ostbahnhof",
+        "ostbf",
+        "südbahnhof",
+        "suedbahnhof",
+        "südbf",
+        "suedbf",
+        "nordbahnhof",
+        "nordbf",
+        "station",
+        "wien",
+        "vor",
     }
 )
 
@@ -343,22 +349,125 @@ def append_disruption_row(
     return _append_row(path, STOERUNGEN_HEADER, row)
 
 
+def _normalise_location(value: str) -> str:
+    """Trim, collapse whitespace, and cap *value* at a sensible length."""
+    cleaned = " ".join(value.split())
+    if len(cleaned) > 80:
+        cleaned = cleaned[:80].rstrip()
+    return cleaned
+
+
+def _resolve_via_directory(candidate: str) -> str | None:
+    """Return the *display* name when *candidate* resolves via the station
+    directory, ``None`` otherwise.
+
+    The directory in ``data/stations.json`` is the project's only
+    curated source of truth for "is this a real Vienna-network
+    station?". A regex-extracted candidate is only accepted as a
+    location when :func:`station_info` recognises it (canonical or
+    alias). The returned string is the user-facing
+    :func:`display_name` (e.g. ``Wien Mitte`` rather than the
+    canonical ``Wien Mitte-Landstraße``) so the dashboard renders the
+    label operators expect to read.
+    """
+    cleaned = _normalise_location(candidate)
+    if not cleaned:
+        return None
+    info = station_info(cleaned)
+    if info is None:
+        return None
+    return display_name(info.name)
+
+
+def _scan_for_directory_station(haystack: str) -> str | None:
+    """Sliding-window scan for a directory-known station in *haystack*.
+
+    Matches longest first within each starting position so that a
+    multi-token name (``Wien Mitte``) wins over the substring match
+    (``Mitte``) when both resolve, and returns the *first* match in
+    source order so the natural reading order of the title/description
+    drives the choice. Mirrors
+    :func:`src.providers.oebb._find_stations_in_text` semantically but
+    is purposefully scoped to the stats-extraction surface (no HTML
+    stripping — the callers already pass plain text).
+
+    ``_GENERIC_DIRECTORY_TOKENS`` filters single-token chunks that the
+    directory's alias rules silently collapse to flagship stations
+    (``Hbf`` → ``Wien Hauptbahnhof`` etc.) — without that filter, every
+    ÖBB description that mentions ``Hbf`` would land all incidents under
+    a single node and skew the dashboard.
+    """
+    if not haystack:
+        return None
+    tokens = [t for t in _TOKEN_SPLIT_RE.split(haystack) if t]
+    tokens = [t for t in tokens if not _NOISE_TOKEN_RE.match(t)]
+    if not tokens:
+        return None
+    n = len(tokens)
+    window = min(_MAX_STATION_WINDOW, n)
+    for start in range(n):
+        max_size = min(window, n - start)
+        for size in range(max_size, 0, -1):
+            chunk_tokens = tokens[start : start + size]
+            chunk = " ".join(chunk_tokens)
+            if size == 1:
+                token_norm = chunk.casefold().rstrip(".:,;")
+                if token_norm in _GENERIC_DIRECTORY_TOKENS:
+                    continue
+                # Drop ultra-short chunks ("S1") to avoid line-token
+                # alias collisions; mirrors the 3-letter floor in the
+                # ÖBB scan.
+                alpha = re.sub(r"[^A-Za-zÄÖÜäöüß]", "", chunk)
+                if len(alpha) < 3:
+                    continue
+            resolved = _resolve_via_directory(chunk.rstrip(".:,;"))
+            if resolved:
+                return resolved
+    return None
+
+
 def extract_location_name(item: dict[str, Any]) -> str:
-    """Best-effort heuristic to pick a representative location for *item*.
+    """Pick a directory-validated location for *item* or ``"unbekannt"``.
 
-    Tries — in order — the most signal-rich shapes seen in the
-    providers' real payloads:
+    The strategy is **catalogue-first**: a candidate string is only
+    returned when it resolves through :func:`station_info` (the curated
+    directory in ``data/stations.json``). Free-form regex matches over
+    capitalised tokens were dropped in 2026-05-09 because German nouns
+    are all capitalised — the heuristic accepted disruption types like
+    ``Demonstration Linie`` / ``Rettungseinsatz Linie`` /
+    ``Polizeieinsatz Linie`` as if they were station names, polluting
+    the README "Häufigste Störungsorte" table with non-locations.
 
-    1. ``zwischen X und Y`` — the X side (canonical ÖBB phrasing for a
-       between-stations disruption).
-    2. ``Wien <Stadtteil>`` — the prefix is the strongest "this is a
-       station name" signal in the corpus.
-    3. The first capitalised multi-word token longer than two letters
-       that is not in :data:`_STOPWORD_LOCATIONS`. Captures e.g.
-       ``Karlsplatz``, ``Floridsdorf``, ``Praterstern``.
+    Pipeline (return on first hit):
 
-    Falls back to ``"unbekannt"`` if nothing matches. The function
-    never raises — a malformed item just returns the fallback string.
+    1. ``" | Haltestelle: ..."`` — WL provider serialises the
+       ``relatedStops`` API field into the description with this
+       prefix; the first comma-separated entry is the primary stop.
+       When the WL stop name is not in the heavy-rail directory we
+       still accept it verbatim (subject to the 80-char clamp) because
+       the stop list comes from a curated upstream source.
+    2. ``" | Station: ..."`` / ``" | Location: ..."`` — WL extras
+       fallback (also curated upstream); only accepted when it
+       resolves through the directory.
+    3. ``"in Richtung X"`` — the Stammstrecke renderer in
+       ``scripts/update_stammstrecke_status.py``; only accepted when
+       it resolves through the directory.
+    4. ``"zwischen X und Y"`` — canonical ÖBB phrasing; only accepted
+       when X resolves through the directory.
+    5. ``"Wien <Stadtteil>"`` — common in ÖBB / VOR descriptions; only
+       accepted when ``"Wien <Stadtteil>"`` resolves through the
+       directory.
+    6. Sliding-window directory scan over the title + description.
+       Filters single-token generic aliases (``Hbf`` etc.) so
+       arbitrary mentions of those words do not auto-canonicalise to
+       flagship stations.
+    7. Final fallback: ``"unbekannt"``. We deliberately do NOT
+       fall back to a free-form regex match here — the previous fix
+       round demonstrated that any such fallback re-pollutes the
+       statistics ledger.
+
+    The function never raises — a malformed item just returns the
+    fallback string.
     """
     title = str(item.get("title") or "")
     description = str(item.get("description") or "")
@@ -371,38 +480,50 @@ def extract_location_name(item: dict[str, Any]) -> str:
     # bounded on adversarial inputs.
     haystack = haystack[:1024]
 
+    halt = _HALTESTELLE_RE.search(haystack)
+    if halt:
+        first_stop = halt.group(1).split(",")[0].strip()
+        resolved = _resolve_via_directory(first_stop)
+        if resolved:
+            return resolved
+        normalised = _normalise_location(first_stop)
+        if normalised:
+            return normalised
+
+    labeled = _LABELED_LOCATION_RE.search(haystack)
+    if labeled:
+        first_label = labeled.group(1).split(",")[0].strip()
+        resolved = _resolve_via_directory(first_label)
+        if resolved:
+            return resolved
+
+    richtung = _RICHTUNG_RE.search(haystack)
+    if richtung:
+        target = richtung.group(1).strip()
+        resolved = _resolve_via_directory(target)
+        if resolved:
+            return resolved
+
     between = _BETWEEN_RE.search(haystack)
     if between:
-        candidate = between.group(1).strip()
-        if candidate:
-            return _normalise_location(candidate)
+        endpoint = _normalise_location(between.group(1).strip())
+        resolved = _resolve_via_directory(endpoint)
+        if resolved:
+            return resolved
 
     wien = _WIEN_PREFIX_RE.search(haystack)
     if wien:
         suffix = wien.group(1).strip()
         if suffix:
-            return f"Wien {suffix}"
+            resolved = _resolve_via_directory(f"Wien {suffix}")
+            if resolved:
+                return resolved
 
-    for match in _STATION_NAME_RE.finditer(haystack):
-        candidate = _normalise_location(match.group(1))
-        if not candidate:
-            continue
-        first_word = candidate.split(maxsplit=1)[0]
-        if first_word in _STOPWORD_LOCATIONS:
-            continue
-        if len(candidate) < 3:
-            continue
-        return candidate
+    scan = _scan_for_directory_station(haystack)
+    if scan:
+        return scan
 
     return "unbekannt"
-
-
-def _normalise_location(value: str) -> str:
-    """Trim, collapse whitespace, and cap *value* at a sensible length."""
-    cleaned = " ".join(value.split())
-    if len(cleaned) > 80:
-        cleaned = cleaned[:80].rstrip()
-    return cleaned
 
 
 __all__ = [

--- a/tests/scripts/test_generate_markdown_stats.py
+++ b/tests/scripts/test_generate_markdown_stats.py
@@ -309,6 +309,45 @@ def test_render_top_locations_handles_empty_aggregate() -> None:
     assert "Noch keine Störungen erfasst" in body
 
 
+def test_render_top_locations_skips_unbekannt_bucket() -> None:
+    """``unbekannt`` (extractor sentinel) must not appear in the ranking.
+
+    Without the filter, periods dominated by line-only disruption
+    mentions ("Demonstration auf Linie 5" / "Polizeieinsatz Linie 13A")
+    would surface ``unbekannt`` as the #1 hotspot — uninformative for
+    operators. The temporal stats (weekday / hour) still see those
+    rows; only the location ranking skips them.
+    """
+    agg = script.StoerungAggregate(
+        by_location=Counter(
+            {script.LOCATION_UNKNOWN: 50, "Wien Karlsplatz": 3, "Volkstheater": 2}
+        ),
+        by_location_hour={
+            script.LOCATION_UNKNOWN: {12: 50},
+            "Wien Karlsplatz": {7: 3},
+            "Volkstheater": {18: 2},
+        },
+        total_disruptions=55,
+    )
+    out = script.render_top_locations(agg, top_n=3)
+    body = "\n".join(out)
+    assert "unbekannt" not in body
+    assert "Wien Karlsplatz" in body
+    assert "Volkstheater" in body
+
+
+def test_render_top_locations_empty_when_only_unbekannt() -> None:
+    """If every disruption has ``unbekannt`` location, ranking is empty."""
+    agg = script.StoerungAggregate(
+        by_location=Counter({script.LOCATION_UNKNOWN: 10}),
+        by_location_hour={script.LOCATION_UNKNOWN: {12: 10}},
+        total_disruptions=10,
+    )
+    out = script.render_top_locations(agg, top_n=5)
+    body = "\n".join(out)
+    assert "Stationszuordnung" in body  # the empty-state placeholder
+
+
 # ---- Full markdown rendering ----------------------------------------------
 
 

--- a/tests/scripts/test_generate_markdown_stats_readme.py
+++ b/tests/scripts/test_generate_markdown_stats_readme.py
@@ -277,6 +277,44 @@ def test_render_disruptions_block_handles_empty_string_location() -> None:
     assert "| 1. | _(leer)_ | 1 |" in block
 
 
+def test_render_disruptions_block_skips_unbekannt_bucket() -> None:
+    """``unbekannt`` rows must not appear in the README's top-N ranking.
+
+    A line-only WL disruption ("Demonstration auf Linie 5") legitimately
+    has no station mention to extract. Counting those under the
+    ``unbekannt`` sentinel and surfacing it as the top README entry
+    would make the snapshot table useless for operators.
+    """
+    rows = [
+        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
+        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
+        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
+        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
+        _make_stoer("Wien Karlsplatz", timestamp=NOW),
+        _make_stoer("Wien Karlsplatz", timestamp=NOW),
+        _make_stoer("Volkstheater", timestamp=NOW),
+    ]
+    block = script.render_readme_disruptions_block(rows, window_days=30)
+    assert "unbekannt" not in block
+    assert "| 1. | Wien Karlsplatz | 2 |" in block
+    assert "| 2. | Volkstheater | 1 |" in block
+    # 3rd row pads with the dash placeholder since only 2 known locations
+    # remain after the filter.
+    assert "| 3. | – | – |" in block
+
+
+def test_render_disruptions_block_empty_when_only_unbekannt() -> None:
+    """If every row has ``unbekannt`` location, table pads with placeholder."""
+    rows = [
+        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
+        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
+    ]
+    block = script.render_readme_disruptions_block(rows, window_days=30)
+    assert "unbekannt" not in block
+    for rank in (1, 2, 3):
+        assert f"| {rank}. | – | – |" in block
+
+
 # ---- README patcher --------------------------------------------------------
 
 

--- a/tests/test_utils_stats.py
+++ b/tests/test_utils_stats.py
@@ -156,15 +156,16 @@ def test_append_disruption_row_normalises_blank_fields(tmp_path: Path) -> None:
 # ---- Location heuristic ---------------------------------------------------
 
 
-def test_extract_location_name_uses_zwischen_pattern() -> None:
+def test_extract_location_name_canonicalises_zwischen_endpoint() -> None:
+    """``zwischen X und Y`` returns the directory-canonical X."""
     item = {
         "title": "S 7: Verspätung",
         "description": "Verspätungen zwischen Floridsdorf und Praterstern wegen Bauarbeiten.",
     }
-    assert stats_utils.extract_location_name(item) == "Floridsdorf"
+    assert stats_utils.extract_location_name(item) == "Wien Floridsdorf"
 
 
-def test_extract_location_name_falls_back_to_wien_prefix() -> None:
+def test_extract_location_name_uses_wien_prefix_when_directory_resolves() -> None:
     item = {
         "title": "ÖBB: Information",
         "description": "Streckensperre rund um Wien Meidling bis Vormittag.",
@@ -177,27 +178,139 @@ def test_extract_location_name_returns_unbekannt_when_nothing_matches() -> None:
     assert stats_utils.extract_location_name(item) == "unbekannt"
 
 
-def test_extract_location_name_skips_stopwords_like_bauarbeiten() -> None:
+def test_extract_location_name_finds_directory_station_in_free_text() -> None:
+    """A station-directory hit in the description returns the canonical name."""
     item = {
         "title": "Bauarbeiten",
         "description": "Bauarbeiten heute, Karlsplatz betroffen.",
     }
     extracted = stats_utils.extract_location_name(item)
-    assert extracted != "Bauarbeiten"
-    assert "Karlsplatz" in extracted
+    assert extracted == "Wien Karlsplatz"
 
 
 def test_extract_location_name_caps_overly_long_strings() -> None:
+    """An unbounded title/description cannot inflate the returned cell."""
     item = {
         "title": "X" * 5000,
         "description": "Wien " + ("a" * 200),
     }
     out = stats_utils.extract_location_name(item)
-    assert len(out) <= 90  # 80-char location cap + small "Wien " prefix slack
+    # No directory hit possible → fallback. The 80-char clamp also still
+    # holds for any structured-pattern branch, hence the relaxed bound.
+    assert len(out) <= 90
 
 
 def test_extract_location_name_handles_non_string_inputs_safely() -> None:
     item: dict[str, object] = {"title": None, "description": 12345}
+    assert stats_utils.extract_location_name(item) == "unbekannt"
+
+
+# ---- Catalogue-anchored extraction: real disruption-type bad cases --------
+#
+# Pre-2026-05-09, the regex-based heuristic accepted any pair of
+# capitalised tokens whose first word was not in a small stopword list,
+# which produced README "Häufigste Störungsorte" entries like
+# ``"Demonstration Linie"`` / ``"Rettungseinsatz Linie"`` /
+# ``"Polizeieinsatz Linie"`` — these are disruption *types* (German
+# nouns are all capitalised), not locations.
+#
+# The pin tests below lock in that the new directory-anchored extractor
+# rejects every shape that used to leak into the CSV. ``"unbekannt"`` is
+# the correct answer because none of these strings contain a station the
+# directory recognises — and we explicitly do NOT want a lower-confidence
+# fallback to backslide into the previous behaviour.
+
+
+@pytest.mark.parametrize(
+    "title,description",
+    [
+        ("13A: Rettungseinsatz", "Rettungseinsatz auf der Linie"),
+        ("5: Demonstration", "Demonstration auf der Linie 5"),
+        ("13A: Polizeieinsatz", "Polizeieinsatz auf der Linie"),
+        ("Signalstörung", "Signalstörung auf der Linie 5"),
+        ("Fahrtbehinderung Falschparker", "Falschparker auf der Linie"),
+        ("Fremder Verkehrsunfall", "Verkehrsunfall, Linie umgeleitet"),
+        ("Fahrtbehinderung Fremder Verkehrsunfall", ""),
+        ("Feuerwehreinsatz", "Feuerwehreinsatz auf der Linie"),
+        # "Demonstration Linie" was the most-frequent leak — explicit pin
+        ("Demonstration Linie", "Demonstration auf Linie 5"),
+        # "Hbf" alone aliases to Wien Hauptbahnhof in the directory but
+        # appearing as a stand-alone word does not signal a Hauptbahnhof
+        # incident — the generic-token filter must keep this a no-match.
+        ("Information", "Verbindungen zum Hbf umgeleitet"),
+    ],
+)
+def test_extract_location_name_rejects_disruption_type_garbage(
+    title: str, description: str
+) -> None:
+    """Disruption-type-prefix titles must never produce a location row."""
+    item = {"title": title, "description": description}
+    assert stats_utils.extract_location_name(item) == "unbekannt"
+
+
+@pytest.mark.parametrize(
+    "description,expected",
+    [
+        # WL "Haltestelle: ..." structured suffix (multiple stops)
+        (
+            "Aufzugstörung | Haltestelle: Stephansplatz, Volkstheater",
+            "Wien Stephansplatz",
+        ),
+        # WL "Station: ..." attribute fallback
+        (
+            "Aufzug außer Betrieb | Station: Westbahnhof",
+            "Wien Westbahnhof",
+        ),
+        # Stammstrecke renderer phrasing
+        (
+            "Durchschnittliche Verspätung von 12 Minuten in Richtung Meidling [Seit 09.05.2026]",
+            "Wien Meidling",
+        ),
+        # Plain free-text mention of a directory-known Vienna station
+        (
+            "Aufzugstörung am Karlsplatz",
+            "Wien Karlsplatz",
+        ),
+    ],
+)
+def test_extract_location_name_picks_up_structured_signals(
+    description: str, expected: str
+) -> None:
+    """Each provider's structured location signal lands on the dashboard."""
+    item = {"title": "Linie U3", "description": description}
+    assert stats_utils.extract_location_name(item) == expected
+
+
+def test_extract_location_name_haltestelle_accepts_unknown_curated_stop() -> None:
+    """A WL stop name we do not have in the directory still passes through.
+
+    The ``relatedStops`` API field is curated upstream, so verbatim
+    pass-through is safe — but only via the explicit ``Haltestelle:``
+    structured prefix, which cannot accidentally fire on free text.
+    """
+    item = {
+        "title": "5A: Aufzug",
+        "description": "Aufzugsdefekt | Haltestelle: Tichtelgasse, Stephansplatz",
+    }
+    out = stats_utils.extract_location_name(item)
+    # "Tichtelgasse" is not in the directory but we still return it
+    # because the structured ``Haltestelle:`` prefix is a curated signal.
+    assert out == "Tichtelgasse"
+
+
+def test_extract_location_name_rejects_hbf_alone_as_generic_alias() -> None:
+    """Standalone ``Hbf`` must not auto-canonicalise to Wien Hauptbahnhof.
+
+    Without the generic-token filter, every text containing ``Hbf``
+    would pin the disruption to the flagship station and skew the
+    dashboard. The filter keeps the single-token alias gate closed.
+    """
+    item = {
+        "title": "Information",
+        "description": "Wegen Bauarbeiten kein Halt am Hbf möglich.",
+    }
+    # "Bauarbeiten" / "Hbf" / "Information" — none resolves through the
+    # directory under the generic-token filter, so the fallback wins.
     assert stats_utils.extract_location_name(item) == "unbekannt"
 
 


### PR DESCRIPTION
## Problem

Die README-Sektion **„Häufigste Störungsorte"** zeigte Einträge wie:

| Rang | Station / Ort | Vorfälle |
|------|---------------|----------|
| 1.   | Demonstration Linie | 2 |
| 2.   | Fremder Verkehrsunfall Linie | 2 |
| 3.   | Fahrtbehinderung Falschparker Linie | 1 |

Das sind weder Orte noch Linien — sondern abgeschnittene Störungstypen aus den WL-Titeln (`5: Demonstration auf Linie 5` etc.).

## Root Cause

`extract_location_name` (in `src/utils/stats.py`) fiel auf eine Regex zurück, die **das erste großgeschriebene Wortpaar** aus Titel/Description nimmt, sofern das **erste** Wort nicht in einer kleinen Stopword-Liste steht. Deutsche Nomen sind alle großgeschrieben → Disruption-Typen wie *Demonstration*, *Rettungseinsatz*, *Polizeieinsatz*, *Signalstörung*, *Feuerwehreinsatz*, *Falschparker* glitten durch und das **zweite** Wort (z.B. *Linie*) wurde nicht geprüft.

Die alten 10 CSV-Zeilen unter `data/stats/stoerungen_2026.csv` belegen den Effekt — alle 10 Zeilen tragen Müll-Locations.

## Solution: directory-anchored extraction

Der freihändige Regex-Fallback fliegt raus. Eine extrahierte Zeichenkette wird nur dann als Location akzeptiert, wenn sie über `station_info` (kuratiertes `data/stations.json`-Direktorium, 196 Stationen mit Alias-Coverage) auflöst. Pipeline (return on first hit):

1. **`| Haltestelle: …`** — strukturiertes WL-`relatedStops`-Suffix
2. **`| Station: …` / `| Location: …`** — WL-Extras-Fallback
3. **`in Richtung X`** — Stammstrecke-Renderer
4. **`zwischen X und Y`** — kanonische ÖBB-Phrasierung
5. **`Wien <X>`** — Präfix
6. **Sliding-Window-Direktoriums-Scan** über Titel + Description (mit Generic-Token-Filter wie `Hbf` → `Wien Hauptbahnhof`-Alias-Kollision)
7. **Final-Fallback: `unbekannt`** — KEIN freihändiger Regex-Fallback mehr

Jede Nicht-Fallback-Rückgabe ist entweder (a) eine kuratierte WL-Stop-Bezeichnung aus dem `Haltestelle:`-Prefix oder (b) ein `station_info`-validierter kanonischer Name (durch `display_name` für die feed-freundliche Form, z.B. `Wien Mitte` statt `Wien Mitte-Landstraße`).

## Top-N-Filter

`render_top_locations` und `render_readme_disruptions_block` überspringen jetzt explizit den `unbekannt`-Bucket — sonst würde eine Periode mit vielen liniengebundenen Meldungen ohne Stationsbezug („Demonstration auf Linie 5") `unbekannt` als #1-Hotspot präsentieren. Die zeitlichen Verteilungen (Wochentag/Stunde) und die Gesamtzahl bleiben unverändert.

`Verschiedene Hotspots` zählt nur noch **bekannte** Stationen (vorher: inkl. `unbekannt`-Sentinel = +1 Inflation).

## CSV-Backfill

Die 10 existierenden Müll-Zeilen in `data/stats/stoerungen_2026.csv` wurden zu `unbekannt` umgeschrieben, damit das temporale Signal (Wochentag/Stunde) erhalten bleibt, ohne dass die Top-N-Tabelle weiter verschmutzt wird.

## Smoke Test

Vorher (Regex-Heuristik) → Jetzt (katalog-gestützt):

| Input | Vorher | Jetzt |
|-------|--------|-------|
| `13A: Rettungseinsatz` / `Rettungseinsatz auf der Linie` | `Rettungseinsatz Linie` | `unbekannt` |
| `5: Demonstration` / `Demonstration auf der Linie 5` | `Demonstration Linie` | `unbekannt` |
| `Aufzugstörung Karlsplatz` | `Aufzugstörung Karlsplatz` | `Wien Karlsplatz` |
| `S 7: Verspätung` / `zwischen Floridsdorf und Praterstern` | `Floridsdorf` | `Wien Floridsdorf` |
| `Linie U3` / `Aufzug \| Haltestelle: Stephansplatz, Volkstheater` | `Linie U3` | `Wien Stephansplatz` |
| `S-Bahn Stammstrecke` / `… in Richtung Meidling [Seit 09.05.2026]` | `S-Bahn Stammstrecke` | `Wien Meidling` |

## Test plan

- [x] `pytest` (2600 passed, 4 skipped)
- [x] `mypy --strict` auf `src/utils/stats.py` + `scripts/generate_markdown_stats.py`
- [x] `ruff check` auf alle berührten Dateien
- [x] Neue Tests für die Bad-Cases (parametrisiert: 10 Disruption-Type-Garbage-Strings → alle `unbekannt`)
- [x] Neue Tests für strukturierte Signale (`Haltestelle:`, `in Richtung`, `Station:`)
- [x] Pin-Test für `Hbf`-Alone-Kollision (würde sonst zu `Wien Hauptbahnhof` aliasen)
- [x] Pin-Test: README/Statistik-Top-N filtert `unbekannt` raus
- [x] Manueller Re-Render von `docs/statistik.md` + `README.md` aus dem aufgeräumten CSV → keine Müll-Hotspots mehr

https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr)_