### PR TITLE
fix(stats): close two remaining write paths to docs/statistik.md

### DIFF
--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -70,13 +70,22 @@ jobs:
           # zu zeigen.
           PAGES_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
 
-      # Regenerate the statistics dashboard (``docs/statistik.md``) AND
-      # patch the README ``<!-- STATS:* -->`` markers with the 30-day
+      # Patch the README ``<!-- STATS:* -->`` markers with the 30-day
       # rolling snapshot. Reads only ``data/stats/*.csv`` (no network),
-      # idempotent at the byte level, atomic write — so a kill-signal
-      # mid-run cannot corrupt either output.
-      - name: Refresh statistics dashboard and README snapshot
-        run: python scripts/generate_markdown_stats.py
+      # idempotent at the byte level, atomic write.
+      #
+      # ``--skip-dashboard`` pins this workflow to README-only output:
+      # ``docs/statistik.md`` is the *yearly* dashboard and is owned by
+      # the once-daily 00:00 Europe/Vienna tick of ``update-cycle.yml``.
+      # Code-push triggers fire at unpredictable times of day and used
+      # to silently move the dashboard's ``_Automatisch erzeugt am ..._``
+      # timestamp every time someone pushed to ``src/**``, breaking the
+      # "exactly one dashboard refresh per Vienna day" contract. Operators
+      # who explicitly want a dashboard regen out-of-band run
+      # ``generate-stats.yml`` (the dedicated ``workflow_dispatch``
+      # escape hatch).
+      - name: Refresh README snapshot (dashboard handled by update-cycle.yml)
+        run: python scripts/generate_markdown_stats.py --skip-dashboard
 
       - name: Pull concurrent remote changes
         if: github.ref == 'refs/heads/main'
@@ -98,12 +107,12 @@ jobs:
           # ``manual-full-refresh.yml`` happens to commit (audit
           # finding 2026-05-09 — this was the reason ``Häufigste
           # Störungsorte`` was sparse in the README until the manual
-          # refresh ran). ``docs/statistik.md`` and ``README.md`` carry
-          # the regenerated human-readable dashboard / snapshot from
-          # the same CSV ledger.
+          # refresh ran). ``README.md`` carries the regenerated 30-day
+          # snapshot from the same CSV ledger.
+          # ``docs/statistik.md`` is intentionally *not* in this
+          # allowlist — see the ``--skip-dashboard`` rationale above.
           file_pattern: |
             data/first_seen.json
             data/stats/stoerungen_*.csv
             docs/feed.xml
-            docs/statistik.md
             README.md

--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -81,9 +81,10 @@ jobs:
       # to silently move the dashboard's ``_Automatisch erzeugt am ..._``
       # timestamp every time someone pushed to ``src/**``, breaking the
       # "exactly one dashboard refresh per Vienna day" contract. Operators
-      # who explicitly want a dashboard regen out-of-band run
-      # ``generate-stats.yml`` (the dedicated ``workflow_dispatch``
-      # escape hatch).
+      # who explicitly want a dashboard regen out-of-band run either
+      # ``generate-stats.yml`` (dedicated dashboard-only escape hatch)
+      # or ``manual-full-refresh.yml`` (the ``alles neu`` button that
+      # also rebuilds caches, station directory and feed).
       - name: Refresh README snapshot (dashboard handled by update-cycle.yml)
         run: python scripts/generate_markdown_stats.py --skip-dashboard
 

--- a/.github/workflows/generate-stats.yml
+++ b/.github/workflows/generate-stats.yml
@@ -3,12 +3,15 @@ name: Generate statistics dashboard
 # DISABLED CRON: ``update-cycle.yml`` regenerates ``docs/statistik.md``
 # once per day at the first cron tick after midnight Europe/Vienna
 # (and patches the README ``<!-- STATS:* -->`` markers on every 30-min
-# tick). All other dashboard-touching workflows
-# (``build-feed.yml``, ``manual-full-refresh.yml``) now pass
-# ``--skip-dashboard`` so the daily-only contract holds.
+# tick). The push-triggered ``build-feed.yml`` passes
+# ``--skip-dashboard`` so a code-push during the day cannot move the
+# dashboard timestamp out-of-band. The operator-triggered
+# ``manual-full-refresh.yml`` *does* regenerate the dashboard — it is
+# the explicit ``alles neu`` button and is expected to refresh every
+# project artefact in one go.
 #
-# This workflow remains as the dedicated ``workflow_dispatch``-only
-# escape hatch for an out-of-band dashboard regeneration — e.g. after
+# This workflow remains as a dedicated ``workflow_dispatch``-only
+# escape hatch for a dashboard-only regeneration — e.g. after
 # hand-editing the CSV ledger or to verify a change to
 # ``generate_markdown_stats.py`` end-to-end without waiting for the
 # next 00:00 Vienna tick. It calls the script with NO flags, so both

