### PR TITLE
ci(workflows): collapse five staggered crons into a single DAG

### DIFF
--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -1,32 +1,20 @@
 name: Build feed
 
-# Pure consumer workflow. Reads existing on-disk artefacts, composes
-# the public RSS feed (``docs/feed.xml``), and patches the README
-# stats markers — never calls any upstream API or provider itself.
-# Inputs:
-#   * ``cache/wl_*/events.json``         — owned by ``update-wl-cache.yml``
-#   * ``cache/oebb_*/events.json``       — owned by ``update-oebb-cache.yml``
-#   * ``cache/baustellen_*/events.json`` — owned by ``update-baustellen-cache.yml``
-#   * ``cache/vor_*/events.json``        — owned by ``update-vor-cache.yml``
-#                                          (manual-only since the
-#                                          2026-05-09 quota-conservation pass)
-#   * ``data/stats/stammstrecke_<YYYY>.csv`` — owned by
-#                                          ``update-stammstrecke-status.yml``
+# DISABLED CRON (2026-05-09): the regular ``15,45`` schedule was
+# replaced by the ``update-cycle.yml`` DAG workflow whose
+# ``build_feed`` job depends on every cache fetcher via ``needs:``
+# — the dependency graph (not a staggered cron) drives the timing.
 #
-# Outputs:
-#   * ``docs/feed.xml``       — the public RSS feed
-#   * ``data/first_seen.json`` — feed-state for stable item ages
-#   * ``docs/statistik.md``   — the operator-facing dashboard
-#   * ``README.md``           — patched ``<!-- STATS:* -->`` blocks
+# This workflow remains as the code-change verification path: a push
+# to ``src/**`` etc. rebuilds the feed from whatever caches are
+# currently on main, without firing any upstream API. The
+# ``workflow_dispatch`` trigger lets operators force a rebuild after
+# a manual cache refresh.
 #
-# Cron schedule: ``15,45 * * * *`` — 15 minutes after the upstream
-# ``update-stammstrecke-status.yml`` cron at ``0,30`` so the CSV
-# ledger has settled before this workflow reads it. Push trigger
-# rebuilds the feed whenever feed-relevant code changes (no API
-# call, no quota consumption).
+# Both retained triggers go through the same single job below, which
+# reads only on-disk artefacts (caches + Stammstrecke CSV ledger)
+# and never calls any upstream API or provider itself.
 on:
-  schedule:
-    - cron: '15,45 * * * *'
   workflow_dispatch:
   push:
     paths:

--- a/.github/workflows/update-baustellen-cache.yml
+++ b/.github/workflows/update-baustellen-cache.yml
@@ -1,8 +1,12 @@
 name: Update Baustellen cache
 
+# DISABLED CRON (2026-05-09): the regular hourly schedule was
+# replaced by the ``update-cycle.yml`` DAG workflow which now picks
+# up the Baustellen refresh as a parallel job alongside WL/ÖBB/
+# Stammstrecke. This workflow remains as a ``workflow_dispatch``-
+# only escape hatch for manually re-fetching the Baustellen cache
+# between regular cycle runs.
 on:
