### PR TITLE
security(logging): close 8-bit C1 terminal-escape drift on every strip_control_chars=False sibling path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,208 @@
+## 2026-05-10 - 8-bit C1 Terminal-Escape Drift: `_INVISIBLE_DANGEROUS_RE` Always-Strip Floor Missed `\x7f-\x9f` (CSI/OSC/DCS 8-bit Primitives) on Every `strip_control_chars=False` Sibling Path
+
+**Vulnerability:** The 2026-05-09 *BiDi-Mark Drift Round 2* round
+(`.jules/sentinel.md`) lifted the BiDi / zero-width / line-terminator
+union into `src/utils/logging.py:_INVISIBLE_DANGEROUS_RE` so the
+unconditional always-strip step in `sanitize_log_message` closes the
+five `strip_control_chars=False` sibling sinks
+(`clean_message`, `_sanitize_log_detail`, `_sanitize_exception_msg`,
+`SafeFormatter.formatException`, `SafeJSONFormatter.formatException`)
+in one cut, while preserving the readability contract for `\n` /
+`\r` / `\t` (C0 chars at `\x09` / `\x0A` / `\x0D`). The fix shape was
+"every code point with NO readability value AND a documented log-
+injection / Trojan-Source primitive must be in the always-strip
+floor".
+
+The closing audit walker enumerated three threat classes (BiDi
+format controls, zero-width chars, line/paragraph separators) but
+deferred a fourth: the **8-bit C1 controls** at `\x80-\x9F`
+(plus DEL at `\x7F`). Per ECMA-48 / ISO 6429 these 32 + 1 code
+points are the 8-bit equivalents of the 7-bit ANSI escape sequences
+the project's `_ANSI_ESCAPE_RE` already defends against on the
+`\x1b`-prefixed boundary:
+
+* `\x9B` is the **8-bit CSI** (Control Sequence Introducer; same
+  shape as `\x1b[`). A planted `\x9b31m` flips the next-rendered
+  text to red on any terminal that honours 8-bit C1.
+* `\x9D` is the **8-bit OSC** (Operating System Command; same
+  shape as `\x1b]`). A planted `\x9d0;HACKED\x07` rewrites the
+  terminal-window title.
+* `\x90` is the **8-bit DCS** (Device Control String; `\x1bP`).
+* `\x9E` / `\x9F` are PM / APC (Privacy Message / Application
+  Program Command) - rarely interpreted but defined as
+  ESC-prefix-escape primitives.
+* The remaining 27 C1 controls are non-printable invisibles with
+  no readability value (PAD, HOP, BPH, NBH, IND, SSA, ESA, HTS,
+  HTJ, VTS, PLD, PLU, RI, SS2, SS3, PU1, PU2, STS, CCH, MW, SPA,
+  EPA, SOS, SGCI, SCI, ST, …).
+
+The 7-bit `_ANSI_ESCAPE_RE` regex
+(`\x1b(?:\[[0-?]*[ -/]*[@-~]|...)`) is anchored to `\x1b` and does
+NOT match the 8-bit forms. Pre-fix `_INVISIBLE_DANGEROUS_RE` was
+`[؜​-‏ -‮⁦-⁩﻿]` - covers
+the BiDi / zero-width / line-terminator family but NOT
+`\x7f-\x9f`. The narrow `_CONTROL_CHARS_RE.sub("")` step that
+DOES strip them is gated by `strip_control_chars=True` - so the
+five `strip_control_chars=False` sibling sinks let the 8-bit
+terminal-escape primitive through verbatim.
+
+**Threat model (highest-impact path):** A compromised provider
+(Wiener Linien / VOR / OEBB upstream, MITM, DNS hijack, poisoned
+`cache/wl/*.json`) returns an HTTP error body or station-info
+field carrying the 8-bit CSI primitive:
+
+```
+ConnectionError: failed to fetch https://example.com/path?q=\x9b31mFAKE OK\x9b0m
+```
+
+The pipeline path:
+
+* `request_safe` catches the `RequestException`, routes through
+  `_sanitize_exception_msg` -> `sanitize_log_message(strip_control_chars=False)`
+  -> `_INVISIBLE_DANGEROUS_RE.sub("", text)` (no match pre-fix) ->
+  the 8-bit CSI byte is preserved verbatim in `exc.args[0]`.
+* The exception propagates up to `RunReport.record_exception` ->
+  `clean_message(message)` -> same `sanitize_log_message(strip_control_chars=False)`
+  pipeline -> 8-bit CSI byte preserved.
+* `RunReport.exception_message` flows into:
+  - `docs/feed_health.json` (public artefact, served by GitHub
+    Pages from `https://origamihase.github.io/wien-oepnv/feed_health.json`)
+    via `build_feed_health_payload` -> `json.dumps(ensure_ascii=False)`
+    which preserves U+0080-U+009F codepoints verbatim.
+  - GitHub Issue body via `submit_auto_issue` for the auto-issue
+    submitter.
+  - The Markdown `feed_health` report rendered into the issue body.
+
+Subscribers / operators consuming the artefact in any 8-bit-C1
+-honouring renderer trigger interpretation of the CSI / OSC / DCS
+sequence:
+* `cat docs/feed_health.json` on xterm with `eightBitInput`
+  enabled.
+* `less docs/feed_health.json` without `-r`/`-R` configured to
+  strip C1.
+* `tail -f log/diagnostics.log` over an SSH connection to a BSD
+  jump-box (BSD console honours 8-bit C1 by default).
+* `journalctl --no-pager` on a TTY without UTF-8 lock.
+* `rxvt` in 8-bit mode, embedded serial terminals (router /
+  switch CLI), legacy enterprise terminals.
+
+The 8-bit primitive succeeds despite the 7-bit `_ANSI_ESCAPE_RE`
+defence — a textbook **8-bit ANSI-escape forging primitive** on a
+public artefact + operator-facing log surface.
+
+The same shape applies to the URL boundary (`_UNSAFE_URL_CHARS`
+in `src/utils/http.py`) and the stations-validation boundary
+(`_UNSAFE_CHARS_RE` in `src/utils/stations_validation.py`). Both
+were sized to mirror the pre-fix `_INVISIBLE_DANGEROUS_RE` floor
+via the inventory tests
+`test_unsafe_url_chars_regex_covers_canonical_invisible_dangerous_set`
+and `test_unsafe_chars_regex_covers_canonical_invisible_dangerous_set`
+— they would FAIL post-fix unless widened in the same PR.
+
+**Severity:** MEDIUM — real exploit shape against terminal
+renderers that honour 8-bit C1, low against modern UTF-8
+terminals (which treat 0x80-0x9F as continuation bytes). Public
+artefact (`docs/feed_health.json`) plus operator-facing log
+surface (every `log.error("... %s ...", str(exc))` call routed
+through `SafeFormatter`). Defence-in-depth gap on the documented
+"always-strip floor" design contract.
+
+**Fix:** Widen `_INVISIBLE_DANGEROUS_RE` in `src/utils/logging.py`
+from
+```
+[؜​-‏ -‮⁦-⁩﻿]
+```
+to
+```
+[\x7f-\x9f؜​-‏ -‮⁦-⁩﻿]
+```
+so the 8-bit terminal-escape primitive set (DEL + 32 C1 controls)
+is stripped UNCONDITIONALLY, independent of the
+`strip_control_chars` flag. `\n` / `\r` / `\t` (C0 chars at
+`\x09` / `\x0A` / `\x0D`) remain outside the always-strip floor
+so the readability contract for traceback formatting is
+preserved. Companion regexes widened in the same PR to maintain
+the inventory invariants:
+
+* `src/utils/http.py:_UNSAFE_URL_CHARS` — added `\x7f-\x9f` (was
+  `\s\x00-\x1f\x7f<>"\^`{|}` + BiDi / zero-width); now
+  `\s\x00-\x1f\x7f-\x9f<>"\^`{|}` + BiDi / zero-width).
+* `src/utils/stations_validation.py:_UNSAFE_CHARS_RE` — added
+  `\x7f-\x9f` (was `<>\x00-\x08\x0b\x0c\x0e-\x1f` + BiDi /
+  zero-width); now
+  `<>\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f` + BiDi / zero-width).
+
+Sibling regexes already covering `\x7f-\x9f` and unaffected by the
+widening:
+
+* `src/build_feed.py:_CONTROL_RE` (Round 6 widened to canonical).
+* `src/utils/stats.py:_CSV_CONTROL_CHARS_RE` (Round 5 widened
+  to canonical).
+* `src/utils/text.py:_MARKDOWN_NORMALISE_UNSAFE_RE` (always
+  covered the C1 set).
+* `src/utils/logging.py:_CONTROL_CHARS_RE` (the strip_control_chars=True
+  path; pre-fix already covered C1).
+
+**Learning:** The 2026-05-09 BiDi-Mark Drift Round 2 prevention
+rule named "the always-strip floor must cover every invisible
+Unicode character with no readability value that is a documented
+log-injection / Trojan-Source primitive". The C1 controls
+(`\x80-\x9f`) qualify on every axis: they are invisible
+(non-printable), have no readability value, and per ECMA-48 are
+8-bit terminal-escape primitives functionally equivalent to the
+7-bit ANSI escapes. Round 2's audit walker enumerated three
+threat classes (BiDi, zero-width, line-terminator) but did NOT
+enumerate the 8-bit-C1 / DEL fourth axis — the audit walker grep
+was scoped to "characters that have a corresponding 7-bit form
+in `_ANSI_ESCAPE_RE`" rather than "characters that escape the
+7-bit defence by being 8-bit equivalents".
+
+The auto-discoverable invariant lives in
+`tests/test_sentinel_log_injection_c1_terminal_escape.py`:
+
+* 32 per-code-point regex-match tests against
+  `sanitize_log_message(strip_control_chars=False)` (one per
+  C1 / DEL char minus NEL which `\s` already collapses).
+* 32 per-code-point tests against `clean_message` (the public-
+  artefact / GitHub-Issue-body sanitiser).
+* 32 per-code-point tests against `_sanitize_log_detail`.
+* 32 per-code-point tests against `_sanitize_exception_msg`.
+* 32 per-code-point tests against `SafeFormatter.formatException`.
+* 32 per-code-point tests against `SafeJSONFormatter.formatException`.
+* Two end-to-end PoCs (8-bit CSI via `record_exception`, 8-bit
+  OSC via `add_error_message`) verifying the published
+  `docs/feed_health.json` artefact carries no C1 byte.
+* Two inventory invariants:
+  - `_INVISIBLE_DANGEROUS_RE` covers the full `\x7f-\x9f` set.
+  - `_INVISIBLE_DANGEROUS_RE` is a subset of `_CONTROL_CHARS_RE`
+    (the strip_control_chars=True full set) so the two paths
+    cannot drift apart.
+* Two regression tests:
+  - `\n` / `\r` / `\t` survive `strip_control_chars=False`.
+  - The Round 2 BiDi / zero-width / line-terminator family
+    continues to be stripped (additive-only widening).
+
+**Prevention:** The deferred-sibling enumeration grep
+(`grep -rn '_CONTROL_RE\b\|_CONTROL_CHARS\b\|_UNSAFE_URL_CHARS\b\|_UNSAFE_CHARS_RE\b' src/ scripts/`)
+remains the closing-checklist trigger for any future widening of
+`_INVISIBLE_DANGEROUS_RE`. The Round 6 grep pattern misses
+suffixed regex names (`_CONTROL_CHARS_RE` vs `_CONTROL_CHARS`)
+due to `\b` word-boundary semantics; the inventory test
+`test_invisible_dangerous_re_subset_of_control_chars_re` pins
+the canonical-pair sync invariant and would catch any future
+widening of `_INVISIBLE_DANGEROUS_RE` that isn't reflected in
+`_CONTROL_CHARS_RE`. The two existing inventory tests
+(`test_unsafe_url_chars_regex_covers_canonical_invisible_dangerous_set`,
+`test_unsafe_chars_regex_covers_canonical_invisible_dangerous_set`)
+fire on every PR that widens the canonical without widening the
+URL / stations-validation boundary. A future widening (e.g.
+Unicode 17 BiDi controls, or a new ANSI-escape variant added to
+ECMA-48) MUST run all four inventory tests as the closing
+checklist; the round closes only when the inventory grep returns
+zero remaining sites and all inventory tests pass.
+
+---
+
 ## 2026-05-10 - Trojan-Source RSS via `src/build_feed.py:_CONTROL_RE` Narrower Than the Canonical `_INVISIBLE_DANGEROUS_RE` — BiDi-Mark Drift Round 6 (Feed-XML Writer Sibling)
 
 **Vulnerability:** The 2026-05-10 *CSV Formula-Injection Invisible-Prefix

