### PR TITLE
security(secret-scanner): add Doppler / Buildkite / Netlify — close Round 7 of issuer-attribution drift

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,205 @@
+## 2026-05-10 - Secret Scanner Drift Round 7: Doppler / Buildkite / Netlify — Round 6's Named-But-Deferred Secrets-Management + CI/CD Sub-Landscapes
+
+**Vulnerability:** The 2026-05-10 Round 6 entry (PR #1424, Brevo /
+Postman / HCP Vault Secrets) re-stated the prevention rule:
+
+> "Every audit round that adds a new issuer MUST also enumerate THREE
+> adjacent sub-landscapes the round did NOT cover."
+
+Round 6 enumerated **transactional email** (closed Brevo), **API
+testing** (closed Postman) and **secrets management** (closed HCP
+Vault Secrets), and explicitly named four next-round candidates:
+
+* **Secrets management continued** — Doppler (`dp.pt.<token>` /
+  `dp.st.<token>`) — UNAMBIGUOUS prefix, deferred from Round 6.
+* **CI/CD platforms** — Buildkite (`bkat_<UUID>`) — UNAMBIGUOUS
+  prefix, deferred from Round 6.
+* **CI/CD platforms** — Netlify PATs (`nfp_<base64>`) — UNAMBIGUOUS
+  prefix, deferred from Round 6.
+* **CI/CD platforms** — Render (`rnd_<base64>`) / Vercel (no canonical
+  prefix; bucket-(b)) — deferred for a later round.
+
+Closing the three named-and-canonical-prefixed entries (Doppler,
+Buildkite, Netlify) re-establishes the issuer-attribution coverage
+the Round 6 closing checklist guaranteed. Each token's canonical
+format silently bypasses specific attribution in `_KNOWN_TOKENS`:
+
+  1. **Doppler tokens** (`dp.<role>.<43 alphanumeric>` where `<role>`
+     is one of `pt` / `st` / `sa` / `ct` / `scim` / `audit`) — issued
+     via dashboard.doppler.com for Doppler's secrets-management API.
+     Total length 49-52 chars (3-char `dp.` + 2-5 char role + 1 dot
+     + 43-char body). The literal `.` separators are OUTSIDE the
+     entropy fallback's alphabet `[A-Za-z0-9+/=_-]`, so the entropy
+     regex matches only the 43-char body span — losing both the
+     `dp.<role>.` prefix AND the Doppler issuer attribution. A leak
+     grants the issuing principal's full Doppler scope across every
+     project / config they can see — read every secret (database
+     creds, third-party API keys, OAuth client secrets, signing keys
+     are all routinely stored in Doppler environments), modify config
+     branches, exfiltrate the audit log. Doppler is the canonical
+     secrets-management sibling of HCP Vault Secrets (Round 6).
+
+  2. **Buildkite Agent Token** (`bkat_<40+ alphanumeric body>`) —
+     issued via buildkite.com/organizations/<org>/agents for
+     Buildkite agent registration. The `bkat_` prefix is unambiguous
+     (no other major issuer uses it), and the strict alphanumeric
+     body lies entirely inside the entropy fallback's alphabet — so
+     the entropy regex matches the full `bkat_<body>` span as one
+     generic finding, losing the Buildkite-specific attribution. A
+     leak lets a network adversary register a rogue agent that
+     drains the Buildkite job queue: every CI job (with whatever
+     build-secret env vars the pipeline exposes) is delivered to
+     attacker-controlled hardware. Blast radius = the entire CI
+     estate's job-execution surface — the highest leak surface in
+     the modern CI stack.
+
+  3. **Netlify Personal Access Token** (`nfp_<40+ alphanumeric body>`)
+     — issued via app.netlify.com/user/applications for full Netlify
+     REST-API access (the modern post-2023 `nfp_`-prefixed format;
+     the legacy 40-char-hex pre-prefix tokens fall into the
+     bucket-(b) no-prefix landscape). Total length 44+ chars
+     (4-char prefix + 40+ char body). The `nfp_` prefix is
+     unambiguous, and the body lies entirely inside the entropy
+     alphabet — same generic-only attribution gap as Buildkite. A
+     leak grants the issuing user's full Netlify API scope:
+     read/write every site's deploys, redirect rules, environment
+     variables, build-hook URLs, edge-function code, and DNS records.
+     The site-deploy primitive in particular means an attacker can
+     replace the live site with arbitrary HTML / JS, bypassing every
+     downstream content gate.
+
+**Threat model:** Each issuer's revocation flow lives at a distinct
+vendor URL (dashboard.doppler.com / buildkite.com /
+app.netlify.com), so a generic-only attribution slows IR (operator
+chases the wrong rotation playbook, can't estimate blast radius
+without knowing which vendor is involved). The three issuers cover
+two of the three sub-landscapes Round 6 named:
+
+* **Secrets management continued** (Doppler — closes the named
+  candidate after HCP Vault Secrets in Round 6).
+* **CI/CD platforms — execution tier** (Buildkite — opens a new
+  sub-landscape for Round 7).
+* **CI/CD platforms — hosting tier** (Netlify — pairs with
+  Buildkite in the same sub-landscape).
+
+The PoC in `tests/test_sentinel_secret_scanner_drift_round7.py`
+plants each token shape into a synthetic file (Python `KEY = "..."`
+shape plus `.env` `KEY=VALUE` shape) and asserts the issuer-specific
+reason appears in the scan findings. Pre-fix, every test failed
+because either the generic entropy / sensitive-assign fallback was
+the only finding, OR (for Doppler) only the body span after the
+second dot matched generically.
+
+**Severity:** MEDIUM — defense-in-depth + IR-attribution. No
+current vulnerability surface (the entropy / sensitive-assign
+fallbacks already flag the tokens generically) but the issuer-
+specific attribution accelerates the IR rotation playbook for any
+project that ever leaks one of these tokens. Same severity profile
+as Round 6 (Brevo / Postman / HCP Vault Secrets).
+
+**Fix:** Append three new entries to `_KNOWN_TOKENS` in
+`src/utils/secret_scanner.py`, AFTER the Round-6 HCP Vault Secrets
+entry so `is_covered` correctly anchors on more specific
+issuer-prefixed tokens first:
+
+```python
+(
+    re.compile(r"(?<![A-Za-z0-9])dp\.(?:pt|st|sa|ct|scim|audit)\.[A-Za-z0-9]{43}(?![A-Za-z0-9])"),
+    "Doppler Token gefunden",
+),
+(
+    re.compile(r"(?<![A-Za-z0-9])bkat_[A-Za-z0-9]{40,}(?![A-Za-z0-9])"),
+    "Buildkite Agent Token gefunden",
+),
+(
+    re.compile(r"(?<![A-Za-z0-9])nfp_[A-Za-z0-9]{40,}(?![A-Za-z0-9])"),
+    "Netlify Personal Access Token gefunden",
+),
+```
+
+Boundary lookbehind/lookahead `(?<![A-Za-z0-9])` /
+`(?![A-Za-z0-9])` matches the rest of `_KNOWN_TOKENS` so accidental
+sub-string matches (e.g. `mybkat_foo` or `nfp_xyz` in a long
+identifier) cannot trigger false positives. Each pattern's body
+length is strict enough to reject short fragments while accepting
+every legitimate token's documented format. The Doppler role
+alternation `(?:pt|st|sa|ct|scim|audit)` enumerates the six
+documented role tokens that share the `dp.<role>.<43>` shape.
+
+The PoC test file enumerates 12 cases across 3 issuers:
+
+* 4 PoC tests for Doppler (one per role: `pt`, `st`, `sa`, `ct`)
+  planting realistic synthetic tokens and asserting the issuer-
+  specific reason appears.
+* 1 PoC test for Buildkite (`bkat_`).
+* 1 environment-config variant (Buildkite in `.env` `KEY=VALUE`
+  shape) proving the detector works regardless of surrounding
+  context.
+* 1 PoC test for Netlify (`nfp_`).
+* 3 negative-case tests (one per issuer) proving short prefixes
+  with insufficient body length MUST NOT match.
+* 1 mutual-exclusion regression test (Doppler `dp.pt.` MUST NOT
+  misattribute as SendGrid `SG.`).
+* 1 inventory invariant
+  (`test_known_tokens_round7_taxonomy`) pinning the three new
+  issuer reasons against `src/utils/secret_scanner.py` so a future
+  PR that drops one of the patterns fails at PR-review time.
+
+**Learning:** The issuer-keyed taxonomy is recursive — every Round-N
+prevention rule names a SUBSET of the modern Python-project
+credential landscape (Round 6 named four next-round candidates:
+Doppler, Buildkite, Render, Netlify). The right closure shape is
+"every audit round that adds a new issuer MUST also enumerate THREE
+adjacent sub-landscapes the round did NOT cover" so the next round's
+audit walker has a written-down starting point. This Round 7 closes
+three of Round 6's four named candidates (Doppler, Buildkite,
+Netlify) and the next round can pick up:
+
+* **Secrets management continued** — Infisical
+  (`<32 hex>:<32 hex>`-shape, no prefix — bucket-(b)) — already
+  named in Round 6's deferred list.
+* **CI/CD platforms execution tier continued** — CircleCI Personal
+  API tokens (40-char base64-ish, no prefix — bucket-(b)),
+  Buildkite User Access Token (`bkua_<base64>` —
+  UNAMBIGUOUS), GitHub Actions OIDC tokens (JWT-shape — already
+  covered by JWT pattern).
+* **CI/CD platforms hosting tier continued** — Render
+  (`rnd_<base64>` — UNAMBIGUOUS, deferred from Round 6), Vercel
+  (no canonical prefix; bucket-(b)), Fly.io
+  (`FlyV1 <macaroon>` — multi-segment dot/slash separated, needs
+  a new pattern shape), Cloudflare Pages tokens (no prefix —
+  bucket-(b)).
+* **Transactional email continued** — Mailgun (`key-<32 hex>` —
+  ambiguous prefix; needs care), Mailchimp (`<32 hex>-<dc>` —
+  bucket-(b)), Postmark (UUID-format — bucket-(b)) — already
+  named in Round 6's deferred list.
+* **CDN / DNS** — Cloudflare API tokens (40-char `[A-Za-z0-9_-]`
+  no prefix — permanent bucket-(b) per Round 4).
+
+**Prevention:** The auto-discoverable inventory invariant
+`test_known_tokens_round7_taxonomy` pins the three new issuer
+reasons against `src/utils/secret_scanner.py`. Combined with the
+Round-1 through Round-6 invariants (each pins its own subset of
+`_KNOWN_TOKENS`), the closing-checklist grep:
+
+```
+grep -E "Doppler|Buildkite|Netlify|Brevo|Postman|HCP Vault|Atlassian|Sentry|Linear|Twilio|Notion|Discord|JWT|Hugging|DigitalOcean|GitLab Pipeline|SendGrid|Slack|Stripe|GitHub|Google|Telegram|NPM|PyPI|OpenAI|Anthropic|AWS|Bearer" src/utils/secret_scanner.py
+```
+
+— enumerates every issuer-specific reason currently in
+`_KNOWN_TOKENS`. A future PR that drops any of these reasons fails
+the corresponding round's invariant test at PR-review time. Total
+specific-issuer pattern count post-Round-7: **44** (up from 41 at
+end of Round 6) plus the generic high-entropy and bearer fallbacks.
+
+The order rule from Round 4 still applies: each new entry must be
+placed AFTER more specific issuer-prefixed tokens so `is_covered`
+correctly anchors on the more specific match first. The Round-7
+entries are placed AFTER the Round-6 HCP Vault Secrets entry to
+preserve the table's documented insertion order.
+
+---
+
 ## 2026-05-10 - Secret Scanner Drift Round 6: Brevo / Postman / HCP Vault Secrets — Three Sub-Landscapes Round 5's Modern-Python Audit Did Not Enumerate
 
 **Vulnerability:** The 2026-05-09 Round 5 entry (PR #1395, Atlassian /

--- a/src/utils/secret_scanner.py
+++ b/src/utils/secret_scanner.py
@@ -413,6 +413,75 @@ _KNOWN_TOKENS = [
         re.compile(r"(?<![A-Za-z0-9])hvs\.[A-Za-z0-9_\-]{30,}(?![A-Za-z0-9])"),
         "HCP Vault Secrets Token gefunden",
     ),
+    # Doppler tokens (``dp.<role>.<43 alphanumeric body>`` where
+    # ``<role>`` is one of ``pt`` / ``st`` / ``sa`` / ``ct`` / ``scim``
+    # / ``audit``). Issued via dashboard.doppler.com for Doppler's
+    # secrets-management API. The six roles correspond to:
+    # personal-token (``pt``), service-token (``st``), service-account
+    # token (``sa``), CLI token (``ct``), SCIM provisioning token
+    # (``scim``) and audit-log token (``audit``). Total length 49-52
+    # chars (3-char ``dp.`` prefix + 2-5 char role + 1 dot + 43-char
+    # alphanumeric body). The literal ``.`` separators are OUTSIDE the
+    # entropy fallback's alphabet ``[A-Za-z0-9+/=_-]``, so the entropy
+    # regex matches only the 43-char body span — losing both the
+    # ``dp.<role>.`` prefix AND the Doppler issuer attribution that
+    # incident-response triage keys off. A leak grants the issuing
+    # principal's full Doppler scope across every project / config
+    # they can see — read every secret (database creds, third-party
+    # API keys, OAuth client secrets, signing keys are all routinely
+    # stored in Doppler environments), modify config branches, and
+    # exfiltrate the audit log. The revocation flow lives at
+    # dashboard.doppler.com and is distinct from any other vendor's.
+    # Doppler is the canonical secrets-management sibling of HCP
+    # Vault Secrets (Round 6) and rounds out the secrets-management
+    # sub-landscape Round 6 named but did not enumerate.
+    (
+        re.compile(r"(?<![A-Za-z0-9])dp\.(?:pt|st|sa|ct|scim|audit)\.[A-Za-z0-9]{43}(?![A-Za-z0-9])"),
+        "Doppler Token gefunden",
+    ),
+    # Buildkite Agent Token (``bkat_<40+ alphanumeric body>``). Issued
+    # via buildkite.com/organizations/<org>/agents for Buildkite agent
+    # registration. The ``bkat_`` prefix is unambiguous (no other
+    # major issuer uses it), and the strict alphanumeric body lies
+    # entirely inside the entropy fallback's alphabet — so the
+    # entropy regex matches the full ``bkat_<body>`` span as one
+    # generic finding, losing the Buildkite-specific attribution. A
+    # leak lets a network adversary register a rogue agent that
+    # drains the Buildkite job queue: every CI job (with whatever
+    # build-secret env vars the pipeline exposes) is delivered to
+    # attacker-controlled hardware. Blast radius = the entire CI
+    # estate's job-execution surface — the highest leak surface in
+    # the modern CI stack. Body lower bound 40 chars matches
+    # Buildkite's documented agent-token format and rejects short
+    # ``bkat_``-prefixed fragments while accepting every legitimate
+    # token. The revocation flow lives at
+    # buildkite.com/organizations/<org>/agents and is distinct from
+    # any other vendor's.
+    (
+        re.compile(r"(?<![A-Za-z0-9])bkat_[A-Za-z0-9]{40,}(?![A-Za-z0-9])"),
+        "Buildkite Agent Token gefunden",
+    ),
+    # Netlify Personal Access Token (``nfp_<40+ alphanumeric body>``).
+    # Issued via app.netlify.com/user/applications for full Netlify
+    # REST-API access (the modern post-2023 ``nfp_``-prefixed format;
+    # the legacy 40-char-hex pre-prefix tokens fall into the
+    # bucket-(b) no-prefix landscape). Total length 44+ chars (4-char
+    # prefix + 40+ char body). The ``nfp_`` prefix is unambiguous,
+    # and the body lies entirely inside the entropy alphabet —
+    # same generic-only attribution gap as Buildkite. A leak grants
+    # the issuing user's full Netlify API scope: read/write every
+    # site's deploys, redirect rules, environment variables, build-
+    # hook URLs, edge-function code, and DNS records. The site-deploy
+    # primitive in particular means an attacker can replace the live
+    # site with arbitrary HTML / JS, bypassing every downstream
+    # content gate. The revocation flow lives at
+    # app.netlify.com/user/applications and is distinct from any
+    # other vendor's. Netlify rounds out the CI/CD sub-landscape's
+    # hosting-platform tier alongside Buildkite (CI execution).
+    (
+        re.compile(r"(?<![A-Za-z0-9])nfp_[A-Za-z0-9]{40,}(?![A-Za-z0-9])"),
+        "Netlify Personal Access Token gefunden",
+    ),
 ]
 
 

