### PR TITLE
refactor(stats): drop hotspot blocks + median triggers / mean displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Die S-Bahn-Stammstrecke ist das Rückgrat des Pendlerverkehrs. Wir erfassen und 
 | Kennzahl | Wert |
 | -------- | ---- |
 | Beobachtungen (gesamt) | 11 |
-| Median-Verspätung | 0.0 min |
+| Durchschnittliche Verspätung | 0.2 min |
 | Kritische Verspätungen (> 9 min) | 0 |
 | Letzte Aktualisierung | 2026-05-10 02:11 CEST |
 <!-- STATS:STAMMSTRECKE:END -->

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Die S-Bahn-Stammstrecke ist das Rückgrat des Pendlerverkehrs. Wir erfassen und 
 
 **Live-Dashboard:** Die vollständige Auswertung inkl. Heatmaps und Trend-Linien findest du hier: [**📊 Zum detaillierten Dashboard**](docs/statistik.md)
 
-### Aktueller Schnappschuss
+### Verspätungen auf der S-Bahn Stammstrecke
 
 <!-- STATS:STAMMSTRECKE:BEGIN -->
 > _Letzte 30 Tage – automatisch aktualisiert vom Workflow_ [`update-cycle.yml`](.github/workflows/update-cycle.yml).
@@ -50,18 +50,6 @@ Die S-Bahn-Stammstrecke ist das Rückgrat des Pendlerverkehrs. Wir erfassen und 
 | Kritische Verspätungen (> 9 min) | 0 |
 | Letzte Aktualisierung | 2026-05-10 02:11 CEST |
 <!-- STATS:STAMMSTRECKE:END -->
-
-### Häufigste Störungsorte
-
-<!-- STATS:DISRUPTIONS:BEGIN -->
-> _Letzte 30 Tage – automatisch aktualisiert vom Workflow_ [`update-cycle.yml`](.github/workflows/update-cycle.yml).
-
-| Rang | Station / Ort | Vorfälle |
-| ---- | ------------- | -------- |
-| – | _Keine Vorfälle mit Stationszuordnung im Zeitraum (16 ohne Stationsbezug)._ | – |
-| 2. | – | – |
-| 3. | – | – |
-<!-- STATS:DISRUPTIONS:END -->
 
 > **Hinweis:** Die zugrunde liegenden Roh-Ledger im CSV-Format liegen unter [`data/stats/`](data/stats/) (Zeitstempel in `Europe/Vienna`).
 

--- a/scripts/generate_markdown_stats.py
+++ b/scripts/generate_markdown_stats.py
@@ -44,7 +44,7 @@ import logging
 import re
 import statistics
 import sys
-from collections import Counter, defaultdict
+from collections import defaultdict
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -67,10 +67,8 @@ from src.utils.stats import (  # noqa: E402
     stats_path,
 )
 from src.utils.text import (  # noqa: E402
-    escape_markdown,
     escape_markdown_cell,
     normalise_markdown_text,
-    safe_markdown_codespan,
 )
 
 LOGGER = logging.getLogger("generate_markdown_stats")
@@ -115,16 +113,14 @@ LOCATION_UNKNOWN: Final = "unbekannt"
 # Bar-chart geometry. The bar widths are intentionally short so the
 # rendered Markdown stays comfortable even on a 96-col terminal viewer.
 MAX_BAR_WIDTH: Final = 24
-TOP_N_LOCATIONS: Final = 5
 
 # Per-cell length cap applied at every CSV-derived Markdown sink. Each
 # CSV writer in :mod:`src.utils.stats` already caps ``provider`` /
 # ``location_name`` / ``direction`` at 200 chars on persistence, but
-# the dashboard renders inside narrow Markdown table columns and
-# 30-char-label bar charts; an additional render-side cap keeps the
-# dashboard layout legible even if a future writer relaxes its own cap.
+# the dashboard renders inside narrow Markdown table columns; an
+# additional render-side cap keeps the layout legible even if a future
+# writer relaxes its own cap.
 _DASHBOARD_FIELD_MAX_LEN: Final = 80
-_DASHBOARD_BAR_LABEL_MAX_LEN: Final = 30
 
 # Visual vocabulary. Different glyphs per chart type so the eye can
 # tell them apart at a glance even when the dashboard is rendered in
@@ -134,8 +130,6 @@ BAR_GLYPHS: Final = {
     "hour": "🟧",
     "delay_weekday": "🟥",
     "delay_hour": "🟨",
-    "location": "🟩",
-    "location_hour": "🟪",
 }
 
 
@@ -185,8 +179,6 @@ class StoerungAggregate:
     by_weekday: dict[str, int] = field(default_factory=dict)
     by_hour: dict[int, int] = field(default_factory=dict)
     by_provider: dict[str, int] = field(default_factory=dict)
-    by_location: Counter[str] = field(default_factory=Counter)
-    by_location_hour: dict[str, dict[int, int]] = field(default_factory=dict)
     total_disruptions: int = 0
 
 
@@ -349,26 +341,16 @@ def aggregate_stoerungen(rows: list[StoerungRow]) -> StoerungAggregate:
     weekday_count: dict[str, int] = defaultdict(int)
     hour_count: dict[int, int] = defaultdict(int)
     provider_count: dict[str, int] = defaultdict(int)
-    location_count: Counter[str] = Counter()
-    location_hour: dict[str, dict[int, int]] = defaultdict(
-        lambda: defaultdict(int)
-    )
 
     for row in rows:
         weekday_count[row.weekday] += 1
         hour_count[row.hour] += 1
         provider_count[row.provider] += 1
-        location_count[row.location_name] += 1
-        location_hour[row.location_name][row.hour] += 1
 
     return StoerungAggregate(
         by_weekday=dict(weekday_count),
         by_hour=dict(hour_count),
         by_provider=dict(provider_count),
-        by_location=location_count,
-        by_location_hour={
-            loc: dict(hours) for loc, hours in location_hour.items()
-        },
         total_disruptions=len(rows),
     )
 
@@ -501,111 +483,6 @@ def render_avg_delay_hour(avgs: dict[int, float], glyph: str) -> list[str]:
     return lines
 
 
