### PR TITLE
ci(update-cycle): replace cron with repository_dispatch (IFTTT-triggered)

### DIFF
--- a/.github/workflows/update-cycle.yml
+++ b/.github/workflows/update-cycle.yml
@@ -38,6 +38,8 @@ on:
   schedule:
     - cron: '0,30 * * * *'
   workflow_dispatch:
+  repository_dispatch:
+    types: [ifttt_feed_trigger]
 
 permissions:
   contents: read

--- a/.github/workflows/update-cycle.yml
+++ b/.github/workflows/update-cycle.yml
@@ -35,8 +35,6 @@ name: Update cycle
 # API-fetching cycles in flight.
 
 on:
-  schedule:
-    - cron: '0,30 * * * *'
   workflow_dispatch:
   repository_dispatch:
     types: [ifttt_feed_trigger]


### PR DESCRIPTION
## Summary
- Replaces the every-30-minute cron trigger in `.github/workflows/update-cycle.yml` with on-demand triggers only.
- Keeps `workflow_dispatch:` for manual runs.
- Adds `repository_dispatch:` with custom type `ifttt_feed_trigger` so an IFTTT webhook can kick off the cycle when upstream publishes new content.

## Diff
```diff
@@ -35,10 +35,9 @@ name: Update cycle
 # API-fetching cycles in flight.

 on:
-  schedule:
-    - cron: '0,30 * * * *'
   workflow_dispatch:
+  repository_dispatch:
+    types: [ifttt_feed_trigger]

 permissions:
   contents: read
```

## Behavioral change
- The cycle no longer self-fires every 30 minutes. From now on it runs **only** when `workflow_dispatch` is invoked manually or `repository_dispatch` of type `ifttt_feed_trigger` arrives via the GitHub API. Trade-off: precise on-publish cadence vs. unconditional 30-min ticks; net win is fewer no-op runs against the free upstream APIs.

## Known follow-ups (not in this PR)
- The leading comment block (lines 3–35) and the dashboard-refresh comments (lines 220–244) still describe a 30-min cron cadence and a "first cron tick after midnight Europe/Vienna" gate. With the cron gone, the dashboard refresh now only runs when an IFTTT trigger happens to land in the `< 0030` Vienna window — if IFTTT misses that window on a given day, the dashboard silently skips that day. Worth either (a) updating the gate to refresh-on-first-trigger-of-the-day, or (b) adding a separate daily cron just for the dashboard. Out of scope here; flagging for a follow-up PR.
- README STATS markers (snapshot of trailing 30 days) are similarly tied to the previous half-hour staleness budget; that budget is now defined by IFTTT cadence.

## Triggering after merge
```
curl -X POST -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer $GH_TOKEN" \
     https://api.github.com/repos/Origamihase/wien-oepnv/dispatches \
     -d '{"event_type":"ifttt_feed_trigger"}'
```
(`repository_dispatch` only fires from the **default branch** by GitHub Actions design, so the trigger is inert until this PR is merged to `main`.)

## Test plan
- [x] `git diff` confirms only `schedule:`/`- cron:` removed and `repository_dispatch:`/`types:` added inside the `on:` block; no other steps, jobs, or triggers touched.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/update-cycle.yml'))"` parses cleanly; `on:` resolves to exactly `workflow_dispatch` + `repository_dispatch{types:[ifttt_feed_trigger]}`.
- [ ] After merge, fire a test dispatch (curl above) and confirm a single `chore: update cycle` commit lands on `main` (atomic-commit semantics unchanged).
- [ ] Confirm IFTTT applet authentication / event payload format matches `event_type: ifttt_feed_trigger`.

https://claude.ai/code/session_01TsPGitexAziqzj8yyzcKEe