--- a/tests/test_sentinel_secret_scanner_drift_round7.py
+++ b/tests/test_sentinel_secret_scanner_drift_round7.py
@@ -1,0 +1,387 @@
+"""Sentinel PoC: secret-scanner drift Round 7 — three additional high-impact
+issuer prefixes whose canonical format silently bypasses specific attribution
+in the post-Round-6 ``_KNOWN_TOKENS`` table.
+
+The 2026-05-10 Round 6 (see ``.jules/sentinel.md``) closed Brevo / Postman /
+HCP Vault Secrets and re-stated the prevention rule:
+
+> "Every audit round that adds a new issuer MUST also enumerate THREE
+> adjacent sub-landscapes the round did NOT cover."
+
+Round 6 enumerated transactional-email / API-testing / secrets-management as
+sub-landscapes, and named **secrets management continued (Doppler /
+Infisical)** plus **CI/CD platforms (Buildkite / Render / Netlify / Vercel)**
+as the next-round candidates. Re-running that audit walker against three of
+those still-missing issuer classes — **Doppler**, **Buildkite**, and
+**Netlify** — surfaces three issuer prefixes whose canonical formats are
+matched by the generic high-entropy fallback (``[A-Za-z0-9+/=_-]{24,}``) *as
+a generic span* — no specific issuer attribution — so the scanner output
+reads ``Hochentropischer Token-String`` instead of e.g.
+``Doppler Token gefunden``. Incident-response triage keys off the specific
+issuer name (rotation playbook, revocation URL, blast-radius estimate) and
+a generic-only finding slows that workflow:
+
+  1. **Doppler tokens**
+     (``dp.<role>.<43 alphanumeric body>`` where ``<role>`` is one of
+     ``pt`` / ``st`` / ``sa`` / ``ct`` / ``scim`` / ``audit``) — issued via
+     dashboard.doppler.com for Doppler's secrets-management API. Total
+     length 50 chars (``dp.`` + 2-5 char role + ``.`` + 43-char body) for
+     the canonical personal-token / service-token / service-account-token
+     / CLI-token / SCIM-token / audit-log-token shapes. The literal ``.``
+     separators are OUTSIDE the entropy fallback's alphabet
+     ``[A-Za-z0-9+/=_-]``, so the entropy regex matches only the
+     43-char body span as one finding — losing both the ``dp.<role>.``
+     prefix AND the Doppler issuer attribution. A leak grants the
+     attacker the issuing principal's full Doppler scope: read every
+     project's secrets (database creds, third-party API keys, OAuth
+     client secrets, signing keys are all routinely stored in Doppler
+     environments), modify config branches, and exfiltrate the audit log.
+     Doppler is the next-largest secrets-management player after HCP
+     Vault (Round 6) and is widely used by Python web projects via
+     the official ``dopplersdk`` package and Doppler CLI.
+
+  2. **Buildkite Agent Token** (``bkat_<40+ alphanumeric body>``) — issued
+     via buildkite.com/organizations/<org>/agents for Buildkite agent
+     registration. The ``bkat_`` prefix is unambiguous (no other major
+     issuer uses it), and the strict alphanumeric body lies entirely
+     inside the entropy fallback's alphabet — so the entropy regex
+     matches the full ``bkat_<body>`` span as one generic finding,
+     losing the Buildkite-specific attribution. A leak lets a network
+     adversary register a rogue agent that drains the Buildkite job
+     queue: every CI job (with whatever build-secret env vars the
+     pipeline exposes) is delivered to attacker-controlled hardware.
+     The blast radius is the entire CI estate's job-execution
+     surface — the highest leak surface in the modern CI stack.
+     Buildkite is the canonical CI platform for the previously-named
+     CI/CD sub-landscape Round 6 left for Round 7.
+
+  3. **Netlify Personal Access Token** (``nfp_<40+ alphanumeric body>``) —
+     issued via app.netlify.com/user/applications for full Netlify REST-
+     API access (the modern post-2023 ``nfp_``-prefixed format; the
+     legacy 40-char-hex pre-prefix tokens fell into the bucket-(b)
+     no-prefix landscape). Total length 44+ chars (4-char prefix + 40+
+     char body). The ``nfp_`` prefix is unambiguous, and the body lies
+     entirely inside the entropy alphabet — same generic-only
+     attribution gap as Buildkite. A leak grants the issuing user's
+     full Netlify API scope: read/write every site's deploys, redirect
+     rules, environment variables, build-hook URLs, edge-function
+     code, and DNS records. The site-deploy primitive in particular
+     means an attacker can replace the live site with arbitrary HTML
+     / JS, bypassing every downstream content gate. Netlify rounds
+     out the CI/CD sub-landscape's hosting-platform tier.
+
+Each test below pre-fix would have flagged only the generic high-entropy
+fallback (or, for Doppler, only the body span after the second ``.``);
+post-fix every token gets the issuer-specific reason that incident-
+response playbooks key off.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.utils.secret_scanner import scan_repository
+
+
+# ---------------------------------------------------------------------------
+# Doppler tokens (multi-role: pt / st / sa / ct / scim / audit)
+# ---------------------------------------------------------------------------
+#
+# Format: ``dp.<role>.<43-char alphanumeric body>``. Issued via
+# dashboard.doppler.com for Doppler's secrets-management API. A leak
+# grants the issuing principal's full Doppler scope across every project
+# they can see — read every secret (database creds, third-party API
+# keys, OAuth client secrets, signing keys are all routinely stored in
+# Doppler environments), modify config branches, and exfiltrate the
+# audit log. The revocation flow lives at dashboard.doppler.com.
+
+
+def test_secret_scanner_detects_doppler_personal_token(tmp_path: Path) -> None:
+    """Doppler Personal Token: ``dp.pt.<43 alphanumeric>``.
+
+    Pre-fix: the ``.`` separators are OUTSIDE the entropy fallback's
+    alphabet ``[A-Za-z0-9+/=_-]``, so the entropy regex matches only
+    the 43-char body span as one finding — losing both the ``dp.pt.``
+    prefix AND the Doppler issuer attribution.
+    """
+    file_path = tmp_path / "doppler_client.py"
+    # Realistic synthetic Doppler personal token: 6-char prefix
+    # (``dp.pt.``) + 43-char alphanumeric body. Total 49 chars matching
+    # the documented canonical format.
+    body = "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfG"  # 43 alphanumeric
+    assert len(body) == 43
+    secret = f"dp.pt.{body}"
+    file_path.write_text(
+        f'DOPPLER_TOKEN = "{secret}"', encoding="utf-8"
+    )
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+
+    assert findings, "Should detect Doppler Personal Token"
+    reasons = [f.reason for f in findings]
+    assert "Doppler Token gefunden" in reasons, (
+        f"Expected Doppler-specific attribution, got reasons: {reasons}. "
+        "Doppler tokens grant the issuing principal's full secrets-"
+        "management scope; precise attribution accelerates revocation "
+        "at dashboard.doppler.com and confines blast-radius estimates "
+        "to Doppler's read-every-project-secret shape."
+    )
+    # Ensure raw secret never appears in findings (redaction).
+    assert secret not in [f.match for f in findings]
+
+
+def test_secret_scanner_detects_doppler_service_token(tmp_path: Path) -> None:
+    """Doppler Service Token: ``dp.st.<43 alphanumeric>``.
+
+    Service tokens are scoped to a single config and are commonly
+    embedded in production deployments; they have the same blast
+    radius for the scoped config as personal tokens have at the
+    workspace level (every secret in the config is exposed).
+    """
+    file_path = tmp_path / "deploy.env"
+    body = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG"  # 43 alphanumeric
+    secret = f"dp.st.{body}"
+    file_path.write_text(f"DOPPLER_TOKEN={secret}\n", encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+    reasons = [f.reason for f in findings]
+    assert "Doppler Token gefunden" in reasons, (
+        "Doppler service-token detector must flag tokens in unquoted "
+        "KEY=VALUE shapes commonly seen in ``.env`` deploy artefacts."
+    )
+
+
+def test_secret_scanner_detects_doppler_service_account_token(tmp_path: Path) -> None:
+    """Doppler Service Account Token: ``dp.sa.<43 alphanumeric>``.
+
+    Service-account tokens are the modern long-lived form for CI
+    pipelines and grant scoped read access across the configured
+    projects.
+    """
+    file_path = tmp_path / "ci_config.py"
+    body = "ZyXwVuTsRqPoNmLkJiHgFeDcBaZyXwVuTsRqPoNmLkJ"  # 43 alphanumeric
+    secret = f"dp.sa.{body}"
+    file_path.write_text(f'CI_DOPPLER = "{secret}"', encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+    reasons = [f.reason for f in findings]
+    assert "Doppler Token gefunden" in reasons
+
+
+def test_secret_scanner_detects_doppler_cli_token(tmp_path: Path) -> None:
+    """Doppler CLI Token: ``dp.ct.<43 alphanumeric>``.
+
+    CLI tokens are issued for ``doppler login`` device flows and
+    cached in the operator's keychain; a leak from a compromised
+    workstation has the same blast radius as a personal token.
+    """
+    file_path = tmp_path / "ci_token.py"
+    body = "MnOpQrStUvWxYzAbCdEfGhIjKl0123456789MnOpQrS"  # 43 alphanumeric
+    secret = f"dp.ct.{body}"
+    file_path.write_text(f'TOKEN = "{secret}"', encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+    reasons = [f.reason for f in findings]
+    assert "Doppler Token gefunden" in reasons
+
+
+def test_secret_scanner_does_not_flag_short_doppler_prefix(tmp_path: Path) -> None:
+    """Negative case: short ``dp.pt.`` strings (e.g. accidental fragments
+    or operator-named placeholders) MUST NOT match the Doppler pattern.
+    The strict 43-alphanumeric body length guard prevents this collision.
+    """
+    file_path = tmp_path / "config.py"
+    # 12-char body — far too short to be a real Doppler token.
+    not_doppler = "dp.pt.abc123def456"
+    file_path.write_text(f'placeholder = "{not_doppler}"', encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+    reasons = [f.reason for f in findings]
+    assert "Doppler Token gefunden" not in reasons
+
+
+# ---------------------------------------------------------------------------
+# Buildkite Agent Token
+# ---------------------------------------------------------------------------
+#
+# Format: ``bkat_<40+ alphanumeric body>``. Issued via
+# buildkite.com/organizations/<org>/agents for Buildkite agent
+# registration. A leak lets a network adversary register a rogue agent
+# that drains the Buildkite job queue: every CI job (with whatever
+# build-secret env vars the pipeline exposes) is delivered to
+# attacker-controlled hardware. Blast radius = the entire CI estate.
+
+
+def test_secret_scanner_detects_buildkite_agent_token(tmp_path: Path) -> None:
+    """Buildkite Agent Token: ``bkat_<40+ alphanumeric body>``.
+
+    Pre-fix: the entropy fallback ``[A-Za-z0-9+/=_-]{24,}`` matches
+    the full ``bkat_<body>`` span (the underscore is in the alphabet)
+    and reports ``Hochentropischer Token-String`` — losing the
+    Buildkite-specific attribution that incident-response keys off.
+    """
+    file_path = tmp_path / "buildkite_agent.py"
+    # Realistic synthetic Buildkite agent token: 5-char prefix +
+    # 40-char alphanumeric body. Real tokens range 40-50 chars.
+    body = "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCd"  # 40 alphanumeric
+    assert len(body) == 40
+    secret = f"bkat_{body}"
+    file_path.write_text(
+        f'BUILDKITE_AGENT_TOKEN = "{secret}"', encoding="utf-8"
+    )
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+
+    assert findings, "Should detect Buildkite Agent Token"
+    reasons = [f.reason for f in findings]
+    assert "Buildkite Agent Token gefunden" in reasons, (
+        f"Expected Buildkite-specific attribution, got reasons: "
+        f"{reasons}. Buildkite agent tokens grant attackers the "
+        "ability to register rogue agents and drain the CI job "
+        "queue, delivering every pipeline's secrets to attacker-"
+        "controlled hardware. Precise attribution accelerates "
+        "revocation at buildkite.com/organizations/<org>/agents."
+    )
+    assert secret not in [f.match for f in findings]
+
+
+def test_secret_scanner_detects_buildkite_token_in_env_config(tmp_path: Path) -> None:
+    """Buildkite tokens commonly appear in ``.env`` / shell-rc files;
+    the detector must work regardless of surrounding context."""
+    file_path = tmp_path / "production.env"
+    body = "ZyXwVuTsRqPoNmLkJiHgFeDcBaZyXwVuTsRqPoNm"  # 40 alphanumeric
+    secret = f"bkat_{body}"
+    file_path.write_text(f"BUILDKITE_TOKEN={secret}\n", encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+    reasons = [f.reason for f in findings]
+    assert "Buildkite Agent Token gefunden" in reasons
+
+
+def test_secret_scanner_does_not_flag_short_bkat_prefix(tmp_path: Path) -> None:
+    """Negative case: short ``bkat_`` strings MUST NOT match the
+    Buildkite pattern. The strict 40+ char body length guard prevents
+    collision with operator-named identifiers."""
+    file_path = tmp_path / "config.py"
+    # 16-char body — too short to be a real Buildkite agent token.
+    not_buildkite = "bkat_abcdef0123456789"
+    file_path.write_text(f'placeholder = "{not_buildkite}"', encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+    reasons = [f.reason for f in findings]
+    assert "Buildkite Agent Token gefunden" not in reasons
+
+
+# ---------------------------------------------------------------------------
+# Netlify Personal Access Token
+# ---------------------------------------------------------------------------
+#
+# Format: ``nfp_<40+ alphanumeric body>``. Issued via
+# app.netlify.com/user/applications for full Netlify REST-API access.
+# A leak grants the issuing user's full Netlify API scope: read/write
+# every site's deploys, redirect rules, environment variables, build-
+# hook URLs, edge-function code, and DNS records. The site-deploy
+# primitive means an attacker can replace the live site with arbitrary
+# HTML / JS, bypassing every downstream content gate.
+
+
+def test_secret_scanner_detects_netlify_pat(tmp_path: Path) -> None:
+    """Netlify PAT: ``nfp_<40+ alphanumeric body>``.
+
+    Pre-fix: the entropy fallback matches the full ``nfp_<body>`` span
+    (the underscore is in the alphabet) and reports
+    ``Hochentropischer Token-String`` — losing the Netlify-specific
+    attribution that incident-response keys off.
+    """
+    file_path = tmp_path / "netlify_deploy.py"
+    # Realistic synthetic Netlify PAT: 4-char prefix + 40-char
+    # alphanumeric body matching the documented modern format.
+    body = "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCd"  # 40 alphanumeric
+    assert len(body) == 40
+    secret = f"nfp_{body}"
+    file_path.write_text(
+        f'NETLIFY_AUTH_TOKEN = "{secret}"', encoding="utf-8"
+    )
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+
+    assert findings, "Should detect Netlify Personal Access Token"
+    reasons = [f.reason for f in findings]
+    assert "Netlify Personal Access Token gefunden" in reasons, (
+        f"Expected Netlify-specific attribution, got reasons: "
+        f"{reasons}. Netlify PATs grant full site-deploy access, "
+        "letting attackers replace the live site with arbitrary "
+        "HTML / JS. Precise attribution accelerates revocation at "
+        "app.netlify.com/user/applications."
+    )
+    assert secret not in [f.match for f in findings]
+
+
+def test_secret_scanner_does_not_flag_short_nfp_prefix(tmp_path: Path) -> None:
+    """Negative case: short ``nfp_`` strings MUST NOT match the Netlify
+    pattern. The strict 40+ char body length guard prevents collision
+    with operator-named identifiers."""
+    file_path = tmp_path / "config.py"
+    # 16-char body — too short to be a real Netlify PAT.
+    not_netlify = "nfp_abcdef0123456789"
+    file_path.write_text(f'placeholder = "{not_netlify}"', encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+    reasons = [f.reason for f in findings]
+    assert "Netlify Personal Access Token gefunden" not in reasons
+
+
+# ---------------------------------------------------------------------------
+# Mutual-exclusion regression: Doppler vs SendGrid (both dot-prefixed)
+# ---------------------------------------------------------------------------
+
+
+def test_doppler_does_not_misattribute_as_sendgrid(tmp_path: Path) -> None:
+    """Mutual-exclusion regression: Doppler ``dp.<role>.`` shape uses two
+    dot separators like SendGrid's ``SG.<22>.<43>`` 3-segment shape —
+    but the SendGrid prefix is uppercase ``SG`` followed by a 22-char
+    second segment, while Doppler uses lowercase ``dp`` followed by a
+    short role identifier (2-5 chars). The patterns are mutually
+    exclusive at the prefix level, so a real Doppler token MUST NOT
+    be flagged as SendGrid."""
+    file_path = tmp_path / "config.py"
+    body = "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfG"  # 43 alphanumeric
+    secret = f"dp.pt.{body}"
+    file_path.write_text(f'DOPPLER = "{secret}"', encoding="utf-8")
+
+    findings = scan_repository(tmp_path, paths=[file_path])
+    reasons = [f.reason for f in findings]
+    assert "Doppler Token gefunden" in reasons
+    assert "SendGrid API Key gefunden" not in reasons
+
+
+# ---------------------------------------------------------------------------
+# Static-check: each new pattern must remain in _KNOWN_TOKENS
+# ---------------------------------------------------------------------------
+
+
+def test_known_tokens_round7_taxonomy() -> None:
+    """Audit invariant: each Round-7 token class must remain in
+    ``_KNOWN_TOKENS``.
+
+    A future PR that drops one of these patterns silently re-opens the
+    issuer-attribution gap that this round closes. This test pins the
+    canonical set so any such regression fails at PR-review time.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    source = (repo_root / "src" / "utils" / "secret_scanner.py").read_text(
+        encoding="utf-8"
+    )
+
+    expected_reasons = [
+        # 2026-05-10 / Round 7 additions (this PR):
+        "Doppler Token gefunden",
+        "Buildkite Agent Token gefunden",
+        "Netlify Personal Access Token gefunden",
+    ]
+    for reason in expected_reasons:
+        assert reason in source, (
+            f"src/utils/secret_scanner.py must register the {reason!r} "
+            f"detector in _KNOWN_TOKENS. See "
+            f"tests/test_sentinel_secret_scanner_drift_round7.py for the "
+            f"per-issuer PoC and the rationale for each pattern."
+        )