--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -93,9 +93,12 @@ DNS_TIMEOUT = 5.0
 # ``_INVISIBLE_DANGEROUS_RE`` set:
 #
 # 1. ASCII whitespace (``\s`` — TAB / LF / CR / SPACE plus the Unicode
-#    LINE SEPARATOR U+2028 and PARAGRAPH SEPARATOR U+2029) and ASCII
-#    C0 controls + DEL (``\x00-\x1f\x7f``). Original payload-shape
-#    motivation: log injection via embedded newlines.
+#    LINE SEPARATOR U+2028 and PARAGRAPH SEPARATOR U+2029), ASCII
+#    C0 controls + DEL (``\x00-\x1f\x7f``), and the **8-bit C1
+#    controls** (``\x80-\x9f``). Original payload-shape motivation:
+#    log injection via embedded newlines plus the ECMA-48 8-bit
+#    terminal-escape primitives (``\x9b`` CSI, ``\x9d`` OSC, ``\x90``
+#    DCS …) that survive the 7-bit ``_ANSI_ESCAPE_RE`` defence.
 # 2. Structural URL-injection characters (``< > " \ ^ ` { | }``).
 #    Original motivation: XSS / template-injection / shell-injection
 #    when a URL is interpolated into a downstream sink without escaping.
@@ -127,8 +130,18 @@ DNS_TIMEOUT = 5.0
 # invariant programmatically so a future widening of
 # ``_INVISIBLE_DANGEROUS_RE`` (e.g. a Unicode 16 BiDi format control)
 # fails the test until the URL validator is widened too.