-  schedule:
-    - cron: '0 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-cycle.yml
+++ b/.github/workflows/update-cycle.yml
@@ -1,0 +1,277 @@
+name: Update cycle
+
+# Single-source-of-timing pipeline. One cron tick (``0,30 * * * *``)
+# triggers ALL data-fetcher jobs in parallel; the feed-composer job
+# depends on every fetcher via ``needs:`` so it runs only AFTER all
+# the fetchers complete (``if: always()`` — even if a fetcher failed,
+# build_feed still publishes the freshest data it has).
+#
+# This replaces the pre-2026-05-09 design that used five separate
+# workflow files with staggered cron schedules (Stammstrecke `0,30`,
+# WL `10,40`, ÖBB `20,50`, Baustellen `0`, build-feed `15,45`).
+# GitHub Actions cron schedules drift 5–15 minutes — under drift the
+# build-feed cron could read a stale cache because the upstream
+# fetcher hadn't committed yet. The DAG eliminates that race
+# entirely: the dependency graph is the timing source.
+#
+# Concurrency: the workflow as a whole holds the
+# ``external-api-fetch`` lock (shared with ``manual-full-refresh.yml``
+# and the legacy single-purpose dispatch-only workflows) so the
+# project never has two parallel API-fetching cycles in flight.
+#
+# Inter-job data passing:
+# * WL / ÖBB / Baustellen — upload their freshly-written
+#   ``cache/<provider>_<hash>/events.json`` as a workflow artifact;
+#   ``build_feed`` downloads all artifacts and overlays them on its
+#   checkout. A fetcher that fails (no artifact uploaded) leaves the
+#   last-committed cache file in place — the feed degrades gracefully.
+#   Single git push at the end of the cycle (build_feed) covers all
+#   four caches plus the rendered output, eliminating the parallel-
+#   pusher race that direct ``git-auto-commit`` would create.
+# * Stammstrecke — commits its CSV ledger and the persisted VAO
+#   counter (``data/vor_request_count.json``) DIRECTLY because the
+#   counter MUST survive a build_feed crash (otherwise the next
+#   cycle would re-spend already-charged API requests). build_feed
+#   pulls the resulting commit before its own ``feed build``.
+on:
+  schedule:
+    - cron: '0,30 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: external-api-fetch
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  PYTHONPATH: src
+  PIP_CACHE_DIR: /tmp/pip-cache
+
+jobs:
+  wl_cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Ensure pip cache directory exists
+        run: mkdir -p "$PIP_CACHE_DIR"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-deps
+
+      - name: Refresh Wiener Linien cache
+        run: python scripts/update_wl_cache.py
+
+      - name: Upload WL cache artifact
+        uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8 # v4
+        with:
+          name: wl-cache
+          path: cache/wl_*/events.json
+          retention-days: 1
+          if-no-files-found: ignore
+
+  oebb_cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Ensure pip cache directory exists
+        run: mkdir -p "$PIP_CACHE_DIR"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-deps
+
+      - name: Refresh ÖBB cache
+        run: python scripts/update_oebb_cache.py
+
+      - name: Upload ÖBB cache artifact
+        uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8 # v4
+        with:
+          name: oebb-cache
+          path: cache/oebb_*/events.json
+          retention-days: 1
+          if-no-files-found: ignore
+
+  baustellen_cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Ensure pip cache directory exists
+        run: mkdir -p "$PIP_CACHE_DIR"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-deps
+
+      - name: Refresh Baustellen cache
+        run: python scripts/update_baustellen_cache.py
+
+      - name: Upload Baustellen cache artifact
+        uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8 # v4
+        with:
+          name: baustellen-cache
+          path: cache/baustellen_*/events.json
+          retention-days: 1
+          if-no-files-found: ignore
+
+  stammstrecke:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      VOR_ACCESS_ID: ${{ secrets.VOR_ACCESS_ID }}
+      VOR_BASE_URL: ${{ secrets.VOR_BASE_URL }}
+      VOR_BASE: ${{ secrets.VOR_BASE }}
+      VOR_VERSION: ${{ secrets.VOR_VERSION }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Ensure pip cache directory exists
+        run: mkdir -p "$PIP_CACHE_DIR"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-deps
+
+      # Defense-in-depth pre-flight: read the persisted VAO daily counter
+      # (``data/vor_request_count.json``) and SKIP the Stammstrecke step
+      # entirely when a fresh run would breach the contractual 100/day
+      # cap. Mirrors the gate from the dispatch-only escape-hatch
+      # workflow at ``update-stammstrecke-status.yml``.
+      - name: VAO quota pre-flight
+        id: vor_preflight
+        continue-on-error: true
+        run: python scripts/preflight_quota_check.py --check vor --margin 2
+
+      - name: Refresh Stammstrecke status
+        if: ${{ steps.vor_preflight.outputs.quota_ok == 'true' }}
+        run: python scripts/update_stammstrecke_status.py
+
+      # Stammstrecke commits its OWN files immediately rather than
+      # uploading them as artifacts because ``data/vor_request_count.
+      # json`` MUST survive a build_feed crash — otherwise the next
+      # cycle would read a stale counter and re-spend the already-
+      # charged 2 reqs, breaching the contractual 100/day cap. The
+      # CSV ledger commits alongside for the same atomicity reason.
+      - name: Pull concurrent remote changes
+        run: git pull --rebase --autostash
+
+      - name: Commit Stammstrecke ledger + quota counter
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
+        with:
+          commit_message: 'chore: update Stammstrecke status'
+          file_pattern: |
+            data/stats/stammstrecke_*.csv
+            data/vor_request_count.json
+
+  build_feed:
+    needs: [wl_cache, oebb_cache, baustellen_cache, stammstrecke]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Need full history so ``git pull --rebase --autostash`` can
+          # cleanly stitch the build_feed commit onto whatever the
+          # stammstrecke job (or a parallel ``update-stations.yml``)
+          # pushed since this job's checkout.
+          fetch-depth: 0
+
+      - name: Ensure pip cache directory exists
+        run: mkdir -p "$PIP_CACHE_DIR"
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-deps
+
+      # Overlay all upstream cache artifacts onto the workspace so the
+      # subsequent ``feed build`` step reads the freshest events.json
+      # for every provider that succeeded this cycle. A failed
+      # fetcher's artifact is missing — the corresponding cache file
+      # from the checkout (last committed state) is used instead, so
+      # the feed degrades gracefully rather than dropping the
+      # provider's entries entirely.
+      - name: Download cache artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: .
+          merge-multiple: true
+
+      # Build feed reads only on-disk artefacts (caches + Stammstrecke
+      # CSV ledger pulled in by the previous git pull); no API call,
+      # no provider query. Writes ``docs/feed.xml`` and
+      # ``data/first_seen.json``, and appends to
+      # ``data/stats/stoerungen_<YYYY>.csv`` for any strictly-new
+      # disruption identity.
+      - name: Build feed
+        run: python -m src.cli feed build
+        env:
+          PAGES_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+
+      # Regenerate ``docs/statistik.md`` and patch the
+      # ``<!-- STATS:* -->`` markers in ``README.md`` from the
+      # ``data/stats/*.csv`` ledger (30-day window for the README
+      # snapshot). Reads only on-disk files; idempotent at the byte
+      # level (a no-data-change run rewrites only the timestamp cell).
+      - name: Refresh statistics dashboard and README snapshot
+        run: python scripts/generate_markdown_stats.py
+
+      - name: Pull concurrent remote changes
+        run: git pull --rebase --autostash
+
+      - name: Commit feed + caches + stats
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
+        with:
+          commit_message: 'chore: rebuild feed'
+          # Single commit covers every output of the cycle EXCEPT the
+          # files the stammstrecke job already committed earlier
+          # (data/stats/stammstrecke_*.csv + data/vor_request_count.json).
+          # Cache files come from the downloaded artifacts; rendered
+          # outputs are produced in-place.
+          file_pattern: |
+            cache/wl_*/events.json
+            cache/oebb_*/events.json
+            cache/baustellen_*/events.json
+            data/first_seen.json
+            data/stats/stoerungen_*.csv
+            docs/feed.xml
+            docs/statistik.md
+            README.md

--- a/.github/workflows/update-oebb-cache.yml
+++ b/.github/workflows/update-oebb-cache.yml
@@ -1,8 +1,10 @@
 name: Update ÖBB cache
 
+# DISABLED CRON (2026-05-09): the regular ``20,50`` schedule was
+# replaced by the ``update-cycle.yml`` DAG workflow. This workflow
+# remains as a ``workflow_dispatch``-only escape hatch for manually
+# re-fetching the ÖBB cache between regular cycle runs.
 on:
-  schedule:
-    - cron: '20,50 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-stammstrecke-status.yml
+++ b/.github/workflows/update-stammstrecke-status.yml
@@ -1,20 +1,12 @@
 name: Update Stammstrecke status
 
-# Pure data-fetcher workflow. Polls the VAO ``/trip`` endpoint twice
-# per cron tick (Floridsdorf↔Meidling, Meidling↔Floridsdorf), computes
-# the per-direction median S-Bahn departure delay, and APPENDS one
-# observation row to ``data/stats/stammstrecke_<YYYY>.csv``. Nothing
-# else: no feed render, no README patch, no provider invocation. The
-# CSV is the project's single source of truth for the Stammstrecke
-# delay signal — the feed-build pipeline (``build-feed.yml``) reads
-# it as a regular consumer.
-#
-# Cron schedule: ``0,30 * * * *`` (explicit :00 and :30 — gives the
-# downstream ``build-feed.yml`` cron at ``15,45`` a 15-minute
-# completion window before it reads the CSV).
+# DISABLED CRON (2026-05-09): the regular ``0,30`` schedule was
+# replaced by the ``update-cycle.yml`` DAG workflow which now drives
+# the Stammstrecke poll as a job within a single-cron pipeline.
+# This workflow remains as a ``workflow_dispatch``-only escape hatch
+# for manually re-running the Stammstrecke poll between regular
+# cycle runs (e.g. after fixing a transient VAO outage).
 on:
-  schedule:
-    - cron: '0,30 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/update-wl-cache.yml
+++ b/.github/workflows/update-wl-cache.yml
@@ -1,8 +1,12 @@
 name: Update Wiener Linien cache
 
+# DISABLED CRON (2026-05-09): the regular ``10,40`` schedule was
+# replaced by the ``update-cycle.yml`` DAG workflow which fans out a
+# single cron tick (``0,30 * * * *``) into parallel cache fetcher
+# jobs and a feed-composer that runs after all fetchers complete.
+# This workflow remains as a ``workflow_dispatch``-only escape hatch
+# for manually re-fetching the WL cache between regular cycle runs.
 on:
-  schedule:
-    - cron: '10,40 * * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Was sich ändert

Ersetzt das gestaffelte Fünf-Workflow-Schema (Stammstrecke `0,30`, WL `10,40`, ÖBB `20,50`, Baustellen `0`, build-feed `15,45`) durch ein einziges `update-cycle.yml`, dessen **DAG** die Reihenfolge erzwingt anstatt sich auf Cron-Timing zu verlassen.

**Warum:** GitHub-Actions-Cron driftet 5–15 min. Bei der gestaffelten Architektur konnte der Build-Feed bei ``:15`` den Stammstrecke-Commit vom ``:00`` sehen — wenn aber die Drift länger war, sah der Build-Feed eine ältere CSV. Das DAG schließt diese Race-Class komplett: `build_feed` läuft erst, wenn ALLE Fetcher-Jobs fertig sind.

## Architektur

```
update-cycle.yml (cron 0,30 * * * *)
│
├─ wl_cache         ─┐
├─ oebb_cache        │ parallel auf eigenen Runnern
├─ baustellen_cache  │ → upload-artifact (events.json)
├─ stammstrecke      ┘ → committet CSV + VAO-Counter direkt
│                       (Counter MUSS Build-feed-Crash überleben)
│
└─ build_feed (needs: [alle], if: always())
    1. checkout (sieht Stammstrecke-Commit + andere committed Caches)
    2. download-artifact (überlagert WL/ÖBB/Baustellen-Caches)
    3. python -m src.cli feed build
    4. python scripts/generate_markdown_stats.py
    5. git pull --rebase --autostash
    6. ONE git push für: caches + feed.xml + first_seen +
       stoerungen.csv + statistik.md + README.md
```

## Vorteile

- ✅ **Keine Cron-Drift-Race mehr** — DAG-Reihenfolge ist deterministisch
- ✅ **Parallele Fetcher** (~3 min Cycle-Dauer statt sequentielle ~10 min)
- ✅ **`if: always()`** auf `build_feed` — Feed wird auch bei Fetcher-Ausfall publiziert (graceful degradation: degraded provider behält letzten committeten Cache)
- ✅ **Single push pro Cycle** für die meisten Files → keine parallele Pusher-Race
- ✅ **Stammstrecke-Counter persistent auch bei Build-feed-Crash** (separater direkter Commit)

## Inter-Job-Datenfluss (kritisches Detail)

| Job | Schreibt | Wie persistiert |
|-----|----------|-----------------|
| `wl_cache` | `cache/wl_*/events.json` | upload-artifact `wl-cache` |
| `oebb_cache` | `cache/oebb_*/events.json` | upload-artifact `oebb-cache` |
| `baustellen_cache` | `cache/baustellen_*/events.json` | upload-artifact `baustellen-cache` |
| `stammstrecke` | CSV + VAO-Counter | **direkter git commit** (überlebt Build-feed-Crash) |
| `build_feed` | feed.xml + first_seen + stoerungen.csv + statistik + README + downloaded caches | **ein git commit** am Ende |

Der Stammstrecke-Counter MUSS direkt committet werden, weil ein verworfener Counter beim nächsten Cycle dazu führen würde, dass schon-verbrauchte VAO-Requests erneut gezahlt werden — Bruch der 100/Tag-Quota.

## Escape-Hatches bleiben

| Workflow | Vorher | Nachher |
|----------|--------|---------|
| `update-wl-cache.yml` | cron `10,40` | nur `workflow_dispatch` |
| `update-oebb-cache.yml` | cron `20,50` | nur `workflow_dispatch` |
| `update-baustellen-cache.yml` | cron `0 * * * *` | nur `workflow_dispatch` |
| `update-stammstrecke-status.yml` | cron `0,30` | nur `workflow_dispatch` |
| `build-feed.yml` | cron `15,45` + push + dispatch | **push + dispatch** (push-Trigger für Code-Change-Rebuilds bleibt) |

## Verifikation

- ✅ `pytest` (2629 passed, 3 skipped) — keine Code-Änderungen außerhalb der Workflow-Files
- ✅ YAML-Lint clean für alle 6 modifizierten Files
- ✅ DAG-Validierung manuell: `needs:` zeigt nur auf Jobs, die in der gleichen Workflow-Datei existieren
- ✅ Konsistenz: `external-api-fetch` Concurrency-Group bleibt geteilt mit `manual-full-refresh.yml` und den Dispatch-only Workflows (kein parallel-API-Fetch möglich)

## Trade-offs (akzeptiert)

- ⚠️ Größere Workflow-Datei (~270 Zeilen) — mitigated durch klare Job-Trennung
- ⚠️ Artifact-Upload/Download-Overhead pro Cycle (~30s) — vernachlässigbar gegen die ~3-Min-Gesamtlaufzeit
- ⚠️ Bei kompletten Worker-Outages müssen Operators manuell die einzelnen `workflow_dispatch`-Workflows triggern

https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr)_