### PR TITLE
fix(workflows): rewrite update-cycle.yml as single-job sequential pipeline

### DIFF
--- a/.github/workflows/update-cycle.yml
+++ b/.github/workflows/update-cycle.yml
@@ -1,38 +1,38 @@
 name: Update cycle
 
-# Single-source-of-timing pipeline. One cron tick (``0,30 * * * *``)
-# triggers ALL data-fetcher jobs in parallel; the feed-composer job
-# depends on every fetcher via ``needs:`` so it runs only AFTER all
-# the fetchers complete (``if: always()`` — even if a fetcher failed,
-# build_feed still publishes the freshest data it has).
+# Single-job sequential pipeline. One cron tick (``0,30 * * * *``)
+# runs every fetcher + the feed composer + the README/stats render
+# in a single runner with shared workspace, then emits ONE commit
+# covering every output.
 #
-# This replaces the pre-2026-05-09 design that used five separate
-# workflow files with staggered cron schedules (Stammstrecke `0,30`,
-# WL `10,40`, ÖBB `20,50`, Baustellen `0`, build-feed `15,45`).
-# GitHub Actions cron schedules drift 5–15 minutes — under drift the
-# build-feed cron could read a stale cache because the upstream
-# fetcher hadn't committed yet. The DAG eliminates that race
-# entirely: the dependency graph is the timing source.
+# Why single-job (replaces the DAG-with-artifacts architecture from
+# 2026-05-09 which broke the README cadence): the artifact-based
+# approach added two failure modes — invalid action SHAs and the
+# ``actions/download-artifact`` glob/pattern semantics — that
+# silently kept ``build_feed`` from ever committing. The single-job
+# rewrite has zero artifact plumbing, no inter-job push race, and a
+# single auto-commit at the end so the operator-visible state moves
+# atomically (or not at all). The trade-off is sequential runtime
+# (~3-5 min vs the DAG's ~2-3 min) and slightly less granular UI
+# observability — both acceptable for a 30-min cron.
 #
-# Concurrency: the workflow as a whole holds the
-# ``external-api-fetch`` lock (shared with ``manual-full-refresh.yml``
-# and the legacy single-purpose dispatch-only workflows) so the
-# project never has two parallel API-fetching cycles in flight.
+# Step order:
+#   1. ``actions/checkout`` (full history for clean rebase later)
+#   2. Python + dependencies
+#   3. WL / ÖBB / Baustellen cache fetchers (sequential; free APIs)
+#   4. VAO quota pre-flight + Stammstrecke poll (gated on counter)
+#   5. ``feed build`` reads all caches + the freshly-appended CSV
+#      ledger and writes ``docs/feed.xml`` + ``data/first_seen.json``
+#      + appends to ``data/stats/stoerungen_<YYYY>.csv``
+#   6. ``generate_markdown_stats.py`` patches the README markers and
+#      regenerates ``docs/statistik.md`` from the ledger
+#   7. ``git pull --rebase --autostash`` + single auto-commit
 #
-# Inter-job data passing:
-# * WL / ÖBB / Baustellen — upload their freshly-written
-#   ``cache/<provider>_<hash>/events.json`` as a workflow artifact;
-#   ``build_feed`` downloads all artifacts and overlays them on its
-#   checkout. A fetcher that fails (no artifact uploaded) leaves the
-#   last-committed cache file in place — the feed degrades gracefully.
-#   Single git push at the end of the cycle (build_feed) covers all
-#   four caches plus the rendered output, eliminating the parallel-
-#   pusher race that direct ``git-auto-commit`` would create.
-# * Stammstrecke — commits its CSV ledger and the persisted VAO
-#   counter (``data/vor_request_count.json``) DIRECTLY because the
-#   counter MUST survive a build_feed crash (otherwise the next
-#   cycle would re-spend already-charged API requests). build_feed
-#   pulls the resulting commit before its own ``feed build``.
+# Concurrency: the workflow holds the ``external-api-fetch`` lock
+# (shared with ``manual-full-refresh.yml`` and the dispatch-only
+# escape-hatch workflows) so the project never has two parallel
+# API-fetching cycles in flight.
+
 on:
   schedule:
     - cron: '0,30 * * * *'
@@ -45,169 +45,30 @@ concurrency:
   group: external-api-fetch
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  PYTHONPATH: src
-  PIP_CACHE_DIR: /tmp/pip-cache
-
 jobs:
