### PR TITLE
docs: align documentation with current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Die S-Bahn-Stammstrecke ist das Rückgrat des Pendlerverkehrs. Wir erfassen und 
 - **RSS-Feed abonnieren:** [`https://origamihase.github.io/wien-oepnv/feed.xml`](https://origamihase.github.io/wien-oepnv/feed.xml)
 - **Projekt-Website:** <https://origamihase.github.io/wien-oepnv/>
 - **JSON-Schema der Events:** [`docs/schema/events.schema.json`](docs/schema/events.schema.json)
-- **Feed-Health-Report:** [`docs/feed-health.md`](docs/feed-health.md) _(automatischer Report nach jedem Build)_
+- **Feed-Health-Report:** `docs/feed-health.md` _(wird lokal nach jedem Feed-Build erzeugt; nicht im Repository versioniert)_
 
 ### 💻 Für Entwickler & Mitwirkende
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,10 +13,11 @@ also expressed prose-first under each diagram.
 
 ## 1. The Transit Data Fetching Pipeline
 
-The headline workflow: a cron job (or GitHub Action) launches
-`python -m src.build_feed`, which orchestrates 4–5 transit-data
-providers in parallel, deduplicates the merged events, and writes a
-single RSS feed.
+The headline workflow: a cron job (or the `update-cycle.yml` GitHub
+Action) launches `python -m src.cli feed build` (which calls
+`build_feed.main()`), orchestrating 4–5 transit-data providers in
+parallel, deduplicating the merged events, and writing a single RSS
+feed.
 
 ```mermaid
 sequenceDiagram
@@ -365,28 +366,34 @@ The relevant CLI flags / env vars:
 
 ## 6. Statistics & Dashboard Pipeline
 
-Operational metrics live entirely outside the RSS pipeline. Two
-append-only CSV ledgers under `data/stats/` capture every relevant
-observation as it happens; a separate daily GitHub Actions job
-aggregates them into a static Markdown dashboard at
-`docs/statistik.md`. The hot-path build never blocks on
-observability I/O.
+Two append-only CSV ledgers under `data/stats/` capture every relevant
+observation as it happens. They serve **two consumers** with
+different windows: the daily Markdown dashboard
+(`docs/statistik.md`, 30-day window) and the RSS feed itself
+(Stammstrecke section, 1-hour window — see
+[`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md)).
+The hot-path build never blocks on observability I/O — both
+consumers tolerate missing or malformed rows gracefully.
 
 ```mermaid
 flowchart LR
     subgraph "Producers (every cron tick)"
-        SS[update_stammstrecke_status.py<br/><i>after median calc</i>]
+        SS[update_stammstrecke_status.py<br/><i>writes one row per direction</i>]
         BF[build_feed.main<br/><i>_update_item_state strict-new branch</i>]
     end
     subgraph "Append-only ledgers (data/stats/)"
         SCSV[stammstrecke_YYYY.csv<br/><i>timestamp, weekday, hour, direction, delay_minutes</i>]
         DCSV[stoerungen_YYYY.csv<br/><i>timestamp, weekday, hour, provider, location_name</i>]
     end
-    subgraph "Aggregator (daily 00:15 UTC)"
-        AGG[generate_markdown_stats.py<br/><i>stdlib only</i>]
+    subgraph "Daily aggregator (cron 15 0 * * *)"
+        AGG[generate_markdown_stats.py<br/><i>stdlib only, 30-day window</i>]
     end
-    subgraph "Output"
+    subgraph "Feed-build consumer"
+        FRP[src/feed/stammstrecke.py<br/><i>1-hour window, 9-min median trigger</i>]
+    end
+    subgraph "Outputs"
         MD[docs/statistik.md<br/><i>ASCII / Emoji bars</i>]
+        RSS[docs/feed.xml<br/><i>0..2 Stammstrecke items</i>]
     end
 
     SS -- append --> SCSV
@@ -394,13 +401,15 @@ flowchart LR
     SCSV --> AGG
     DCSV --> AGG
     AGG --> MD
+    SCSV --> FRP
+    FRP --> RSS
 ```
 
 ### Architectural goals
 
 | Goal | Embodied by |
 | --- | --- |
-| **CI/CD decoupling** — the daily aggregator job runs on its own cron, never blocks `build-feed.yml` | `.github/workflows/generate-stats.yml` (cron `15 0 * * *`, `concurrency: generate-stats-${{ github.ref }}`) |
+| **CI/CD decoupling** — the daily aggregator job runs on its own cron, never blocks `update-cycle.yml` | `.github/workflows/generate-stats.yml` (cron `15 0 * * *`, `concurrency: generate-stats-${{ github.ref }}`) |
 | **Strictly zero data-science dependencies** — no `numpy`, `pandas`, `matplotlib`; CI install stays sub-second | `scripts/generate_markdown_stats.py` imports only `csv`, `collections`, `datetime`, `statistics`, `pathlib`, `zoneinfo`, `argparse` |
 | **Append-only, lock-free producers** — single-line writes on POSIX are atomic below `PIPE_BUF` (4 KiB), so concurrent cron ticks cannot interleave bytes mid-line | `src/utils/stats.py:_append_row` (mode `"a"`, no `flock`) |
 | **Strict-new gating for disruptions** — long-lived events recorded once, not once per build | `src/build_feed.py:_update_item_state` records only on the *strict* state-cache miss (neither `_identity` nor `guid` had a prior entry) |
@@ -474,8 +483,8 @@ Tagesbudget:
 
 | Konsument | Default-Calls/Tag | Konfigurierbar |
 | :--- | ---: | :--- |
-| **Stammstrecke `/trip`** (`*/30` × 2 Richtungen) | 96 | `cron`-Plan in `build-feed.yml`, `MAX_TRIPS_PER_QUERY` |
-| **Station-Enrichment `location.name`** (monatlich, Stammstrecke-Whitelist) | ~10 (1× pro Monat) | `STAMMSTRECKE_VOR_IDS` in `scripts/update_vor_stations.py` |
+| **Stammstrecke `/trip`** (`0,30 * * * *` × 2 Richtungen) | 96 | `cron`-Plan in `update-cycle.yml` (bzw. `update-stammstrecke-status.yml`), `MAX_TRIPS_PER_QUERY` |
+| **Station-Enrichment `location.name`** (wöchentlich, Stammstrecke-Whitelist) | ~10 (1× pro Woche) | `STAMMSTRECKE_VOR_IDS` in `scripts/update_vor_stations.py` |
 | **Disruption-Polling `departureBoard`** | **0** (default) | `VOR_MONITOR_STATIONS_WHITELIST` env (default: leerer String) |
 | **Tagesbudget gesamt** | **96 / 100** | — |
 
@@ -498,15 +507,16 @@ Drei zusammenwirkende Mechanismen schützen das Budget:
    Tagesbudget reißen würde, raised `_QuotaExceeded` *vor* dem
    Network Call und schreibt einen leeren Cache.
 
-Die monatliche Burst durch das Stations-Enrichment fällt nur auf den
-1. eines Monats (Cron `0 1 1 * *`); selbst mit voller Stammstrecke-
-Aktivität an diesem Tag bleiben 4 Calls Puffer. Sollte das Budget in
-Zukunft enger werden, sind die niedrig-hängenden Hebel:
+Der Burst durch das Stations-Enrichment fällt nur auf den wöchentlichen
+Sonntag-Lauf (Cron `0 1 * * 0` in `.github/workflows/update-stations.yml`);
+selbst mit voller Stammstrecke-Aktivität an diesem Tag bleiben mindestens
+4 Calls Puffer. Sollte das Budget in Zukunft enger werden, sind die
+niedrig-hängenden Hebel:
 