+#
+# 2026-05-10 "8-bit C1 / DEL Drift": ``_INVISIBLE_DANGEROUS_RE`` was
+# widened to ``\x7f-\x9f`` (DEL + 32 C1 controls) so the 8-bit
+# terminal-escape primitives (``\x9b`` CSI, ``\x9d`` OSC, ``\x90``
+# DCS, ``\x9e`` PM, ``\x9f`` APC) cannot bypass the
+# ``strip_control_chars=False`` sibling sinks. The URL validator is
+# widened in the same PR to mirror the new canonical floor — a
+# planted feed/redirect URL carrying ``\x9b...m`` would otherwise
+# slip past the validator and trigger SGR colour command interpretation
+# in any 8-bit-C1-honouring terminal that renders the URL.
 _UNSAFE_URL_CHARS = re.compile(
-    r"[\s\x00-\x1f\x7f<>\"\\^`{|}"
+    r"[\s\x00-\x1f\x7f-\x9f<>\"\\^`{|}"
     r"\u061c\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]"
 )
 

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -40,22 +40,42 @@ _CONTROL_CHARS_RE = re.compile(
     r"[\x00-\x1f\x7f-\x9f\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069\ufeff]"
 )
 # Always-strip set: invisible Unicode characters that have NO readability
-# value and are pure log-injection / Trojan-Source primitives. The 2026-05-09
-# round (PR #1363) added these code points to ``_CONTROL_CHARS_RE`` so the
-# ``strip_control_chars=True`` (default) path strips them. The drift was the
-# ``strip_control_chars=False`` branch \u2014 used by ``clean_message``,
+# value and are pure log-injection / Trojan-Source / terminal-escape
+# primitives. The 2026-05-09 round (PR #1363) added the BiDi / zero-width
+# code points to ``_CONTROL_CHARS_RE`` so the ``strip_control_chars=True``
+# (default) path strips them. The drift was the ``strip_control_chars=False``
+# branch \u2014 used by ``clean_message``,
 # ``_sanitize_log_detail`` (``src/feed/reporting.py``),
 # ``_sanitize_exception_msg`` (``src/utils/http.py``),
 # ``SafeFormatter.formatException`` and ``SafeJSONFormatter.formatException``
 # (``src/feed/logging_safe.py``) \u2014 which bypasses ``_CONTROL_CHARS_RE``