--- a/.github/workflows/generate-stats.yml
+++ b/.github/workflows/generate-stats.yml
@@ -1,17 +1,18 @@
 name: Generate statistics dashboard
 
-# DISABLED CRON (2026-05-09): the regular nightly schedule was
-# retired because ``update-cycle.yml`` (cron ``0,30 * * * *``)
-# regenerates the same ``docs/statistik.md`` + README markers every
-# 30 minutes from the same CSV ledger via its ``build_feed`` job. A
-# nightly run could only see rows that had already been committed
-# during the day — it cannot recover anything ``update-cycle.yml``
-# missed, so it adds no resilience and just emits redundant
-# no-op commits.
+# DISABLED CRON: ``update-cycle.yml`` regenerates ``docs/statistik.md``
+# once per day at the first cron tick after midnight Europe/Vienna
+# (and patches the README ``<!-- STATS:* -->`` markers on every 30-min
+# tick). All other dashboard-touching workflows
+# (``build-feed.yml``, ``manual-full-refresh.yml``) now pass
+# ``--skip-dashboard`` so the daily-only contract holds.
 #
-# This workflow remains as a ``workflow_dispatch``-only escape
-# hatch for manually re-rendering the dashboard after editing the
-# CSV ledger by hand.
+# This workflow remains as the dedicated ``workflow_dispatch``-only
+# escape hatch for an out-of-band dashboard regeneration — e.g. after
+# hand-editing the CSV ledger or to verify a change to
+# ``generate_markdown_stats.py`` end-to-end without waiting for the
+# next 00:00 Vienna tick. It calls the script with NO flags, so both
+# ``docs/statistik.md`` and the README markers are written.
 on:
   workflow_dispatch:
 

--- a/.github/workflows/manual-full-refresh.yml
+++ b/.github/workflows/manual-full-refresh.yml
@@ -120,16 +120,23 @@ jobs:
           # schreiben statt auf das Original-Repo zu zeigen.
           PAGES_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
 
-      # ----- 4) Statistik-Dashboard und README-Snapshot -----
-      # Regeneriert docs/statistik.md (Dashboard) und patcht zugleich die
-      # <!-- STATS:* --> Marker im README mit dem 30-Tage-Schnappschuss.
-      # Liest ausschliesslich aus data/stats/*.csv (read-only) und schreibt
-      # via atomic_write — ein Lauf ohne neue Daten patcht das README nur,
-      # wenn sich die "Letzte Aktualisierung"-Zelle aendert. Muss nach dem
+      # ----- 4) README-Snapshot -----
+      # Patcht die <!-- STATS:* --> Marker im README mit dem 30-Tage-
+      # Schnappschuss. Liest ausschliesslich aus data/stats/*.csv
+      # (read-only) und schreibt via atomic_write. Muss nach dem
       # Stammstrecke-Schritt laufen, damit die Auswertung den frischen
       # CSV-Eintrag enthaelt.
-      - name: Refresh statistics dashboard and README snapshot
-        run: python scripts/generate_markdown_stats.py
+      #
+      # ``--skip-dashboard``: docs/statistik.md (das Jahres-Dashboard)
+      # gehoert dem 00:00-Vienna-Tick von ``update-cycle.yml``. Manuelle
+      # Voll-Refreshes laufen zu beliebigen Tageszeiten und wuerden den
+      # ``_Automatisch erzeugt am ..._``-Timestamp mehrfach pro Tag
+      # versetzen — das verletzt die Vereinbarung "genau ein Dashboard-
+      # Update pro Vienna-Tag". Operatoren, die eine ausserplanmaessige
+      # Dashboard-Regeneration brauchen, triggern den dedizierten
+      # ``generate-stats.yml``-Workflow.
+      - name: Refresh README snapshot (dashboard handled by update-cycle.yml)
+        run: python scripts/generate_markdown_stats.py --skip-dashboard
 
       # ----- 5) Aenderungen committen und pushen -----
       - name: Pull concurrent remote changes

--- a/.github/workflows/manual-full-refresh.yml
+++ b/.github/workflows/manual-full-refresh.yml
@@ -120,23 +120,25 @@ jobs:
           # schreiben statt auf das Original-Repo zu zeigen.
           PAGES_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
 