-* Cron `*/30` → `*/60` (halbiert Stammstrecke auf 48 Calls/Tag).
-* `MAX_TRIPS_PER_QUERY = 5` → `3` (kein API-Effekt, da `numF` ein
+* Cron `0,30 * * * *` → `0 * * * *` (halbiert Stammstrecke auf 48 Calls/Tag).
+* `MAX_TRIPS_PER_QUERY = 6` → `3` (kein API-Effekt, da `numF` ein
   Server-side-Cap ist und VAO mehrere Trips pro Call erlaubt).
-* Operating-Hours-Cron (`0,30 4-23 * * *` statt `*/30 * * * *`) — die
+* Operating-Hours-Cron (`0,30 4-23 * * *` statt `0,30 * * * *`) — die
   Stammstrecke fährt zwischen 00:30 und 04:00 nur ausgedünnt, das
   Monitoring liefert dort kaum Signal.
 

--- a/docs/archive/audits/INDEX.md
+++ b/docs/archive/audits/INDEX.md
@@ -38,4 +38,5 @@ Chronologische Übersicht aller archivierten Audits dieses Projekts.
 Der periodisch regenerierte Validator-Report liegt nicht hier im Archiv,
 sondern direkt unter
 [`docs/stations_validation_report.md`](../../stations_validation_report.md)
-(wird vom monatlichen `update-stations.yml`-Workflow überschrieben).
+(wird vom wöchentlichen `update-stations.yml`-Workflow überschrieben,
+Cron `0 1 * * 0`).

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,6 +20,7 @@ in der [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 - [Nutzung als Datenquelle in Drittprojekten](#nutzung-als-datenquelle-in-drittprojekten)
 - [Stationsverzeichnis](#stationsverzeichnis)
 - [Automatisierte Workflows](#automatisierte-workflows)
+- [Skripte im Überblick](#skripte-im-überblick)
 - [Entwicklung & Qualitätssicherung](#entwicklung--qualitätssicherung)
 - [Developer Experience & Observability](#developer-experience--observability)
 - [Authentifizierung & Sicherheit](#authentifizierung--sicherheit)
@@ -40,7 +41,7 @@ in der [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 ## Systemüberblick
 
 > **🪶 Architektur-Karte für neue Mitwirkende:** Eine visuelle
-> Erklärung des Fetch-Pipelines, der `request_safe`-Sicherheitskette
+> Erklärung der Fetch-Pipeline, der `request_safe`-Sicherheitskette
 > und der Resilience-Schichten findet sich in
 > [`docs/architecture.md`](architecture.md) (mit Mermaid-Diagrammen).
 
@@ -67,10 +68,10 @@ Der Feed-Build folgt einem klaren Ablauf:
 | `data/`               | Stationsverzeichnis, GTFS-Testdaten und Hilfslisten (z. B. Pendler-Whitelist).                   |
 | `docs/`               | Audit-Berichte, Referenzen, Beispiel-Feeds und das offizielle VAO/VOR-API-Handbuch.              |
 | `.github/workflows/`  | Automatisierte Jobs für Cache-Updates, Stationspflege, Feed-Erzeugung und Tests.                |
-| `tests/`              | Umfangreiche Pytest-Suite (~1000 Tests) für Feed-Logik, Provider-Adapter und Utility-Funktionen.  |
+| `tests/`              | Umfangreiche Pytest-Suite (über 2000 Tests in ca. 390 Modulen) für Feed-Logik, Provider-Adapter und Utility-Funktionen. |
 
 
-> **Hinweis zu Cache-Pfaden:** Die tatsächlichen Verzeichnisse unter `cache/` tragen einen Hash-Suffix zur Cache-Versionierung (Stand Mai 2026: `cache/wl_9d709a/`, `cache/oebb_c40d21/`, `cache/vor_929f1c/`). In dieser Dokumentation werden aus Lesbarkeitsgründen verkürzte Schreibweisen wie `cache/wl/events.json` verwendet — sie verweisen jeweils auf das aktuelle Provider-Verzeichnis.
+> **Hinweis zu Cache-Pfaden:** Die tatsächlichen Verzeichnisse unter `cache/` tragen einen Hash-Suffix zur Cache-Versionierung (Stand Mai 2026: `cache/wl_9d709a/`, `cache/oebb_c40d21/`, `cache/vor_929f1c/`, `cache/baustellen_d438c3/`). In dieser Dokumentation werden aus Lesbarkeitsgründen verkürzte Schreibweisen wie `cache/wl/events.json` verwendet — sie verweisen jeweils auf das aktuelle Provider-Verzeichnis. Der **Stammstrecke-Monitor** persistiert nicht mehr in einer eigenen JSON-Cache-Datei; seit der 2026-05-09-Migration liest der Feed-Builder die Beobachtungen direkt aus dem CSV-Ledger `data/stats/stammstrecke_<YYYY>.csv` (siehe [`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md)).
 
 ## Installation & Setup
 
@@ -212,16 +213,16 @@ Der Meldungsfeed sammelt offizielle Störungs- und Hinweisinformationen der Wien
 - **Umsetzung**: Der Provider implementiert einen **strengen Geo-Filter** (`_is_relevant`):
   - Eine Meldung wird akzeptiert, wenn sie das Keyword "Wien"/"Vienna" oder einen expliziten Wiener Bahnhof enthält.
   - Meldungen, die *nur* Pendlerbahnhöfe (ohne Wien-Bezug) oder *nur* ferne Bahnhöfe erwähnen, werden verworfen.
-  - Dies stellt sicher, dass "Störungen im Bereich Mödling" ohne Wien-Bezug (z.B. Richtung Süden) nicht einfließen, solange keine Auswirkung auf die Wien-Verbindung explizit genannt ist (siehe [data/stations.json](../data/stations.json) für Definitionen von `in_vienna` und `pendler`).
+  - Dies stellt sicher, dass "Störungen im Bereich Mödling" ohne Wien-Bezug (z. B. Richtung Süden) nicht einfließen, solange keine Auswirkung auf die Wien-Verbindung explizit genannt ist (siehe [data/stations.json](../data/stations.json) für Definitionen von `in_vienna` und `pendler`).
 - **Quelle**: Offizielle ÖBB-Störungsinformationen.
 - **Cache**: `cache/oebb/events.json`.
 
 ### Verkehrsverbund Ost-Region (VOR)
 
-- **Anforderung**: Nur Abfragen für "Flughafen Wien" und "Hauptbahnhof Wien".
-- **Umsetzung**: Der Provider verwendet standardmäßig eine Whitelist (`VOR_MONITOR_STATIONS_WHITELIST`), die auf `"Wien Hauptbahnhof,Flughafen Wien"` voreingestellt ist.
-  - Dies minimiert API-Requests ("VAO Start" Kontingent) und fokussiert auf die zentralen Pendlerknoten.
-  - Weitere Stationen werden nur bei expliziter Konfiguration abgerufen.
+- **Anforderung**: VAO-Tagesbudget (100 Requests/Tag) wird primär durch den S-Bahn-Stammstrecken-Monitor verbraucht (96 Calls/Tag); zusätzliches Disruption-Polling ist daher standardmäßig deaktiviert.
+- **Umsetzung**: Die Monitor-Whitelist `VOR_MONITOR_STATIONS_WHITELIST` ist seit der 2026-05-09-Migration auf einen leeren String voreingestellt (`DEFAULT_MONITOR_WHITELIST = ""` in `src/providers/vor.py`), das `departureBoard`-Polling läuft also per Default nicht.
+  - Operatoren, die das Legacy-Verhalten brauchen (z. B. nur „Wien Hauptbahnhof,Flughafen Wien"), setzen die Variable explizit als Umgebungsvariable.
+  - Weitere Stationen werden nur bei expliziter Konfiguration abgerufen — und auch nur unter Berücksichtigung des Tagesbudgets.
 - **Quelle**: VOR/VAO-ReST-API, authentifiziert über Access Token.
 - **Cache**: `cache/vor/events.json`.
 
@@ -349,7 +350,7 @@ damit kurze Stellencodes wie `Sue`/`Su` distinkt bleiben).
 
 
 Die GitHub Action `.github/workflows/update-stations.yml` aktualisiert
-`data/stations.json` monatlich automatisch (Cron `0 1 1 * *`). Pipeline-Schritte:
+`data/stations.json` wöchentlich automatisch (Cron `0 1 * * 0`, Sonntag 01:00 UTC). Pipeline-Schritte:
 
 1. **VOR-Stop-Liste auffrischen** – `scripts/fetch_vor_haltestellen.py`
    holt die aktuelle Liste vom HAFAS-Endpoint `anachb.vor.at` und
@@ -392,7 +393,7 @@ no-space-Source-Format + Vienna/Pendler Mutual-Exclusivity).
 persistiert; mit `--fail-on-issues` bricht die CLI bei jedem Befund mit
 einem Fehlercode ab. In CI läuft der Validator als Pflicht-Gate (siehe
 `.github/workflows/test.yml`); zusätzlich regeneriert
-`update-stations.yml` den persistenten Report im monatlichen Daten-Refresh.
+`update-stations.yml` den persistenten Report im wöchentlichen Daten-Refresh.
 
 ### Pendler-Whitelist
 
@@ -426,19 +427,78 @@ Nachnutzung zu gewährleisten.
 
 Die wichtigsten GitHub Actions:
 
-- `update-wl-cache.yml`, `update-oebb-cache.yml`, `update-vor-cache.yml`, `update-baustellen-cache.yml` – füllen die Provider-Caches.
-- `update-stations.yml` – pflegt wöchentlich (Sonntag) `data/stations.json`. Die Anreicherungs-Hierarchie ist **OSM-first**: OpenStreetMap (Overpass API) liefert die primären Koordinaten, der vorgeschaltete Smoke-Test (`scripts/check_overpass_status.py`) bricht den OSM-Schritt aber kontrolliert ab, falls der Mirror down ist (siehe `docs/architecture.md` §5). Google Places ist nur als Fallback für Stationen ohne OSM-Koordinaten aktiv.
-- `update-google-places-stations.yml` – **manueller Eskapehatch** (nur `workflow_dispatch`); der reguläre OSM-first/Google-Fallback läuft als Teil von `update-stations.yml`.
-- `build-feed.yml` – die zentrale Cron-Pipeline (alle 30 Min): fragt zuerst den VAO-Median für die S-Bahn-Stammstrecke ab und appendet die Beobachtung an die CSV-Ledger unter `data/stats/`, baut anschließend `docs/feed.xml` aus allen Caches + der Stammstrecke-CSV (1-Stunden-Fenster, 9-Min-Threshold) und patcht zuletzt die `<!-- STATS:* -->`-Marker im README mit der 30-Tage-Statistik. Push-Trigger (`src/**` Code-Änderungen) bauen nur den Feed neu, ohne neue API-Abfrage.
-- `generate-stats.yml` – nightly Belt-and-Suspenders: regeneriert `docs/statistik.md` aus den CSV-Ledgers, falls eine 30-Min-Iteration ausgefallen ist.
+- `update-cycle.yml` – die zentrale Cron-Pipeline (Cron `0,30 * * * *`, alle 30 Minuten): einziger Job, der in einem Runner sequenziell die Provider-Cache-Fetcher (WL, ÖBB, Baustellen), den VAO-Pre-flight + die Stammstrecke-Abfrage, den Feed-Build (`docs/feed.xml`, `data/first_seen.json`, `data/stats/stoerungen_<YYYY>.csv`) sowie das README-/`docs/statistik.md`-Render ausführt und alles in einem Auto-Commit zusammenfasst. Hält die `external-api-fetch`-Concurrency-Lane, damit nie zwei API-Cycles parallel laufen.
+- `update-wl-cache.yml`, `update-oebb-cache.yml`, `update-vor-cache.yml`, `update-baustellen-cache.yml` – einzeln triggerbare Cache-Aktualisierungen (`workflow_dispatch`); die produktive Aktualisierung läuft im `update-cycle.yml`-Job.
+- `build-feed.yml` – Code-Change-Verifikationspfad. Der reguläre Cron wurde 2026-05-09 in `update-cycle.yml` migriert; dieser Workflow läuft nur noch auf `push` (für `src/**`, `requirements.txt`, `pyproject.toml`, `.github/workflows/build-feed.yml`) sowie auf `workflow_dispatch` und baut den Feed aus den vorhandenen Caches neu — ohne neue API-Abfrage.
+- `update-stations.yml` – pflegt wöchentlich (Sonntag 01:00 UTC, Cron `0 1 * * 0`) `data/stations.json`. Die Anreicherungs-Hierarchie ist **OSM-first**: OpenStreetMap (Overpass API) liefert die primären Koordinaten, der vorgeschaltete Smoke-Test (`scripts/check_overpass_status.py`) bricht den OSM-Schritt aber kontrolliert ab, falls der Mirror down ist (siehe `docs/architecture.md` §5). Google Places ist nur als Fallback für Stationen ohne OSM-Koordinaten aktiv.
+- `update-google-places-stations.yml` – **manueller Escape-Hatch** (nur `workflow_dispatch`); der reguläre OSM-first/Google-Fallback läuft als Teil von `update-stations.yml`.
+- `update-stammstrecke-status.yml` – fragt jede halbe Stunde die VOR/VAO `/trip`-API ab und schreibt die Beobachtung als CSV-Zeile in `data/stats/stammstrecke_<YYYY>.csv`. Wird parallel zur in `update-cycle.yml` integrierten Variante als unabhängiger Pfad gepflegt.
+- `generate-stats.yml` – nightly Belt-and-Suspenders (Cron `15 0 * * *`): regeneriert `docs/statistik.md` aus den CSV-Ledgers, falls eine 30-Min-Iteration ausgefallen ist.
+- `manual-full-refresh.yml` – `workflow_dispatch`-only-Komplettlauf für Disaster-Recovery (führt alle Cache-Fetcher + Feed-Build hintereinander aus).
 - `test.yml` & `test-vor-api.yml` – führen die vollständige Test-Suite bzw. VOR-spezifische Integrationstests aus; `test.yml` läuft bei jedem Push sowie Pull Request und stellt die kontinuierliche Testabdeckung sicher.
-- `mypy-strict.yml`, `bandit.yml`, `codeql.yml`, `seo-guard.yml` – ergänzende Qualitäts-Gates (strikte Typprüfung, Security-Lint, CodeQL-Scan, SEO/Sitemap-Pflege).
+- `mypy-strict.yml`, `bandit.yml`, `codeql.yml`, `complexity-gate.yml`, `seo-guard.yml` – ergänzende Qualitäts-Gates (strikte Typprüfung, Security-Lint, CodeQL-Scan, Komplexitäts-Baseline, SEO/Sitemap-Pflege).
 
-Cache-Update-Workflows committen ihre Ergebnisse in den Branch; der Feed-Build liest beim nächsten Lauf den jeweils aktuellen Stand. Eine direkte `needs:`-Abhängigkeit zwischen Workflows ist in GitHub Actions nicht vorgesehen — bei zeitkritischer Konsistenz lässt sich stattdessen ein `workflow_run`-Trigger ergänzen.
+Der `update-cycle.yml`-Job committet alle Cache-, Feed- und Statistik-Outputs in einem einzigen Commit; ein direkter `needs:`-Trigger zwischen Workflows ist damit unnötig. Andere Cache-Update-Workflows (`update-*-cache.yml`) committen ihre Ergebnisse einzeln und werden vom nächsten Cycle-Lauf eingelesen.
+
+## Skripte im Überblick
+
+Der Ordner `scripts/` versammelt alle Wartungs- und Hilfsskripte. Die
+meisten werden auch über die einheitliche CLI (`python -m src.cli …`)
+gekapselt; ein Direktaufruf bleibt jedoch sinnvoll, wenn Sondermodi
+benötigt werden (z. B. `--no-download` für die WL-OGD-CSVs).
+
+### Provider-Caches & Feed-Daten
+
+| Skript | Aufgabe |
+| --- | --- |
+| `update_wl_cache.py` | Liest die Realtime-Störungen der Wiener Linien und schreibt `cache/wl/events.json`. CLI: `python -m src.cli cache update wl`. |
+| `update_oebb_cache.py` | Holt die ÖBB-Störungs-RSS-Feeds, filtert sie strikt auf Wien-Bezug (`_is_relevant`) und persistiert sie. CLI: `python -m src.cli cache update oebb`. |
+| `update_vor_cache.py` | Aktualisiert den VOR-Cache (`cache/vor/events.json`) inklusive `last_run.json`. CLI: `python -m src.cli cache update vor`. |
+| `update_baustellen_cache.py` | Lädt den Baustellen-Layer der Stadt Wien (oder den `data/samples/baustellen_sample.geojson`-Fallback) und legt Events ab. CLI: `python -m src.cli cache update baustellen`. |
+| `update_stammstrecke_status.py` | Cron-Producer für den S-Bahn-Stammstrecke-Monitor. Schreibt eine Beobachtungs-Zeile pro Lauf und Richtung in `data/stats/stammstrecke_<YYYY>.csv` (siehe [Reference](reference/stammstrecke_provider_logic.md)). |
+| `generate_markdown_stats.py` | Aggregiert die CSV-Ledger zu `docs/statistik.md` (30-Tage-Fenster) und patcht die `<!-- STATS:* -->`-Marker im README. |
+
+### Stationsverzeichnis
+
+| Skript | Aufgabe |
+| --- | --- |
+| `update_all_stations.py` | Wrapper für den vollständigen Stationsverzeichnis-Refresh; ruft die folgenden Sub-Skripte gegen ein Temp-File auf und committet erst nach erfolgreicher Validierung. CLI: `python -m src.cli stations update all`. |
+| `update_station_directory.py` | Lädt das ÖBB-Excel und ergänzt OSM-/Google-Places-Koordinaten (OSM-First, siehe `docs/architecture.md` §5). |
+| `update_vor_stations.py` | Importiert VOR-Daten aus CSV oder API; live-Anreicherung via `location.name` ist auf `STAMMSTRECKE_VOR_IDS` begrenzt. |
+| `update_wl_stations.py` | Lädt `wienerlinien-ogd-haltestellen.csv` und `wienerlinien-ogd-haltepunkte.csv` von `data.wien.gv.at`. Mit `--no-download` werden die lokal gepinnten CSVs verwendet. |
+| `enrich_station_aliases.py` | Sucht alternative Schreibweisen pro Station und schreibt sie ins Verzeichnis. |
+| `fetch_vor_haltestellen.py` | Holt die aktuelle Liste vom HAFAS-Endpoint `anachb.vor.at` und überschreibt `data/vor-haltestellen.csv`. |
+| `fetch_google_places_stations.py` | Optionaler Sekundär-Fallback (manueller Workflow `update-google-places-stations.yml`); nutzt das Quota-Stateful-Modul aus `src/places/`. |
+| `validate_stations.py` | CLI-Front-end für `src.utils.stations_validation`; das gleiche Verhalten ist via `python -m src.cli stations validate` erreichbar. |
+| `validate_vor_mapping.py` | Prüft `data/vor-haltestellen.mapping.json` auf duplikate IDs und Format-Drift. |
+
+### Auth- & Diagnose-Helfer
+
+| Skript | Aufgabe |
+| --- | --- |
+| `verify_vor_access_id.py` | Smoke-Test für `VOR_ACCESS_ID` und `VOR_BASE_URL`. CLI: `python -m src.cli tokens verify vor`. |
+| `verify_google_places_access.py` | Health-Check der Google-Places-Schlüssel (deckt FieldMask-/PERMISSION_DENIED-Fälle auf). CLI: `python -m src.cli tokens verify google-places`. |
+| `check_vor_auth.py` | Prüft den vollständigen Auth-Pfad (`VorAuth`) inklusive Header. CLI: `python -m src.cli tokens verify vor-auth`. |
+| `check_overpass_status.py` | OSM-Mirror-Smoke-Test mit `out count`-Query; setzt `WIEN_OEPNV_OSM_ENRICH=0` im CI, falls der Mirror down ist. |
+| `preflight_quota_check.py` | Hard-Gate für `update-cycle.yml`: bricht **vor** jeder API-Anfrage ab, wenn das persistierte Tagesbudget bereits ausgeschöpft ist. Stdlib-only, eigene Exit-Codes. |
+| `scan_secrets.py` | Repository-Scan via `src.utils.secret_scanner`. CLI: `python -m src.cli security scan`. |
+| `configure_feed.py` | Interaktiver Konfigurations-Assistent (schreibt `.env`). CLI: `python -m src.cli config wizard`. |
+| `scaffold_provider_plugin.py` | Erzeugt ein lauffähiges Provider-Plugin-Skelett (`register_providers`-Hook); siehe [How-to](how-to/provider_plugins.md). |
+
+### Statische Analyse & Build-Hygiene
+
+| Skript | Aufgabe |
+| --- | --- |
+| `run_static_checks.py` | Dispatcher für `ruff check`, `mypy --strict`, `pip-audit` und den Secret-Scanner; CI-äquivalent. CLI: `python -m src.cli checks`. |
+| `check_complexity.py` | C901-Komplexitäts-Gate (Threshold 15, Allowlist `.c901-baseline.txt`). |
+| `regen_c901_baseline.sh` | Regeneriert die Baseline nach gezielten Refactors; lokal ausführen, Diff committen. |
+| `regen_mypy_baseline.sh` | Regeneriert `.mypy-baseline.txt` (gleiche Mechanik wie c901). |
+| `generate_sitemap.py` | Generiert `docs/sitemap.xml` und `docs/feed.xml`-Hinweise; läuft im `seo-guard.yml`-Workflow. |
+| `gtfs.py` | GTFS-Hilfsmodul (`read_gtfs_stops`); wird von Tests und vom Stations-Validator konsumiert. |
 
 ## Entwicklung & Qualitätssicherung
 
-- **Tests**: `python -m pytest` führt rund 1000 Unit- und Integrationstests aus (`tests/`).
+- **Tests**: `python -m pytest` führt über 2000 Unit- und Integrationstests in rund 390 Modulen unter `tests/` aus.
 - **Kontinuierliche Tests**: Die GitHub Action `test.yml` automatisiert die im Audit empfohlene regelmäßige Testausführung und bricht Builds bei fehlschlagender Test-Suite ab.
 - **Statische Analyse & Typprüfung**: `ruff check` (Stil/Konsistenz, Regelgruppen `E`, `F`, `S`, `B`) und `mypy --strict` (vollständige Typabdeckung über `src/` und `tests/`, derzeit 0 Errors) laufen identisch zur CI via `python -m src.cli checks`. Optional lassen sich über `--fix` Ruff-Autofixes aktivieren oder zusätzliche Argumente an Ruff durchreichen. Ein zusätzlicher `mypy-strict.yml`-Workflow setzt das Allowlist-Gate auf Pull Requests durch.
 - **Pre-Commit-Hooks**: `.pre-commit-config.yaml` aktiviert lokale Checks (Ruff, mypy, Secret-Scan, Whitespace-Hygiene) bei jedem `git commit`. Einmalig nach dem Klonen `pre-commit install` ausführen — Details in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/how-to/provider_plugins.md
+++ b/docs/how-to/provider_plugins.md
@@ -53,7 +53,9 @@ python -m src.cli feed build
 ```
 
 Während des Builds erscheinen der Providerstatus und mögliche Warnungen im
-Feed-Health-Report (`docs/feed-health.md`).
+Feed-Health-Report. Dieser wird lokal nach jedem Lauf unter
+`docs/feed-health.md` (Markdown) und `docs/feed-health.json` (JSON)
+abgelegt; beide Dateien sind **nicht** im Repository versioniert.
 
 ## 4. Tests
 

--- a/docs/how-to/test-api-secrets.md
+++ b/docs/how-to/test-api-secrets.md
@@ -82,7 +82,7 @@ gh run watch
 
 Der Workflow führt `curl`-Abfragen sowie die vollständige Test-Suite (`pytest`) aus.
 
-*   **Smoke test VOR endpoint**: Prüft, ob ein einfacher Abruf (z.B. nach "Wien Hauptbahnhof") mit den hinterlegten Secrets einen HTTP 200 Status liefert.
+*   **Smoke test VOR endpoint**: Prüft, ob ein einfacher Abruf (z. B. nach "Wien Hauptbahnhof") mit den hinterlegten Secrets einen HTTP 200 Status liefert.
 *   **Run pytest**: Validiert die gesamte Integrationslogik.
 
 Schlägt der "Smoke test" fehl, sind meist die Secrets ungültig oder abgelaufen.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ Der gesamte Code steht als Open Source zur Verfügung, sodass du jederzeit nachv
 1. **Repository klonen** und ein virtuelles Environment anlegen (`python -m venv .venv`).
 2. **Abhängigkeiten installieren** mit `pip install -r requirements.txt`.
 3. **Caches aktualisieren** via `python -m src.cli cache update`.
-4. **Feed bauen** mit `python -m src.cli feed build`, um `docs/feed.xml` zu generieren (anschließend steht der Gesundheitsbericht unter `docs/feed-health.md` bereit).
+4. **Feed bauen** mit `python -m src.cli feed build`, um `docs/feed.xml` zu generieren (anschließend steht der Gesundheitsbericht lokal unter `docs/feed-health.md` bereit – die Datei ist nicht im Repository versioniert).
 5. **Qualitätscheck** vor dem nächsten Build optional mit `python -m src.cli feed lint` durchführen.
 6. **Statische Analysen** optional mit `scripts/run_static_checks.py` ausführen.
 
@@ -37,7 +37,7 @@ Weitere Details findest du in der [ausführlichen Projektdokumentation](../READM
 |-------------|--------|----------------|
 | Wiener Linien (WL) | Störungs- und Echtzeitmeldungen für U-Bahn, Straßenbahn und Bus | Mehrmals täglich |
 | ÖBB | Informationen zum regionalen und nationalen Bahnverkehr im Großraum Wien | Nach Fahrplanänderungen und Ereignissen |
-| Verkehrsverbund Ost-Region (VOR) | Verbundweite Meldungen und VAO/VAO-API-Dokumentation | Kontinuierlich |
+| Verkehrsverbund Ost-Region (VOR) | Verbundweite Meldungen und VOR/VAO-API-Dokumentation | Kontinuierlich |
 | Stadt Wien (OGD) | Baustellen- und Ereignisdaten als Fallback | Täglich |
 
 Alle Datenquellen werden revisionssicher versioniert, inklusive Lizenzhinweisen. Informiere dich vor der Weiterverwendung über die jeweiligen Nutzungsbedingungen.
@@ -81,7 +81,7 @@ Der Code steht unter der MIT-Lizenz. Prüfe bei externen Datenquellen die indivi
 
 - [Projektübersicht im README](../README.md)
 - [API-Referenzen und Audits](reference/)
-- [Feed Health Report](feed-health.md)
+- Feed-Health-Report: `docs/feed-health.md` (lokal nach jedem Build erzeugt)
 - [Eventschema für Integrationen](schema/events.schema.json)
 - [Feed als RSS-Dokument](feed.xml)
 

--- a/docs/performance_monitoring_plan.md
+++ b/docs/performance_monitoring_plan.md
@@ -1,64 +1,91 @@
-# Performance- & Monitoring-Konzept für den Wien ÖPNV Feed
+# Performance- & Monitoring-Konzept (Vorschlag)
 
-Dieses Dokument beschreibt die Ergänzungen, mit denen das Projekt um
-regelmäßige Performance-Analysen und Monitoring-Dashboards erweitert
-wurde. Ziel ist es, Auffälligkeiten bei Latenzen oder Feed-Generierung
-frühzeitig zu erkennen und datenbasiert zu optimieren.
+> ⚠️ **Status: Konzeptpapier / Roadmap.** Dieses Dokument skizziert
+> einen vorgeschlagenen Ausbau der Performance-Telemetrie für den
+> Wien ÖPNV Feed. Die hier genannten Artefakte
+> (`log/performance-metrics.jsonl`, `log/performance-warnings.log`,
+> ein `make profile-feed`-Target, ein eigenes `docs/how-to/profiling.md`)
+> sind **noch nicht implementiert** und dürfen nicht als beschriebene
+> Features verwechselt werden. Der aktuelle Beobachtbarkeits-Stack
+> beschränkt sich auf:
+>
+> * `log/errors.log` und `log/diagnostics.log` (rotierende Textlogs;
+>   konfigurierbar über `LOG_DIR`, `LOG_MAX_BYTES`, `LOG_BACKUP_COUNT`,
+>   `LOG_FORMAT`),
+> * `docs/feed-health.md` (Markdown-Bericht nach jedem Feed-Build,
+>   lokal, **nicht** committed) und
+> * die statistischen CSV-Ledger unter `data/stats/`, aus denen
+>   `scripts/generate_markdown_stats.py` täglich `docs/statistik.md`
+>   regeneriert.
+>
+> Bevor weitere Performance-Features implementiert werden, sollte
+> dieses Dokument vom Hauptprojekt aktualisiert oder durch eine
+> realisierte Variante ersetzt werden.
 
-## 1. Metrik-Erfassung
+Ziel des Konzepts: Auffälligkeiten bei Latenzen oder Feed-
+Generierung frühzeitig erkennen und datenbasiert optimieren.
 
-- **Feed-Laufzeiten**: Jeder Aufruf von `build_feed.py` protokolliert die
-  Gesamtdauer sowie Zeiten der Provider-Abschnitte in einer neuen
-  Metrik-Datei `log/performance-metrics.jsonl`. Die Datei verwendet
-  JSON-Lines, damit sie leicht ingestiert werden kann.
-- **Provider-Sicht**: Zusätzlich zu den bisherigen Warn-Logs werden die
-  Wartezeiten einzelner API-Anfragen erfasst. Daraus lässt sich erkennen,
-  ob Timeouts oder Retries zunehmen.
-- **Cache-Trefferquote**: Die `cache`-Utilities loggen, ob Datensätze aus
-  dem Cache oder von der Quelle stammen. Dadurch bleibt sichtbar, wie gut
-  die konfigurierten Cache-Laufzeiten greifen.
+## 1. Geplante Metrik-Erfassung
 
-## 2. Alarmierung
+- **Feed-Laufzeiten**: Jeder Aufruf von `python -m src.cli feed build`
+  protokolliert die Gesamtdauer sowie Zeiten der Provider-Abschnitte
+  in einer geplanten Metrik-Datei `log/performance-metrics.jsonl`. Die
+  Datei verwendet JSON-Lines, damit sie leicht ingestiert werden kann.
+- **Provider-Sicht**: Zusätzlich zu den bisherigen Warn-Logs sollen
+  die Wartezeiten einzelner API-Anfragen erfasst werden. Daraus
+  ließe sich erkennen, ob Timeouts oder Retries zunehmen.
+- **Cache-Trefferquote**: Die `cache`-Utilities sollen loggen, ob
+  Datensätze aus dem Cache oder von der Quelle stammen. Dadurch
+  bliebe sichtbar, wie gut die konfigurierten Cache-Laufzeiten
+  greifen.
 
-- **Warnschwellen**: Überschreiten die Feed-Laufzeiten einen konfigurier-
-  baren Schwellenwert (`FEED_RUN_WARN_THRESHOLD`), wird ein dedizierter
-  Log-Eintrag unter `log/performance-warnings.log` erzeugt. Dieser kann
-  von gängigen Log-Monitoring-Lösungen (z. B. Loki, ELK) verarbeitet
-  werden.
-- **Hook-System**: Für kritische Abweichungen lässt sich ein eigener
-  Callback registrieren (`PERFORMANCE_ALERT_HOOK`). Sobald die Laufzeit
-  den definierten Höchstwert überschreitet, ruft die Anwendung den Hook
-  auf (z. B. zur Versendung eines Webhooks oder einer ChatOps-Nachricht).
+## 2. Geplante Alarmierung
 
-## 3. Dashboards
+- **Warnschwellen**: Überschreiten die Feed-Laufzeiten einen
+  konfigurierbaren Schwellenwert (`FEED_RUN_WARN_THRESHOLD`), würde
+  ein dedizierter Log-Eintrag unter `log/performance-warnings.log`
+  erzeugt. Dieser könnte von gängigen Log-Monitoring-Lösungen
+  (z. B. Loki, ELK) verarbeitet werden.
+- **Hook-System**: Für kritische Abweichungen sollte sich ein eigener
+  Callback registrieren lassen (`PERFORMANCE_ALERT_HOOK`). Sobald die
+  Laufzeit den definierten Höchstwert überschritte, ruft die
+  Anwendung den Hook auf (z. B. zur Versendung eines Webhooks oder
+  einer ChatOps-Nachricht).
 
-- **Zeitreihen**: Aus den JSON-Lines lassen sich Dashboards in Grafana
-  oder einer ähnlichen Lösung aufbauen. Empfohlene Panels: Feed-Gesamt-
-  dauer, Provider-Dauern, Anzahl der Cache-Treffer, Anzahl der Warnungen.
-- **Fehlerverfolgung**: In `log/errors.log` erfasste Fehler lassen sich
-  mit den Performance-Kurven kombinieren, um Korrelationen zwischen
-  Ausfällen und Latenzspitzen zu finden.
+## 3. Geplante Dashboards
 
-## 4. Profiling-Workflows
+- **Zeitreihen**: Aus den JSON-Lines ließen sich Dashboards in
+  Grafana oder einer ähnlichen Lösung aufbauen. Empfohlene Panels:
+  Feed-Gesamt­dauer, Provider-Dauern, Anzahl der Cache-Treffer,
+  Anzahl der Warnungen.
+- **Fehlerverfolgung**: In `log/errors.log` erfasste Fehler ließen
+  sich mit den Performance-Kurven kombinieren, um Korrelationen
+  zwischen Ausfällen und Latenzspitzen zu finden.
 
-- **Lokale Analysen**: Für tiefergehende Profiling-Sessions steht ein
-  Makefile-Target `make profile-feed` zur Verfügung, das `python -m
-  cProfile` mit aussagekräftigen Parametern ausführt und die Auswertung
-  in `log/profile/latest.pstat` ablegt.
-- **Vergleichsläufe**: Die Ergebnisse können mit `snakeviz` oder `pyprof2calltree`
-  visualisiert werden. Eine Anleitung zum Aufruf befindet sich in
-  `docs/how-to/profiling.md`.
+## 4. Geplante Profiling-Workflows
 
-## 5. Betriebliches Vorgehen
+- **Lokale Analysen**: Für tiefergehende Profiling-Sessions soll
+  ein Makefile-Target `make profile-feed` zur Verfügung stehen,
+  das `python -m cProfile` mit aussagekräftigen Parametern ausführt
+  und die Auswertung in `log/profile/latest.pstat` ablegt.
+- **Vergleichsläufe**: Die Ergebnisse sollen mit `snakeviz` oder
+  `pyprof2calltree` visualisiert werden. Eine separate Anleitung
+  (geplant: `docs/how-to/profiling.md`) würde die Aufrufe
+  beschreiben.
 
-1. **Regelmäßige Überprüfung**: Performance-Dashboards täglich prüfen und
-   Warnungen automatisieren.
-2. **Incident-Response**: Bei Alarmen zunächst die betroffenen Provider
-   prüfen. Erhöhte Latenzen werden in der JSONL-Datei mit konkretem
-   Zeitstempel dokumentiert.
+## 5. Betriebliches Vorgehen (Zielzustand)
+
+1. **Regelmäßige Überprüfung**: Performance-Dashboards täglich
+   prüfen und Warnungen automatisieren.
+2. **Incident-Response**: Bei Alarmen zunächst die betroffenen
+   Provider prüfen. Erhöhte Latenzen würden in der JSONL-Datei mit
+   konkretem Zeitstempel dokumentiert.
 3. **Kontinuierliche Anpassung**: Schwellenwerte und Cache-Strategie
    mindestens vierteljährlich evaluieren und bei Bedarf anpassen.
 
-Mit diesen Ergänzungen existiert nun ein belastbares Fundament, um die
+Mit diesem Ausbau entstünde ein belastbares Fundament, um die
 Feed-Erzeugung nicht nur funktional, sondern auch hinsichtlich
 Performance und Zuverlässigkeit kontinuierlich zu überwachen.
+Bis zur Umsetzung sind die unter `log/`, `docs/feed-health.md`
+und `data/stats/` verfügbaren Artefakte die Basis für
+Performance-Untersuchungen.

--- a/docs/reference/oebb_provider_logic.md
+++ b/docs/reference/oebb_provider_logic.md
@@ -4,9 +4,9 @@
 Der ÖBB Provider hat die Aufgabe, Störungsmeldungen des österreichischen Zugverkehrs (ÖBB) abzurufen und sie einer strengen Filterung zu unterziehen. Ziel ist es, ausschließlich Meldungen in den Feed aufzunehmen, die einen **strikten Wien-Bezug** aufweisen oder für Pendler in und um Wien relevant sind. Irrelevante Meldungen aus dem reinen Fern- oder Auslandsverkehr werden frühzeitig verworfen.
 
 ## Die Herausforderung der ÖBB-Rohdaten
-Die von der ÖBB bereitgestellten RSS-Feeds weisen oft komplexe, mutierte Titel auf, die sowohl Kategorien, Liniencodes als auch Streckenabschnitte vermischen (z.B. `"REX 51: Störung: Wien Hbf ↔ Wr. Neustadt"`).
+Die von der ÖBB bereitgestellten RSS-Feeds weisen oft komplexe, mutierte Titel auf, die sowohl Kategorien, Liniencodes als auch Streckenabschnitte vermischen (z. B. `"REX 51: Störung: Wien Hbf ↔ Wr. Neustadt"`).
 
-Ein simples Splitten (z.B. beim ersten oder letzten Doppelpunkt) ist unzureichend und fehleranfällig, da echte Stationsnamen selbst Doppelpunkte enthalten können (wie etwa `"Wien 10.: Favoriten"`). Ein naiver Split würde diese gültigen Stationsnamen zerstören.
+Ein simples Splitten (z. B. beim ersten oder letzten Doppelpunkt) ist unzureichend und fehleranfällig, da echte Stationsnamen selbst Doppelpunkte enthalten können (wie etwa `"Wien 10.: Favoriten"`). Ein naiver Split würde diese gültigen Stationsnamen zerstören.
 
 Daher erfolgt das Parsing der Präfixe **iterativ**. In einer `while`-Schleife wird mittels regulärer Ausdrücke jeweils von vorne geprüft, ob der Anfang des Textes ein bekanntes Präfix (wie `"Störung:"` oder `"REX 51:"`) ist. Ist das der Fall, wird es abgeschnitten und die Prüfung wiederholt, bis kein bekanntes Präfix mehr gefunden wird. Dadurch bleiben reguläre Bestandteile des Titels, die Doppelpunkte enthalten, geschützt.
 
@@ -17,7 +17,7 @@ Die folgende Matrix veranschaulicht, wann eine Verbindung als "Wien-relevant" ei
 
 | Endpunkt 1 (A) | Endpunkt 2 (B) | Ergebnis | Begründung / Bedingung |
 | :--- | :--- | :--- | :--- |
-| **Unbekannt** | **Unbekannt** | ❌ **Verworfen** | Komplett unbekannte Strecke, typischerweise reiner Fern-/Auslandsverkehr (z.B. Budapest ↔ Bratislava). |
+| **Unbekannt** | **Unbekannt** | ❌ **Verworfen** | Komplett unbekannte Strecke, typischerweise reiner Fern-/Auslandsverkehr (z. B. Budapest ↔ Bratislava). |
 | **Wien** | **Wien** | ✅ **Behalten** | Innerstädtische Verbindung. |
 | **Wien** | **Pendlerbahnhof** | ✅ **Behalten** | Relevante Pendelstrecke. |
 | **Wien** | **Unbekannt** | ✅ **Behalten** | Mindestens ein Endpunkt ist bekannt und liegt in Wien. |

--- a/docs/reference/stammstrecke_provider_logic.md
+++ b/docs/reference/stammstrecke_provider_logic.md
@@ -1,15 +1,23 @@
-# S-Bahn Stammstrecke Provider Logic (`scripts/update_stammstrecke_status.py`)
+# S-Bahn Stammstrecke Provider Logic
 
-## Zweck des Monitors
+Das Stammstrecken-Verspätungs-Monitoring überwacht die zentrale
+Pendlerachse Wien Floridsdorf ↔ Wien Meidling auf signifikante
+Verspätungen und emittiert daraus dynamisch Feed-Events. Die Logik
+verteilt sich auf zwei Module:
 
-Das Stammstrecken-Verspätungs-Monitoring läuft alle 30 Minuten als
-erster API-Schritt in `.github/workflows/build-feed.yml` (vor der
-eigentlichen Feed-Render-Phase) und beobachtet unabhängig vom
-RSS-basierten ÖBB-Provider die zwei Hauptachsen der Wiener
-S-Bahn-Stammstrecke. Bei Median-Verspätungen über
-`DELAY_THRESHOLD_MINUTES` Minuten emittiert der Monitor schema-konforme
-Events nach `cache/stammstrecke/events.json`, die der Feed-Builder
-beim nächsten Lauf in den RSS-Feed übernimmt.
+| Komponente | Verantwortlichkeit |
+| :--- | :--- |
+| `scripts/update_stammstrecke_status.py` | Cron-Producer: fragt alle 30 Min die VOR/VAO `/trip`-API ab und hängt eine Beobachtungs-Zeile an `data/stats/stammstrecke_<YYYY>.csv` (CSV-Ledger). |
+| `src/feed/stammstrecke.py` | Feed-Renderer: liest die zuletzt geschriebenen Zeilen, bestimmt für jede Richtung über ein 1-Stunden-Fenster den Median der Verspätung und erzeugt — ggf. — einen schema-konformen FeedItem. |
+
+Diese Trennung wurde am 2026-05-09 eingeführt (zuvor schrieb der
+Cron-Job direkt in `cache/stammstrecke/events.json`). Sie hat zwei
+Vorteile: (a) das CSV-Ledger ist die einzige Quelle der Wahrheit
+sowohl für den RSS-Feed (1-Stunden-Fenster) als auch für das
+30-Tage-Dashboard in `docs/statistik.md`; (b) die Schwellen-Logik
+lebt jetzt im Feed-Builder und wird für jeden Build neu ausgewertet —
+ein nachträglich angepasster Threshold wirkt sofort, ohne dass der
+Cron-Job neu laufen muss.
 
 ## Migration: pyhafas → VOR/VAO ReST API (2026-05-09)
 
@@ -23,26 +31,33 @@ auf die im Projekt bereits etablierte VOR/VAO-Infrastruktur portiert
 — gleicher authentifizierter Session-Stack, gleicher Quota-Counter,
 gleicher `fetch_content_safe`-HTTP-Layer wie die Disruption-Provider.
 
-## Datenquelle und Abfrage
+Im selben Schritt wurde das alte JSON-Cache-Layout entsorgt: der Cron-
+Job schreibt nur noch eine **Beobachtungs-Zeile** pro Lauf und
+Richtung in das CSV-Ledger; die Threshold- und First-Seen-Logik
+wurde nach `src/feed/stammstrecke.py` verschoben und arbeitet zur
+Build-Zeit auf den Ledger-Zeilen.
+
+## Cron-Producer (`scripts/update_stammstrecke_status.py`)
+
+### Datenquelle und Abfrage
 
 | Aspekt | Wert |
 | :--- | :--- |
 | Endpoint | `${VOR_BASE_URL}trip` (offizielle VOR/VAO ReST API) |
-| Library | direkter `requests`-Aufruf via `src.utils.http.fetch_content_safe` |
+| HTTP-Layer | `src.utils.http.fetch_content_safe` (SSRF-Guard, Slowloris-Cap, MAX_PAYLOAD_SIZE) |
 | Auth | `accessId` als Query-Parameter via `vor_provider.VorAuth` |
 | Richtung 1 | Wien Floridsdorf (`490033400`) → Wien Meidling (`490101500`) |
 | Richtung 2 | Wien Meidling (`490101500`) → Wien Floridsdorf (`490033400`) |
 | `maxChange` | `0` (nur direkte S-Bahn-Verbindungen) |
-| `numF` | `5` (die unmittelbar nächsten 5 S-Bahnen je Richtung — VAO-Limit `numF ≤ 6`) |
+| `numF` | `6` (`MAX_TRIPS_PER_QUERY`, VAO-Cap; eine möglichst große Median-Stichprobe pro Richtung) |
 | `rtMode` | `SERVER_DEFAULT` (Echtzeitdaten aktivieren) |
-| Cron | `*/30 * * * *` (alle 30 Minuten) |
+| Cron | `0,30 * * * *` (alle 30 Minuten, läuft als Schritt im `update-cycle.yml` sowie eigenständig in `update-stammstrecke-status.yml`) |
 
 **Beide Richtungen werden strikt getrennt ausgewertet.** Eine
 Zusammenlegung würde die Daten verfälschen — eine Störung in eine
-Richtung läuft häufig in der Gegenrichtung normal weiter, der Median
-über beide Richtungen würde das Signal verdünnen.
+Richtung läuft häufig in der Gegenrichtung normal weiter.
 
-## Filter und Aggregation (pro Richtung)
+### Filter und Aggregation pro Richtung
 
 Aus den zurückgegebenen `Trip`-Objekten werden alle Trips ausgewählt,
 die genau **einen Ride-Leg** enthalten (Walk-Vor-/Nachläufe sind
@@ -73,110 +88,26 @@ separat für jede Richtung:
 * Pures `0`-Delay aus tatsächlich verspätungsfreien Fahrten zählt
   vollwertig.
 
-## Schwellenwert und Cache-Schreibverhalten
+Der berechnete Median pro Richtung wird als eine Zeile an
+`data/stats/stammstrecke_<YYYY>.csv` angehängt (Spalten:
+`timestamp, weekday, hour, direction, delay_minutes`, ISO 8601
+`Europe/Vienna`). **Es werden keine Schwellenwerte oder Events mehr
+direkt vom Cron-Skript erzeugt** — die Render-Phase arbeitet
+ausschließlich auf den Ledger-Zeilen.
 
-Liegt der Median für eine Richtung **strikt über 9 Minuten**, wird
-genau ein schema-konformes Event (`docs/schema/events.schema.json`)
-für diese Richtung erzeugt. Pro Cron-Tick entsteht damit eine Liste
-mit `0`, `1` oder `2` Events in `cache/stammstrecke/events.json` —
-abhängig davon, in welcher Richtung der Schwellenwert überschritten
-wurde:
-
-```json
-[
-  {
-    "source": "ÖBB",
-    "category": "Störung",
-    "title": "S-Bahn Stammstrecke Verspätungen",
-    "description": "Durchschnittliche Verspätung von 12.5 Minuten in Richtung Meidling [Seit 09.05.2026]",
-    "link": "https://www.oebb.at/de/fahrplan/…/aktuelle-stoerungsmeldungen",
-    "guid": "<sha256(stammstrecke_delay_meidling|<iso-first-seen>)>",
-    "pubDate": "2026-05-09T08:30:00+02:00",
-    "starts_at": "2026-05-09T08:30:00+02:00",
-    "ends_at": null,
-    "first_seen": "2026-05-09T08:30:00+02:00",
-    "_identity": "stammstrecke_delay_meidling|<iso-first-seen>"
-  }
-]
-```
-
-Die richtungsspezifischen `guid`- und `_identity`-Werte stellen
-sicher, dass Feed-Reader die beiden Meldungen als **separate**
-Notifications anzeigen.
-
-> **Hinweis zur Konsistenz:** Das Event-Feld `source` bleibt
-> bewusst auf `"ÖBB"`, weil Feed-Reader-Subscribers den Wechsel der
-> Datenquelle nicht bemerken sollen. Die VOR-API ist intern, die
-> Stammstrecke selbst betreibt die ÖBB.
-
-### first_seen-Persistenz und Episoden-stabile GUIDs
-
-Beim Aufbau der Events liest das Skript den vorhandenen Cache und
-extrahiert pro Richtung den `first_seen`-Zeitstempel. Solange die
-Verspätungs-Episode anhält (jeder Cron-Tick beobachtet wieder
-Median > 9), wird `first_seen` (und damit `guid` und das
-`Seit DD.MM.YYYY`-Datum in der Beschreibung) **unverändert
-übernommen**. Der `pubDate` rollt auf den aktuellen Beobachtungs-
-Zeitpunkt fort, signalisiert also Frische ohne neue Notification
-auszulösen.
-
-| Feld | Verhalten über mehrere Cron-Ticks |
-| :--- | :--- |
-| `pubDate` | aktualisiert sich bei jedem Tick |
-| `starts_at` | = `first_seen` (stabil pro Episode) |
-| `first_seen` | Persistenz: gleicher Wert solange Episode anhält |
-| `guid` | abgeleitet von `(prefix, first_seen)` → stabil pro Episode |
-| `description` | "[Seit DD.MM.YYYY]" zeigt `first_seen`-Datum |
-
-Erst wenn eine Episode endet (Median ≤ 9 *oder* API-Fehler ⇒ Cache
-geleert), bekommt das nächste high-median-Event eine **frische**
-`first_seen`-Marke und damit eine neue `guid`. Dies modelliert
-"erneute Verspätungsphase" als eigene Notification.
-
-Liegt der Median ≤ 9 Minuten (oder gibt es keine S-Bahn-Legs mit
-Verspätungsdaten), wird **kein** Event für diese Richtung emittiert.
-Liegen für beide Richtungen keine Bedingungen vor, schreibt das
-Skript ein leeres Array `[]`. Die Cache-Datei ist damit zu jedem
-Zeitpunkt entweder eine gültige (möglicherweise leere) Liste — der
-Feed-Builder muss niemals einen "Datei fehlt"-Fall handhaben, sobald
-der erste Cron-Lauf erfolgt ist.
-
-## Self-Healing (Cache zwingend leeren)
-
-Der Cache wird **zwingend** auf `[]` gesetzt, sobald *eine* der
-folgenden Bedingungen eintritt:
-
-| Trigger | Folge |
-| :--- | :--- |
-| Beliebige Exception bei jeder einzelnen Richtung (`RequestException`, JSON-Decode-Fehler, malformiertes Payload) | Cache `[]`, Exit `1` |
-| `_QuotaExceeded` (VAO-Tageslimit erreicht) bei *allen* Richtungen | Cache `[]`, Exit `1` |
-| `CircuitBreakerOpen` (vorgeschalteter Breaker offen) | Cache `[]`, Exit `0` |
-| Median ≤ 9 Minuten in *beiden* Richtungen | Cache `[]`, Exit `0` |
-| Keine S-Bahn-Legs mit Verspätungsdaten in beiden Richtungen | Cache `[]`, Exit `0` |
-
-Damit wird sichergestellt, dass der RSS-Feed **niemals** veraltete
-Stammstrecke-Warnungen aus einem früheren Run trägt — eine Recovery
-oder ein API-Ausfall propagiert innerhalb höchstens eines Cron-Ticks
-(30 Minuten) in den öffentlichen Feed.
-
-Per-Direction-Isolation bleibt erhalten: ein transienter Fehler bei
-*einer* Richtung verwirft nicht das Event der anderen Richtung. Nur
-wenn **alle** Richtungen scheitern (oder der Breaker offen ist) wird
-der Cache vollständig geleert.
-
-## Resilience und API Rate-Limit
+### Resilience und API Rate-Limit
 
 Die VOR/VAO API erlaubt **100 Requests pro Tag** (das `VAO Start`-
-Kontingent). Der Monitor ist damit der dominante VOR-Konsument:
+Kontingent). Der Monitor ist mit Abstand der dominante VOR-Konsument:
 
 | Komponente | Calls/Tag |
 | :--- | ---: |
-| Stammstrecke (`*/30` × 2 Richtungen) | 96 |
-| Station-Enrichment (monatlich, Stammstrecke-Whitelist) | ~10 (1× pro Monat) |
+| Stammstrecke (`0,30 * * * *` × 2 Richtungen) | 96 |
+| Station-Enrichment (wöchentlich, Stammstrecke-Whitelist) | ~10 (1× pro Woche) |
 | Disruption-Polling (`DEFAULT_MONITOR_WHITELIST=""`) | 0 |
 | **Tagesbudget gesamt** | **96 / 100** |
 
-Der Monitor charged ein Quota-Slot **vor** jedem Network Call via
+Der Producer charged ein Quota-Slot **vor** jedem Network Call via
 `_charge_one_request`; eine quota-erschöpfte Stunde produziert
 sauber `_QuotaExceeded`, ohne den Endpoint zu treffen.
 
@@ -188,7 +119,7 @@ Die Circuit-Breaker-Konfiguration deckelt zusätzlich:
   Stunde lang OPEN, bevor ein Probe-Call zugelassen wird.
 
 Im Normalbetrieb produziert die Pipeline durch den Cron-Plan
-(`*/30 * * * *` = 2 Ausführungen pro Stunde) und 2 Richtungen pro
+(`0,30 * * * *` = 2 Ausführungen pro Stunde) und 2 Richtungen pro
 Ausführung **4 Calls pro Stunde** — komfortabel unter dem Limit.
 
 Weitere Schutzmechanismen:
@@ -199,18 +130,16 @@ Weitere Schutzmechanismen:
   mehr notwendig wie noch in der pyhafas-Ära.
 * **CircuitBreakerOpen** kurzschließt nach erstem Auftreten innerhalb
   einer Iteration: wenn der Breaker während der Abarbeitung der ersten
-  Richtung öffnet, wird die zweite Richtung *nicht* mehr versucht
-  (sie würde sowieso short-circuiten). Bereits gesammelte Events der
-  ersten Richtung bleiben erhalten und werden geschrieben.
+  Richtung öffnet, wird die zweite Richtung *nicht* mehr versucht.
+  Bereits gesammelte CSV-Zeilen der ersten Richtung sind über den
+  best-effort-`append_stammstrecke_row`-Pfad bereits geschrieben.
 * **Per-Direction-Fehlerisolation**: ein transienter Fehler bei
   Richtung 1 (RequestException, Connection Reset etc.) wirft Richtung
-  2 *nicht* weg. Der Cache wird mit den Events geschrieben, die wir
-  haben — leere Daten bei kompletter Degradation, partielle Daten bei
-  gemischtem Erfolg.
-* **Atomares Schreiben** (`src.utils.files.atomic_write`): TOCTOU-
-  sicherer Pfad mit kryptographisch zufälligem Temp-Dateinamen,
-  `os.fsync` und abschließendem `os.replace`. Ein Crash mitten im
-  Write hinterlässt *keinen* halbgeschriebenen Cache-Eintrag.
+  2 *nicht* weg.
+* **Atomares Schreiben** für CSV-Zeilen ist nicht nötig: einzelne
+  Append-Schreibvorgänge unterhalb des `PIPE_BUF`-Limits (4 KiB) sind
+  unter POSIX atomar; der Renderer toleriert zudem fehlerhafte
+  Einzelzeilen über `csv.reader` + `fromisoformat`-Try/Except.
 * **Logging** (`src.feed.logging_safe.setup_script_logging` →
   `SafeFormatter`): Jede Diagnose-Nachricht wird durch das projekt-
   weite Sanitisierungsverfahren (Secret-Redaktion, ANSI-/BiDi-Stripping,
@@ -218,24 +147,126 @@ Weitere Schutzmechanismen:
   Action-Log fließt. **Wichtig:** Exception-Strings werden bewusst
   *nicht* via `%s` oder `exc_info=True` geloggt — `VorAuth` injiziert
   `accessId` in jede prepared-Request-URL, und `RequestException`
-  kann die URL im Message tragen (Pattern aus `update_vor_cache.py`).
+  kann die URL im Message tragen.
 * **Zeitzone** (`zoneinfo.ZoneInfo("Europe/Vienna")`): GitHub Actions
   läuft in UTC. Sowohl die Anfrage-Zeit (`date=` / `time=` Parameter)
-  als auch das gespeicherte `pubDate` / `starts_at` werden konsequent
-  auf Europe/Vienna ausgerichtet, damit der RSS-Feed konsistente
-  Zeitstempel liefert (Sommer-/Winterzeit korrekt).
+  als auch der CSV-`timestamp` werden konsequent auf Europe/Vienna
+  ausgerichtet.
 * **JSON-Depth-Bomb-Schutz**: `_query_trips` umschließt
   `json.loads` mit `except (ValueError, RecursionError)` und
   re-raised als `ValueError` — eine deeply-nested-aber-wohlgeformte
   Antwort vom Upstream landet damit im pro-Richtungs-Error-Branch
   statt eine `BaseException`-getriebene Recursion-Failure aus dem
-  Skript zu propagieren (Drift-Defence-Walker pinned).
+  Skript zu propagieren.
 
-## Stationsnamen-Auflösung
+## Feed-Renderer (`src/feed/stammstrecke.py`)
+
+Die Funktion `compute_stammstrecke_events` wird vom Feed-Builder über
+`src.feed.providers.read_cache_stammstrecke()` aufgerufen (Provider-
+Flag `STAMMSTRECKE_ENABLE`, default `True`). Sie erzeugt die FeedItems
+ausschließlich aus den jüngsten CSV-Zeilen, ohne irgendeinen JSON-
+Cache zu lesen oder zu schreiben.
+
+### Konstanten
+
+| Name | Wert | Bedeutung |
+| :--- | :--- | :--- |
+| `DELAY_THRESHOLD_MINUTES` | `9.0` | Median > 9 Minuten innerhalb des Feed-Fensters → Event wird emittiert. |
+| `FEED_WINDOW` | `1 h` | Zeitfenster (rückwirkend von `now`), in dem der Trigger-Median berechnet wird. |
+| `EPISODE_LOOKBACK` | `6 h` | Max. Rückblick zur Bestimmung des `first_seen`-Zeitpunkts der laufenden Episode. |
+| `EPISODE_GAP_TOLERANCE` | `70 min` | Maximale Lücke zwischen zwei Beobachtungen, ehe eine Episode als beendet gilt (deckt einen ausgefallenen Cron-Tick ab). |
+| `EVENT_SOURCE` | `"VOR/VAO"` | `source`-Feld der emittierten Events (vorher `"ÖBB"`; geändert mit der Migration, weil die Datenquelle inzwischen technisch die VOR/VAO-API ist). |
+| `EVENT_CATEGORY` | `"Störung"` | RSS-`category`-Feld. |
+| `EVENT_TITLE` | `"S-Bahn Stammstrecke Verspätungen"` | konstantes Item-Title. |
+| `EVENT_LINK` | `https://www.wienerlinien.at/web/wienerlinien/oeffis-stoerungen-strecke` | weiterführender Link für Feed-Reader. |
+
+### Trigger-Gate, Anzeigewert, First-Seen
+
+Pro Richtung und pro Build:
+
+1. Lade alle CSV-Zeilen aus dem `EPISODE_LOOKBACK`-Fenster (6 Stunden).
+2. Filtere auf das jüngste `FEED_WINDOW` (1 Stunde) — typischerweise
+   2 Beobachtungen.
+3. **Trigger**: liegt der **Median** der Verspätungswerte in dieser
+   Untermenge **strikt** über `DELAY_THRESHOLD_MINUTES`, wird ein
+   Event emittiert. Median statt Mean: ein einzelner Ausreißer kann
+   die Richtung nicht alleine ins Event drücken.
+4. **Anzeigewert**: das Event-`description`-Feld zeigt den **Mittelwert**
+   (`mean`) derselben Untermenge — für End-Nutzer:innen leichter
+   interpretierbar als der Median.
+5. **`first_seen`**: gehe vom jüngsten Above-Threshold-Sample im
+   6-Stunden-Lookback rückwärts und nimm den frühesten Zeitpunkt einer
+   zusammenhängenden Folge mit `> DELAY_THRESHOLD_MINUTES` und
+   Sample-Abstand `≤ EPISODE_GAP_TOLERANCE` als Episode-Start. Dieser
+   Wert geht in `starts_at`, `first_seen`, `guid`-Hash und das
+   `Seit DD.MM.YYYY`-Datum ein.
+
+### Event-Schema
+
+```json
+{
+  "source": "VOR/VAO",
+  "category": "Störung",
+  "title": "S-Bahn Stammstrecke Verspätungen",
+  "description": "Durchschnittliche Verspätung von 12.5 Minuten in Richtung Meidling [Seit 09.05.2026]",
+  "link": "https://www.wienerlinien.at/web/wienerlinien/oeffis-stoerungen-strecke",
+  "guid": "<sha256(stammstrecke_delay_meidling|<iso-first-seen>)>",
+  "pubDate": "2026-05-10T08:30:00+02:00",
+  "starts_at": "2026-05-09T08:30:00+02:00",
+  "ends_at": null,
+  "first_seen": "2026-05-09T08:30:00+02:00",
+  "_identity": "stammstrecke_delay_meidling|<iso-first-seen>"
+}
+```
+
+Pro Build entsteht eine Liste mit `0`, `1` oder `2` Events
+(unabhängig pro Richtung). Die richtungsspezifischen `guid`- und
+`_identity`-Werte stellen sicher, dass Feed-Reader die beiden
+Meldungen als **separate** Notifications anzeigen.
+
+| Feld | Verhalten über mehrere Builds |
+| :--- | :--- |
+| `pubDate` | aktualisiert sich bei jedem Build (= aktueller Zeitstempel) |
+| `starts_at` | = `first_seen` (stabil pro Episode) |
+| `first_seen` | unverändert solange dieselbe Episode anhält |
+| `guid` | abgeleitet von `(prefix, first_seen)` → stabil pro Episode |
+| `description` | "[Seit DD.MM.YYYY]" zeigt `first_seen`-Datum |
+
+Erst wenn das Trigger-Gate auflöst (Median ≤ 9 oder das Episode-
+Lookback findet nichts) und später erneut zuschlägt, bekommt das
+nächste Event eine **frische** `first_seen`-Marke und damit eine neue
+`guid`. Dies modelliert "erneute Verspätungsphase" als eigene
+Notification.
+
+### Self-Healing & Resilienz
+
+Da die FeedItems jetzt zur Build-Zeit aus dem CSV-Ledger generiert
+werden, übernimmt das CSV-Ledger das Self-Healing implizit:
+
+* Ein **API-Ausfall** des Producers schreibt einfach keine neue
+  Zeile. Der nächste Build findet nichts im 1-Stunden-Fenster und
+  emittiert kein Event — die alte Warnung verschwindet automatisch
+  innerhalb spätestens einer Stunde.
+* Eine **Recovery** auf der Stammstrecke schreibt `delay_minutes ≤ 9`
+  in die nächste Zeile; das Trigger-Gate löst aus, das Event wird
+  beim nächsten Build nicht mehr emittiert.
+* Der Reader ist **best-effort, no-throw**: jede I/O-Exception unter
+  `read_recent_stammstrecke_observations` wird auf WARNING-Level
+  geloggt und liefert eine leere Liste zurück. Eine fehlende oder
+  korrupte CSV kippt niemals den Feed-Build.
+* **Malformed-Row-Tolerance**: Einzelne Zeilen, die `fromisoformat`
+  oder `float()` nicht parsen, werden übersprungen (sentinel-test
+  in `tests/test_sentinel_csv_size_bomb.py`).
+
+### Stationsnamen-Auflösung
 
 Die in `description` angezeigten Ziel-Stationsnamen ("Meidling" /
 "Floridsdorf") werden **nicht hartcodiert**, sondern über das
-kanonische Stationsverzeichnis (`src.utils.stations`) aufgelöst:
+kanonische Stationsverzeichnis (`src.utils.stations`) aufgelöst. Der
+Producer legt für jede Richtung ein Tupel `(_Direction)` an, das
+`target_label` aus `display_name(canonical_name(seed))` ableitet und
+mit dem `Wien `-Präfix-Strip eine kompakte Form für die `description`
+erzeugt:
 
 ```
 canonical_name("Wien Meidling")  →  "Wien Meidling"  (Verzeichnis-Hit)
@@ -243,14 +274,11 @@ display_name("Wien Meidling")    →  "Wien Meidling"  (kein Override)
 strip "Wien "                    →  "Meidling"       (Kompakt-Form)
 ```
 
-Der kompakte `in Richtung Meidling`-Stil entsteht durch Strippen
-des `Wien `-Präfix nach dem Verzeichnis-Lookup — die Beschreibung
-setzt Wien implizit voraus, deshalb wirkt das volle "Wien Meidling"
-in dieser Stelle redundant. Wenn das Verzeichnis später eine
-kanonische Umbenennung (z. B. `Wien Meidling` →
-`Wien Meidling/Philadelphiabrücke`) oder einen `display_name`-Override
-registriert, propagiert das automatisch in den Suffix nach
-`in Richtung `.
+Wenn das Verzeichnis später eine kanonische Umbenennung (z. B.
+`Wien Meidling` → `Wien Meidling/Philadelphiabrücke`) oder einen
+`display_name`-Override registriert, propagiert das beim nächsten
+Cron-Lauf automatisch in die CSV-`direction`-Spalte und damit in den
+Suffix nach `in Richtung `.
 
 Die Fallback-Kette in `_short_target_label` deckt drei Failure-Modi
 ab:
@@ -260,66 +288,68 @@ ab:
    `data/stations.json`): exception swallowing + Strip.
 3. `display_name` liefert leer: ebenfalls Seed mit Strip.
 
-## Statistik-Logging (Append-Only CSV)
+## Statistik-Logging und Dashboard
 
-Nach jeder erfolgreichen Median-Berechnung — *unabhängig* davon, ob
-die Schwelle überschritten wird oder nicht — schreibt das Skript eine
-Zeile in `data/stats/stammstrecke_YYYY.csv` (Spalten `timestamp,
-weekday, hour, direction, delay_minutes`, ISO 8601 `Europe/Vienna`).
-Damit reflektiert das Dashboard (`docs/statistik.md`, regeneriert
-durch `scripts/generate_markdown_stats.py`) und der README-Snapshot
-die *gesamte* Verteilung der Verspätungen und nicht nur die
-Eskalationen, die als RSS-Event emittiert wurden. Der Writer
-(`src.utils.stats.append_stammstrecke_row`) ist **best-effort**:
-jeder I/O-Fehler wird auf WARNING-Level geloggt und geschluckt, damit
-eine fehlgeschlagene Statistik niemals den Cron-Lauf kippt.
+Das CSV-Ledger ist gleichzeitig die Datenquelle für das tägliche
+Statistik-Dashboard:
+
+* **Producer** — `scripts/update_stammstrecke_status.py` schreibt
+  pro Cron-Tick und Richtung eine Zeile, **unabhängig** davon, ob
+  die 9-Minuten-Schwelle überschritten wird oder nicht. Damit
+  reflektiert das Dashboard die *gesamte* Verteilung (auch
+  on-time-Fahrten).
+* **Renderer** — `scripts/generate_markdown_stats.py` regeneriert
+  `docs/statistik.md` täglich aus den CSV-Ledgers (30-Tage-Fenster).
+* **Feed-Builder** — liest dasselbe Ledger mit einem 1-Stunden-Fenster.
+
+Beide Konsumenten benutzen denselben Reader-Pfad
+(`src.utils.stats.read_recent_stammstrecke_observations`) und
+profitieren damit vom gleichen Bounded-Read- und Tolerance-Verhalten.
 Architektur-Kontext und Diagramm: siehe Section 6 in
 [`docs/architecture.md`](../architecture.md).
-
-## Feed-Integration
-
-Der Feed-Builder lädt die Datei beim Build über
-`src.feed.providers.read_cache_stammstrecke()` (registriert unter dem
-Provider-Flag `STAMMSTRECKE_ENABLE`, default `True`). Der Loader liest
-direkt aus dem fixen Pfad `cache/stammstrecke/events.json` mit dem
-kanonischen Größencap (`read_capped_json`) — er nutzt **nicht** das
-gehashte `cache/<sanitized-provider>_<6hex>/events.json`-Layout der
-übrigen Provider, weil die Stammstrecken-Cache-Datei häufig manuell
-inspiziert wird und der vorhersagbare Pfad die Operator-Erfahrung
-verbessert.
 
 ## Erweiterungs-Punkte
 
 * **Schwelle anpassen**: Konstante `DELAY_THRESHOLD_MINUTES` in
-  `scripts/update_stammstrecke_status.py`. Aktuell `9` (dokumentierter
-  Standard "deutliche Stammstrecken-Beeinträchtigung").
+  `src/feed/stammstrecke.py`. Aktuell `9.0` (dokumentierter Standard
+  "deutliche Stammstrecken-Beeinträchtigung").
 * **VOR-Stations-IDs**: `FLORIDSDORF_VOR_ID` / `MEIDLING_VOR_ID` —
   Stop-IDs aus dem VOR/VAO-Stations­verzeichnis (`data/stations.json`).
   Pinned an die jeweils gültigen IDs, sodass eine Verzeichnis-Drift
   nicht stillschweigend den Monitor umlenken kann.
 * **Stationsnamen-Seeds**: `FLORIDSDORF_CANONICAL_SEED` /
   `MEIDLING_CANONICAL_SEED` sind die Lookup-Keys, die durch das
-  Stationsverzeichnis kanonisch aufgelöst werden. Eine Umbenennung
-  in `data/stations.json` propagiert automatisch ins Description-Feld.
-* **Richtungs-Tabelle**: `DIRECTIONS` (Tuple aus `_Direction`-Records).
-  Jede Richtung trägt Origin, Destination, das im Description-Feld
-  angezeigte Ziel-Label und den Identity-Prefix für `guid` /
-  `_identity`.
+  Stationsverzeichnis kanonisch aufgelöst werden.
+* **Richtungs-Tabelle**: `DIRECTIONS` in `src/feed/stammstrecke.py`
+  spiegelt die Producer-Tupel wider; `target_label` muss byteweise
+  zur CSV-`direction`-Spalte passen.
 * **HTTP-Timeout**: `QUERY_TIMEOUT` (Default-Sekunden) und
-  `MAX_QUERY_TIMEOUT` (oberer Clamp). Wird direkt an
+  `MAX_QUERY_TIMEOUT` (oberer Clamp) im Producer. Wird direkt an
   `fetch_content_safe(timeout=…)` durchgereicht.
-* **Sample-Größe**: `MAX_TRIPS_PER_QUERY` (aktuell `5`, VAO-Cap `6`).
-  Liefert den Median über die *unmittelbar nächsten 5* anstehenden
-  S-Bahnen pro Richtung — eine ungerade Sample-Größe macht den Median
-  exakt zum mittleren Element (statt Mittel zweier Werte) und liefert
-  dadurch eine Aussage robust gegen Ausreißer und nahe an der
-  Operator-Erwartung „wie ist es *jetzt*?". Höhere Werte glätten,
-  vergrößern aber die VAO-Payload und entkoppeln den Median vom
-  aktuellen Betriebszustand.
+* **Sample-Größe**: `MAX_TRIPS_PER_QUERY` (aktuell `6`, VAO-Cap).
+  Liefert den Median über bis zu 6 unmittelbar anstehende S-Bahnen
+  pro Richtung — die VAO-Antwortgröße ist zwischen `numF=5` und
+  `numF=6` identisch, der Cap maximiert die Stichprobe ohne extra
+  Quota-Kosten.
 * **Regex für S-Bahn-Linien**: `_S_BAHN_LINE_RE`. Erfasst alle ÖBB-
   S-Bahn-Linien (`S\d+`), inklusive zukünftiger Erweiterungen
   (`S 90`, `S 100`).
 * **Rate-Limit**: `BREAKER_FAILURE_THRESHOLD` /
-  `BREAKER_RECOVERY_TIMEOUT`. Aktuell auf 10 / 3600 s gesetzt. Das
+  `BREAKER_RECOVERY_TIMEOUT`. Aktuell auf `10` / `3600 s` gesetzt. Das
   100/Tag-VAO-Budget wird durch den `_charge_one_request`-Pfad
   zusätzlich am Skript-Eingang geschützt.
+* **Window-Längen** im Renderer: `FEED_WINDOW` (1 h) und
+  `EPISODE_LOOKBACK` (6 h) in `src/feed/stammstrecke.py`. Eine
+  Verkürzung des Feed-Window erhöht die Reaktionszeit, vergrößert
+  aber das Risiko von Flapping; eine Verlängerung beruhigt das Signal,
+  verzögert aber die Recovery-Sichtbarkeit.
+
+## Verwandte Dokumentation
+
+* **ÖBB-RSS-Scraper-Logik** — siehe [`oebb_provider_logic.md`](oebb_provider_logic.md).
+  Das ist der separate Provider, der die Störungs-RSS-Feeds der ÖBB
+  ausliest; er hat keine Verbindung zum Stammstrecke-Monitor (außer
+  dass beide Pendler-Verbindungen abdecken).
+* **Architektur-Karte** — [`docs/architecture.md`](../architecture.md)
+  §6 (Statistik & Dashboard Pipeline) und §7 (VOR/VAO API Rate-Limit
+  Optimization).


### PR DESCRIPTION
## Summary

Comprehensive review of all Markdown files in the repository root and `docs/` against the actual implementation in `src/` and `scripts/`. The audit surfaced significant drift introduced by the 2026-05-09 Stammstrecke migration and the cron-pipeline consolidation; this PR aligns the prose, tables and diagrams with what the code does today.

### Major rewrites

- **`docs/reference/stammstrecke_provider_logic.md`** — full rewrite. The cron script no longer writes `cache/stammstrecke/events.json`; it appends one observation row per direction to the CSV ledger and `src/feed/stammstrecke.py` renders feed events at build time (1 h trigger window, 6 h episode lookback, 70 min gap tolerance). `EVENT_SOURCE` is now `"VOR/VAO"` (was `"ÖBB"`) and `MAX_TRIPS_PER_QUERY` is `6` (was `5`).
- **`docs/development.md`** — fixed the outdated `VOR_MONITOR_STATIONS_WHITELIST` default (now empty string per `DEFAULT_MONITOR_WHITELIST = ""`), corrected the `update-stations.yml` schedule (weekly Sunday `0 1 * * 0`, not monthly `0 1 1 * *`), updated the test count (>2000 across ~390 modules), introduced `update-cycle.yml` as the central cron pipeline (`build-feed.yml` is now the code-change verification path), demoted "Eskapehatch" to "Escape-Hatch" and added a brand-new **Skripte im Überblick** section that documents every script under `scripts/` (including the previously undocumented `preflight_quota_check.py`, `check_complexity.py`, `validate_vor_mapping.py`, `gtfs.py`, `regen_*.sh`, etc.).
- **`docs/performance_monitoring_plan.md`** — added a prominent banner clarifying that this is a concept paper. `log/performance-metrics.jsonl`, `FEED_RUN_WARN_THRESHOLD`, `PERFORMANCE_ALERT_HOOK`, `make profile-feed` and `docs/how-to/profiling.md` do not yet exist; the prose was reworded into the conditional/Konjunktiv to reflect the planned state.

### Targeted fixes

- **`docs/architecture.md`** — refreshed the §6 statistics-pipeline diagram to show Stammstrecke feeding both the dashboard and the RSS feed renderer; updated §7 rate-limit table and cron callouts (`update-cycle.yml`, `MAX_TRIPS_PER_QUERY = 6`); reworded the §1 headline to point at the unified CLI entry point (`python -m src.cli feed build`).
- **`README.md`, `docs/index.md`, `docs/how-to/provider_plugins.md`** — clarified that `docs/feed-health.md` (and `docs/feed-health.json`) are local build artefacts, not committed files. Removes the broken file link the README and index used to render.
- **`docs/archive/audits/INDEX.md`** — corrected "monatlichen `update-stations.yml`-Workflow" to weekly with the explicit cron expression.
- **`docs/index.md`** — fixed the typo `VAO/VAO` → `VOR/VAO`.
- **`docs/how-to/test-api-secrets.md`, `docs/reference/oebb_provider_logic.md`** — normalised `z.B.` → `z. B.` per Duden typography.
- **`docs/development.md`** — fixed gender (`des Fetch-Pipelines` → `der Fetch-Pipeline`); spelled out `Cron 0,30 * * * *` semantics consistently with `update-cycle.yml`.

### Verification

- All internal Markdown file links resolve (`python3 /tmp/check_anchors.py` parity check).
- All anchor links resolve against GitHub-style heading slugs.
- No new files were created; documentation lives in existing locations.

## Test plan

- [ ] `mkdocs`/Pages render: visually skim the GitHub Pages deploy for `docs/index.md`, `docs/development.md`, `docs/architecture.md`, `docs/reference/stammstrecke_provider_logic.md`.
- [ ] `seo-guard.yml` workflow succeeds (sitemap regeneration touches the docs tree).
- [ ] Sanity check on a fresh clone that the cross-links in the README header (`docs/development.md`, `CONTRIBUTING.md`, `docs/architecture.md`, `docs/schema/events.schema.json`) all resolve.

https://claude.ai/code/session_01G7ajetHLVqtY2z63SuL8K1

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7ajetHLVqtY2z63SuL8K1)_