-  wl_cache:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Ensure pip cache directory exists
-        run: mkdir -p "$PIP_CACHE_DIR"
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
-
-      - name: Refresh Wiener Linien cache
-        run: python scripts/update_wl_cache.py
-
-      - name: Upload WL cache artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: wl-cache
-          path: cache/wl_*/events.json
-          retention-days: 1
-          if-no-files-found: ignore
-
-  oebb_cache:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Ensure pip cache directory exists
-        run: mkdir -p "$PIP_CACHE_DIR"
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
-
-      - name: Refresh ÖBB cache
-        run: python scripts/update_oebb_cache.py
-
-      - name: Upload ÖBB cache artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: oebb-cache
-          path: cache/oebb_*/events.json
-          retention-days: 1
-          if-no-files-found: ignore
-
-  baustellen_cache:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Ensure pip cache directory exists
-        run: mkdir -p "$PIP_CACHE_DIR"
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
-
-      - name: Refresh Baustellen cache
-        run: python scripts/update_baustellen_cache.py
-
-      - name: Upload Baustellen cache artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: baustellen-cache
-          path: cache/baustellen_*/events.json
-          retention-days: 1
-          if-no-files-found: ignore
-
-  stammstrecke:
+  cycle:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+      PYTHONPATH: src
+      PIP_CACHE_DIR: /tmp/pip-cache
+      # VOR/VAO API credentials — required by ``scripts/update_stammstrecke_
+      # status.py``. Without these env vars VAO rejects every request
+      # with HTTP 400 (errorText="Missing value for required param accessId").
       VOR_ACCESS_ID: ${{ secrets.VOR_ACCESS_ID }}
       VOR_BASE_URL: ${{ secrets.VOR_BASE_URL }}
       VOR_BASE: ${{ secrets.VOR_BASE }}
       VOR_VERSION: ${{ secrets.VOR_VERSION }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Ensure pip cache directory exists
-        run: mkdir -p "$PIP_CACHE_DIR"
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-
-      - name: Install dependencies
-        uses: ./.github/actions/install-deps
-
-      # Defense-in-depth pre-flight: read the persisted VAO daily counter
-      # (``data/vor_request_count.json``) and SKIP the Stammstrecke step
-      # entirely when a fresh run would breach the contractual 100/day
-      # cap. Mirrors the gate from the dispatch-only escape-hatch
-      # workflow at ``update-stammstrecke-status.yml``.
-      - name: VAO quota pre-flight
-        id: vor_preflight
-        continue-on-error: true
-        run: python scripts/preflight_quota_check.py --check vor --margin 2
-
-      - name: Refresh Stammstrecke status
-        if: ${{ steps.vor_preflight.outputs.quota_ok == 'true' }}
-        run: python scripts/update_stammstrecke_status.py
-
-      # Stammstrecke commits its OWN files immediately rather than
-      # uploading them as artifacts because ``data/vor_request_count.
-      # json`` MUST survive a build_feed crash — otherwise the next
-      # cycle would read a stale counter and re-spend the already-
-      # charged 2 reqs, breaching the contractual 100/day cap. The
-      # CSV ledger commits alongside for the same atomicity reason.
-      - name: Pull concurrent remote changes
-        run: git pull --rebase --autostash
-
-      - name: Commit Stammstrecke ledger + quota counter
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
-        with:
-          commit_message: 'chore: update Stammstrecke status'
-          file_pattern: |
-            data/stats/stammstrecke_*.csv
-            data/vor_request_count.json
-
-  build_feed:
-    needs: [wl_cache, oebb_cache, baustellen_cache, stammstrecke]
-    if: always()
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Need full history so ``git pull --rebase --autostash`` can
-          # cleanly stitch the build_feed commit onto whatever the
-          # stammstrecke job (or a parallel ``update-stations.yml``)
-          # pushed since this job's checkout.
+          # cleanly stitch our commit onto whatever the parallel
+          # ``update-stations.yml`` (Sundays) pushed during this run.
           fetch-depth: 0
 
       - name: Ensure pip cache directory exists
@@ -222,64 +83,85 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/install-deps
 
-      # Overlay all upstream cache artifacts onto the workspace so the
-      # subsequent ``feed build`` step reads the freshest events.json
-      # for every provider that succeeded this cycle. A failed
-      # fetcher's artifact is missing — the corresponding cache file
-      # from the checkout (last committed state) is used instead, so
-      # the feed degrades gracefully rather than dropping the
-      # provider's entries entirely.
-      # ``actions/download-artifact`` is the only floating-tag action
-      # in the repo. The corresponding SHA pin is omitted because the
-      # action is not yet used elsewhere in the workflow set, so there
-      # is no proven-valid pinned reference to copy. The supply-chain
-      # risk is low: the action only writes to the workspace
-      # filesystem and runs no shell from the upstream payload. Pin
-      # to a SHA once the action is added to the repo's standard
-      # ``# v4`` review pass.
-      - name: Download cache artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: .
-          merge-multiple: true
+      # ----- Cache fetchers (free APIs, no quota gate) ---------------------
 
-      # Build feed reads only on-disk artefacts (caches + Stammstrecke
-      # CSV ledger pulled in by the previous git pull); no API call,
-      # no provider query. Writes ``docs/feed.xml`` and
-      # ``data/first_seen.json``, and appends to
-      # ``data/stats/stoerungen_<YYYY>.csv`` for any strictly-new
-      # disruption identity.
+      - name: Refresh Wiener Linien cache
+        run: python scripts/update_wl_cache.py
+        continue-on-error: true
+
+      - name: Refresh ÖBB cache
+        run: python scripts/update_oebb_cache.py
+        continue-on-error: true
+
+      - name: Refresh Baustellen cache
+        run: python scripts/update_baustellen_cache.py
+        continue-on-error: true
+
+      # ----- Stammstrecke (VOR /trip — the single quota-gated API) --------
+
+      # Defense-in-depth pre-flight: read the persisted VAO daily
+      # counter (``data/vor_request_count.json``) and SKIP the
+      # Stammstrecke poll when a fresh run would breach the
+      # contractual 100/day cap. The in-script ``_charge_one_request``
+      # guard (``update_stammstrecke_status.py:331``) is still active
+      # as a second-layer enforcer; this preflight makes the
+      # budget-exhausted state explicit at the top of the workflow
+      # log so operators can spot it without scraping the script's
+      # DEBUG output. ``--margin 2`` mirrors the 2 ``/trip`` requests
+      # the monitor makes per run.
+      - name: VAO quota pre-flight
+        id: vor_preflight
+        # ``continue-on-error: true`` — the preflight script
+        # intentionally exits 1 when the budget is exhausted. We do
+        # NOT want that to fail the workflow; instead the conditional
+        # gate on ``steps.vor_preflight.outputs.quota_ok`` controls
+        # the API step below.
+        continue-on-error: true
+        run: python scripts/preflight_quota_check.py --check vor --margin 2
+
+      - name: Refresh Stammstrecke status
+        if: ${{ steps.vor_preflight.outputs.quota_ok == 'true' }}
+        continue-on-error: true
+        run: python scripts/update_stammstrecke_status.py
+
+      # ----- Feed build (no API call — pure consumer of caches) -----------
+
       - name: Build feed
         run: python -m src.cli feed build
         env:
+          # Atom self/alternate-Links werden direkt im Python-Builder
+          # geschrieben. Aus dem aktuellen Repo abgeleitet, damit Forks
+          # korrekte atom:link-URLs schreiben statt auf das
+          # Original-Repo zu zeigen.
           PAGES_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
 
-      # Regenerate ``docs/statistik.md`` and patch the
-      # ``<!-- STATS:* -->`` markers in ``README.md`` from the
-      # ``data/stats/*.csv`` ledger (30-day window for the README
-      # snapshot). Reads only on-disk files; idempotent at the byte
-      # level (a no-data-change run rewrites only the timestamp cell).
+      # ----- README + dashboard render (no API call) ----------------------
+
       - name: Refresh statistics dashboard and README snapshot
         run: python scripts/generate_markdown_stats.py
+
+      # ----- Single atomic commit -----------------------------------------
 
       - name: Pull concurrent remote changes
         run: git pull --rebase --autostash
 
-      - name: Commit feed + caches + stats
+      - name: Commit cycle outputs
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
-          commit_message: 'chore: rebuild feed'
-          # Single commit covers every output of the cycle EXCEPT the
-          # files the stammstrecke job already committed earlier
-          # (data/stats/stammstrecke_*.csv + data/vor_request_count.json).
-          # Cache files come from the downloaded artifacts; rendered
-          # outputs are produced in-place.
+          commit_message: 'chore: update cycle'
+          # Single commit covers every artefact this cycle could
+          # touch. ``data/vor_request_count.json`` MUST be committed
+          # so the next runner sees today's quota usage and the
+          # contractual 100/day cap stays enforceable across CI
+          # invocations.
           file_pattern: |
-            cache/wl_*/events.json
-            cache/oebb_*/events.json
             cache/baustellen_*/events.json
+            cache/oebb_*/events.json
+            cache/wl_*/events.json
             data/first_seen.json
+            data/stats/stammstrecke_*.csv
             data/stats/stoerungen_*.csv
+            data/vor_request_count.json
             docs/feed.xml
             docs/statistik.md
             README.md


### PR DESCRIPTION
## Was sich ändert

Schreibt `update-cycle.yml` von der DAG-mit-Artifacts-Architektur (PR #1404 + SHA-Fix in #1405) zu einem **single-job sequenziellen Workflow** um. Grund: trotz SHA-Fix produzierte der `build_feed`-Job auf main nie einen `chore: rebuild feed`-Commit — der README blieb am 2026-05-09 21:09 CEST kleben.

## Root-Cause-Analyse

Nach Merge von #1405 (SHA-Pin-Fix für upload-artifact):
- `stammstrecke`-Job committet seitdem zuverlässig (`bcbf0f9`, `4b264f3`, …) — keine Artifact-Dependency
- `build_feed`-Job landet **nie** einen Commit auf main
- Lokal funktioniert `python scripts/generate_markdown_stats.py` einwandfrei: liest 9 Stammstrecke-Zeilen, würde README von „1 Beobachtung" auf „9 Beobachtungen" updaten

**Wahrscheinliche Fehlerstelle:** Die `actions/download-artifact@v4`-Step in `build_feed` hat brüchige Multi-Artifact-Semantik wenn upstream-Jobs short-circuiten. Ohne explizites `pattern` und mit `merge-multiple: true` ist das Verhalten je nach Action-Version verschieden — einer der Zustände blockt den Job vor dem feed-build-Step.

## Fix: Radikale Vereinfachung

Statt der 5-Job-DAG mit Artifact-Passing: **ein einziger Job, alle Schritte sequenziell, ein git commit am Ende**:

```
1.  checkout (fetch-depth: 0)
2.  Python + dependencies
3.  Refresh WL cache              continue-on-error
4.  Refresh ÖBB cache              continue-on-error
5.  Refresh Baustellen cache       continue-on-error
6.  VAO quota pre-flight (gate)
7.  Refresh Stammstrecke status   gated; continue-on-error
8.  Build feed
9.  Refresh README + statistik
10. git pull --rebase --autostash
11. ONE auto-commit
```

## Vorteile

- ✅ **Keine Artifact-Plumbing** → kein `download-artifact`-Fail-Mode
- ✅ **Keine inter-job Push-Race** (alles in einem Runner, ein Commit)
- ✅ **Atomare Sichtbarkeit** der Cycle-Outputs (entweder alle oder keine)
- ✅ **Robust gegen transiente Provider-Ausfälle**: `continue-on-error` auf Fetcher-Steps → Feed degradiert graceful auf last-committed Cache
- ✅ **Single source of timing** unverändert: cron `0,30 * * * *`

## Trade-offs (akzeptiert)

- ⚠️ Sequenzielle Laufzeit ~3-5 min statt DAG's ~2-3 min (well inside 30-min cron interval)
- ⚠️ Weniger granulare Job-UI-Observability — aber Step-UI im Single-Job zeigt jeden Schritt einzeln

## Erwartetes Verhalten nach Merge

Nächster `update-cycle.yml`-Run sollte einen `chore: update cycle`-Commit produzieren mit:
- Alle Cache-Files (cache/wl_*, cache/oebb_*, cache/baustellen_*)
- data/stats/stammstrecke_*.csv + stoerungen_*.csv
- data/vor_request_count.json
- data/first_seen.json
- docs/feed.xml + docs/statistik.md
- **README.md mit aktuellem Timestamp und 9 Beobachtungen**

https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUbtMmoLhj1xACaBg3Ghbr)_