### PR TITLE
feat(orchestrator): auto-quarantine failing stations instead of hard-fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+* **Changed (Auto-Quarantine für `update_all_stations.py`)**: Blockierende
+  Validation-Issues (`provider_issues`, `cross_station_id_issues`,
+  `naming_issues`, `security_issues`) brechen die Pipeline nicht mehr ab.
+  Stattdessen werden die betroffenen Einträge aus dem gemergten
+  `tmp_stations_path` herausgefiltert, in `data/quarantine.json`
+  persistiert (mit `timestamp` / `count` / pro-Station-Issues) und der
+  Rest des Pipelines (Diff, Heartbeat, Atomic-Copy-Back) läuft mit dem
+  gültigen Subset weiter. Damit überlebt der Feed eine partielle
+  Upstream-Korruption (einzelne kaputte VOR-/OEBB-/WL-Einträge) und
+  exitet mit `0`. Der ``<global>``-Sentinel der Provider-Issue-Liste
+  (z. B. "Need at least two VOR entries") wird übersprungen — er
+  korrespondiert mit keinem einzelnen Eintrag und kann nicht
+  quarantänisiert werden. Tests: 5 neue Cases in
+  `test_update_all_stations_diff_heartbeat.py` /
+  `test_update_all_stations_wrapper.py` decken Identifier-Filterung,
+  Partition-Logik, End-to-End-Quarantine-Schreiben und den
+  ``<global>``-Skip ab. Mypy `--strict` bleibt clean.
 * **Changed (Stammstrecke-Monitor → VOR/VAO ReST API)**: Der S-Bahn-
   Stammstrecken-Verspätungs-Monitor wurde von `pyhafas` (`OEBBProfile`)
   auf die offizielle VOR/VAO ReST `/trip`-API portiert. Hintergrund:

--- a/scripts/update_all_stations.py
+++ b/scripts/update_all_stations.py
@@ -7,7 +7,11 @@ Pipeline:
   2. Run every script in :data:`_SCRIPT_ORDER` against the temp file.
   3. Validate the merged result. ``provider_issues``,
      ``cross_station_id_issues``, ``naming_issues`` and ``security_issues``
-     are hard gates — the working tree is left untouched on any of them.
+     trigger the *auto-quarantine* path: instead of aborting the run, the
+     offending entries are partitioned out of the merged file, persisted
+     to ``data/quarantine.json`` for operator review, and the pipeline
+     proceeds with the remaining valid stations. This soft-fail
+     behaviour lets the feed survive partial upstream data corruption.
   4. Compute the before/after diff (added/removed/renamed/coord-shifted)
      and write ``data/stations_last_run.json`` (heartbeat) plus
      ``docs/stations_diff.md`` (human-readable diff report).
@@ -40,6 +44,7 @@ from src.utils.files import atomic_write, read_capped_json  # noqa: E402  (impor
 from src.utils.stations_validation import (  # noqa: E402
     StationValidationError,
     ValidationReport,
+    _format_identifier,
     validate_stations,
 )
 
@@ -68,7 +73,15 @@ _SCRIPT_OUTPUT_FLAG = {
 _DEFAULT_HEARTBEAT_PATH = REPO_ROOT / "data" / "stations_last_run.json"
 _DEFAULT_DIFF_REPORT_PATH = REPO_ROOT / "docs" / "stations_diff.md"
 _DEFAULT_POLYGON_PATH = REPO_ROOT / "data" / "LANDESGRENZEOGD.json"
+_DEFAULT_QUARANTINE_PATH = REPO_ROOT / "data" / "quarantine.json"
 _COORD_SHIFT_THRESHOLD_M = 100.0
+
+# Sentinel identifier the validator emits for directory-wide provider
+# issues (e.g. "Need at least two VOR entries") that cannot be tied to
+# a single station. The auto-quarantine logic skips this marker — no
+# entry's ``_format_identifier`` ever matches it, and removing
+# arbitrary stations would not repair the global condition.
+_GLOBAL_ISSUE_SENTINEL = "<global>"
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -323,7 +336,7 @@ def _build_heartbeat(
 
 
 def _collect_blocking_issues(report: ValidationReport) -> list[tuple[str, str]]:
-    """Return (category, message) tuples for issues that must block the commit."""
+    """Return (category, message) tuples for issues that trigger auto-quarantine."""
     blocking: list[tuple[str, str]] = []
     for provider in report.provider_issues:
         blocking.append(("provider", provider.reason))
@@ -345,6 +358,148 @@ def _collect_blocking_issues(report: ValidationReport) -> list[tuple[str, str]]:
             f"{security.name} ({security.identifier}): {security.reason}",
         ))
     return blocking
