### PR TITLE
fix(stats): align statistik.md ⌀ Verspätung with README + split cadence

### DIFF
--- a/.github/workflows/update-cycle.yml
+++ b/.github/workflows/update-cycle.yml
@@ -217,8 +217,31 @@ jobs:
 
       # ----- README + dashboard render (no API call) ----------------------
 
+      # Cadence split: the README STATS markers refresh on every 30-min
+      # cron tick (the snapshot covers the trailing 30 days, so a
+      # half-hour staleness window is the operator-visible budget).
+      # ``docs/statistik.md`` is the *yearly* dashboard — its values
+      # only meaningfully change once per day, so writing it 48× a day
+      # was pure churn (each tick refreshed the
+      # ``_Automatisch erzeugt am ..._`` timestamp at the top of the
+      # file and triggered a commit). The gate below pins the dashboard
+      # write to the first cron tick after midnight Europe/Vienna:
+      # ``TZ=Europe/Vienna date +%H%M`` is DST-correct (the env var
+      # rebinds the active zone for that single ``date`` invocation),
+      # and the ``-lt 30`` window absorbs up to ~29 min of GH Actions
+      # cron jitter on the 00:00 Vienna tick. If a tick is delayed
+      # beyond that window the dashboard misses one day; the next
+      # day's tick catches up. The README markers are unaffected.
       - name: Refresh statistics dashboard and README snapshot
-        run: python scripts/generate_markdown_stats.py
+        run: |
+          vienna_hhmm=$(TZ=Europe/Vienna date +%H%M)
+          if [ "$vienna_hhmm" -lt 30 ]; then
+            echo "Vienna-local $vienna_hhmm — refreshing dashboard + README markers."
+            python scripts/generate_markdown_stats.py
+          else
+            echo "Vienna-local $vienna_hhmm — README-only tick (dashboard skipped)."
+            python scripts/generate_markdown_stats.py --skip-dashboard
+          fi
 
       # ----- Single atomic commit -----------------------------------------
 

--- a/docs/statistik.md
+++ b/docs/statistik.md
@@ -8,7 +8,7 @@ _Automatisch erzeugt am 2026-05-10T16:35+02:00 (Europe/Vienna)._
 | --- | ---: |
 | Stammstrecke-Beobachtungen (2026) | 26 |
 | Davon über 9-min-Schwelle | 0 |
-| ⌀ Verspätung (alle Tage) | 0.4 min |
+| ⌀ Verspätung (alle Tage) | 0.2 min |
 | Erfasste Störungen (2026) | 53 |
 
 ## Stammstrecke

--- a/scripts/generate_markdown_stats.py
+++ b/scripts/generate_markdown_stats.py
@@ -495,11 +495,19 @@ def _format_summary_section(
 ) -> list[str]:
     """Render the top-of-report key metrics block."""
     if stammstrecke.total_observations:
-        delays = [
-            stammstrecke.by_weekday_avg[wd]
-            for wd in stammstrecke.by_weekday_avg
-        ]
-        global_avg = statistics.fmean(delays) if delays else 0.0
+        # Observation-weighted (micro) average so the headline matches
+        # the README's ``Durchschnittliche Verspätung`` cell. The earlier
+        # implementation took ``fmean`` over the per-weekday averages,
+        # which silently macro-averaged: a Saturday with 3 observations
+        # was weighted as heavily as a Sunday with 23, distorting the
+        # number any time the daily distribution was uneven. Multiplying
+        # each per-weekday mean by its observation count recovers the
+        # original delay sum exactly without re-iterating the raw rows.
+        total = sum(
+            stammstrecke.by_weekday_avg[wd] * stammstrecke.by_weekday_count[wd]
+            for wd in stammstrecke.by_weekday_count
+        )
+        global_avg = total / stammstrecke.total_observations
     else:
         global_avg = 0.0
 
@@ -917,6 +925,17 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--skip-dashboard",
+        action="store_true",
+        help=(
+            "Skip regenerating docs/statistik.md (only the README STATS "
+            "markers are patched). Inverse of ``--skip-readme``; used by "
+            "``update-cycle.yml`` so the dashboard refreshes once daily "
+            "at the 00:00 Europe/Vienna tick while the README snapshot "
+            "continues to update on every 30-min tick."
+        ),
+    )
+    parser.add_argument(
         "--now-iso",
         type=str,
         default=None,
@@ -967,31 +986,43 @@ def main(argv: list[str] | None = None) -> int:
         sanitize_log_arg(str(args.stats_dir)),
     )
 