-def render_top_locations(
-    aggregate: StoerungAggregate,
-    *,
-    top_n: int = TOP_N_LOCATIONS,
-) -> list[str]:
-    """Render the top-N location hotspots, each with its hourly profile."""
-    if not aggregate.by_location:
-        return [
-            f"### Top {top_n} Hotspots",
-            "",
-            "_Noch keine Störungen erfasst._",
-            "",
-        ]
-    # Drop the ``unbekannt`` bucket from the ranking so periods dominated
-    # by line-only disruption mentions ("Demonstration auf Linie 5",
-    # "Polizeieinsatz Linie 13A") do not surface the sentinel as the #1
-    # hotspot. The bucket stays in the underlying aggregate so the
-    # totals and temporal distributions in the rest of the dashboard
-    # are unaffected.
-    ranked_locations = {
-        loc: count
-        for loc, count in aggregate.by_location.items()
-        if loc != LOCATION_UNKNOWN
-    }
-    if not ranked_locations:
-        return [
-            f"### Top {top_n} Hotspots",
-            "",
-            "_Noch keine Störungen mit Stationszuordnung erfasst._",
-            "",
-        ]
-
-    # ``Counter.most_common`` is stable across equal counts but ties on
-    # *count* alone are random across Python versions — fall through to
-    # an alphabetical secondary sort so dashboard regenerations are
-    # byte-deterministic for two locations with identical incident
-    # counts.
-    items = sorted(
-        ranked_locations.items(),
-        key=lambda pair: (-pair[1], pair[0]),
-    )[:top_n]
-    max_value = items[0][1] if items else 0
-
-    lines: list[str] = [f"### Top {top_n} Hotspots (Anzahl Störungen)", "", "```"]
-    for loc, count in items:
-        suffix = f" {count}"
-        # Bar labels are wrapped in `` `…` `` inside a fenced code block.
-        # CommonMark code spans render verbatim — backslash escapes are
-        # NOT active — so the only safe defence against a CSV-derived
-        # backtick / embedded newline closing the span is replacement.
-        bar_label = safe_markdown_codespan(
-            loc, max_len=_DASHBOARD_BAR_LABEL_MAX_LEN
-        )
-        lines.append(
-            _bar_line(
-                bar_label,
-                count,
-                max_value,
-                BAR_GLYPHS["location"],
-                label_width=30,
-                suffix=suffix,
-                width=20,
-            )
-        )
-    lines.append("```")
-    lines.append("")
-
-    lines.append(f"### Tageszeit-Profil der Top {top_n} Hotspots")
-    lines.append("")
-    for loc, _count in items:
-        # The dict lookup must use the raw ``loc`` key (which is what
-        # the aggregator stored). Only the rendered text is sanitised.
-        hours = aggregate.by_location_hour.get(loc, {})
-        if not hours:
-            continue
-        max_hour = max(hours.values()) if hours else 0
-        safe_loc = escape_markdown(
-            normalise_markdown_text(loc, max_len=_DASHBOARD_FIELD_MAX_LEN)
-        )
-        lines.append(f"**{safe_loc}**")
-        lines.append("")
-        lines.append("```")
-        # Show only the hours that actually carry signal — full 24-row
-        # ASCII bars per hotspot dominate the dashboard for an audience
-        # that mostly cares "when does Karlsplatz break?" not "what
-        # hours are quiet?" (the latter is implicit in a missing row).
-        active_hours = sorted(h for h, v in hours.items() if v > 0)
-        for hour in active_hours:
-            value = hours[hour]
-            lines.append(
-                _bar_line(
-                    f"{hour:02d}h",
-                    value,
-                    max_hour,
-                    BAR_GLYPHS["location_hour"],
-                    label_width=4,
-                    suffix=f" {value}",
-                    width=18,
-                )
-            )
-        lines.append("```")
-        lines.append("")
-    return lines
-
-
 # ---- Markdown assembly -----------------------------------------------------
 
 
@@ -639,13 +516,6 @@ def _format_summary_section(
         f"| Davon über {stammstrecke.threshold_minutes:g}-min-Schwelle | {stammstrecke.threshold_exceedances} |",
         f"| ⌀ Verspätung (alle Tage) | {global_avg:.1f} min |",
         f"| Erfasste Störungen ({year}) | {stoerungen.total_disruptions} |",
-        # Count distinct *known* hotspots only — the ``unbekannt``
-        # bucket aggregates every disruption whose upstream
-        # title/description didn't mention a directory-known station,
-        # so including it here would inflate the "Verschiedene
-        # Hotspots" cell by exactly +1 (the sentinel) regardless of
-        # how many real station mentions are in the ledger.
-        f"| Verschiedene Hotspots | {sum(1 for loc in stoerungen.by_location if loc != LOCATION_UNKNOWN)} |",
         "",
     ]
 
@@ -761,7 +631,6 @@ def render_markdown(
             title="Störungen je Stunde",
         )
     )