+
+
+def _collect_quarantine_identifiers(report: ValidationReport) -> set[str]:
+    """Return the identifiers of stations that should be auto-quarantined.
+
+    The string format mirrors :func:`stations_validation._format_identifier`
+    so a downstream caller can match each entry deterministically. The
+    ``<global>`` sentinel emitted by ``_find_provider_issues`` for
+    directory-wide conditions is filtered out — no individual station
+    matches it and removing one would not repair the underlying issue.
+    """
+    identifiers: set[str] = set()
+    for provider in report.provider_issues:
+        identifier = provider.identifier
+        if identifier and identifier != _GLOBAL_ISSUE_SENTINEL:
+            identifiers.add(identifier)
+    for cross in report.cross_station_id_issues:
+        if cross.identifier:
+            identifiers.add(cross.identifier)
+    for naming in report.naming_issues:
+        if naming.identifier:
+            identifiers.add(naming.identifier)
+    for security in report.security_issues:
+        if security.identifier:
+            identifiers.add(security.identifier)
+    return identifiers
+
+
+def _collect_quarantine_reasons(
+    report: ValidationReport,
+) -> dict[str, list[dict[str, str]]]:
+    """Map quarantineable identifier → list of ``{category, reason}`` dicts.
+
+    The returned mapping powers the per-station ``issues`` array in
+    ``data/quarantine.json`` so operators can review *why* each entry
+    was removed without correlating against the run log.
+    """
+    reasons: dict[str, list[dict[str, str]]] = {}
+    for provider in report.provider_issues:
+        identifier = provider.identifier
+        if not identifier or identifier == _GLOBAL_ISSUE_SENTINEL:
+            continue
+        reasons.setdefault(identifier, []).append({
+            "category": "provider",
+            "reason": provider.reason,
+        })
+    for cross in report.cross_station_id_issues:
+        if not cross.identifier:
+            continue
+        reasons.setdefault(cross.identifier, []).append({
+            "category": "cross-station",
+            "reason": (
+                f"alias '{cross.alias}' collides with {cross.colliding_field} "
+                f"of '{cross.colliding_name}' ({cross.colliding_identifier})"
+            ),
+        })
+    for naming in report.naming_issues:
+        if not naming.identifier:
+            continue
+        reasons.setdefault(naming.identifier, []).append({
+            "category": "naming",
+            "reason": naming.reason,
+        })
+    for security in report.security_issues:
+        if not security.identifier:
+            continue
+        reasons.setdefault(security.identifier, []).append({
+            "category": "security",
+            "reason": security.reason,
+        })
+    return reasons
+
+
+def _partition_stations(
+    stations: Sequence[Mapping[str, Any]],
+    quarantine_identifiers: set[str],
+) -> tuple[list[Mapping[str, Any]], list[Mapping[str, Any]]]:
+    """Split *stations* into ``(valid, quarantined)`` by identifier match.
+
+    Each station's identifier is recomputed with
+    :func:`stations_validation._format_identifier` so the match honours
+    the exact format the validator emitted into the report.
+    """
+    valid: list[Mapping[str, Any]] = []
+    quarantined: list[Mapping[str, Any]] = []
+    for entry in stations:
+        if _format_identifier(entry) in quarantine_identifiers:
+            quarantined.append(entry)
+        else:
+            valid.append(entry)
+    return valid, quarantined
+
+
+def _write_stations_payload(
+    path: Path, stations: Sequence[Mapping[str, Any]]
+) -> None:
+    """Atomically rewrite *path* with the canonical wrapped JSON shape.
+
+    Mirrors the ``{"stations": [...]}`` envelope written by
+    ``scripts/update_station_directory.py:write_json`` so a downstream
+    consumer reading the merged temp file (and the final copy-back to
+    ``data/stations.json``) sees the same format as a clean run.
+    """
+    payload = {"stations": [dict(entry) for entry in stations]}
+    with atomic_write(path, mode="w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
+
+def _write_quarantine_file(
+    path: Path,
+    quarantined: Sequence[Mapping[str, Any]],
+    reasons_by_identifier: Mapping[str, Sequence[Mapping[str, str]]],
+    timestamp: str,
+) -> None:
+    """Atomically write the auto-quarantine sidecar at *path*.
+
+    The file is operator-facing diagnostic state — keep the schema
+    forwards-compatible by emitting a wrapped object with an explicit
+    ``count``, the original ``entry`` payload, and the validator's
+    ``issues`` so a future drift in either side is auditable.
+    """
+    entries: list[dict[str, Any]] = []
+    for entry in quarantined:
+        identifier = _format_identifier(entry)
+        name_obj = entry.get("name")
+        name = name_obj.strip() if isinstance(name_obj, str) else ""
+        entries.append({
+            "identifier": identifier,
+            "name": name or "<unknown>",
+            "issues": [dict(reason) for reason in reasons_by_identifier.get(identifier, ())],
+            "entry": dict(entry),
+        })
+    payload: dict[str, Any] = {
+        "timestamp": timestamp,
+        "count": len(entries),
+        "stations": entries,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with atomic_write(path, mode="w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -407,20 +562,59 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             return 1
 
+        # Auto-quarantine path (replaces the previous hard-fail return).
+        # Blocking issues no longer halt the pipeline. Instead, the
+        # offending entries are partitioned out of the merged file,
+        # persisted to data/quarantine.json for operator review, and
+        # the remainder of the run proceeds with the valid set so a
+        # partial upstream corruption does not stop the feed update.
         blocking = _collect_blocking_issues(report)
+        timestamp = datetime.now(UTC).isoformat(timespec="seconds")
         if blocking:
             for category, message in blocking:
-                logging.error("%s issue: %s", category, message)
-            logging.error(
-                "Validation failed on the new stations data. Working tree left unmodified."
+                logging.warning("validation issue (%s): %s", category, message)
+
+            quarantine_identifiers = _collect_quarantine_identifiers(report)
+            merged_stations = _load_stations(tmp_stations_path)
+            valid_stations, quarantined_stations = _partition_stations(
+                merged_stations, quarantine_identifiers
             )
-            return 1
+
+            if quarantined_stations:
+                _write_stations_payload(tmp_stations_path, valid_stations)
+                _write_quarantine_file(
+                    _DEFAULT_QUARANTINE_PATH,
+                    quarantined_stations,
+                    _collect_quarantine_reasons(report),
+                    timestamp,
+                )
+                quarantined_names = [
+                    str(entry.get("name") or "<unknown>")
+                    for entry in quarantined_stations
+                ]
+                logging.warning(
+                    "Auto-quarantined %d station(s) with blocking validation issues; "
+                    "details written to %s. Affected: %s",
+                    len(quarantined_stations),
+                    _DEFAULT_QUARANTINE_PATH,
+                    ", ".join(quarantined_names),
+                )
+            else:
+                # Either every blocking issue was the ``<global>`` sentinel
+                # or the validator's identifiers did not match any merged
+                # entry. Without a target to remove, auto-quarantine cannot
+                # repair the directory — log the gap and proceed with the
+                # full set so the pipeline survives.
+                logging.warning(
+                    "Auto-quarantine could not isolate the failing stations "
+                    "(no entry matched the validator's identifiers); proceeding "
+                    "with the unmodified merged set."
+                )
 
         # Compute the diff between the pre-update snapshot and the merged file
         # before atomic copy-back so the heartbeat reflects what is about to land.
         after_snapshot = _load_stations(tmp_stations_path)
         diff = _compute_diff(before_snapshot, after_snapshot)
-        timestamp = datetime.now(UTC).isoformat(timespec="seconds")
         polygon_vertices = _count_polygon_vertices(_DEFAULT_POLYGON_PATH)
         heartbeat = _build_heartbeat(
             report=report,

--- a/tests/test_update_all_stations_diff_heartbeat.py
+++ b/tests/test_update_all_stations_diff_heartbeat.py
@@ -115,8 +115,7 @@ def test_load_stations_handles_wrapped_and_bare_lists(tmp_path: Path) -> None:
 
 
 def test_collect_blocking_issues_includes_naming_and_security() -> None:
-    """Beyond the original provider/cross-station gates, naming + security
-    issues now also block the commit (added in this PR)."""
+    """All four blocking categories surface in the auto-quarantine list."""
     from src.utils.stations_validation import (
         NamingIssue,
         ProviderIssue,
@@ -139,6 +138,210 @@ def test_collect_blocking_issues_includes_naming_and_security() -> None:
     blocking = wrapper._collect_blocking_issues(report)
     categories = {cat for cat, _ in blocking}
     assert categories == {"provider", "naming", "security"}
+
+
+def test_collect_quarantine_identifiers_filters_global_sentinel() -> None:
+    """The synthetic ``<global>`` identifier emitted for directory-wide
+    provider issues must be filtered out — it does not correspond to a
+    single station and cannot be auto-quarantined."""
+    from src.utils.stations_validation import (
+        CrossStationIDIssue,
+        NamingIssue,
+        ProviderIssue,
+        SecurityIssue,
+        ValidationReport,
+    )
+
+    report = ValidationReport(
+        total_stations=4,
+        duplicates=(),
+        alias_issues=(),
+        coordinate_issues=(),
+        gtfs_issues=(),
+        security_issues=(SecurityIssue(identifier="bst:11", name="S", reason="x"),),
+        cross_station_id_issues=(
+            CrossStationIDIssue(
+                identifier="bst:12",
+                name="C",
+                alias="abc",
+                colliding_identifier="bst:99",
+                colliding_name="D",
+                colliding_field="bst_code",
+            ),
+        ),
+        provider_issues=(
+            ProviderIssue(identifier="<global>", name="<global>", reason="<2 VOR"),
+            ProviderIssue(identifier="bst:13", name="P", reason="bad VOR id"),
+        ),
+        naming_issues=(NamingIssue(identifier="bst:14", name="N", reason="dup"),),
+        gtfs_stop_count=0,
+    )
+
+    ids = wrapper._collect_quarantine_identifiers(report)
+    assert ids == {"bst:11", "bst:12", "bst:13", "bst:14"}
+    assert "<global>" not in ids
+
+
+def test_partition_stations_splits_by_identifier_match() -> None:
+    """_partition_stations honours the same identifier shape the validator
+    emits, so an entry whose ``_format_identifier`` matches a member of
+    the quarantine set is moved to the quarantined bucket."""
+    good = {"bst_id": 1, "bst_code": "A", "name": "Good A", "source": "vor"}
+    bad = {"bst_id": 2, "bst_code": "B", "name": "Bad B", "source": "vor"}
+
+    quarantine_ids = {"bst:2 / code:B / source:vor"}
+    valid, quarantined = wrapper._partition_stations([good, bad], quarantine_ids)
+
+    assert valid == [good]
+    assert quarantined == [bad]
+
+
+def test_wrapper_auto_quarantines_matching_stations(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end: a provider_issue with a matching identifier removes
+    the offending entry, writes ``data/quarantine.json``, and exits 0."""
+    from src.utils.stations_validation import (
+        ProviderIssue,
+        ValidationReport,
+        _format_identifier,
+    )
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    good_a: dict[str, Any] = {
+        "bst_id": 1, "bst_code": "A", "name": "Good A", "source": "vor",
+    }
+    bad_b: dict[str, Any] = {
+        "bst_id": 2, "bst_code": "B", "name": "Bad B", "source": "vor",
+    }
+    good_c: dict[str, Any] = {
+        "bst_id": 3, "bst_code": "C", "name": "Good C", "source": "vor",
+    }
+
+    stations_path = data_dir / "stations.json"
+    stations_path.write_text(
+        json.dumps({"stations": [good_a, bad_b, good_c]}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    bad_identifier = _format_identifier(bad_b)
+    failing_report = ValidationReport(
+        total_stations=3,
+        duplicates=(),
+        alias_issues=(),
+        coordinate_issues=(),
+        gtfs_issues=(),
+        security_issues=(),
+        cross_station_id_issues=(),
+        provider_issues=(
+            ProviderIssue(
+                identifier=bad_identifier,
+                name="Bad B",
+                reason="Invalid bst_code for VOR: B",
+            ),
+        ),
+        naming_issues=(),
+        gtfs_stop_count=0,
+    )
+
+    monkeypatch.setattr(
+        "scripts.update_all_stations.subprocess.run", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(wrapper, "validate_stations", lambda *a, **kw: failing_report)
+
+    quarantine_path = data_dir / "quarantine.json"
+    monkeypatch.setattr(wrapper, "_DEFAULT_HEARTBEAT_PATH", tmp_path / "heartbeat.json")
+    monkeypatch.setattr(wrapper, "_DEFAULT_DIFF_REPORT_PATH", tmp_path / "diff.md")
+    monkeypatch.setattr(wrapper, "_DEFAULT_QUARANTINE_PATH", quarantine_path)
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = wrapper.main([])
+    assert exit_code == 0
+
+    final_payload = json.loads(stations_path.read_text(encoding="utf-8"))
+    assert isinstance(final_payload, dict) and "stations" in final_payload
+    final_names = {entry["name"] for entry in final_payload["stations"]}
+    assert final_names == {"Good A", "Good C"}, (
+        f"Bad B should have been quarantined out of stations.json, got {final_names}"
+    )
+
+    assert quarantine_path.exists(), "quarantine.json should be written"
+    quarantine_payload = json.loads(quarantine_path.read_text(encoding="utf-8"))
+    assert quarantine_payload["count"] == 1
+    assert len(quarantine_payload["stations"]) == 1
+    quarantined_entry = quarantine_payload["stations"][0]
+    assert quarantined_entry["name"] == "Bad B"
+    assert quarantined_entry["identifier"] == bad_identifier
+    assert quarantined_entry["entry"] == bad_b
+    assert quarantined_entry["issues"] == [
+        {"category": "provider", "reason": "Invalid bst_code for VOR: B"}
+    ]
+    assert "timestamp" in quarantine_payload
+
+
+def test_wrapper_skips_quarantine_for_global_only_issue(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A ``<global>``-only provider_issue cannot quarantine any station;
+    the pipeline still proceeds and writes no quarantine file."""
+    from src.utils.stations_validation import (
+        ProviderIssue,
+        ValidationReport,
+    )
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    stations_path = data_dir / "stations.json"
+    stations_path.write_text(
+        json.dumps(
+            {"stations": [{"bst_id": 1, "bst_code": "A", "name": "Good"}]},
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    global_only_report = ValidationReport(
+        total_stations=1,
+        duplicates=(),
+        alias_issues=(),
+        coordinate_issues=(),
+        gtfs_issues=(),
+        security_issues=(),
+        cross_station_id_issues=(),
+        provider_issues=(
+            ProviderIssue(
+                identifier="<global>",
+                name="<global>",
+                reason="Need at least two VOR entries",
+            ),
+        ),
+        naming_issues=(),
+        gtfs_stop_count=0,
+    )
+
+    monkeypatch.setattr(
+        "scripts.update_all_stations.subprocess.run", lambda *a, **kw: None
+    )
+    monkeypatch.setattr(wrapper, "validate_stations", lambda *a, **kw: global_only_report)
+
+    quarantine_path = data_dir / "quarantine.json"
+    monkeypatch.setattr(wrapper, "_DEFAULT_HEARTBEAT_PATH", tmp_path / "heartbeat.json")
+    monkeypatch.setattr(wrapper, "_DEFAULT_DIFF_REPORT_PATH", tmp_path / "diff.md")
+    monkeypatch.setattr(wrapper, "_DEFAULT_QUARANTINE_PATH", quarantine_path)
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = wrapper.main([])
+    assert exit_code == 0
+    assert not quarantine_path.exists(), (
+        "quarantine.json must not be created when the only blocking issue is the "
+        "<global> sentinel — there's no individual station to remove"
+    )
+
+    final_payload = json.loads(stations_path.read_text(encoding="utf-8"))
+    assert final_payload["stations"][0]["name"] == "Good"
 
 
 def test_wrapper_writes_heartbeat_and_diff_on_success(

--- a/tests/test_update_all_stations_wrapper.py
+++ b/tests/test_update_all_stations_wrapper.py
@@ -3,14 +3,17 @@
 
 Stellt sicher, dass:
 1. Bei erfolgreicher Validation `data/stations.json` aktualisiert wird.
-2. Bei fehlgeschlagener Validation `data/stations.json` unverändert bleibt.
+2. Bei einer Validation, deren Issues auf keine reale Station passen,
+   die Pipeline (auto-quarantine) den Working Tree unverändert lässt
+   und erfolgreich exitet.
+3. Bei einem Fehler im finalen atomic_write die Bytes von
+   `data/stations.json` unverändert bleiben.
 
 Hintergrund: Vor diesem Wrapper konnte ein update-Sub-Skript einen
 Konflikt direkt in den Working Tree schreiben. Der separate
 Validator-Step bemerkte den Fehler erst nach dem Schreiben (siehe
 PR #1102, 900100-Aspern-Nord-Regression). Der Wrapper schreibt
-gegen ein Temp-File und kopiert nur bei erfolgreicher Validation
-zurück.
+gegen ein Temp-File und kopiert nur nach Auto-Quarantine zurück.
 
 Janitor PR #1321: file-level S603 suppression. The single
 subprocess.run(...) in this file invokes sys.executable against a
@@ -30,18 +33,17 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_wrapper_preserves_stations_json_on_validation_failure(
+def test_wrapper_proceeds_when_no_quarantineable_match(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Bei Validation-Fehler bleibt data/stations.json bytewise unverändert.
+    """Auto-Quarantine ohne passende Station: bytewise unverändert + exit 0.
 
     Verfahren: sub-scripts werden zu no-ops gemockt (subprocess.run gibt
     None zurück), validate_stations liefert einen Report mit einem
-    provider_issue. Wrapper.main() läuft in-process, damit die Mocks
-    greifen. Der initiale shutil.copy2 hat tmp_stations_path bereits
-    mit dem unveränderten Original gefüllt; ohne erfolgreiche Validation
-    findet das abschließende shutil.copy zurück nie statt, das Original
-    bleibt bytewise erhalten.
+    provider_issue, dessen Identifier auf keine reale Station passt.
+    Die Auto-Quarantine-Logik findet keinen Match und proceedet mit dem
+    unveränderten Merge-Set. Erwartung: exit 0 und Bytes unverändert.
+    Pinst die "no-match = no-modification"-Garantie der Auto-Quarantine.
     """
     from src.utils.stations_validation import ProviderIssue, ValidationReport
     from scripts import update_all_stations as wrapper
@@ -57,7 +59,9 @@ def test_wrapper_preserves_stations_json_on_validation_failure(
         "scripts.update_all_stations.subprocess.run", lambda *a, **kw: None
     )
 
-    # Force validation to fail with a provider_issue.
+    # The identifier ``<test>`` matches no station, so auto-quarantine
+    # cannot isolate any entry and the pipeline falls back to the
+    # unmodified merged set.
     failing_report = ValidationReport(
         total_stations=0,
         duplicates=(),
@@ -80,10 +84,12 @@ def test_wrapper_preserves_stations_json_on_validation_failure(
 
     exit_code = wrapper.main([])
 
-    assert exit_code == 1, f"Wrapper should return 1 on validation failure, got {exit_code}"
+    assert exit_code == 0, (
+        f"Wrapper should auto-quarantine and exit 0 on validation failure, got {exit_code}"
+    )
     assert real_stations.read_bytes() == original_bytes, (
-        "Wrapper modified data/stations.json on validation failure — "
-        "copy-on-write contract violated"
+        "Wrapper modified data/stations.json on auto-quarantine no-match — "
+        "the unchanged-bytes contract for the no-match path was violated"
     )
 
 


### PR DESCRIPTION
## Summary

`scripts/update_all_stations.py` previously aborted with exit `1` when `validate_stations()` returned any `provider_issues`, `cross_station_id_issues`, `naming_issues`, or `security_issues`, halting the entire feed update on a single bad upstream entry. This PR converts the four blocking categories into a **soft-fail auto-quarantine** path so the pipeline survives partial upstream data corruption.

## Behaviour

1. After `validate_stations()` runs, the offending entries are partitioned out of the merged `tmp_stations_path` by matching `_format_identifier(entry)` against the validator's emitted identifiers (`provider_issues`, `cross_station_id_issues`, `naming_issues`, `security_issues`).
2. Quarantined entries are persisted to `data/quarantine.json` via `src.utils.files.atomic_write` (utf-8, `ensure_ascii=False`, `indent=2`). The schema is forwards-compatible:
   ```json
   {
     "timestamp": "2026-05-10T...+00:00",
     "count": 1,
     "stations": [
       {
         "identifier": "bst:2 / code:B / source:vor",
         "name": "Bad B",
         "issues": [{"category": "provider", "reason": "..."}],
         "entry": { ...original station entry... }
       }
     ]
   }
   ```
3. `tmp_stations_path` is atomically rewritten with only the valid subset using the canonical `{"stations": [...]}` envelope, then the existing diff + heartbeat + atomic copy-back run unchanged. The script exits **`0`**.
4. The validator's `<global>` sentinel (e.g. `"Need at least two VOR entries"`) is **skipped** — no individual station matches it and removing one cannot repair the directory-wide condition. If the only blocking issue is global, the pipeline proceeds with the full set and logs a warning.
5. Blocking issues are logged at `WARNING` level (was `ERROR`) since they no longer halt the run.

## Implementation notes

- New helpers in `scripts/update_all_stations.py`:
  - `_collect_quarantine_identifiers(report)` — set[str] of identifiers, with `<global>` filtered out.
  - `_collect_quarantine_reasons(report)` — `{identifier → [{category, reason}, …]}` for the per-station `issues` payload.
  - `_partition_stations(stations, ids)` — `(valid, quarantined)` split.
  - `_write_stations_payload(path, stations)` — canonical `{"stations": [...]}` atomic write.
  - `_write_quarantine_file(path, quarantined, reasons, timestamp)` — atomic-writes `data/quarantine.json`.
- Imports `_format_identifier` from `src.utils.stations_validation` (private name, but the canonical identifier producer the validator uses — same precedent as `stations_validation`'s own `_normalize_token` import from `stations`).
- Strictly follows the project's existing security conventions: `src.utils.files.atomic_write` for every write, `read_capped_json` (via the existing `_load_stations`) with `MAX_JSON_FILE_BYTES = 50 MiB` for every read.
- `mypy --strict` stays clean (`Success: no issues found in 440 source files`).
- Ruff + bandit + complexity gate all pass.

## Test plan

- [x] `tests/test_update_all_stations_diff_heartbeat.py` — 4 new cases:
  - [x] `test_collect_quarantine_identifiers_filters_global_sentinel` — verifies `<global>` is filtered.
  - [x] `test_partition_stations_splits_by_identifier_match` — unit-tests the partition logic.
  - [x] `test_wrapper_auto_quarantines_matching_stations` — end-to-end with synthetic 3-station data dir; asserts `stations.json` lost the bad entry, `quarantine.json` contains it with correct identifier/issues/entry, exit `0`.
  - [x] `test_wrapper_skips_quarantine_for_global_only_issue` — `<global>`-only report → exit `0`, no `quarantine.json` written, `stations.json` unchanged.
- [x] `tests/test_update_all_stations_wrapper.py` — `test_wrapper_preserves_stations_json_on_validation_failure` renamed to `test_wrapper_proceeds_when_no_quarantineable_match` and updated for the new "no-match → exit `0`, bytes unchanged" contract.
- [x] Full test suite: 3405 passed, 3 skipped (no regressions).
- [x] `mypy --strict src tests` — clean.
- [x] `ruff check` — clean.
- [x] `bandit` — no new findings.
- [x] C901 complexity gate — passes.

https://claude.ai/code/session_01XWoZoN4y9QsU3XfgVq6iyg

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWoZoN4y9QsU3XfgVq6iyg)_