-    sm_agg = aggregate_stammstrecke(sm_rows)
-    st_agg = aggregate_stoerungen(st_rows)
-
-    markdown = render_markdown(
-        year=args.year,
-        generated_at=now,
-        stammstrecke=sm_agg,
-        stoerungen=st_agg,
-    )
-
-    try:
-        write_dashboard(markdown, output_path=args.output)
-    except OSError as exc:
-        LOGGER.error(
-            "Konnte Dashboard nicht schreiben (%s): %s",
-            sanitize_log_arg(str(args.output)),
-            sanitize_log_arg(str(exc)),
+    if args.skip_dashboard:
+        # ``update-cycle.yml`` passes this flag on every 30-min tick
+        # except the one that lands inside the 00:00 Europe/Vienna hour.
+        # Skipping the aggregation + render avoids the unnecessary
+        # CPU + write work (and prevents the 30-min churn of the
+        # ``_Automatisch erzeugt am ..._`` timestamp leaking into the
+        # commit log).
+        LOGGER.info(
+            "Dashboard-Schritt übersprungen (--skip-dashboard) — "
+            "README wird weiterhin gepatcht."
         )
-        return 1
+    else:
+        sm_agg = aggregate_stammstrecke(sm_rows)
+        st_agg = aggregate_stoerungen(st_rows)
 
-    LOGGER.info(
-        "Dashboard geschrieben: %s (%d Bytes).",
-        sanitize_log_arg(str(args.output)),
-        len(markdown.encode("utf-8")),
-    )
+        markdown = render_markdown(
+            year=args.year,
+            generated_at=now,
+            stammstrecke=sm_agg,
+            stoerungen=st_agg,
+        )
+
+        try:
+            write_dashboard(markdown, output_path=args.output)
+        except OSError as exc:
+            LOGGER.error(
+                "Konnte Dashboard nicht schreiben (%s): %s",
+                sanitize_log_arg(str(args.output)),
+                sanitize_log_arg(str(exc)),
+            )
+            return 1
+
+        LOGGER.info(
+            "Dashboard geschrieben: %s (%d Bytes).",
+            sanitize_log_arg(str(args.output)),
+            len(markdown.encode("utf-8")),
+        )
 
     if args.skip_readme:
         return 0

--- a/tests/scripts/test_generate_markdown_stats.py
+++ b/tests/scripts/test_generate_markdown_stats.py
@@ -350,6 +350,39 @@ def test_render_markdown_handles_empty_aggregates_gracefully() -> None:
     assert "_Keine Daten verfügbar._" in md
 
 
+def test_render_markdown_global_avg_uses_observation_weighted_mean() -> None:
+    """``⌀ Verspätung (alle Tage)`` must equal the README's micro-average,
+    not an unweighted ``fmean`` over the per-weekday means.
+
+    The empirical distribution Sa(3 obs avg 2/3 min) and So(23 obs avg
+    4/23 min) is the regression that motivated the fix on branch
+    ``claude/fix-delay-statistics``: the broken macro-average rendered
+    ``0.4 min`` while the README cell — computed from the raw rows —
+    showed ``0.2 min``. Pinning both rendering paths to the same
+    observation-weighted mean closes that drift.
+    """
+    sm_agg = script.StammstreckeAggregate(
+        by_weekday_count={"Sa": 3, "So": 23},
+        by_weekday_avg={"Sa": 2.0 / 3.0, "So": 4.0 / 23.0},
+        by_hour_count={},
+        by_hour_avg={},
+        by_direction={"Meidling": 15, "Floridsdorf": 11},
+        total_observations=26,
+        threshold_exceedances=0,
+        threshold_minutes=9.0,
+    )
+    md = script.render_markdown(
+        year=2026,
+        generated_at=datetime(2026, 5, 10, 16, 35, tzinfo=VIENNA_TZ),
+        stammstrecke=sm_agg,
+        stoerungen=script.StoerungAggregate(),
+    )
+    # 3*(2/3) + 23*(4/23) = 6.0 → 6.0/26 ≈ 0.231 → "0.2 min"
+    assert "| ⌀ Verspätung (alle Tage) | 0.2 min |" in md
+    # Anti-regression: the previous macro-average rendered "0.4 min".
+    assert "| ⌀ Verspätung (alle Tage) | 0.4 min |" not in md
+
+
 # ---- write_dashboard ------------------------------------------------------
 
 

--- a/tests/scripts/test_generate_markdown_stats_readme.py
+++ b/tests/scripts/test_generate_markdown_stats_readme.py
@@ -424,6 +424,89 @@ def test_main_skip_readme_flag_leaves_readme_untouched(
     assert output.exists()
 
 
+def test_main_skip_dashboard_flag_leaves_dashboard_untouched(
+    tmp_path: Path,
+) -> None:
+    """``--skip-dashboard`` preserves docs/statistik.md byte-stable while
+    still patching the README STATS markers.
+
+    Mirrors the symmetric ``--skip-readme`` contract used by
+    ``update-cycle.yml``: every 30-min cron tick patches the README
+    snapshot, but only the cron tick that lands inside the 00:00
+    Europe/Vienna hour additionally rewrites the yearly dashboard.
+    """
+    stats_dir = tmp_path / "stats"
+    _seed_csvs(stats_dir)
+    readme = tmp_path / "README.md"
+    readme.write_text(_readme_with_markers(), encoding="utf-8")
+    output = tmp_path / "statistik.md"
+    pre_image = "# pre-existing dashboard content — must survive\n"
+    output.write_text(pre_image, encoding="utf-8")
+    output_snapshot = output.read_bytes()
+
+    rc = script.main(
+        [
+            "--year",
+            "2026",
+            "--stats-dir",
+            str(stats_dir),
+            "--output",
+            str(output),
+            "--readme-path",
+            str(readme),
+            "--skip-dashboard",
+            "--now-iso",
+            "2026-05-09T12:00:00+02:00",
+        ]
+    )
+    assert rc == 0
+    # Dashboard file untouched (byte-stable).
+    assert output.read_bytes() == output_snapshot
+    # README markers patched with the real values.
+    new_readme = readme.read_text(encoding="utf-8")
+    assert "Beobachtungen (gesamt)" in new_readme
+    assert "_Platzhalter Stammstrecke._" not in new_readme
+
+
+def test_main_skip_dashboard_and_skip_readme_combined_is_noop(
+    tmp_path: Path,
+) -> None:
+    """Combining ``--skip-dashboard`` with ``--skip-readme`` is a
+    degenerate no-op: neither output is touched. The flags are
+    independent toggles, not mutually exclusive — the script still
+    exits 0 so an operator who passes both by accident gets a clean
+    log instead of an error.
+    """
+    stats_dir = tmp_path / "stats"
+    _seed_csvs(stats_dir)
+    readme = tmp_path / "README.md"
+    readme.write_text(_readme_with_markers(), encoding="utf-8")
+    readme_snapshot = readme.read_bytes()
+    output = tmp_path / "statistik.md"
+    output.write_text("# untouched\n", encoding="utf-8")
+    output_snapshot = output.read_bytes()
+
+    rc = script.main(
+        [
+            "--year",
+            "2026",
+            "--stats-dir",
+            str(stats_dir),
+            "--output",
+            str(output),
+            "--readme-path",
+            str(readme),
+            "--skip-dashboard",
+            "--skip-readme",
+            "--now-iso",
+            "2026-05-09T12:00:00+02:00",
+        ]
+    )
+    assert rc == 0
+    assert readme.read_bytes() == readme_snapshot
+    assert output.read_bytes() == output_snapshot
+
+
 def test_main_invalid_now_iso_returns_error(tmp_path: Path) -> None:
     stats_dir = tmp_path / "stats"
     _seed_csvs(stats_dir)


### PR DESCRIPTION
## Summary

Two related drifts on the Stammstrecke statistics surface, fixed in one go:

### 1. Headline ⌀ disagreed between README and statistik.md
`_format_summary_section` macro-averaged across the per-weekday means, so a Saturday with 3 observations was weighted as heavily as a Sunday with 23. The README cell, computed from the raw rows via `statistics.mean`, used a true micro-average. With the 2026-05-10 ledger this drift surfaced as **0.4 min on the dashboard vs 0.2 min in the README** — same 26 observations.

Fix: recover the original delay sum from the already-aggregated `by_weekday_avg × by_weekday_count` and divide by `total_observations`. Same observation-weighted mean as the README, no extra iteration over raw rows. The committed `docs/statistik.md` now shows `0.2 min`.

### 2. Cadence churn
`update-cycle.yml` regenerated the full dashboard on every 30-min cron tick, refreshing the `_Automatisch erzeugt am ..._` timestamp at the top of `docs/statistik.md` and triggering a commit each time. The yearly aggregates only meaningfully change on a daily granularity.

Fix: split the cadence.
- README STATS markers (the 30-day snapshot) keep refreshing every 30 min.
- The yearly dashboard refreshes once per day at the first cron tick after midnight Europe/Vienna.

Implemented via a new `--skip-dashboard` CLI flag (mirror of the existing `--skip-readme`) and a `TZ=Europe/Vienna date +%H%M` gate in the workflow that absorbs up to ~29 min of cron jitter on the 00:00 tick.

## Test plan
- [x] `test_render_markdown_global_avg_uses_observation_weighted_mean` pins the corrected micro-average against the empirical Sa(3)/So(23) distribution that triggered the bug.
- [x] `test_main_skip_dashboard_flag_leaves_dashboard_untouched` pins the `--skip-dashboard` contract: dashboard byte-stable, README still patched.
- [x] `test_main_skip_dashboard_and_skip_readme_combined_is_noop` pins the degenerate combination so a future caller passing both flags by accident gets a clean no-op exit.
- [x] All 51 tests in the three `test_generate_markdown_stats*` files pass locally.
- [ ] First post-merge cycle: confirm the README markers still update on the next 30-min tick and that `docs/statistik.md` only refreshes on the 00:00 Vienna tick.

https://claude.ai/code/session_01UrxeraqMXYVxLT9sWhsg1m

---
_Generated by [Claude Code](https://claude.ai/code/session_01UrxeraqMXYVxLT9sWhsg1m)_