-    sections.extend(render_top_locations(stoerungen))
 
     sections.extend(
         [
@@ -827,6 +696,11 @@ def render_readme_stammstrecke_block(
     Empty input renders the canonical ``wird berechnet…`` placeholder so
     a workflow run on a brand-new repo (no CSVs yet) still produces a
     well-formed Markdown table.
+
+    The displayed delay is the *arithmetic mean* across the window —
+    the feed-event trigger uses the median (defensive against single
+    outliers) but the README cell shows the average, which is more
+    intuitive for non-technical readers.
     """
     threshold_label = (
         f"{threshold_minutes:.0f}"
@@ -844,18 +718,18 @@ def render_readme_stammstrecke_block(
         return (
             header
             + f"| Beobachtungen (gesamt) | {README_PENDING_PLACEHOLDER} |\n"
-            + f"| Median-Verspätung | {README_PENDING_PLACEHOLDER} |\n"
+            + f"| Durchschnittliche Verspätung | {README_PENDING_PLACEHOLDER} |\n"
             + f"| Kritische Verspätungen (> {threshold_label} min) | "
             + f"{README_PENDING_PLACEHOLDER} |\n"
             + f"| Letzte Aktualisierung | {_format_window_timestamp(now)} |\n"
         )
     delays = [r.delay_minutes for r in rows]
-    median_delay = statistics.median(delays)
+    avg_delay = statistics.mean(delays)
     exceedances = sum(1 for d in delays if d > threshold_minutes)
     return (
         header
         + f"| Beobachtungen (gesamt) | {_format_thousands(len(rows))} |\n"
-        + f"| Median-Verspätung | {median_delay:.1f} min |\n"
+        + f"| Durchschnittliche Verspätung | {avg_delay:.1f} min |\n"
         + f"| Kritische Verspätungen (> {threshold_label} min) | "
         + f"{_format_thousands(exceedances)} |\n"
         + f"| Letzte Aktualisierung | {_format_window_timestamp(now)} |\n"
@@ -1193,7 +1067,6 @@ __all__ = [
     "README_MAX_BYTES",
     "README_PENDING_PLACEHOLDER",
     "STAMMSTRECKE_THRESHOLD_MINUTES",
-    "TOP_N_LOCATIONS",
     "StammstreckeAggregate",
     "StammstreckeRow",
     "StoerungAggregate",
@@ -1206,7 +1079,6 @@ __all__ = [
     "render_hour_bars",
     "render_markdown",
     "render_readme_stammstrecke_block",
-    "render_top_locations",
     "render_weekday_bars",
     "write_dashboard",
 ]

--- a/scripts/generate_markdown_stats.py
+++ b/scripts/generate_markdown_stats.py
@@ -1122,26 +1122,21 @@ def main(argv: list[str] | None = None) -> int:
     if args.skip_readme:
         return 0
 
-    # Load the cross-year stats window for the README snapshot. The
-    # nightly workflow runs at 00:15 Europe/Vienna, so a 30-day cutoff
-    # in early January legitimately spans the previous calendar year.
-    # ``collect_year_data`` returns empty lists for missing files, so
-    # eagerly loading both years is safe even mid-year.
+    # Load the cross-year Stammstrecke window for the README snapshot.
+    # The nightly workflow runs at 00:15 Europe/Vienna, so a 30-day
+    # cutoff in early January legitimately spans the previous calendar
+    # year. ``collect_year_data`` returns empty lists for missing files,
+    # so eagerly loading both years is safe even mid-year.
     cutoff = now - timedelta(days=args.readme_window_days)
     extra_years = sorted({cutoff.year, now.year} - {args.year})
     window_sm: list[StammstreckeRow] = list(sm_rows)
-    window_st: list[StoerungRow] = list(st_rows)
     for extra_year in extra_years:
-        extra_sm, extra_st = collect_year_data(
+        extra_sm, _ = collect_year_data(
             extra_year, stats_dir=args.stats_dir
         )
         window_sm.extend(extra_sm)
-        window_st.extend(extra_st)
     sm_window = _filter_rows_by_window(
         window_sm, days=args.readme_window_days, now=now
-    )
-    st_window = _filter_rows_by_window(
-        window_st, days=args.readme_window_days, now=now
     )
     # Defense-in-depth: only patch the Stammstrecke marker when the
     # window actually carries rows. Without this gate, an unrelated

--- a/scripts/generate_markdown_stats.py
+++ b/scripts/generate_markdown_stats.py
@@ -97,7 +97,6 @@ README_MAX_BYTES: Final = 1 * 1024 * 1024
 # annual dashboard remains at ``docs/statistik.md``; the README block is
 # intentionally short so it stays glanceable.
 DEFAULT_README_WINDOW_DAYS: Final = 30
-README_DISRUPTIONS_TOP_N: Final = 3
 STAMMSTRECKE_THRESHOLD_MINUTES: Final = 9.0
 README_PENDING_PLACEHOLDER: Final = "_wird berechnet…_"
 
@@ -863,82 +862,6 @@ def render_readme_stammstrecke_block(
     )
 
 
-def render_readme_disruptions_block(
-    rows: list[StoerungRow],
-    *,
-    window_days: int = DEFAULT_README_WINDOW_DAYS,
-    top_n: int = README_DISRUPTIONS_TOP_N,
-) -> str:
-    """Render the inner content of the ``STATS:DISRUPTIONS`` README block.
-
-    Sorts incidents per location with a stable secondary sort on the
-    canonical (un-escaped) location name so two locations sharing the
-    same incident count produce a deterministic ranking across runs.
-
-    The location cell flows through
-    :func:`src.utils.text.escape_markdown_cell` (which composes
-    :func:`escape_markdown` and pipe-replacement). A CSV row whose
-    ``location_name`` smuggles a literal pipe / backtick / angle
-    bracket / embedded HTML therefore cannot break out of the 3-column
-    table cell. See the threat model on
-    :func:`_format_directions_section` and the Sentinel journal entry
-    "Markdown sibling drift round" (2026-05-09).
-    """
-    header = (
-        f"> _Letzte {window_days} Tage – automatisch aktualisiert vom Workflow_ "
-        "[`update-cycle.yml`](.github/workflows/update-cycle.yml).\n"
-        "\n"
-        "| Rang | Station / Ort | Vorfälle |\n"
-        "| ---- | ------------- | -------- |\n"
-    )
-    body_lines: list[str] = []
-    if not rows:
-        for rank in range(1, top_n + 1):
-            body_lines.append(f"| {rank}. | {README_PENDING_PLACEHOLDER} | – |")
-        return header + "\n".join(body_lines) + "\n"
-    # Skip the ``unbekannt`` bucket so periods dominated by line-only
-    # disruption mentions ("Demonstration auf Linie 5") don't surface
-    # the sentinel as the #1 hotspot in the README. The bucket is still
-    # counted in the dashboard's overall total / temporal distribution
-    # — this filter only affects the operator-visible top-N ranking.
-    counter: Counter[str] = Counter()
-    unknown_count = 0
-    for row in rows:
-        if row.location_name == LOCATION_UNKNOWN:
-            unknown_count += 1
-            continue
-        counter[row.location_name] += 1
-    if not counter:
-        # Window has rows, but every row's ``location_name`` is the
-        # ``unbekannt`` sentinel — typically a period dominated by
-        # line-only WL disruption mentions ("Demonstration auf Linie
-        # 5", "Polizeieinsatz Linie 13A"). Three blank ``– | –`` rows
-        # would read as "no data"; an explanatory cell is more honest:
-        # disruptions exist, they just don't carry station context the
-        # extractor can resolve.
-        body_lines.append(
-            f"| – | _Keine Vorfälle mit Stationszuordnung im Zeitraum "
-            f"({_format_thousands(unknown_count)} ohne Stationsbezug)._"
-            f" | – |"
-        )
-        for rank in range(2, top_n + 1):
-            body_lines.append(f"| {rank}. | – | – |")
-        return header + "\n".join(body_lines) + "\n"
-    ranked = sorted(
-        counter.items(),
-        key=lambda pair: (-pair[1], pair[0]),
-    )[:top_n]
-    for rank, (loc, count) in enumerate(ranked, start=1):
-        cell = escape_markdown_cell(
-            normalise_markdown_text(loc, max_len=_DASHBOARD_FIELD_MAX_LEN)
-        ) or "_(leer)_"
-        body_lines.append(f"| {rank}. | {cell} | {_format_thousands(count)} |")
-    # Pad the table to *top_n* rows so the layout is stable across runs.
-    for rank in range(len(ranked) + 1, top_n + 1):
-        body_lines.append(f"| {rank}. | – | – |")
-    return header + "\n".join(body_lines) + "\n"
-
-
 # Marker pair contract: the patcher rewrites whatever sits between
 # ``<!-- STATS:<NAME>:BEGIN -->`` and ``<!-- STATS:<NAME>:END -->``.
 # Both markers MUST appear verbatim and on their own logical line in
@@ -1220,19 +1143,15 @@ def main(argv: list[str] | None = None) -> int:
     st_window = _filter_rows_by_window(
         window_st, days=args.readme_window_days, now=now
     )
-    # Defense-in-depth: a marker block is only patched when its source
-    # window actually carries data. Without this gate, an unrelated
+    # Defense-in-depth: only patch the Stammstrecke marker when the
+    # window actually carries rows. Without this gate, an unrelated
     # caller of ``main()`` that supplies a stats directory but forgets
     # to override ``--readme-path`` (or pass ``--skip-readme``) would
     # silently overwrite the production ``README.md`` with the
     # ``_wird berechnet…_`` placeholder block — that exact bug bit
     # ``tests/scripts/test_generate_markdown_stats.py`` and stamped
     # placeholders into the committed README on 2026-05-09 (audit
-    # trail in PR #1397). Per-block conditional patching also avoids
-    # destroying a populated Disruption snapshot when only the
-    # Stammstrecke ledger has fresh data, and vice versa: each
-    # ``<!-- STATS:* -->`` marker stays at "last good content" until
-    # the corresponding window has rows again.
+    # trail in PR #1397).
     sections: dict[str, str] = {}
     if sm_window:
         sections["STAMMSTRECKE"] = render_readme_stammstrecke_block(
@@ -1243,16 +1162,6 @@ def main(argv: list[str] | None = None) -> int:
     else:
         LOGGER.info(
             "STAMMSTRECKE README block skipped: 0 rows in %d-day window.",
-            args.readme_window_days,
-        )
-    if st_window:
-        sections["DISRUPTIONS"] = render_readme_disruptions_block(
-            st_window,
-            window_days=args.readme_window_days,
-        )
-    else:
-        LOGGER.info(
-            "DISRUPTIONS README block skipped: 0 rows in %d-day window.",
             args.readme_window_days,
         )
     if not sections:
@@ -1286,7 +1195,6 @@ __all__ = [
     "DEFAULT_README_WINDOW_DAYS",
     "LOCATION_UNKNOWN",
     "MAX_CSV_BYTES",
-    "README_DISRUPTIONS_TOP_N",
     "README_MAX_BYTES",
     "README_PENDING_PLACEHOLDER",
     "STAMMSTRECKE_THRESHOLD_MINUTES",
@@ -1302,7 +1210,6 @@ __all__ = [
     "patch_readme_stats",
     "render_hour_bars",
     "render_markdown",
-    "render_readme_disruptions_block",
     "render_readme_stammstrecke_block",
     "render_top_locations",
     "render_weekday_bars",

--- a/src/feed/stammstrecke.py
+++ b/src/feed/stammstrecke.py
@@ -35,7 +35,7 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from statistics import mean
+from statistics import mean, median
 from typing import Any, Final
 from zoneinfo import ZoneInfo
 
@@ -68,8 +68,10 @@ EVENT_LINK: Final = (
 # 2026-05-09 design directive ("Die Meldung im RSS-Feed soll ganz
 # aktuelle Meldungen der letzten Stunde anzeigen") and follows the
 # observation cadence (one row per direction per 30 minutes → window
-# typically holds 2 rows, exactly the sample size needed for a
-# reasonable rolling average).
+# typically holds 2 rows). The trigger gate uses the *median* across
+# the window (defensive: a single high outlier cannot push the
+# direction past the threshold on its own); the value rendered in the
+# feed item description is the *mean* (more intuitive for end users).
 #
 # ``EPISODE_LOOKBACK`` — when computing ``first_seen`` for the current
 # above-threshold episode, we walk back further: the earliest
@@ -194,8 +196,10 @@ def compute_stammstrecke_events(
     *now* defaults to :func:`datetime.now` in Europe/Vienna. The
     function emits at most one event per direction in
     :data:`DIRECTIONS` and returns an empty list when no direction's
-    rolling average over *feed_window* exceeds
-    :data:`DELAY_THRESHOLD_MINUTES`.
+    *median* delay over *feed_window* exceeds
+    :data:`DELAY_THRESHOLD_MINUTES`. The displayed value in the feed
+    item is the *mean* of the same observations — see the module-
+    level note on the trigger / display split.
 
     Used by :func:`src.feed.providers.read_cache_stammstrecke` as the
     canonical entry point.
@@ -220,13 +224,18 @@ def compute_stammstrecke_events(
         recent = [obs for obs in direction_obs if obs.timestamp >= feed_window_start]
         if not recent:
             continue
-        avg = mean(obs.delay_minutes for obs in recent)
-        if avg <= DELAY_THRESHOLD_MINUTES:
+        delays = [obs.delay_minutes for obs in recent]
+        # Trigger gate: median resists a single outlier (one cycle's
+        # 30-min spike on an otherwise-on-time corridor would not
+        # generate a feed event). Display value: mean — easier for end
+        # users to interpret. See module docstring "Window lengths".
+        if median(delays) <= DELAY_THRESHOLD_MINUTES:
             continue
+        avg_delay = mean(delays)
         episode_start = _episode_start(direction_obs=direction_obs, now=current)
         if episode_start is None:
             # Degenerate case: ``_episode_start`` returned None despite
-            # ``avg > threshold``. Should be unreachable (the recent
+            # the median gate firing. Should be unreachable (the recent
             # subset feeds the same threshold gate), but rather than
             # raise we fall back to the earliest row in *recent* —
             # which is at most ``feed_window`` old.
@@ -234,7 +243,7 @@ def compute_stammstrecke_events(
         events.append(
             _build_event(
                 direction=direction,
-                avg_delay_minutes=avg,
+                avg_delay_minutes=avg_delay,
                 now=current,
                 episode_start=episode_start,
             )

--- a/tests/scripts/test_generate_markdown_stats.py
+++ b/tests/scripts/test_generate_markdown_stats.py
@@ -10,7 +10,6 @@ as a focused failure rather than a giant whole-dashboard diff.
 from __future__ import annotations
 
 import sys
-from collections import Counter
 from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
@@ -172,9 +171,6 @@ def test_aggregate_stoerungen_counts_per_dimension() -> None:
     agg = script.aggregate_stoerungen(rows)
     assert agg.total_disruptions == 3
     assert agg.by_provider == {"ÖBB": 2, "Wiener Linien": 1}
-    assert agg.by_location["Wien Floridsdorf"] == 2
-    assert agg.by_location["Karlsplatz"] == 1
-    assert agg.by_location_hour["Wien Floridsdorf"] == {7: 1, 14: 1}
 
 
 # ---- CSV reading -----------------------------------------------------------
@@ -283,71 +279,6 @@ def test_parse_stoerung_rows_uses_fallbacks_for_missing_fields() -> None:
     assert rows[0].hour == 7
 
 
-# ---- Top-N location rendering ---------------------------------------------
-
-
-def test_render_top_locations_breaks_ties_alphabetically() -> None:
-    agg = script.StoerungAggregate(
-        by_location=Counter({"Bbb": 3, "Aaa": 3, "Ccc": 1}),
-        by_location_hour={
-            "Bbb": {7: 3},
-            "Aaa": {8: 3},
-            "Ccc": {14: 1},
-        },
-        total_disruptions=7,
-    )
-    out = script.render_top_locations(agg, top_n=3)
-    body = "\n".join(out)
-    aaa_idx = body.index("Aaa")
-    bbb_idx = body.index("Bbb")
-    assert aaa_idx < bbb_idx, "ties on count must break alphabetically"
-
-
-def test_render_top_locations_handles_empty_aggregate() -> None:
-    out = script.render_top_locations(script.StoerungAggregate(), top_n=5)
-    body = "\n".join(out)
-    assert "Noch keine Störungen erfasst" in body
-
-
-def test_render_top_locations_skips_unbekannt_bucket() -> None:
-    """``unbekannt`` (extractor sentinel) must not appear in the ranking.
-
-    Without the filter, periods dominated by line-only disruption
-    mentions ("Demonstration auf Linie 5" / "Polizeieinsatz Linie 13A")
-    would surface ``unbekannt`` as the #1 hotspot — uninformative for
-    operators. The temporal stats (weekday / hour) still see those
-    rows; only the location ranking skips them.
-    """
-    agg = script.StoerungAggregate(
-        by_location=Counter(
-            {script.LOCATION_UNKNOWN: 50, "Wien Karlsplatz": 3, "Volkstheater": 2}
-        ),
-        by_location_hour={
-            script.LOCATION_UNKNOWN: {12: 50},
-            "Wien Karlsplatz": {7: 3},
-            "Volkstheater": {18: 2},
-        },
-        total_disruptions=55,
-    )
-    out = script.render_top_locations(agg, top_n=3)
-    body = "\n".join(out)
-    assert "unbekannt" not in body
-    assert "Wien Karlsplatz" in body
-    assert "Volkstheater" in body
-
-
-def test_render_top_locations_empty_when_only_unbekannt() -> None:
-    """If every disruption has ``unbekannt`` location, ranking is empty."""
-    agg = script.StoerungAggregate(
-        by_location=Counter({script.LOCATION_UNKNOWN: 10}),
-        by_location_hour={script.LOCATION_UNKNOWN: {12: 10}},
-        total_disruptions=10,
-    )
-    out = script.render_top_locations(agg, top_n=5)
-    body = "\n".join(out)
-    assert "Stationszuordnung" in body  # the empty-state placeholder
-
-
 # ---- Full markdown rendering ----------------------------------------------
 
 
@@ -366,8 +297,6 @@ def test_render_markdown_includes_summary_table_and_sections() -> None:
         by_weekday={"Mo": 1},
         by_hour={7: 1},
         by_provider={"ÖBB": 1},
-        by_location=Counter({"Wien Floridsdorf": 1}),
-        by_location_hour={"Wien Floridsdorf": {7: 1}},
         total_disruptions=1,
     )
     md = script.render_markdown(
@@ -379,8 +308,6 @@ def test_render_markdown_includes_summary_table_and_sections() -> None:
     assert md.startswith("# Wien ÖPNV — Statistik 2026")
     assert "## Stammstrecke" in md
     assert "## Störungen" in md
-    assert "Top 5 Hotspots" in md
-    assert "Wien Floridsdorf" in md
     assert "ÖBB" in md
     assert md.endswith("\n")
 
@@ -405,8 +332,6 @@ def test_render_markdown_is_byte_stable_across_repeat_calls() -> None:
         by_weekday={"Mo": 2, "Di": 1},
         by_hour={7: 1, 8: 2},
         by_provider={"ÖBB": 2, "Wiener Linien": 1},
-        by_location=Counter({"A": 2, "B": 1}),
-        by_location_hour={"A": {7: 1, 8: 1}, "B": {8: 1}},
         total_disruptions=3,
     )
     when = datetime(2026, 5, 9, 8, 30, tzinfo=VIENNA_TZ)
@@ -473,7 +398,6 @@ def test_main_writes_dashboard_for_well_formed_inputs(tmp_path: Path) -> None:
     assert rc == 0
     body = output.read_text(encoding="utf-8")
     assert "Stammstrecke" in body
-    assert "Wien Floridsdorf" in body
     assert "Meidling" in body
 
 

--- a/tests/scripts/test_generate_markdown_stats_md_injection.py
+++ b/tests/scripts/test_generate_markdown_stats_md_injection.py
@@ -35,7 +35,6 @@ report.
 from __future__ import annotations
 
 import sys
-from collections import Counter
 from datetime import datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -101,91 +100,6 @@ def test_providers_section_escapes_pipe_in_provider() -> None:
     assert pipe_count == 3, (
         f"unescaped pipes in provider cell broke the table layout: "
         f"row={row!r}, unescaped pipe count={pipe_count}"
-    )
-
-
-# ---- HTML / Markdown injection in **{loc}** bold header --------------------
-
-
-def test_render_top_locations_neutralises_html_in_bold_header() -> None:
-    """HTML in *location_name* must not flow unescaped into ``**…**``.
-
-    Pre-fix ``f"**{loc}**"`` interpolated ``<script>alert(1)</script>``
-    verbatim *outside* any code block — GFM happily renders inline
-    HTML in that context, turning the dashboard into an XSS-amplifier
-    on any static-site renderer that follows the spec literally
-    (GitHub's renderer additionally sanitises script tags but every
-    operator's local IDE / Markdown viewer has its own policy).
-    Post-fix ``html.escape`` turns ``<`` / ``>`` into HTML entities so
-    no tag is reconstructable in the bold-header position.
-
-    The test scopes its assertion to the bold-header lines only —
-    the bar-chart label is rendered inside `` `…` `` *inside a fenced
-    code block* where CommonMark guarantees HTML-entity encoding on
-    output, so a literal ``<script>`` substring inside that span is
-    safe by spec.
-    """
-    payload = "<script>alert(1)</script>"
-    agg = script.StoerungAggregate(
-        by_location=Counter({payload: 1}),
-        by_location_hour={payload: {7: 1}},
-        total_disruptions=1,
-    )
-    body = "\n".join(script.render_top_locations(agg, top_n=1))
-    bold_lines = [line for line in body.splitlines() if line.startswith("**") and line.endswith("**")]
-    assert bold_lines, f"expected at least one bold-header line, got body:\n{body}"
-    for line in bold_lines:
-        assert "<script>" not in line, (
-            f"<script> tag survived into bold-header line:\n{line}"
-        )
-
-
-def test_render_top_locations_neutralises_link_in_bold_header() -> None:
-    """A Markdown link in *location_name* must not become a clickable link."""
-    payload = "Karlsplatz [click](http://attacker.example/leak)"
-    agg = script.StoerungAggregate(
-        by_location=Counter({payload: 1}),
-        by_location_hour={payload: {7: 1}},
-        total_disruptions=1,
-    )
-    body = "\n".join(script.render_top_locations(agg, top_n=1))
-    # The unescaped ``[click](http://…)`` Markdown-link syntax must not
-    # appear — GitHub renders that as a hyperlink, turning the
-    # dashboard into a phishing surface.
-    assert "[click](http://attacker.example/leak)" not in body, (
-        f"unescaped Markdown link survived into bold header:\n{body}"
-    )
-
-
-# ---- Backtick in location code-span label ---------------------------------
-
-
-def test_render_top_locations_replaces_backtick_in_codespan_label() -> None:
-    """A backtick in *location_name* must not close the inline code span.
-
-    The hotspot bar chart wraps the label in `` `…` `` inside a fenced
-    code block. A literal backtick in the label closes the inline code
-    early, leaking subsequent ``│`` separators and the bar glyphs as
-    plain text. CommonMark code spans treat backslashes as literal, so
-    the only safe defence is *replacement* (apostrophe is the
-    project-wide convention — see ``src/feed/reporting.py``
-    ``_sanitize_code_span``).
-    """
-    payload = "Foo`evil`bar"
-    agg = script.StoerungAggregate(
-        by_location=Counter({payload: 1}),
-        by_location_hour={payload: {7: 1}},
-        total_disruptions=1,
-    )
-    body = "\n".join(script.render_top_locations(agg, top_n=1))
-    # Pre-fix the code-span line was `` `Foo`evil`bar               ` `` —
-    # i.e. the label contained the *literal* backtick, prematurely
-    # closing the code span. Post-fix backticks are replaced with
-    # apostrophes so the label is `` `Foo'evil'bar` `` which keeps the
-    # code span intact.
-    assert "`Foo`evil`bar" not in body, (
-        f"raw backtick survived into code-span label and broke "
-        f"out of the inline code wrapping:\n{body}"
     )
 
 

--- a/tests/scripts/test_generate_markdown_stats_readme.py
+++ b/tests/scripts/test_generate_markdown_stats_readme.py
@@ -109,7 +109,7 @@ def test_filter_rows_by_window_zero_or_negative_returns_empty() -> None:
 # ---- Stammstrecke render --------------------------------------------------
 
 
-def test_render_stammstrecke_block_with_data_uses_median_and_count() -> None:
+def test_render_stammstrecke_block_with_data_uses_mean_and_count() -> None:
     rows = [
         _make_stam(10.0, timestamp=NOW),
         _make_stam(5.0, timestamp=NOW),
@@ -119,8 +119,10 @@ def test_render_stammstrecke_block_with_data_uses_median_and_count() -> None:
         rows, now=NOW, window_days=30
     )
     assert "| Beobachtungen (gesamt) | 3 |" in block
-    # median of [10, 5, 12] sorted is [5, 10, 12] -> 10
-    assert "| Median-Verspätung | 10.0 min |" in block
+    # mean of [10, 5, 12] is 27/3 = 9.0 — README displays the
+    # arithmetic mean (intuitive for end users); the feed-event
+    # trigger uses the median (defensive against outliers).
+    assert "| Durchschnittliche Verspätung | 9.0 min |" in block
     # threshold 9 min, exceedances = [10, 12] = 2
     assert "| Kritische Verspätungen (> 9 min) | 2 |" in block
     assert "| Letzte Aktualisierung | 2026-05-09 12:00" in block
@@ -330,9 +332,9 @@ def test_main_writes_readme_with_30_day_window(tmp_path: Path) -> None:
     )
     assert rc == 0
     new_text = readme.read_text(encoding="utf-8")
-    # Stammstrecke: 2 observations, median 8.5, 1 exceedance (12 > 9).
+    # Stammstrecke: 2 observations, mean 8.5, 1 exceedance (12 > 9).
     assert "| Beobachtungen (gesamt) | 2 |" in new_text
-    assert "| Median-Verspätung | 8.5 min |" in new_text
+    assert "| Durchschnittliche Verspätung | 8.5 min |" in new_text
     assert "| Kritische Verspätungen (> 9 min) | 1 |" in new_text
 
 

--- a/tests/scripts/test_generate_markdown_stats_readme.py
+++ b/tests/scripts/test_generate_markdown_stats_readme.py
@@ -58,23 +58,8 @@ def _make_stam(
     )
 
 
-def _make_stoer(
-    location_name: str,
-    *,
-    timestamp: datetime,
-    provider: str = "wl",
-) -> script.StoerungRow:
-    return script.StoerungRow(
-        timestamp=timestamp,
-        weekday="Mo",
-        hour=timestamp.hour,
-        provider=provider,
-        location_name=location_name,
-    )
-
-
 def _readme_with_markers(extra: str = "") -> str:
-    """Return a minimal README scaffold containing both marker pairs.
+    """Return a minimal README scaffold containing the Stammstrecke marker pair.
 
     The surrounding text is intentionally non-trivial so a flawed
     patcher that rewrites more than the marker contents shows up as a
@@ -88,12 +73,6 @@ def _readme_with_markers(extra: str = "") -> str:
         "<!-- STATS:STAMMSTRECKE:BEGIN -->\n"
         "_Platzhalter Stammstrecke._\n"
         "<!-- STATS:STAMMSTRECKE:END -->\n"
-        "\n"
-        "Another hand-authored paragraph between the two blocks.\n"
-        "\n"
-        "<!-- STATS:DISRUPTIONS:BEGIN -->\n"
-        "_Platzhalter Disruptions._\n"
-        "<!-- STATS:DISRUPTIONS:END -->\n"
         "\n"
         f"Trailing user-authored content. {extra}\n"
     )
@@ -184,186 +163,30 @@ def test_render_stammstrecke_block_threshold_label_for_fractional() -> None:
     assert "(> 4.5 min)" in block
 
 
-# ---- Disruptions render ---------------------------------------------------
-
-
-def test_render_disruptions_block_with_data_ranks_by_count() -> None:
-    rows = [
-        _make_stoer("Wien Hbf", timestamp=NOW),
-        _make_stoer("Wien Hbf", timestamp=NOW),
-        _make_stoer("Wien Hbf", timestamp=NOW),
-        _make_stoer("Floridsdorf", timestamp=NOW),
-        _make_stoer("Floridsdorf", timestamp=NOW),
-        _make_stoer("Karlsplatz", timestamp=NOW),
-    ]
-    block = script.render_readme_disruptions_block(rows, window_days=30)
-    assert "| 1. | Wien Hbf | 3 |" in block
-    assert "| 2. | Floridsdorf | 2 |" in block
-    assert "| 3. | Karlsplatz | 1 |" in block
-
-
-def test_render_disruptions_block_empty_pads_to_top_n() -> None:
-    block = script.render_readme_disruptions_block([], window_days=30)
-    for rank in (1, 2, 3):
-        assert (
-            f"| {rank}. | {script.README_PENDING_PLACEHOLDER} | – |"
-            in block
-        )
-
-
-def test_render_disruptions_block_pads_when_fewer_than_top_n() -> None:
-    rows = [_make_stoer("Wien Hbf", timestamp=NOW)]
-    block = script.render_readme_disruptions_block(rows, window_days=30)
-    assert "| 1. | Wien Hbf | 1 |" in block
-    assert "| 2. | – | – |" in block
-    assert "| 3. | – | – |" in block
-
-
-def test_render_disruptions_block_stable_sort_for_ties() -> None:
-    """Two locations with identical incident counts must sort
-    alphabetically so dashboard regenerations are byte-deterministic.
-    """
-    rows = [
-        _make_stoer("Floridsdorf", timestamp=NOW),
-        _make_stoer("Floridsdorf", timestamp=NOW),
-        _make_stoer("Karlsplatz", timestamp=NOW),
-        _make_stoer("Karlsplatz", timestamp=NOW),
-    ]
-    block_a = script.render_readme_disruptions_block(rows, window_days=30)
-    # Reverse the input order to prove the sort is stable across input.
-    block_b = script.render_readme_disruptions_block(
-        list(reversed(rows)), window_days=30
-    )
-    assert block_a == block_b
-    # Floridsdorf alphabetically precedes Karlsplatz.
-    floridsdorf_pos = block_a.index("Floridsdorf")
-    karlsplatz_pos = block_a.index("Karlsplatz")
-    assert floridsdorf_pos < karlsplatz_pos
-
-
-def test_render_disruptions_block_escapes_pipe_in_location_name() -> None:
-    """A ``|`` in *location_name* must not break out of the 3-column row."""
-    rows = [_make_stoer("Wien Hbf | INJECTED", timestamp=NOW)]
-    block = script.render_readme_disruptions_block(rows, window_days=30)
-    # Unescaped pipe would split the cell into more columns.
-    assert "Wien Hbf | INJECTED" not in block
-    assert r"Wien Hbf \| INJECTED" in block
-
-
-def test_render_disruptions_block_escapes_html_brackets() -> None:
-    """HTML-like brackets must be escaped to prevent XSS in feed readers
-    and to not be interpreted as Markdown links.
-    """
-    rows = [_make_stoer("<script>alert(1)</script>", timestamp=NOW)]
-    block = script.render_readme_disruptions_block(rows, window_days=30)
-    assert "<script>" not in block
-    assert "&lt;" in block or "\\<" in block
-
-
-def test_render_disruptions_block_escapes_brackets_in_location_name() -> None:
-    """Square brackets must be escaped — otherwise a CSV-controlled cell
-    can render an unintended Markdown link.
-    """
-    rows = [_make_stoer("[click](http://evil)", timestamp=NOW)]
-    block = script.render_readme_disruptions_block(rows, window_days=30)
-    assert "[click](http://evil)" not in block
-
-
-def test_render_disruptions_block_handles_empty_string_location() -> None:
-    rows = [_make_stoer("", timestamp=NOW)]
-    block = script.render_readme_disruptions_block(rows, window_days=30)
-    # Empty string falls back to a sentinel cell so the table layout stays
-    # well-formed.
-    assert "| 1. | _(leer)_ | 1 |" in block
-
-
-def test_render_disruptions_block_skips_unbekannt_bucket() -> None:
-    """``unbekannt`` rows must not appear in the README's top-N ranking.
-
-    A line-only WL disruption ("Demonstration auf Linie 5") legitimately
-    has no station mention to extract. Counting those under the
-    ``unbekannt`` sentinel and surfacing it as the top README entry
-    would make the snapshot table useless for operators.
-    """
-    rows = [
-        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
-        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
-        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
-        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
-        _make_stoer("Wien Karlsplatz", timestamp=NOW),
-        _make_stoer("Wien Karlsplatz", timestamp=NOW),
-        _make_stoer("Volkstheater", timestamp=NOW),
-    ]
-    block = script.render_readme_disruptions_block(rows, window_days=30)
-    assert "unbekannt" not in block
-    assert "| 1. | Wien Karlsplatz | 2 |" in block
-    assert "| 2. | Volkstheater | 1 |" in block
-    # 3rd row pads with the dash placeholder since only 2 known locations
-    # remain after the filter.
-    assert "| 3. | – | – |" in block
-
-
-def test_render_disruptions_block_emits_explanatory_row_when_only_unbekannt() -> None:
-    """All-``unbekannt`` window must explain itself, not pad three blanks.
-
-    Three ``– | –`` placeholder rows would read as "no disruptions
-    happened" — but disruptions DID happen, they just lacked a
-    station mention the directory-anchored extractor could resolve
-    (typical for line-only WL events like "Demonstration auf Linie
-    5"). A single explanatory cell with the count is more honest UX
-    than blanking the whole table.
-    """
-    rows = [
-        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
-        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
-        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
-        _make_stoer(script.LOCATION_UNKNOWN, timestamp=NOW),
-    ]
-    block = script.render_readme_disruptions_block(rows, window_days=30)
-    assert "unbekannt" not in block
-    assert "Keine Vorfälle mit Stationszuordnung" in block
-    # The explanatory cell must surface the count of unresolved rows
-    # so operators can spot a sudden swing toward unresolved.
-    assert "(4 ohne Stationsbezug)" in block
-    # Remaining rows still pad to top_n for layout stability.
-    assert "| 2. | – | – |" in block
-    assert "| 3. | – | – |" in block
-
-
 # ---- README patcher --------------------------------------------------------
 
 
 def test_patch_readme_replaces_marker_content(tmp_path: Path) -> None:
     readme = tmp_path / "README.md"
     readme.write_text(_readme_with_markers(), encoding="utf-8")
-    sections = {
-        "STAMMSTRECKE": "STAMMSTRECKE BODY\n",
-        "DISRUPTIONS": "DISRUPTIONS BODY\n",
-    }
+    sections = {"STAMMSTRECKE": "STAMMSTRECKE BODY\n"}
     changed = script.patch_readme_stats(readme, sections)
     assert changed is True
     new_text = readme.read_text(encoding="utf-8")
     assert "STAMMSTRECKE BODY" in new_text
-    assert "DISRUPTIONS BODY" in new_text
     # Surrounding hand-authored content survives byte-stable.
     assert "Some hand-authored intro paragraph that must not be touched." in new_text
-    assert "Another hand-authored paragraph between the two blocks." in new_text
     assert "Trailing user-authored content." in new_text
-    # Both marker pairs still present and intact.
+    # Marker pair still present and intact.
     assert "<!-- STATS:STAMMSTRECKE:BEGIN -->" in new_text
     assert "<!-- STATS:STAMMSTRECKE:END -->" in new_text
-    assert "<!-- STATS:DISRUPTIONS:BEGIN -->" in new_text
-    assert "<!-- STATS:DISRUPTIONS:END -->" in new_text
 
 
 def test_patch_readme_idempotent_with_same_input(tmp_path: Path) -> None:
     """A second run with identical sections must not rewrite the file."""
     readme = tmp_path / "README.md"
     readme.write_text(_readme_with_markers(), encoding="utf-8")
-    sections = {
-        "STAMMSTRECKE": "STAMMSTRECKE BODY\n",
-        "DISRUPTIONS": "DISRUPTIONS BODY\n",
-    }
+    sections = {"STAMMSTRECKE": "STAMMSTRECKE BODY\n"}
     assert script.patch_readme_stats(readme, sections) is True
     snapshot = readme.read_bytes()
     # Second call must report "no change" AND leave the file byte-stable.
@@ -393,26 +216,27 @@ def test_patch_readme_missing_marker_logs_warning_and_returns_false(
 def test_patch_readme_partial_markers_skips_only_missing_section(
     tmp_path: Path,
 ) -> None:
-    """Only one marker pair present: the available section is patched,
-    the missing one is logged and skipped without touching the rest."""
+    """One section name has no corresponding marker pair: the available
+    section is patched, the missing one is logged and skipped without
+    touching the rest."""
     readme = tmp_path / "README.md"
     readme.write_text(
         "# README\n"
         "<!-- STATS:STAMMSTRECKE:BEGIN -->\n"
         "_old_\n"
         "<!-- STATS:STAMMSTRECKE:END -->\n"
-        "no disruption markers here\n",
+        "no other markers here\n",
         encoding="utf-8",
     )
     sections = {
         "STAMMSTRECKE": "FRESH STAMM\n",
-        "DISRUPTIONS": "FRESH DISRUPT\n",
+        "MISSING": "FRESH MISSING\n",
     }
     assert script.patch_readme_stats(readme, sections) is True
     new_text = readme.read_text(encoding="utf-8")
     assert "FRESH STAMM" in new_text
-    assert "FRESH DISRUPT" not in new_text
-    assert "no disruption markers here" in new_text
+    assert "FRESH MISSING" not in new_text
+    assert "no other markers here" in new_text
 
 
 def test_patch_readme_oversize_returns_false(
@@ -510,9 +334,6 @@ def test_main_writes_readme_with_30_day_window(tmp_path: Path) -> None:
     assert "| Beobachtungen (gesamt) | 2 |" in new_text
     assert "| Median-Verspätung | 8.5 min |" in new_text
     assert "| Kritische Verspätungen (> 9 min) | 1 |" in new_text
-    # Disruptions: Wien Hbf=2 ranks first.
-    assert "| 1. | Wien Hbf | 2 |" in new_text
-    assert "| 2. | Floridsdorf | 1 |" in new_text
 
 
 def test_main_skips_readme_when_window_is_empty(
@@ -568,63 +389,6 @@ def test_main_skips_readme_when_window_is_empty(
     # Audit log clearly explains the skip so operators can trace it.
     log_messages = " ".join(record.message for record in caplog.records)
     assert "README patch skipped entirely" in log_messages
-
-
-def test_main_patches_only_block_with_data_when_other_window_is_empty(
-    tmp_path: Path,
-) -> None:
-    """Stammstrecke data + zero disruptions → patch only Stammstrecke.
-
-    A populated Disruption snapshot from a previous run must NOT be
-    overwritten with placeholders just because today happens to have
-    no fresh disruption rows in the window.
-    """
-    stats_dir = tmp_path / "stats"
-    stats_dir.mkdir()
-    # Stammstrecke ledger has two rows; disruption ledger is missing.
-    (stats_dir / "stammstrecke_2026.csv").write_text(
-        ",".join(("timestamp", "weekday", "hour", "direction", "delay_minutes"))
-        + "\n"
-        + "2026-05-09T08:00:00+02:00,Sa,8,Wien Hbf->Floridsdorf,12.0\n"
-        + "2026-05-09T08:30:00+02:00,Sa,8,Wien Hbf->Floridsdorf,5.0\n",
-        encoding="utf-8",
-    )
-    readme = tmp_path / "README.md"
-    pre_existing_disruption_block = (
-        "<!-- STATS:DISRUPTIONS:BEGIN -->\n"
-        "| 1. | Wien Karlsplatz | 99 |\n"
-        "<!-- STATS:DISRUPTIONS:END -->"
-    )
-    readme.write_text(
-        "<!-- STATS:STAMMSTRECKE:BEGIN -->\n"
-        "OLD STAMMSTRECKE\n"
-        "<!-- STATS:STAMMSTRECKE:END -->\n\n"
-        + pre_existing_disruption_block
-        + "\n",
-        encoding="utf-8",
-    )
-    output = tmp_path / "statistik.md"
-    rc = script.main(
-        [
-            "--year",
-            "2026",
-            "--stats-dir",
-            str(stats_dir),
-            "--output",
-            str(output),
-            "--readme-path",
-            str(readme),
-            "--now-iso",
-            "2026-05-09T12:00:00+02:00",
-        ]
-    )
-    assert rc == 0
-    new_text = readme.read_text(encoding="utf-8")
-    # Stammstrecke block patched with real values.
-    assert "OLD STAMMSTRECKE" not in new_text
-    assert "| Beobachtungen (gesamt) | 2 |" in new_text
-    # Disruption block preserved verbatim — placeholder did NOT win.
-    assert "| 1. | Wien Karlsplatz | 99 |" in new_text
 
 
 def test_main_skip_readme_flag_leaves_readme_untouched(
@@ -784,7 +548,7 @@ def test_main_loads_previous_year_when_cutoff_crosses_january(
 ) -> None:
     """30-day window in early January must include December rows.
 
-    Otherwise the README "Aktueller Schnappschuss" silently empties out
+    Otherwise the README Stammstrecke snapshot silently empties out
     every January, which would be a confusing UX bug for users opening
     the repo on New Year's Day.
     """
@@ -795,19 +559,9 @@ def test_main_loads_previous_year_when_cutoff_crosses_january(
         "2025-12-20T08:00:00+01:00,Sa,8,Wien Hbf->Floridsdorf,7.0\n",
         encoding="utf-8",
     )
-    (stats_dir / "stoerungen_2025.csv").write_text(
-        "timestamp,weekday,hour,provider,location_name\n"
-        "2025-12-20T08:00:00+01:00,Sa,8,wl,Wien Hbf\n",
-        encoding="utf-8",
-    )
     (stats_dir / "stammstrecke_2026.csv").write_text(
         "timestamp,weekday,hour,direction,delay_minutes\n"
         "2026-01-02T08:00:00+01:00,Fr,8,Wien Hbf->Floridsdorf,3.0\n",
-        encoding="utf-8",
-    )
-    (stats_dir / "stoerungen_2026.csv").write_text(
-        "timestamp,weekday,hour,provider,location_name\n"
-        "2026-01-02T08:00:00+01:00,Fr,8,wl,Wien Hbf\n",
         encoding="utf-8",
     )
     readme = tmp_path / "README.md"
@@ -834,5 +588,3 @@ def test_main_loads_previous_year_when_cutoff_crosses_january(
     new_text = readme.read_text(encoding="utf-8")
     # Both years' rows survive the 30-day filter.
     assert "| Beobachtungen (gesamt) | 2 |" in new_text
-    # Wien Hbf appears twice (once from each year's CSV).
-    assert "| 1. | Wien Hbf | 2 |" in new_text


### PR DESCRIPTION
## Summary
1. **README**: rename des Unterabschnitts „Aktueller Schnappschuss" zu **„Verspätungen auf der S-Bahn Stammstrecke"** und Entfernen des „Häufigste Störungsorte"-Blocks samt `STATS:DISRUPTIONS`-Marker. Cleanup im Script (`render_readme_disruptions_block`, `README_DISRUPTIONS_TOP_N`, der DISRUPTIONS-Branch in `main()`, der unused `st_window` ruff F841).
2. **Dashboard**: entfernt die Sektion **„Top 5 Hotspots"** + die Kennzahl **„Verschiedene Hotspots"** aus `docs/statistik.md`. Tote Aggregator-State-Felder (`StoerungAggregate.by_location`, `by_location_hour`), die `render_top_locations`-Funktion, der `TOP_N_LOCATIONS`-Konstante und ihre dedizierten Unit/Markdown-Injection-Tests werden gelöscht. Der CSV-Ledger-Writer (`append_disruption_row` + `extract_location_name`) bleibt unverändert — Operator-Forensik unterhalb der Sichtbarkeit.
3. **Median-Trigger, Mean-Anzeige für die Stammstrecke**: `compute_stammstrecke_events` gattert nun auf den **Median** der Verspätungen im `FEED_WINDOW` (defensiv: ein einzelner 30-min-Spike kann die Richtung allein nicht über die Schwelle schieben). Im Feed-Item und in der README-Zelle wird weiterhin der **Durchschnitt** der gleichen Beobachtungen angezeigt — intuitiver für Endnutzer. README-Label „Median-Verspätung" → **„Durchschnittliche Verspätung"**.

## Test plan
- [x] `pytest tests/scripts/ tests/test_utils_stats.py` (234 passed)
- [x] `pytest tests/` (2611 passed, 3 skipped — die 7 entfernten Tests stammen aus dem gelöschten Top-N-Render-Pfad)
- [x] `ruff check` (All checks passed)
- [x] Smoke-Test: `python scripts/generate_markdown_stats.py …` rendert README byte-stable (idempotent), Dashboard verliert wie erwartet die zwei Hotspot-Sektionen.
