### PR TITLE
security(feed): sanitise per-item &lt;guid&gt; via _sanitize_text — close last RSS sink routing through str.strip()-only

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,145 @@
+## 2026-05-10 - Trojan-Source RSS Drift Round 7: Per-Item `<guid>` Element Was the Last RSS Sink Routing Through `str.strip()`-Only
+
+**Vulnerability:** The 2026-05-10 *Trojan-Source RSS via build_feed
+`_CONTROL_RE` drift* round (PR #1413) closed the per-item title /
+description / time-line sinks via `_sanitize_text(s)` (the canonical
+`_CONTROL_RE` strip — C0/C1 controls + DEL + BiDi format controls +
+zero-width chars + line/paragraph separators + BOM). But the
+**per-item `<guid>`** element in `src/build_feed.py:_format_item_content`
+sat on a separate code path:
+
+    raw_guid = it.get("guid") or ident
+    guid = str(raw_guid).strip() if raw_guid is not None else ident
+
+`str.strip()` only removes ASCII whitespace from the EDGES; internal
+control / BiDi / zero-width characters survive verbatim. The guid then
+flows into the published RSS XML's `<guid>...</guid>` element via
+`ET.SubElement(item, "guid").text = formatted.guid` — XML
+serialisation escapes `<>&` but does NOT strip Unicode BiDi marks,
+zero-width chars, U+202E (RLO), U+2028 (LSEP), or U+200B (ZWSP).
+
+The bug bypassed every prior round of the *Trojan-Source RSS Drift*
+family (Rounds 1-6 + the BiDi-Mark Drift family) — the canonical
+`_sanitize_text` helper was applied to title and summary but the
+journal's audit walker had not enumerated the guid as a sibling sink
+because it routed through a separate variable name (`raw_guid` vs
+`raw_title` / `raw_desc`).
+
+**Threat model:** The published `docs/feed.xml` (served from
+`https://origamihase.github.io/wien-oepnv/feed.xml`) is fetched by:
+
+* Every subscriber's RSS reader (Feedly, NetNewsWire, Inoreader,
+  FreshRSS, Vivaldi RSS, …) — many of these display the guid in
+  the item's metadata pane.
+* Every operator-facing forensic tool (XML viewers, IDE inspectors,
+  GitHub's online file viewer, `cat`/`less` on a TTY).
+
+When the upstream-supplied guid contains:
+
+* **U+202E (RLO)** — Right-to-Left Override. A guid like
+  `click-here-‮evil-12345` renders as `click-here-54321-live` in
+  any Unicode-aware viewer — the documented CVE-2021-42574 "Trojan
+  Source" primitive on a public artefact. Every subscriber's RSS
+  reader displays the inverted text. Phishing primitive.
+* **U+200B-U+200D (ZWSP/ZWNJ/ZWJ)** — Zero-width chars create
+  cache-key collisions and equality-check disagreements; an
+  attacker churning the dedup window with visually-identical guids
+  floods the feed.
+* **U+2028 / U+2029 (LSEP/PSEP)** — Line/paragraph separators that
+  several Unicode-aware RSS parsers honour as line breaks, splitting
+  a single guid into two records or breaking the XML element
+  boundary in a SIEM splitter.
+* **U+FEFF (BOM)** — Byte Order Mark inside a guid causes parser
+  divergence; some parsers skip it, others store it, leading to
+  identifier mismatch.
+* **\x00-\x08, \x0B-\x0C, \x0E-\x1F, \x7F-\x9F** — Most are invalid
+  in XML 1.0 and may cause parser exceptions in downstream RSS
+  consumers, breaking feed availability for affected readers.
+
+Per-item guids are *upstream-controlled* — the OEBB provider takes
+`<guid>` directly from the upstream RSS XML
+(`src/providers/oebb.py:_derive_guid`, which uses `raw_guid` if ≤128
+chars), and similarly for WL/VOR/Baustellen which hash upstream-
+controlled fields via `make_guid()`. A compromised upstream / DNS
+hijack / MITM (despite TLS — e.g. compromised CA, compromised CDN
+endpoint, or sidechannel like cache poisoning post-publication) can
+plant a malicious guid that flows verbatim into the public feed.
+
+**Severity:** LOW-MEDIUM — Trojan-Source primitive on a public
+artefact, contingent on upstream behaviour. No current vulnerability
+surface (every upstream-supplied guid in `cache/*/events.json` is
+HTTPS-URL-shaped with no BiDi / control chars) but a structural
+drift candidate that mirrors the exact shape closed by:
+
+* 2026-05-10 *Trojan-Source RSS via _CONTROL_RE drift* (PR #1413) —
+  closed the title / description / time-line sinks.
+* 2026-05-10 *CSV Formula-Injection Bypass* (PR #1412) — closed the
+  CSV writer.
+* 2026-05-10 *8-bit C1 Terminal-Escape Drift* (PR #1414) — widened
+  the canonical floor.
+
+**Fix:** Single-line change — apply `_sanitize_text` to the upstream-
+supplied guid before assignment, mirroring the title /
+description sanitisation that already happens in
+`_format_item_content`. Additive-only: every legitimate guid in the
+live cache (HTTPS-URL-shaped, no BiDi / control chars) is unchanged
+post-fix.
+
+The PoC test
+`tests/test_sentinel_guid_trojan_source.py` enumerates 6 cases:
+
+* 1 per-code-point coverage test parametrised over 26 canonical
+  Trojan-Source / control characters (BiDi + zero-width + line
+  separators + 8-bit C1 + ASCII C0 + DEL).
+* 3 happy-path regression tests (legitimate ASCII / HTTPS URL /
+  Unicode letters preserved).
+* 1 end-to-end Trojan-Source PoC with the classic RLO payload.
+* 1 inventory invariant test that plants every canonical dangerous
+  char in a single guid and asserts the published `<guid>` element
+  carries none of them — fires on any future regression that
+  bypasses `_sanitize_text` for the guid.
+
+**Learning:** The Trojan-Source RSS Drift family closed the title /
+description / time-line sinks via per-sink audit, but the closing-
+checklist grep
+(`grep -rnE '_sanitize_text\\(' src/build_feed.py`) only enumerated
+SITES that already CALL the helper — it did not enumerate sites
+that SHOULD call it but don't. The pattern: **closing-checklist
+greps that enumerate `helper_name` only catch sites that already
+use the helper, not sites that miss it**.
+
+The structural fix-shape pattern: when a canonical sanitiser exists
+(`_sanitize_text`, `escape_markdown`, `escape_markdown_cell`,
+`safe_markdown_codespan`), the closing-checklist must also walk
+**every variable that lands in a public sink** and assert it routes
+through the canonical helper — not just `grep helper_name`. The
+pattern matches the 2026-05-10 *Markdown Injection Drift Round 3*
+(8 bullet-body sinks at the `ValidationReport.to_markdown()`
+boundary) which closed a similar gap by walking every interpolated
+variable and verifying it had `_safe_md` applied.
+
+**Prevention:** The auto-discoverable inventory invariant
+`test_inventory_no_dangerous_chars_in_guid_element` plants every
+canonical dangerous char in a single guid fixture and asserts the
+published `<guid>` element carries none of them. A future PR that
+re-introduces a guid path bypassing `_sanitize_text` (e.g. a new
+provider whose guid generation skips the sanitiser, or a refactor
+that moves the assignment without preserving the helper call)
+fails the test at PR-review time.
+
+The closing-checklist grep is amended for the *Trojan-Source RSS
+Drift* family: walk every per-item RSS element emission in
+`_emit_item` (`title`, `link`, `guid`, `pubDate`, `description`,
+`content:encoded`, `<ext:first_seen>`, `<ext:starts_at>`,
+`<ext:ends_at>`) and assert each upstream-supplied text-typed field
+routes through `_sanitize_text` (or another canonical sanitiser
+documented in the journal). The `pubDate` / `<ext:*>` fields
+parse upstream timestamps via `_fmt_rfc2822` which is already
+control-char-safe; `link` is HTTPS-only-pinned by `_resolve_item_link`
+(PR #1419); `title`, `summary`, and now `guid` route through
+`_sanitize_text`. The family is closed across all six per-item
+sinks.
+
 ## 2026-05-10 - HTTPS-only Provider URL Drift Round 3: Per-Item RSS `<link>` Element Was the Last Publishing Surface Still Accepting `http://`
 
 **Vulnerability:** PRs #1415 / #1416 (HTTPS-only Provider URL Drift

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -1771,7 +1771,20 @@ def _format_item_content(
     link = _resolve_item_link(it.get("link"), ident)
 
     raw_guid = it.get("guid") or ident
-    guid = str(raw_guid).strip() if raw_guid is not None else ident
+    # Security: route the upstream-supplied guid through ``_sanitize_text``
+    # (canonical ``_CONTROL_RE`` strip — C0/C1 controls + DEL + BiDi format
+    # controls + zero-width chars + line separators + BOM) before it lands
+    # in the published RSS XML's ``<guid>`` element. The pre-fix
+    # ``str.strip()``-only path let upstream-controlled BiDi marks (CVE-
+    # 2021-42574 Trojan-Source primitive), zero-width characters, and
+    # line/paragraph separators flow into ``docs/feed.xml`` verbatim —
+    # XML serialisation escapes ``<>&`` but does NOT strip Unicode BiDi
+    # / zero-width / control chars. Mirrors the canonical sanitisation
+    # already applied to the title (line ~1812: ``title_out =
+    # _sanitize_text(title_out)``) and summary (line ~1782:
+    # ``summary = _sanitize_text(summary).strip()``) — closes the LAST
+    # per-item RSS sink that still routed through ``str.strip()``-only.
+    guid = _sanitize_text(str(raw_guid)).strip() if raw_guid is not None else ident
     if not guid:
         guid = ident
 

--- a/tests/test_sentinel_guid_trojan_source.py
+++ b/tests/test_sentinel_guid_trojan_source.py
@@ -1,0 +1,300 @@
+"""Sentinel PoC: Per-item ``<guid>`` element in the published RSS feed
+is not sanitised for BiDi / zero-width / control characters — Trojan-
+Source primitive on the published feed.
+
+Threat model
+------------
+
+The pre-fix flow in ``src/build_feed.py:_format_item_content`` applies
+``_sanitize_text`` (which strips the canonical ``_CONTROL_RE`` set —
+C0/C1 controls + DEL + BiDi format controls + zero-width chars + line
+separators + BOM) to the **title** and **summary**. But the **guid**
+is only ``str.strip()``-ed:
+
+    raw_guid = it.get("guid") or ident
+    guid = str(raw_guid).strip() if raw_guid is not None else ident
+
+``str.strip()`` only removes ASCII whitespace from the EDGES; internal
+control / BiDi / zero-width characters survive verbatim. The guid then
+flows into the published RSS XML's ``<guid>...</guid>`` element via
+``ET.SubElement(item, "guid").text = formatted.guid`` — XML
+serialisation escapes ``<>&`` but does NOT strip Unicode BiDi marks,
+zero-width chars, or U+202E (RLO).
+
+The published ``docs/feed.xml`` is fetched by every subscriber's RSS
+reader (Feedly, NetNewsWire, Inoreader, FreshRSS, …) and by every
+operator-facing forensic tool (XML viewers, IDE inspectors, GitHub's
+file viewer). When the guid contains:
+
+* **U+202E (RLO)** — Right-to-Left Override. A guid like
+  ``A‮B-disruption-12345`` renders as ``A54321-noitpursid-B`` in
+  any Unicode-aware viewer — the documented CVE-2021-42574 "Trojan
+  Source" primitive on a public artefact.
+* **U+200B-U+200D (ZWSP/ZWNJ/ZWJ)** — Zero-width chars create cache-
+  key collisions and equality-check disagreements; an attacker
+  churning the dedup window with visually-identical guids floods the
+  feed.
+* **U+2028 / U+2029 (LSEP/PSEP)** — Line/paragraph separators that
+  several Unicode-aware RSS parsers honour as line breaks, splitting
+  a single guid into two records or breaking the XML element
+  boundary in a SIEM splitter.
+* **U+FEFF (BOM)** — Byte Order Mark inside a guid causes parser
+  divergence; some parsers skip it, others store it, leading to
+  identifier mismatch.
+* **\\x00-\\x08, \\x0B-\\x0C, \\x0E-\\x1F, \\x7F-\\x9F** — Most are
+  invalid in XML 1.0 and may cause parser exceptions in downstream
+  RSS consumers, breaking feed availability for affected readers.
+
+Per-item guids are *upstream-controlled* — the OEBB provider takes
+``<guid>`` directly from the upstream RSS XML (verified at
+``src/providers/oebb.py:_derive_guid`` line ~1450, which uses
+``raw_guid`` if ≤128 chars), and similarly for WL/VOR/Baustellen
+which use ``make_guid()`` based on upstream-controlled fields. A
+compromised upstream / DNS-hijack / MITM (despite TLS, e.g. via
+compromised CA or compromised CDN endpoint) can plant a malicious
+guid that flows verbatim into the public feed.
+
+Severity
+--------
+
+LOW-MEDIUM — Trojan-Source primitive on a public artefact, contingent
+on upstream behaviour. No current vulnerability surface (every
+upstream-supplied guid in ``cache/*/events.json`` is
+HTTPS-URL-shaped with no BiDi / control chars) but a structural
+drift candidate that mirrors the exact shape closed by:
+
+* 2026-05-10 *Trojan-Source RSS via _CONTROL_RE drift* (PR #1413) —
+  closed for the title / description / time-line sinks.
+* 2026-05-10 *CSV Formula-Injection Bypass* (PR #1412) — closed for
+  the CSV writer.
+* 2026-05-10 *8-bit C1 Terminal-Escape Drift* (PR #1414) — widened
+  the canonical floor.
+
+The guid is the LAST per-item RSS sink that still routes through a
+``str.strip()``-only path instead of the canonical ``_sanitize_text``
+helper.
+
+Fix shape
+---------
+
+Apply ``_sanitize_text`` to the guid before assignment, mirroring
+the title / description sanitisation that already happens in
+``_format_item_content``. Single-line change, no new helper, no API
+impact. The fix is **additive-only**: every legitimate guid in the
+live cache (HTTPS-URL-shaped, no BiDi / control chars) is unchanged
+post-fix.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+from defusedxml import ElementTree as ET
+
+from src import build_feed
+
+
+def _emit_item_str(
+    item: Any, now: datetime.datetime, state: dict[str, Any]
+) -> tuple[str, str]:
+    """Mirror the helper from ``test_link_sanitization.py`` so the
+    PoC tests use the canonical XML-emit contract."""
+    ident, elem, replacements = build_feed._emit_item(item, now, state)
+    xml_str = ET.tostring(elem, encoding="unicode")
+    for ph, content in replacements.items():
+        xml_str = xml_str.replace(ph, content)
+    return ident, xml_str
+
+
+# ---------------------------------------------------------------------------
+# Per-code-point coverage — the canonical Trojan-Source / control
+# character set must be stripped from the guid.
+# ---------------------------------------------------------------------------
+
+
+CANONICAL_DANGEROUS_CHARS: tuple[tuple[str, str], ...] = (
+    # CVE-2021-42574 BiDi Trojan-Source primitives
+    ("‮", "RLO (Right-to-Left Override)"),
+    ("‭", "LRO (Left-to-Right Override)"),
+    ("‪", "LRE (Left-to-Right Embedding)"),
+    ("‫", "RLE (Right-to-Left Embedding)"),
+    ("‬", "PDF (Pop Directional Formatting)"),
+    ("⁦", "LRI (Left-to-Right Isolate)"),
+    ("⁧", "RLI (Right-to-Left Isolate)"),
+    ("⁨", "FSI (First Strong Isolate)"),
+    ("⁩", "PDI (Pop Directional Isolate)"),
+    # Zero-width chars
+    ("​", "ZWSP (Zero-Width Space)"),
+    ("‌", "ZWNJ (Zero-Width Non-Joiner)"),
+    ("‍", "ZWJ (Zero-Width Joiner)"),
+    ("‎", "LRM (Left-to-Right Mark)"),
+    ("‏", "RLM (Right-to-Left Mark)"),
+    ("؜", "ALM (Arabic Letter Mark)"),
+    ("﻿", "BOM (Byte Order Mark / ZWNBSP)"),
+    # Line/paragraph separators
+    (" ", "LSEP (Line Separator)"),
+    (" ", "PSEP (Paragraph Separator)"),
+    # 8-bit C1 controls
+    ("\x80", "C1 PAD"),
+    ("\x9B", "C1 CSI (Control Sequence Introducer)"),
+    ("\x9D", "C1 OSC (Operating System Command)"),
+    ("\x9F", "C1 APC (Application Program Command)"),
+    # ASCII C0 control + DEL
+    ("\x01", "SOH"),
+    ("\x1B", "ESC"),
+    ("\x1F", "US"),
+    ("\x7F", "DEL"),
+)
+
+
+# ---------------------------------------------------------------------------
+# (1) Per-code-point Trojan-Source / control char strip.
+# ---------------------------------------------------------------------------
+
+
+def _make_item(now: datetime.datetime, guid: str) -> dict[str, Any]:
+    """Build a minimal RSS item dict that exercises the GUID emission."""
+    return {
+        "title": "Test Item",
+        "link": "https://example.com/disruption",
+        "guid": guid,
+        "pubDate": now,
+        "description": "Description",
+    }
+
+
+def test_guid_strips_canonical_dangerous_chars() -> None:
+    """Pre-fix: every canonical Trojan-Source / control character in the
+    upstream-supplied guid flows verbatim into the published RSS XML's
+    ``<guid>`` element (only ``str.strip()`` is applied, which strips
+    ASCII whitespace from edges only). Post-fix: the
+    ``_sanitize_text`` helper strips the canonical ``_CONTROL_RE`` set
+    so the published feed never carries the documented Trojan-Source
+    primitives.
+
+    Closes the per-item ``<guid>`` Trojan-Source gap — the last RSS
+    sink that still routed through ``str.strip()``-only instead of
+    the canonical ``_sanitize_text`` helper used for title /
+    description / time-line.
+    """
+    now = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
+    state: dict[str, dict[str, Any]] = {}
+
+    for code_point, label in CANONICAL_DANGEROUS_CHARS:
+        guid = f"valid-prefix{code_point}valid-suffix-12345"
+        item = _make_item(now, guid)
+
+        ident, xml = _emit_item_str(item, now, state)
+
+        assert code_point not in xml, (
+            f"Trojan-Source / control char {label} (U+{ord(code_point):04X}) "
+            f"survived in published RSS XML's <guid> element. This is a "
+            f"documented Trojan-Source primitive on a public artefact."
+        )
+
+
+# ---------------------------------------------------------------------------
+# (2) Legitimate guids — happy path regression.
+# ---------------------------------------------------------------------------
+
+
+def test_guid_legitimate_ascii_preserved() -> None:
+    """Regression: legitimate ASCII guids must continue to be preserved
+    unchanged. Pre- and post-fix behaviour are identical for the
+    legitimate case."""
+    now = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
+    state: dict[str, dict[str, Any]] = {}
+
+    item = _make_item(now, "abc-12345-disruption-key")
+    ident, xml = _emit_item_str(item, now, state)
+    assert "abc-12345-disruption-key" in xml
+
+
+def test_guid_legitimate_https_url_preserved() -> None:
+    """Regression: legitimate HTTPS URL guids (the OEBB upstream
+    shape) must be preserved verbatim."""
+    now = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
+    state: dict[str, dict[str, Any]] = {}
+
+    guid = "https://fahrplan.oebb.at/bin/query.exe/dn?ujm=1&mapType=TRACKINFO&829791"
+    item = _make_item(now, guid)
+    ident, xml = _emit_item_str(item, now, state)
+    # XML escaping turns & into &amp; — verify by unescaping:
+    assert "https://fahrplan.oebb.at/bin/query.exe/dn?ujm=1" in xml.replace("&amp;", "&")
+
+
+def test_guid_unicode_letters_preserved() -> None:
+    """Regression: legitimate Unicode letters (German umlauts, etc.)
+    in guids must be preserved — only the documented Trojan-Source /
+    control set is stripped."""
+    now = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
+    state: dict[str, dict[str, Any]] = {}
+
+    item = _make_item(now, "Wien-Heiligenstadt-Bahnhof-Störung-12345")
+    ident, xml = _emit_item_str(item, now, state)
+    assert "Wien-Heiligenstadt-Bahnhof-Störung-12345" in xml
+
+
+# ---------------------------------------------------------------------------
+# (3) End-to-end Trojan-Source PoC — RLO mark on a guid renders
+#     reversed text in Unicode-aware readers.
+# ---------------------------------------------------------------------------
+
+
+def test_guid_rlo_trojan_source_published_feed_xml() -> None:
+    """End-to-end Trojan-Source PoC: an upstream-supplied guid carrying
+    U+202E (RLO) renders inverted text in any Unicode-aware RSS reader
+    or XML viewer that displays the guid (Feedly, NetNewsWire, GitHub
+    Pages preview, IDE inspector). Post-fix, the RLO is stripped at
+    the ``_sanitize_text`` boundary so the published feed never
+    carries the inversion primitive."""
+    now = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
+    state: dict[str, dict[str, Any]] = {}
+
+    # The classic Trojan-Source payload: legitimate-looking prefix +
+    # RLO + reversed suffix. In a Unicode-aware viewer this renders
+    # as if the suffix is the prefix and vice versa — perfect
+    # phishing primitive for any reader that displays the guid.
+    item = _make_item(now, "click-here-‮evil-12345")
+    ident, xml = _emit_item_str(item, now, state)
+
+    assert "‮" not in xml, (
+        "U+202E (RLO) Trojan-Source mark survived in published RSS "
+        "XML's <guid> element after fix; this is a documented "
+        "phishing primitive on every Unicode-aware RSS reader."
+    )
+
+
+# ---------------------------------------------------------------------------
+# (4) Inventory invariant — no canonical Trojan-Source / control
+#     character ever survives in the published <guid> element.
+# ---------------------------------------------------------------------------
+
+
+def test_inventory_no_dangerous_chars_in_guid_element() -> None:
+    """Auto-discoverable inventory walker: planted upstream guids
+    carrying every canonical Trojan-Source / control character must
+    never survive the sanitisation. A future regression that
+    re-introduces a path bypassing ``_sanitize_text`` for the guid
+    fails this test at PR-review time."""
+    now = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
+    state: dict[str, dict[str, Any]] = {}
+
+    # Build a guid that contains EVERY canonical dangerous code point
+    # — if even one survives, the test fails.
+    payload_chars = "".join(cp for cp, _ in CANONICAL_DANGEROUS_CHARS)
+    guid = f"safe-prefix{payload_chars}safe-suffix-12345"
+    item = _make_item(now, guid)
+
+    ident, xml = _emit_item_str(item, now, state)
+
+    leaked: list[str] = []
+    for code_point, label in CANONICAL_DANGEROUS_CHARS:
+        if code_point in xml:
+            leaked.append(f"{label} (U+{ord(code_point):04X})")
+
+    assert not leaked, (
+        f"Trojan-Source / control characters leaked into <guid>: {leaked}. "
+        f"Apply ``_sanitize_text`` to the guid before XML emission."
+    )


### PR DESCRIPTION
## Summary

Closes the **Trojan-Source RSS Drift Round 7**: the per-item `<guid>` element in `src/build_feed.py:_format_item_content` was the LAST per-item RSS sink that still routed through `str.strip()`-only instead of the canonical `_sanitize_text` helper. PR #1413 closed the title / description / time-line sinks; PR #1419 closed the per-item link. This PR closes the guid.

## Threat model

`str.strip()` removes ASCII whitespace from EDGES only — internal control / BiDi / zero-width characters survive verbatim. The upstream-supplied guid (from OEBB's RSS XML `<guid>`, or `make_guid()` over upstream-controlled fields for WL/VOR/Baustellen) flows into the published `<guid>` element. XML serialisation escapes `<>&` but does NOT strip Unicode BiDi marks, zero-width chars, U+202E (RLO), U+2028 (LSEP), or U+200B (ZWSP).

A compromised upstream / DNS hijack / MITM (despite TLS — via compromised CA / CDN endpoint, or sidechannel like cache poisoning post-publication) plants a malicious guid that flows verbatim into `docs/feed.xml`. Subscribers' RSS readers (Feedly, NetNewsWire, Inoreader, FreshRSS, Vivaldi RSS, …) and operator-facing forensic tools (XML viewers, IDE inspectors, GitHub's online file viewer) display the inverted text — the CVE-2021-42574 Trojan-Source primitive on a public artefact.

**Severity:** LOW-MEDIUM — Trojan-Source primitive contingent on upstream behaviour. No current vulnerability (every upstream-supplied guid in `cache/*/events.json` is HTTPS-URL-shaped with no dangerous chars) but a structural drift candidate.

## Fix

Single-line change: apply `_sanitize_text` to the upstream-supplied guid, mirroring the title and summary sanitisation already applied in `_format_item_content`. Additive-only — every legitimate guid in the live cache is unchanged post-fix.

## PoC test coverage

`tests/test_sentinel_guid_trojan_source.py` (6 cases):

- 1 per-code-point coverage test parametrised over 26 canonical Trojan-Source / control characters (BiDi format controls + BiDi isolates + zero-width chars + line/paragraph separators + 8-bit C1 + ASCII C0 + DEL).
- 3 happy-path regression tests (legitimate ASCII / HTTPS URL / Unicode letters preserved).
- 1 end-to-end Trojan-Source PoC with the classic RLO payload.
- 1 inventory invariant test (`test_inventory_no_dangerous_chars_in_guid_element`) that plants every canonical dangerous char in a single guid fixture and asserts the published `<guid>` carries none of them — fires on any future regression bypassing `_sanitize_text` for the guid.

## Closing the family

This closes the **Trojan-Source RSS Drift family** across all six per-item RSS sinks:

| Sink | Sanitiser | Closed by |
| --- | --- | --- |
| `<title>` | `_sanitize_text` | PR #1413 |
| `<link>` | `_resolve_item_link` (HTTPS-only + `validate_http_url`) | PR #1419 |
| **`<guid>`** | **`_sanitize_text`** | **THIS PR** |
| `<pubDate>` | `_fmt_rfc2822` (date format, control-char-safe by construction) | n/a |
| `<description>` | `_sanitize_text` (via `summary = _sanitize_text(summary).strip()`) | PR #1413 |
| `<content:encoded>` | CDATA + `_cdata_content` (escapes `]]>`) | n/a |

## Learning

The closing-checklist grep that the prior round used (`grep -rnE '_sanitize_text\(' src/build_feed.py`) only enumerated SITES that already CALL the helper — it did not enumerate sites that SHOULD call it but don't. The structural fix-shape pattern: when a canonical sanitiser exists, the closing-checklist must walk **every variable that lands in a public sink** and assert it routes through the canonical helper — not just `grep helper_name`. The journal entry documents this lesson alongside the parallel pattern from Markdown Injection Drift Round 3.

## Test plan

- [x] `pytest` — 3044 tests pass (3 skipped); 6 new tests fail pre-fix (3 cases) and pass post-fix.
- [x] `python scripts/run_static_checks.py` — ruff, mypy (1.10.x project pin), bandit, secret scanner, C901 gate, pip-audit all clean.
- [x] Existing `tests/test_link_sanitization.py` and the entire build_feed test suite continue to pass.

https://claude.ai/code/session_01G47X52nMVkEyZTc1vKLcqa

---
_Generated by [Claude Code](https://claude.ai/code/session_01G47X52nMVkEyZTc1vKLcqa)_