### PR TITLE
docs(stats): drop stale hotspot section from statistik.md

### DIFF
--- a/docs/statistik.md
+++ b/docs/statistik.md
@@ -10,7 +10,6 @@ _Automatisch erzeugt am 2026-05-10T02:11+02:00 (Europe/Vienna)._
 | Davon über 9-min-Schwelle | 0 |
 | ⌀ Verspätung (alle Tage) | 0.3 min |
 | Erfasste Störungen (2026) | 16 |
-| Verschiedene Hotspots | 0 |
 
 ## Stammstrecke
 
@@ -151,10 +150,6 @@ _Automatisch erzeugt am 2026-05-10T02:11+02:00 (Europe/Vienna)._
 `22h ` │ ························  0
 `23h ` │ ························  0
 ```
-
-### Top 5 Hotspots
-
-_Noch keine Störungen mit Stationszuordnung erfasst._
 
 ---
 


### PR DESCRIPTION
## Summary

- Entfernt die `### Top 5 Hotspots`-Sektion und die `| Verschiedene Hotspots | 0 |`-Zeile aus `docs/statistik.md`.
- Begründung: Standorte und Linien lassen sich nicht immer 100 % zuordnen — die Statistik soll nur sichere Daten enthalten.
- Hinweis: Der Dashboard-Generator (`scripts/generate_markdown_stats.py`) emittiert beide Blöcke seit Commit `e6d168a` ohnehin nicht mehr. Die Markdown-Datei hatte die Reste nur noch als Stand vor der letzten Regeneration. Beim nächsten Lauf wären sie automatisch verschwunden.

## Test plan

- [x] `git diff` zeigt nur die zwei beabsichtigten Streichungen
- [ ] Optional: `python scripts/generate_markdown_stats.py --skip-readme` lokal laufen lassen und prüfen, dass die Datei byte-identisch bleibt

https://claude.ai/code/session_01E8g5DsZCxSGtseqKT5oift

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8g5DsZCxSGtseqKT5oift)_