### PR TITLE
fix(workflows): commit data/stats/stoerungen_*.csv from build-feed.yml

### DIFF
--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -102,10 +102,20 @@ jobs:
           # ``docs/feed.xml`` is the public output; ``data/first_seen.json``
           # is the build-feed state file tracking item ages and must
           # commit alongside the feed to keep the merge stable.
-          # ``docs/statistik.md`` and ``README.md`` carry the regenerated
-          # human-readable dashboard / snapshot from the same CSV ledger.
+          # ``data/stats/stoerungen_<YYYY>.csv`` is appended by
+          # ``build_feed.py:append_disruption_row`` whenever a strictly-
+          # new disruption identity arrives; without committing it
+          # here every Build-feed run silently drops those rows on the
+          # ephemeral runner and the dashboard never grows past what
+          # ``manual-full-refresh.yml`` happens to commit (audit
+          # finding 2026-05-09 — this was the reason ``Häufigste
+          # Störungsorte`` was sparse in the README until the manual
+          # refresh ran). ``docs/statistik.md`` and ``README.md`` carry
+          # the regenerated human-readable dashboard / snapshot from
+          # the same CSV ledger.
           file_pattern: |
             data/first_seen.json
+            data/stats/stoerungen_*.csv
             docs/feed.xml
             docs/statistik.md
             README.md


### PR DESCRIPTION
## Was sich ändert

Audit-Befund: ``src/build_feed.py:1661`` ruft ``src.utils.stats.append_disruption_row(...)`` für jede strikt-neue Disruption-Identität während des Feed-Builds. Die appendierten Zeilen landen auf dem ephemeren CI-Runner unter ``data/stats/stoerungen_<YYYY>.csv``, **aber das `file_pattern` der `build-feed.yml` enthielt die Datei nicht**. Folge: jede Build-feed-Iteration verlor die frischen Disruption-Stats-Zeilen, sobald der Runner herunterfuhr.

Das erklärt, warum „Häufigste Störungsorte"/„Top Hotspots" im Dashboard sparse blieb, obwohl die Cron-Pipeline alle 30 Min lief: die Zeilen existierten kurzzeitig auf dem Runner, wurden aber nie nach main durchgereicht. Wachstum gab es nur über
- ``manual-full-refresh.yml`` (commit ``add_options: -A``)
- ``generate-stats.yml`` nightly cron (file_pattern ``data/stats/*.csv``) — sah aber nur Zeilen, die schon committed waren

## Fix

One-line file_pattern Ergänzung in ``build-feed.yml``:

```diff
           file_pattern: |
             data/first_seen.json
+            data/stats/stoerungen_*.csv
             docs/feed.xml
             docs/statistik.md
             README.md
```

Plus erläuternder Kommentar im YAML, der die historische Ursache des sparse-Dashboards dokumentiert.

## Verifikation

- ✅ ``pytest`` (2629 passed, 3 skipped)
- ✅ YAML-Lint clean
- ✅ Cross-Check: ``data/stats/stoerungen_*.csv`` ist auch im ``generate-stats.yml`` nightly file_pattern — kein doppel-commit-Konflikt, da das Renderskript bytewise idempotent ist
- ✅ Kein Overlap mit ``update-stammstrecke-status.yml``'s file_pattern (``data/stats/stammstrecke_*.csv`` + ``data/vor_request_count.json``) — sauber getrennte Schreib-Verantwortlichkeiten

## Vorgänger
Folge-Commit zu PR #1402 (gemergt). Wurde beim End-to-End-Audit der Update-Routine als Bug identifiziert.

https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr)_