-# entirely to preserve readable ``\n``/``\r``/``\t`` in tracebacks. That
-# leaks the BiDi / zero-width / line-terminator family verbatim into the
-# public ``feed_health.json`` artefact and the GitHub Issue body submitted
-# by ``submit_auto_issue``. Stripping unconditionally (independent of the
-# flag) closes every sibling path in one cut while preserving the readable
-# newline contract every ``strip_control_chars=False`` caller relies on.
+# entirely to preserve readable ``\n``/``\r``/``\t`` in tracebacks.
+#
+# 2026-05-10 (8-bit C1 / DEL Drift): the always-strip floor was widened to
+# ``\x7f-\x9f`` (DEL + the 32 ECMA-48 C1 controls). The 7-bit ANSI escape
+# regex ``_ANSI_ESCAPE_RE`` matches ``\x1b``-prefixed CSI/OSC/Fe sequences
+# but NOT their **8-bit** equivalents \u2014 ``\x9b`` (CSI, 8-bit form of
+# ``ESC [``), ``\x9d`` (OSC, 8-bit form of ``ESC ]``), ``\x90`` (DCS),
+# ``\x9e`` (PM), ``\x9f`` (APC). Per ECMA-48 / ISO 6429, terminals that
+# honour 8-bit C1 (xterm with ``eightBitInput``, several BSD consoles,
+# ``rxvt`` in 8-bit mode) interpret ``\x9b31m`` exactly as ``\x1b[31m``.
+# A hostile upstream payload (compromised provider, MITM, DNS hijack,
+# poisoned cache file) carrying ``\x9b...m`` in an exception text reaches
+# the operator-facing log line and the public ``docs/feed_health.json``
+# artefact verbatim pre-fix \u2014 bypassing the ``_ANSI_ESCAPE_RE``
+# defence at the 7-bit boundary entirely. Pinning ``\x7f-\x9f`` into the
+# always-strip floor closes every ``strip_control_chars=False`` sibling
+# path in one cut. ``\n``/``\r``/``\t`` (C0 ``\x09``/``\x0a``/``\x0d``)
+# remain outside the always-strip floor so the readability contract for
+# traceback formatting is preserved.
+#
+# Stripping unconditionally (independent of the flag) leaks the BiDi /
+# zero-width / line-terminator / 8-bit-C1 family out of the public
+# ``feed_health.json`` artefact and the GitHub Issue body submitted by
+# ``submit_auto_issue`` while preserving the readable newline contract
+# every ``strip_control_chars=False`` caller relies on.
 _INVISIBLE_DANGEROUS_RE = re.compile(
-    r"[\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069\ufeff]"
+    r"[\x7f-\x9f\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069\ufeff]"
 )
 _LOG_INJECTION_RE = re.compile(r"[\n\r\t]")
 # ANSI escape codes: comprehensive matching for CSI, OSC, Fe, and 2-byte sequences

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -616,8 +616,19 @@ def _find_gtfs_issues(
 # per CVE-2021-42574). The widened set keeps the two regexes in sync;
 # any future widening of ``_INVISIBLE_DANGEROUS_RE`` MUST be reflected
 # here \u2014 pinned by ``test_unsafe_chars_regex_covers_canonical_invisible_dangerous_set``.
+#
+# 2026-05-10 "8-bit C1 / DEL Drift": ``_INVISIBLE_DANGEROUS_RE`` was
+# widened to ``\x7f-\x9f`` (DEL + 32 ECMA-48 C1 controls, including
+# the 8-bit terminal-escape primitives ``\x9b`` CSI / ``\x9d`` OSC /
+# ``\x90`` DCS) so the ``strip_control_chars=False`` sibling sinks
+# inherit the defence. The stations validator is widened in the same
+# PR to mirror the new canonical floor \u2014 a planted ``stations.json``
+# carrying ``\x9b...m`` in a ``name`` / ``bst_code`` / ``vor_id`` /
+# ``aliases`` field would otherwise flow through to the GitHub Issue
+# body the directory validator emits and trigger SGR colour
+# interpretation in any 8-bit-C1-honouring terminal that views it.
 _UNSAFE_CHARS_RE = re.compile(
-    r"[<>\x00-\x08\x0b\x0c\x0e-\x1f\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069\ufeff]"
+    r"[<>\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069\ufeff]"
 )
 
 # Pattern for the synthetic ``bst_id``/``bst_code`` values assigned to

--- a/tests/test_sentinel_log_injection_c1_terminal_escape.py
+++ b/tests/test_sentinel_log_injection_c1_terminal_escape.py
@@ -1,0 +1,508 @@
+"""Sentinel: close 8-bit C1-control terminal-escape drift in every
+``strip_control_chars=False`` code path.
+
+Threat model — Round 3 (8-bit C1 Drift)
+---------------------------------------
+Round 1 (PR #1363, journaled 2026-05-09) widened
+``src/utils/logging.py:_CONTROL_CHARS_RE`` to cover the BiDi /
+zero-width / line-terminator family on the
+``strip_control_chars=True`` (default) path.
+
+Round 2 (journaled 2026-05-09 *BiDi-Mark Drift Round 2*) closed the
+``strip_control_chars=False`` sibling branch by lifting the BiDi /
+zero-width / line-terminator union into ``_INVISIBLE_DANGEROUS_RE``
+and applying it UNCONDITIONALLY (independent of the flag) inside
+``sanitize_log_message``. That round explicitly named the readability
+contract: ``\\n`` / ``\\r`` / ``\\t`` MUST survive
+``strip_control_chars=False`` for traceback formatting.
+
+Round 3 closes the **8-bit C1 control / terminal-escape** sibling
+that survives the Round 2 fix:
+
+* The 7-bit ANSI escape regex
+  ``src/utils/logging.py:_ANSI_ESCAPE_RE`` matches ``\\x1b`` (ESC)
+  followed by CSI / OSC / Fe sequences. It is anchored to ``\\x1b``
+  and does NOT match the **8-bit** equivalents:
+    - ``\\x9b`` (CSI, 8-bit form of ``ESC [``)
+    - ``\\x9d`` (OSC, 8-bit form of ``ESC ]``)
+    - ``\\x90`` (DCS, 8-bit form of ``ESC P``)
+    - ``\\x9e`` (PM, 8-bit form of ``ESC ^``)
+    - ``\\x9f`` (APC, 8-bit form of ``ESC _``)
+  Per ECMA-48 / ISO 6429, these C1 controls are functionally
+  IDENTICAL to their two-byte 7-bit forms — a terminal that honours
+  8-bit C1 (xterm with ``eightBitInput`` enabled, several BSD
+  consoles, embedded serial terminals, ``rxvt`` in 8-bit mode)
+  interprets ``\\x9b31m`` exactly as ``\\x1b[31m`` (set foreground
+  red).
+
+* ``_INVISIBLE_DANGEROUS_RE`` (the always-strip floor) covers the
+  BiDi / zero-width / line-terminator family but NOT
+  ``\\x7f-\\x9f`` (DEL + the 32 C1 controls). The narrow regex
+  ``_CONTROL_CHARS_RE.sub("")`` step that DOES strip them is gated
+  by ``strip_control_chars=True`` — so every
+  ``strip_control_chars=False`` sibling path lets them through:
+
+    - ``src/feed/reporting.py:clean_message`` (canonical sanitiser
+      for every provider detail / warning / error / exception
+      message rendered into ``docs/feed_health.json`` AND the
+      GitHub Issue body submitted by ``submit_auto_issue``)
+    - ``src/feed/reporting.py:_sanitize_log_detail`` (provider
+      diagnostic strings posted to the issue body)
+    - ``src/utils/http.py:_sanitize_exception_msg`` (rewrites
+      ``RequestException.args[0]`` for every network-level error
+      caught by ``request_safe``; the exception text is then routed
+      through every WARNING/ERROR site that logs ``str(exc)``)
+    - ``src/feed/logging_safe.py:SafeFormatter.formatException``
+      (renders the traceback for every ``log.exception(...)`` call
+      in the production feed builder)
+    - ``src/feed/logging_safe.py:SafeJSONFormatter.formatException``
+      (same drift on the JSON log channel)
+
+**Exploit shape:** A hostile upstream (compromised provider, MITM,
+DNS hijack, planted cache file) returns an error response carrying
+the 8-bit CSI primitive ``\\x9b...m`` (a SGR colour command) or
+``\\x9d...\\x07`` (an OSC sequence that, e.g., changes the terminal
+title). The error flows through:
+
+    HTTP fetch → request_safe.RequestException →
+    _sanitize_exception_msg → exc.args[0] →
+    log.error("... %s ...", str(exc)) → SafeFormatter → handler
+
+If the operator's terminal supports 8-bit C1 (``cat
+log/diagnostics.log``, ``less`` without ``-r``/``-R`` configured to
+strip ANSI, ``tail -f`` over an SSH connection to a BSD jump-box,
+``journalctl`` on a TTY without ``--no-pager``), the byte sequence
+is interpreted as a terminal command — the standard ANSI-escape
+forging primitive (CVE-style log forgery, fake colour-coded "OK"
+markers, terminal-title rewrite) succeeds despite the
+``_ANSI_ESCAPE_RE`` defence at the 7-bit boundary.
+
+A second sink with the same shape is ``docs/feed_health.json`` (a
+public artefact published to GitHub Pages). Operators who
+``cat docs/feed_health.json`` or pipe it through a JSON pretty-
+printer rendered on a C1-honouring terminal trigger the same
+interpretation. The published JSON carries the C1 byte verbatim
+because ``json.dumps(ensure_ascii=False)`` preserves Unicode
+codepoints U+0080-U+009F.
+
+**Severity:** MEDIUM — real exploit shape against terminal renderers
+that honour 8-bit C1, low against modern UTF-8 terminals (which
+treat 0x80-0x9F as continuation bytes), public artefact (``docs/
+feed_health.json``) plus operator-facing log surface, defence-in-
+depth gap on the documented "always-strip floor".
+
+**Fix:** Widen ``_INVISIBLE_DANGEROUS_RE`` to include
+``\\x7f-\\x9f`` (DEL + the 32 C1 controls) so the unconditional
+strip step closes the 8-bit terminal-escape primitive on every
+``strip_control_chars=False`` sibling path. ``\\n``/``\\r``/``\\t``
+remain outside the always-strip floor (they are C0, not C1) so the
+readability contract for traceback formatting is preserved. The
+companion regexes ``_UNSAFE_URL_CHARS`` (URL boundary) and
+``_UNSAFE_CHARS_RE`` (stations validation boundary) are widened
+in the same PR to maintain the canonical-coverage invariant pinned
+by ``test_unsafe_url_chars_regex_covers_canonical_invisible_dangerous_set``
+and ``test_unsafe_chars_regex_covers_canonical_invisible_dangerous_set``.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from src.feed.logging_safe import SafeFormatter, SafeJSONFormatter
+from src.feed.reporting import (
+    FeedHealthMetrics,
+    RunReport,
+    _sanitize_log_detail,
+    build_feed_health_payload,
+    clean_message,
+)
+from src.utils.http import _sanitize_exception_msg
+from src.utils.logging import sanitize_log_message
+from src.utils import logging as canonical_logging
+
+
+def _empty_metrics() -> FeedHealthMetrics:
+    """Helper: minimal ``FeedHealthMetrics`` for the end-to-end PoCs.
+    The C1 byte under test rides the ``RunReport`` channel, not the
+    metrics channel, so empty-zero metrics are sufficient.
+    """
+    return FeedHealthMetrics(
+        raw_items=0,
+        filtered_items=0,
+        deduped_items=0,
+        new_items=0,
+        duplicate_count=0,
+        duplicates=(),
+    )
+
+
+# Canonical 8-bit C1 control / DEL set: all 33 code points U+007F..U+009F.
+# Each is invisible (no readability value) and is either DEL itself
+# (\x7f) or a C1 control with a documented 7-bit ESC-prefixed equivalent
+# under ECMA-48 / ISO 6429.
+_C1_TERMINAL_ESCAPE_CHARS: tuple[tuple[str, str], ...] = (
+    ("\x7f", "U+007F DEL"),
+    ("\x80", "U+0080 PAD"),
+    ("\x81", "U+0081 HOP"),
+    ("\x82", "U+0082 BPH"),
+    ("\x83", "U+0083 NBH"),
+    ("\x84", "U+0084 IND"),
+    # NOTE: \x85 (NEL) is intentionally omitted — Python's regex `\s`
+    # matches U+0085 (it has the Whitespace property), so the
+    # `re.sub(r"\s+", " ", ...)` step in `clean_message` already
+    # collapses it. Including it here would pass even pre-fix and
+    # dilute the PoC.
+    ("\x86", "U+0086 SSA"),
+    ("\x87", "U+0087 ESA"),
+    ("\x88", "U+0088 HTS"),
+    ("\x89", "U+0089 HTJ"),
+    ("\x8a", "U+008A VTS"),
+    ("\x8b", "U+008B PLD"),
+    ("\x8c", "U+008C PLU"),
+    ("\x8d", "U+008D RI"),
+    ("\x8e", "U+008E SS2"),
+    ("\x8f", "U+008F SS3"),
+    ("\x90", "U+0090 DCS (8-bit ESC P)"),
+    ("\x91", "U+0091 PU1"),
+    ("\x92", "U+0092 PU2"),
+    ("\x93", "U+0093 STS"),
+    ("\x94", "U+0094 CCH"),
+    ("\x95", "U+0095 MW"),
+    ("\x96", "U+0096 SPA"),
+    ("\x97", "U+0097 EPA"),
+    ("\x98", "U+0098 SOS"),
+    ("\x99", "U+0099 SGCI"),
+    ("\x9a", "U+009A SCI"),
+    ("\x9b", "U+009B CSI (8-bit ESC [)"),
+    ("\x9c", "U+009C ST"),
+    ("\x9d", "U+009D OSC (8-bit ESC ])"),
+    ("\x9e", "U+009E PM (8-bit ESC ^)"),
+    ("\x9f", "U+009F APC (8-bit ESC _)"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Per-code-point bypass tests — pre-fix every assert FAILS.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("char,name", _C1_TERMINAL_ESCAPE_CHARS)
+def test_sanitize_log_message_strips_c1_with_strip_control_chars_disabled(
+    char: str, name: str
+) -> None:
+    """``sanitize_log_message(strip_control_chars=False)`` MUST strip
+    every 8-bit C1 control / DEL — the unconditional always-strip
+    floor must cover the 8-bit terminal-escape primitive set so the
+    five sibling sinks (``clean_message``, ``_sanitize_log_detail``,
+    ``_sanitize_exception_msg``, ``SafeFormatter.formatException``,
+    ``SafeJSONFormatter.formatException``) inherit the defence in
+    one cut.
+    """
+    payload = f"prefix{char}suffix"
+    sanitized = sanitize_log_message(payload, strip_control_chars=False)
+    assert char not in sanitized, (
+        f"{name} ({char!r}) leaked through "
+        f"sanitize_log_message(strip_control_chars=False): {sanitized!r}"
+    )
+
+
+@pytest.mark.parametrize("char,name", _C1_TERMINAL_ESCAPE_CHARS)
+def test_clean_message_strips_c1_terminal_escape(char: str, name: str) -> None:
+    """``clean_message`` is the canonical sanitiser for every provider
+    detail / warning / error / exception text rendered into the public
+    ``docs/feed_health.json`` artefact AND the GitHub Issue body. It
+    MUST strip the 8-bit C1 / DEL set — pre-fix the
+    ``sanitize_log_message(strip_control_chars=False)`` delegation
+    leaks them verbatim.
+    """
+    payload = f"VOR error: {char}terminal-injected"
+    cleaned = clean_message(payload)
+    assert char not in cleaned, (
+        f"{name} ({char!r}) survived clean_message: {cleaned!r}"
+    )
+
+
+@pytest.mark.parametrize("char,name", _C1_TERMINAL_ESCAPE_CHARS)
+def test_sanitize_log_detail_strips_c1_terminal_escape(
+    char: str, name: str
+) -> None:
+    """``_sanitize_log_detail`` cleans provider-supplied diagnostic
+    strings before posting them to the GitHub Issue body. Pre-fix the
+    narrow ``_CONTROL_CHARS_RE = re.compile(r"[\\x00-\\x1f\\x7f]")``
+    in ``src/feed/reporting.py:30`` covers neither the C1 controls
+    nor the wider canonical set; the delegation to ``clean_message``
+    inherits the same drift so the C1 byte slips through.
+    """
+    payload = f"OSM diagnostic: {char} done"
+    sanitized = _sanitize_log_detail(payload)
+    assert char not in sanitized, (
+        f"{name} ({char!r}) survived _sanitize_log_detail: {sanitized!r}"
+    )
+
+
+@pytest.mark.parametrize("char,name", _C1_TERMINAL_ESCAPE_CHARS)
+def test_http_sanitize_exception_msg_strips_c1_terminal_escape(
+    char: str, name: str
+) -> None:
+    """``_sanitize_exception_msg`` rewrites
+    ``RequestException.args[0]`` for every network-level error
+    surfaced by ``request_safe``. Pre-fix the
+    ``sanitize_log_message(strip_control_chars=False)`` delegation
+    leaks the 8-bit C1 byte into every downstream
+    ``logger.error("... %s ...", str(exc))`` site.
+    """
+    payload = (
+        "ConnectionError: failed to fetch "
+        f"https://example.com/path?q={char}injected"
+    )
+    sanitized = _sanitize_exception_msg(payload)
+    assert char not in sanitized, (
+        f"{name} ({char!r}) survived _sanitize_exception_msg: {sanitized!r}"
+    )
+
+
+@pytest.mark.parametrize("char,name", _C1_TERMINAL_ESCAPE_CHARS)
+def test_safe_formatter_format_exception_strips_c1_terminal_escape(
+    char: str, name: str
+) -> None:
+    """The traceback rendered by ``SafeFormatter.formatException`` is
+    appended to every log record carrying ``exc_info``. Pre-fix the
+    formatter passes ``strip_control_chars=False`` to preserve
+    readable newlines — but that also leaks the C1 family so a
+    hostile exception text containing ``\\x9b31m`` smuggles a SGR
+    colour command into operator-facing log output.
+    """
+    formatter = SafeFormatter("%(message)s")
+    try:
+        raise ValueError(f"VOR error: {char}injected")
+    except ValueError:
+        import sys
+
+        ei: Any = sys.exc_info()
+        rendered = formatter.formatException(ei)
+
+    assert char not in rendered, (
+        f"{name} ({char!r}) survived "
+        f"SafeFormatter.formatException: {rendered!r}"
+    )
+
+
+@pytest.mark.parametrize("char,name", _C1_TERMINAL_ESCAPE_CHARS)
+def test_safe_json_formatter_format_exception_strips_c1_terminal_escape(
+    char: str, name: str
+) -> None:
+    """``SafeJSONFormatter.formatException`` shares the same drift —
+    the JSON-formatted log line carries the rendered traceback
+    verbatim (``ensure_ascii=False`` preserves Unicode), so a C1
+    primitive in an upstream exception slips through into structured
+    logs ingested by SIEM / observability stacks that may render
+    them on a C1-honouring terminal.
+    """
+    formatter = SafeJSONFormatter()
+    try:
+        raise RuntimeError(f"Hostile: {char}forged")
+    except RuntimeError:
+        import sys
+
+        ei: Any = sys.exc_info()
+        rendered = formatter.formatException(ei)
+
+    assert char not in rendered, (
+        f"{name} ({char!r}) survived "
+        f"SafeJSONFormatter.formatException: {rendered!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end PoC — the public ``feed_health.json`` artefact must NOT
+# carry an 8-bit C1 / DEL byte even when a hostile upstream plants one
+# in an exception message.
+# ---------------------------------------------------------------------------
+
+
+def test_feed_health_json_does_not_carry_8bit_csi() -> None:
+    """End-to-end PoC: a hostile upstream raises an exception whose
+    text contains the 8-bit CSI primitive ``\\x9b31m`` (a SGR colour
+    command). The exception is routed through
+    ``RunReport.record_exception`` -> ``clean_message`` -> the public
+    ``docs/feed_health.json`` artefact via
+    ``build_feed_health_payload`` -> ``json.dumps``.
+
+    Pre-fix: the C1 byte survives ``clean_message`` and lands in the
+    JSON. Operators who ``cat docs/feed_health.json`` on a 8-bit-C1
+    -honouring terminal trigger the SGR command — the standard ANSI-
+    escape forging primitive succeeds despite the ``_ANSI_ESCAPE_RE``
+    defence at the 7-bit boundary.
+
+    Post-fix: the unconditional always-strip floor in
+    ``_INVISIBLE_DANGEROUS_RE`` removes the byte, so the published
+    JSON carries only printable / readable text.
+    """
+    report = RunReport(statuses=[])
+    report.record_exception(
+        RuntimeError("VOR error: \x9b31mFAKE OK\x9b0m injected via 8-bit CSI")
+    )
+
+    payload = build_feed_health_payload(report, _empty_metrics())
+    rendered = json.dumps(payload, ensure_ascii=False)
+
+    assert "\x9b" not in rendered, (
+        "8-bit CSI (U+009B) leaked into the published feed_health.json — "
+        f"rendered payload: {rendered!r}"
+    )
+
+
+def test_feed_health_json_does_not_carry_8bit_osc() -> None:
+    """End-to-end PoC: a hostile upstream emits an error message
+    containing the 8-bit OSC primitive ``\\x9d0;HACKED\\x07`` (a
+    terminal-title rewrite). The same RunReport -> feed_health.json
+    pipeline as the CSI PoC. Post-fix the OSC byte is stripped at
+    the always-strip floor.
+    """
+    report = RunReport(statuses=[])
+    report.add_error_message(
+        clean_message(
+            "OEBB error: \x9d0;HACKED\x07 terminal-title rewrite primitive"
+        )
+    )
+
+    payload = build_feed_health_payload(report, _empty_metrics())
+    rendered = json.dumps(payload, ensure_ascii=False)
+
+    assert "\x9d" not in rendered, (
+        "8-bit OSC (U+009D) leaked into the published feed_health.json — "
+        f"rendered payload: {rendered!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inventory invariant — every 8-bit C1 / DEL code point in
+# ``_INVISIBLE_DANGEROUS_RE`` is also covered by the canonical
+# ``_CONTROL_CHARS_RE`` (the latter is the strip_control_chars=True
+# path; both paths must agree on the C1 floor).
+# ---------------------------------------------------------------------------
+
+
+def test_invisible_dangerous_re_covers_8bit_c1_and_del() -> None:
+    """Inventory invariant: ``_INVISIBLE_DANGEROUS_RE`` MUST cover the
+    full ``\\x7f-\\x9f`` set (DEL + 32 C1 controls).
+
+    The 8-bit terminal-escape primitives U+0080..U+009F are the
+    canonical bypass shape against the 7-bit ``_ANSI_ESCAPE_RE``
+    defence. Pinning the always-strip floor to include them is the
+    closing-checklist for the BiDi-Mark / Terminal-Escape Drift
+    family.
+
+    A regression here means a future PR has narrowed the canonical
+    floor — either intentionally (the readability contract was
+    misread to require C1 preservation) or accidentally (a
+    code-formatting tool collapsed the character class).
+    """
+    canonical = canonical_logging._INVISIBLE_DANGEROUS_RE
+    missing: list[int] = []
+    for cp in range(0x7F, 0xA0):
+        if not canonical.fullmatch(chr(cp)):
+            missing.append(cp)
+    assert not missing, (
+        "_INVISIBLE_DANGEROUS_RE is narrower than the 8-bit C1 / DEL "
+        f"canonical floor; missing {len(missing)} code point(s): "
+        + ", ".join(f"U+{cp:04X}" for cp in missing)
+        + "\nThe always-strip floor must cover the 8-bit terminal-escape "
+        "primitive set so the strip_control_chars=False sibling paths "
+        "(clean_message, _sanitize_log_detail, _sanitize_exception_msg, "
+        "SafeFormatter.formatException, SafeJSONFormatter.formatException) "
+        "inherit the defence."
+    )
+
+
+def test_invisible_dangerous_re_subset_of_control_chars_re() -> None:
+    """Inventory invariant: every code point matched by
+    ``_INVISIBLE_DANGEROUS_RE`` (the always-strip floor) must also
+    match ``_CONTROL_CHARS_RE`` (the strip_control_chars=True full
+    set). The two paths must agree on the strip set so widening one
+    cannot drift apart from the other.
+    """
+    canonical_invisible = canonical_logging._INVISIBLE_DANGEROUS_RE
+    canonical_control = canonical_logging._CONTROL_CHARS_RE
+
+    canonical_code_points: list[int] = []
+    for cp in range(0x110000):
+        if canonical_invisible.fullmatch(chr(cp)):
+            canonical_code_points.append(cp)
+
+    assert canonical_code_points, (
+        "Canonical _INVISIBLE_DANGEROUS_RE matches nothing — likely a "
+        "regression in the canonical regex itself"
+    )
+
+    missing: list[int] = []
+    for cp in canonical_code_points:
+        if not canonical_control.fullmatch(chr(cp)):
+            missing.append(cp)
+
+    assert not missing, (
+        "_CONTROL_CHARS_RE is narrower than _INVISIBLE_DANGEROUS_RE; "
+        f"missing {len(missing)} code point(s): "
+        + ", ".join(f"U+{cp:04X}" for cp in missing[:20])
+        + (" …" if len(missing) > 20 else "")
+        + "\nThe two regexes must stay in sync: any code point in the "
+        "always-strip floor must also be in the full strip_control_chars=True "
+        "set so the two paths cannot drift apart."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression: existing readability contract preserved.
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_log_message_strip_disabled_still_preserves_newlines() -> None:
+    """Round 2 readability contract: ``\\n`` / ``\\r`` / ``\\t`` MUST
+    survive ``strip_control_chars=False`` for traceback formatting.
+    Round 3 widens ``_INVISIBLE_DANGEROUS_RE`` to add the C1 / DEL
+    set but MUST NOT regress on the C0 readability contract.
+    """
+    payload = "line1\nline2\rline3\tindented"
+    sanitized = sanitize_log_message(payload, strip_control_chars=False)
+    assert "\n" in sanitized
+    assert "\r" in sanitized
+    assert "\t" in sanitized
+
+
+def test_sanitize_log_message_strip_disabled_round2_charset_still_stripped() -> None:
+    """Round 2 invariant: the BiDi / zero-width / line-terminator
+    family MUST continue to be stripped on the
+    ``strip_control_chars=False`` path. Round 3 is additive — it
+    widens the always-strip floor without narrowing the existing
+    set.
+    """
+    round2_chars = (
+        "؜", "​", "‌", "‍", "‎", "‏",
+        " ", " ", "‪", "‫", "‬", "‭",
+        "‮", "⁦", "⁧", "⁨", "⁩", "﻿",
+    )
+    for char in round2_chars:
+        payload = f"prefix{char}suffix"
+        sanitized = sanitize_log_message(payload, strip_control_chars=False)
+        assert char not in sanitized, (
+            f"Round 2 char {hex(ord(char))} regressed on strip_control_chars=False"
+        )
+
+
+def test_sanitize_log_message_default_path_still_strips_c1() -> None:
+    """Pre-existing invariant: the strip_control_chars=True (default)
+    path strips the full canonical set including C1 / DEL via
+    ``_CONTROL_CHARS_RE``. Round 3 must not regress this — the
+    default path should still strip C1 / DEL (now via either the
+    always-strip floor OR the explicit ``_CONTROL_CHARS_RE`` step,
+    both of which cover the set).
+    """
+    for char, name in _C1_TERMINAL_ESCAPE_CHARS:
+        payload = f"prefix{char}suffix"
+        sanitized = sanitize_log_message(payload, strip_control_chars=True)
+        assert char not in sanitized, (
+            f"{name} ({char!r}) regressed on strip_control_chars=True path: "
+            f"{sanitized!r}"
+        )


### PR DESCRIPTION
## Summary

Closes an **8-bit ANSI-escape forging primitive** at the `src/utils/logging.py:_INVISIBLE_DANGEROUS_RE` always-strip floor that bypasses every `strip_control_chars=False` sibling sanitiser path.

The 2026-05-09 *BiDi-Mark Drift Round 2* round lifted the BiDi / zero-width / line-terminator union into the always-strip floor so the five `strip_control_chars=False` sibling sinks (`clean_message`, `_sanitize_log_detail`, `_sanitize_exception_msg`, `SafeFormatter.formatException`, `SafeJSONFormatter.formatException`) inherit the defence in one cut while preserving `\n` / `\r` / `\t` for traceback formatting. The closing audit walker enumerated three threat classes (BiDi, zero-width, line/paragraph separator) but **deferred the fourth axis: the 8-bit C1 controls at `\x80-\x9f`** (plus DEL at `\x7f`).

Per ECMA-48 / ISO 6429 these 32+1 code points are the **8-bit equivalents** of the 7-bit ANSI escape sequences the project's `_ANSI_ESCAPE_RE` already defends against on the `\x1b`-prefixed boundary:

- `\x9b` is **CSI** (Control Sequence Introducer; same shape as `\x1b[`) — `\x9b31m` flips the next-rendered text to red on any 8-bit-C1-honouring terminal.
- `\x9d` is **OSC** (Operating System Command; same shape as `\x1b]`) — `\x9d0;HACKED\x07` rewrites the terminal-window title.
- `\x90` is **DCS** (Device Control String; same shape as `\x1bP`).
- The remaining 27 C1 controls are non-printable invisibles with no readability value.

A hostile upstream (compromised provider, MITM, DNS hijack, poisoned `cache/wl/*.json`) carrying `\x9b...m` in an exception text reaches the operator-facing log line and the public `docs/feed_health.json` artefact verbatim pre-fix — interpreted as SGR colour command on any 8-bit-C1-honouring terminal renderer (xterm with `eightBitInput`, BSD console, `rxvt` in 8-bit mode, embedded serial terminals, legacy enterprise terminals).

## Fix

- **`src/utils/logging.py:_INVISIBLE_DANGEROUS_RE`** — added `\x7f-\x9f` (DEL + 32 C1 controls) so the unconditional always-strip step closes every `strip_control_chars=False` sibling sink. `\n` / `\r` / `\t` (C0 `\x09` / `\x0a` / `\x0d`) remain outside the floor — the readability contract for traceback formatting is preserved.
- **`src/utils/http.py:_UNSAFE_URL_CHARS`** — widened to `\x7f-\x9f` (was `\x7f` only). Maintains the inventory invariant pinned by `test_unsafe_url_chars_regex_covers_canonical_invisible_dangerous_set`.
- **`src/utils/stations_validation.py:_UNSAFE_CHARS_RE`** — widened to `\x7f-\x9f`. Maintains the inventory invariant pinned by `test_unsafe_chars_regex_covers_canonical_invisible_dangerous_set`.

Sibling regexes already covering `\x7f-\x9f` and unaffected: `_CONTROL_RE` (build_feed.py, Round 6), `_CSV_CONTROL_CHARS_RE` (stats.py, Round 5), `_MARKDOWN_NORMALISE_UNSAFE_RE` (text.py), `_CONTROL_CHARS_RE` (logging.py).

## Test plan

199 PoC tests in `tests/test_sentinel_log_injection_c1_terminal_escape.py`:

- [x] 32 per-code-point tests against `sanitize_log_message(strip_control_chars=False)` (one per C1 / DEL char minus NEL which `\s` already collapses)
- [x] 32 per-code-point tests against `clean_message`
- [x] 32 per-code-point tests against `_sanitize_log_detail`
- [x] 32 per-code-point tests against `_sanitize_exception_msg`
- [x] 32 per-code-point tests against `SafeFormatter.formatException`
- [x] 32 per-code-point tests against `SafeJSONFormatter.formatException`
- [x] End-to-end PoC: 8-bit CSI via `record_exception` survives into `docs/feed_health.json` pre-fix, stripped post-fix
- [x] End-to-end PoC: 8-bit OSC via `add_error_message` survives into `docs/feed_health.json` pre-fix, stripped post-fix
- [x] Inventory invariant: `_INVISIBLE_DANGEROUS_RE` covers the full `\x7f-\x9f` set
- [x] Inventory invariant: `_INVISIBLE_DANGEROUS_RE` is a subset of `_CONTROL_CHARS_RE`
- [x] Regression: `\n` / `\r` / `\t` survive `strip_control_chars=False`
- [x] Regression: Round 2 BiDi / zero-width / line-terminator family still stripped
- [x] Regression: `strip_control_chars=True` (default) path still strips C1

Local: 2944 tests passed, 3 skipped. `python scripts/run_static_checks.py`: ruff clean, mypy clean (CI-pinned 1.10.x), bandit clean, secret scanner clean, C901 clean, pip-audit clean.

https://claude.ai/code/session_012CBfqvR21e8niUFfL4ttrT

---
_Generated by [Claude Code](https://claude.ai/code/session_012CBfqvR21e8niUFfL4ttrT)_