-      # ----- 4) README-Snapshot -----
-      # Patcht die <!-- STATS:* --> Marker im README mit dem 30-Tage-
-      # Schnappschuss. Liest ausschliesslich aus data/stats/*.csv
-      # (read-only) und schreibt via atomic_write. Muss nach dem
+      # ----- 4) Statistik-Dashboard und README-Snapshot -----
+      # Regeneriert docs/statistik.md (Dashboard) und patcht zugleich die
+      # <!-- STATS:* --> Marker im README mit dem 30-Tage-Schnappschuss.
+      # Liest ausschliesslich aus data/stats/*.csv (read-only) und schreibt
+      # via atomic_write — ein Lauf ohne neue Daten patcht das README nur,
+      # wenn sich die "Letzte Aktualisierung"-Zelle aendert. Muss nach dem
       # Stammstrecke-Schritt laufen, damit die Auswertung den frischen
       # CSV-Eintrag enthaelt.
       #
-      # ``--skip-dashboard``: docs/statistik.md (das Jahres-Dashboard)
-      # gehoert dem 00:00-Vienna-Tick von ``update-cycle.yml``. Manuelle
-      # Voll-Refreshes laufen zu beliebigen Tageszeiten und wuerden den
-      # ``_Automatisch erzeugt am ..._``-Timestamp mehrfach pro Tag
-      # versetzen — das verletzt die Vereinbarung "genau ein Dashboard-
-      # Update pro Vienna-Tag". Operatoren, die eine ausserplanmaessige
-      # Dashboard-Regeneration brauchen, triggern den dedizierten
-      # ``generate-stats.yml``-Workflow.
-      - name: Refresh README snapshot (dashboard handled by update-cycle.yml)
-        run: python scripts/generate_markdown_stats.py --skip-dashboard
+      # Kein ``--skip-dashboard`` hier (anders als ``build-feed.yml``):
+      # Dieser Workflow wird ausschliesslich per ``workflow_dispatch``
+      # vom Operator gestartet — das ist eine bewusste Override-Aktion,
+      # die das gesamte Projekt frisch ziehen soll. Die einmal-pro-Tag-
+      # Vereinbarung fuer ``docs/statistik.md`` ist ein Schutz vor der
+      # *automatischen* 30-min-Churn (cron in ``update-cycle.yml`` und
+      # push-getriggertes ``build-feed.yml``); ein expliziter Operator-
+      # Trigger soll daran nicht scheitern.
+      - name: Refresh statistics dashboard and README snapshot
+        run: python scripts/generate_markdown_stats.py
 
       # ----- 5) Aenderungen committen und pushen -----
       - name: Pull concurrent remote changes


### PR DESCRIPTION
## Summary

Follow-up to #1425. That PR gated `update-cycle.yml` (the 30-min cron) so `docs/statistik.md` only refreshes once per Vienna day. But two other workflows still rewrote the dashboard outside that window — they were missed in the original audit:

- **`build-feed.yml`** fires on every `push` to `src/**` (and on `workflow_dispatch`). A code push at 14:00 Vienna silently bumped the dashboard's `_Automatisch erzeugt am ..._` timestamp mid-day, violating the "exactly one refresh per Vienna day" contract. Now passes `--skip-dashboard`; commit `file_pattern` allowlist drops `docs/statistik.md` to mirror.

- **`manual-full-refresh.yml`** is the operator's "alles neu" Sammeltrigger (`workflow_dispatch` only). After review, **kept regenerating the dashboard** — the daily-only contract is a defence against *automatic* churn; an explicit operator override should refresh every project artefact in one go (caches, station directory, feed, dashboard).

Comment headers on all three touched workflows updated so the next reader doesn't have to reverse-engineer the cadence from the YAML.

## After this PR

| Trigger | Dashboard | README markers |
|---|---|---|
| `update-cycle.yml` cron, 00:00 Vienna tick | **regen** | patched |
| `update-cycle.yml` cron, every other tick | skip | patched |
| `build-feed.yml` push to `src/**` | skip | patched |
| `build-feed.yml` workflow_dispatch | skip | patched |
| `manual-full-refresh.yml` workflow_dispatch | **regen** | patched |
| `generate-stats.yml` workflow_dispatch | **regen** | patched |

Net effect: the dashboard is rewritten exactly once per Vienna day on the auto-path, plus on demand via two operator-driven manual workflows.

## Test plan
- [x] All 51 tests in the three `test_generate_markdown_stats*` files still pass — no script changes, only YAML routing.
- [ ] First post-merge `build-feed.yml` push: confirm `docs/statistik.md` is byte-stable in the auto-commit (the file shouldn't appear in the diff).
- [ ] First post-merge 00:00 Vienna tick: confirm the dashboard is rewritten and committed via `update-cycle.yml`.
- [ ] Confirm `generate-stats.yml` (manual) and `manual-full-refresh.yml` (manual) still rewrite the dashboard end-to-end.

https://claude.ai/code/session_01UrxeraqMXYVxLT9sWhsg1m