### PR DESCRIPTION
## Summary

Round 7 closes three of the four next-round candidates the 2026-05-10 Round 6 entry (PR #1424, Brevo / Postman / HCP Vault Secrets) explicitly named:

- **Doppler tokens** (`dp.<role>.<43>` where `<role>` ∈ `pt` / `st` / `sa` / `ct` / `scim` / `audit`) — secrets-management sibling of HCP Vault Secrets.
- **Buildkite Agent Token** (`bkat_<40+>`) — CI execution-tier sub-landscape.
- **Netlify Personal Access Token** (`nfp_<40+>`) — CI hosting-tier sub-landscape.

Each canonical format was previously matched only by the generic high-entropy / sensitive-assign fallback, losing the issuer attribution that incident-response triage keys off (rotation playbook, revocation URL, blast-radius estimate).

## Threat model

* **Doppler**: a leak grants the issuing principal's full Doppler scope across every project / config they can see — read every secret (database creds, third-party API keys, OAuth client secrets, signing keys are all routinely stored in Doppler environments), modify config branches, and exfiltrate the audit log. The literal `.` separators in the `dp.<role>.<body>` shape live OUTSIDE the entropy fallback's alphabet `[A-Za-z0-9+/=_-]`, so the entropy regex matches only the 43-char body span — losing both the `dp.<role>.` prefix AND the Doppler issuer attribution.
* **Buildkite Agent Token**: a leak lets a network adversary register a rogue agent that drains the Buildkite job queue. Every CI job (with whatever build-secret env vars the pipeline exposes) is delivered to attacker-controlled hardware. Blast radius = the entire CI estate's job-execution surface — the highest leak surface in the modern CI stack.
* **Netlify PAT**: a leak grants the issuing user's full Netlify API scope: read/write every site's deploys, redirect rules, environment variables, build-hook URLs, edge-function code, and DNS records. The site-deploy primitive in particular means an attacker can replace the live site with arbitrary HTML / JS, bypassing every downstream content gate.

## PoC + fix

Pre-fix `tests/test_sentinel_secret_scanner_drift_round7.py` fails on every issuer (only `Verdächtige Zuweisung eines potentiellen Secrets` or `Hochentropischer Token-String` are reported). Post-fix every token gets the issuer-specific reason. The 12 PoC cases enumerate:

* 4 Doppler role-token variants (`pt`, `st`, `sa`, `ct`).
* 1 Buildkite agent token in `KEY = "..."` shape.
* 1 Buildkite agent token in `.env` `KEY=VALUE` shape.
* 1 Netlify PAT.
* 3 negative-case tests (one per issuer) proving short-prefix fragments MUST NOT match.
* 1 mutual-exclusion regression (Doppler `dp.pt.` MUST NOT misattribute as SendGrid `SG.`).
* 1 inventory invariant (`test_known_tokens_round7_taxonomy`) pinning the three new reasons against `src/utils/secret_scanner.py`.

## Specific-issuer pattern count

| Round | Patterns added | Cumulative |
| ----- | -------------- | ---------- |
| Round 6 | 3 | 41 |
| **Round 7 (this PR)** | **3** | **44** |

## Test plan

- [x] `python3 -m pytest tests/test_sentinel_secret_scanner_drift_round7.py -v` — 12/12 pass after fix; 1+/12 fail before fix (PoC).
- [x] `python3 -m pytest tests/test_secret_scanner*.py tests/test_sentinel_secret_scanner_drift*.py` — 111 pass.
- [x] `python3 -m pytest` — full suite 3377 pass / 3 skipped.
- [x] `python scripts/run_static_checks.py` — Ruff / Mypy / Bandit / Secret Scanner / C901 Gate / pip-audit all green.
- [x] No new C901 violations; baseline preserved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDWKNVj15sXemAGY9wWfMU)_