### PR TITLE
security: BiDi/Trojan-Source leak in places quota + VOR request count + cache heartbeat writers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,130 @@
+## 2026-05-11 - Trojan-Source BiDi Drift Round 11 (Places Quota + VOR Request Count + Cache Heartbeat Sidecars): `MonthlyQuota.save_atomic` (`data/places_quota.json`), `save_request_count`'s Atomic Write (`data/vor_request_count.json`), and `write_status` (`cache/<provider>/last_run.json`) Were the Three Sibling Writers the Round-10 Closing-Checklist Named But Deferred
+
+**Vulnerability:** Round 10 (PR #1435) closed `_save_state`
+(`data/first_seen.json`) and the orchestrator heartbeat
+(`data/stations_last_run.json`). The Round-10 closing checklist's
+"Named but deferred" list explicitly identified three sibling writers
+in the same operator-facing JSON sidecar family — all three still
+using `ensure_ascii=False`:
+
+  1. `src/places/quota.py:MonthlyQuota.save_atomic` →
+     `data/places_quota.json`. Committed to `main` by
+     `.github/workflows/update-google-places-stations.yml:160`
+     (`git add data/places_quota.json`). The dataclass serialises
+     `month_key`, `daily_key` (both `str` fields), `counts`, `total`
+     and `daily_total`. Today `daily_key` / `month_key` are populated
+     from internal helpers (`current_daily_key` /
+     `current_month_key` return safe ASCII), but the schema is
+     dictionary-shaped and forward-compatible.
+  2. `src/providers/vor.py:save_request_count` line 1562 (pre-fix) →
+     `data/vor_request_count.json`. Used
+     `json.dump(payload, handle, ensure_ascii=False)` inline. The
+     payload is `{"date": <ISO date>, "requests": <int>}` today, but
+     the file is committed by both `update-vor-cache.yml` (line 97)
+     and `update-stammstrecke-status.yml` (line 96).
+  3. `src/utils/cache.py:write_status` → `cache/<provider>/last_run.json`.
+     Committed by `update-vor-cache.yml` (line 96) via
+     `file_pattern: cache/vor*/last_run.json`. Used
+     `json.dump(status, fh, ensure_ascii=False, indent=2,
+     sort_keys=True)`. Callers (e.g.
+     `scripts/update_vor_cache.py:_record_status`) build the payload
+     from runtime state — a future provider-reported error fragment or
+     station name would flow through unchanged.
+
+**Threat model:**
+
+  1. Attacker compromises an upstream provider (cache poisoning, DNS
+     hijack of an unpinned upstream, leaked CI secret store) or an
+     operator mis-edits the on-disk sidecar.
+  2. A planted value carrying U+202E (RLO) or any other primitive in
+     the canonical CVE-2021-42574 union (BiDi controls
+     U+202A-U+202E / U+2066-U+2069, zero-width primitives
+     U+200B-U+200F, Unicode line/paragraph separators
+     U+2028-U+2029, BOM U+FEFF, C1 controls `\x9b` CSI / `\x9d`
+     OSC / `\x90` DCS) reaches the writer.
+  3. `ensure_ascii=False` emits the primitive as its raw UTF-8 byte
+     triplet — e.g. `\xe2\x80\xae` for U+202E — verbatim into the
+     on-disk file.
+  4. The respective workflow commits the file to `main`. Operator
+     reviewing via `cat` / `less` / `git diff` / GitHub web UI / IDE
+     preview sees the BiDi-reversed display, hiding the attack.
+
+Even though today's payloads carry only safe scalar values
+(integers + ISO dates + hard-coded status tokens), the writer-shape
+contract MUST be `ensure_ascii=True` regardless — the defence is
+forward-compatible against future schema-drift additions, mirroring
+the Round 9/10 invariant for `_write_quarantine_file`, `_save_state`
+and `_write_heartbeat_file`.
+
+**Reproduced:** `tests/test_sentinel_quota_status_trojan_source.py`
+contains 70 PoC tests:
+
+  * 1 + 21 (parametrised) + 1 for the quota writer
+    (`MonthlyQuota.save_atomic`).
+  * 1 + 21 + 1 for the extracted VOR writer
+    (`_write_request_count_file`).
+  * 1 + 21 + 1 + 1 for `write_status` (the extra is a German
+    round-trip via the `ü` escape).
+
+Pre-fix repro: `daily_key="2026-05-10‮moc.live"` produced an
+`data/places_quota.json` with raw bytes `... 0\xe2\x80\xaemoc.live ...`.
+Post-fix: `‮` (6 ASCII bytes) instead of `\xe2\x80\xae` (3 raw
+bytes), no BiDi trigger in any viewer.
+
+**Fix:**
+
+  * `src/places/quota.py:MonthlyQuota.save_atomic`: flip
+    `ensure_ascii=False` → `ensure_ascii=True` at the `json.dump`
+    site. The method already lived in a centralised helper shape so
+    no extraction was needed.
+  * `src/utils/cache.py:write_status`: same one-line flip; the
+    function was already a centralised helper.
+  * `src/providers/vor.py`: extract the inline `atomic_write` block
+    from `save_request_count` (lines 1582-1588 pre-fix) into a new
+    `_write_request_count_file(path, payload)` helper that uses
+    `ensure_ascii=True`. Mirrors the Round 10
+    `_write_heartbeat_file` extraction pattern so the canonical
+    fix-shape lives in exactly one place per writer family.
+
+**Learning:** the Round-10 closing-checklist's "Named but deferred"
+list correctly predicted every site that needed the next round's
+fix. The deferred set is the canonical seed for the next drift
+round — the `cache/<provider>/events.json` writer
+(`src/utils/cache.py:write_cache`) remains the sole deferred sidecar
+because of the diff-bloat trade-off (provider-fetched German titles
++ descriptions; switching to `ensure_ascii=True` would massively
+bloat the committed cache diff). That fix needs to pair with a
+normalisation step at the cache-ingestion boundary, not a blanket
+flag flip.
+
+The drift-walker invariant for the `data/*.json` and
+`cache/<provider>/*.json` sidecar family is now uniform:
+
+  * **Closed in this round:** `MonthlyQuota.save_atomic`
+    (`data/places_quota.json`), `_write_request_count_file`
+    (`data/vor_request_count.json`), `write_status`
+    (`cache/<provider>/last_run.json`).
+  * **Already closed:** `_save_state` (`data/first_seen.json`,
+    Round 10), `_write_heartbeat_file`
+    (`data/stations_last_run.json`, Round 10),
+    `_write_quarantine_file` (`data/quarantine.json`, Round 9),
+    `_render_diff_markdown` (`docs/stations_diff.md`, Round 9),
+    `ValidationReport.to_markdown()` (Round 3),
+    `render_feed_health_markdown` / GitHub-Issue body (Round 2),
+    `docs/statistik.md` stats dashboard (Round 1),
+    `data/stats/*.csv` CSV writer, RSS XML writers, sitemap writer,
+    `_escape_env_value` `.env` writer.
+  * **Named but deferred** (out of scope for this round, queued for
+    a dedicated provider-cache sanitisation round):
+    * `cache/<provider>/events.json`
+      (`src/utils/cache.py:write_cache`) — see "Learning" above.
+      The fix shape for this one is NOT a blanket
+      `ensure_ascii=True` flag flip; the next round MUST pair the
+      flag flip with a Trojan-Source primitive scrubber at the
+      ingestion boundary (`read_cache` / provider parsers) so the
+      committed diff stays compact for legitimate German titles
+      while still rejecting the canonical attack-byte union.
+
 ## 2026-05-11 - Trojan-Source BiDi Drift Round 10 (Build-Feed State Cache + Stations Heartbeat): `_save_state` (`data/first_seen.json`) and `_build_heartbeat` Writer (`data/stations_last_run.json`) Were the Sibling-Writer Pair the Round-9 Closing-Checklist Named But Deferred
 
 **Vulnerability:** Round 9 (PR #1434) closed the auto-quarantine

--- a/src/places/quota.py
+++ b/src/places/quota.py
@@ -186,10 +186,25 @@ class MonthlyQuota:
             "daily_key": self.daily_key,
             "daily_total": int(self.daily_total),
         }
-        # Explicitly set 0600 permissions
+        # Explicitly set 0600 permissions.
+        # Security (Trojan-Source / BiDi-Mark Drift Round 11): the file is
+        # operator-facing diagnostic state, committed to ``main`` by the
+        # ``update-google-places-stations.yml`` cron job (see its line 160
+        # ``git add data/places_quota.json``) and reviewed via ``cat`` /
+        # ``less`` / the GitHub web UI / IDE preview. ``ensure_ascii=True``
+        # escapes every non-ASCII code point as a literal ``\uXXXX``
+        # sequence, so a future quota-state field carrying station- /
+        # provider- / environment-controlled content cannot leak the
+        # canonical CVE-2021-42574 Trojan-Source / zero-width / Unicode-
+        # line-terminator / 8-bit C1 union as raw UTF-8 bytes. Mirrors the
+        # canonical fix shape pinned in PR #1434 / PR #1435 for the
+        # sibling ``data/*.json`` sidecar writers (``_write_quarantine_file``,
+        # ``_save_state``, ``_write_heartbeat_file``). Forensic intent is
+        # preserved (``MonthlyQuota.load`` recovers the original string from
+        # the literal escape sequence via ``json.loads``).
         path.parent.mkdir(parents=True, exist_ok=True)
         with atomic_write(path, mode="w", encoding="utf-8", permissions=0o600) as handle:
-            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            json.dump(payload, handle, ensure_ascii=True, indent=2, sort_keys=True)
             handle.write("\n")
 
     def maybe_reset_month(self) -> bool:

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -413,6 +413,31 @@ REQUEST_COUNT_FILE = _resolve_path(
 )
 
 
+def _write_request_count_file(path: Path, payload: Mapping[str, Any]) -> None:
+    """Atomically write the VOR per-day request-count payload to *path*.
+
+    Security (Trojan-Source / BiDi-Mark Drift Round 11): the file is
+    operator-facing diagnostic state, committed to ``main`` by the
+    ``update-vor-cache.yml`` and ``update-stammstrecke-status.yml`` cron
+    jobs (both list ``data/vor_request_count.json`` in their
+    ``file_pattern``) and reviewed via ``cat`` / ``less`` / the GitHub
+    web UI / IDE preview. ``ensure_ascii=True`` escapes every non-ASCII
+    code point as a literal ``\\uXXXX`` sequence, so a future request-
+    count payload field carrying station- / provider- / environment-
+    controlled content cannot leak the canonical CVE-2021-42574
+    Trojan-Source / zero-width / Unicode-line-terminator / 8-bit C1
+    union as raw UTF-8 bytes. Mirrors the canonical fix shape pinned
+    in PR #1434 / PR #1435 for the sibling ``data/*.json`` sidecar
+    writers (``_write_quarantine_file``, ``_save_state``,
+    ``_write_heartbeat_file``). Forensic intent is preserved
+    (``load_request_count`` recovers the original string from the
+    literal escape via ``json.loads``).
+    """
+    with atomic_write(path, mode="w", encoding="utf-8", permissions=0o600) as handle:
+        json.dump(payload, handle, ensure_ascii=True)
+        handle.write("\n")
+
+
 MAPPING_FILE = _resolve_path(
     _get_env("VOR_STATION_NAME_MAP"), default=DATA_DIR / "vor-haltestellen.mapping.json"
 )
@@ -1555,12 +1580,10 @@ def save_request_count(now_ignored: datetime | None = None) -> int:
 
                         payload = {"date": date_iso, "requests": new_total}
                         try:
-                            # Replaced custom atomic write logic with centralized utility
-                            with atomic_write(
-                                REQUEST_COUNT_FILE, mode="w", encoding="utf-8", permissions=0o600
-                            ) as handle:
-                                json.dump(payload, handle, ensure_ascii=False)
-                                handle.write("\n")
+                            # Centralised atomic + ASCII-safe write —
+                            # see ``_write_request_count_file`` for the
+                            # Trojan-Source threat model.
+                            _write_request_count_file(REQUEST_COUNT_FILE, payload)
                         except OSError:
                             log.critical("Failed to write to request count file. Quota mechanism poisoned.")
                             _QUOTA_CACHE["count"] = MAX_REQUESTS_PER_DAY + 1

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -429,10 +429,26 @@ def write_status(provider: str, status: dict[str, Any]) -> None:
     status_file = _status_file(provider)
 
     try:
+        # Security (Trojan-Source / BiDi-Mark Drift Round 11): the file
+        # is operator-facing diagnostic state, committed to ``main`` by
+        # the cron pipeline (``update-vor-cache.yml`` line 96 lists
+        # ``cache/vor*/last_run.json`` in its ``file_pattern``) and
+        # reviewed via ``cat`` / ``less`` / the GitHub web UI / IDE
+        # preview. ``ensure_ascii=True`` escapes every non-ASCII code
+        # point as a literal ``\uXXXX`` sequence, so a future status
+        # payload field carrying station- / provider- / environment-
+        # controlled content (e.g. a provider-reported error fragment)
+        # cannot leak the canonical CVE-2021-42574 Trojan-Source /
+        # zero-width / Unicode-line-terminator / 8-bit C1 union as raw
+        # UTF-8 bytes. Mirrors the canonical fix shape pinned in PR
+        # #1434 / PR #1435 for the sibling ``data/*.json`` sidecar
+        # writers. Forensic intent is preserved (``read_status``
+        # recovers the original string from the literal escape via
+        # ``json.loads``).
         with atomic_write(
             status_file, mode="w", encoding="utf-8", permissions=0o600
         ) as fh:
-            json.dump(status, fh, ensure_ascii=False, indent=2, sort_keys=True)
+            json.dump(status, fh, ensure_ascii=True, indent=2, sort_keys=True)
             fh.write("\n")
     except Exception:
         log.exception(

--- a/tests/test_sentinel_quota_status_trojan_source.py
+++ b/tests/test_sentinel_quota_status_trojan_source.py
@@ -1,0 +1,427 @@
+"""Sentinel PoC: Trojan-Source / BiDi-Mark leakage at the three
+committed operator-facing JSON sidecar writers that the *BiDi-Mark
+Drift Round 10* closing-checklist named but deferred —
+``MonthlyQuota.save_atomic`` (``data/places_quota.json``),
+``save_request_count``'s atomic-write site
+(``data/vor_request_count.json``), and ``write_status``
+(``cache/<provider>/last_run.json``).
+
+All three files are committed to ``main`` by the cron pipeline:
+
+  * ``data/places_quota.json`` — ``update-google-places-stations.yml``
+    line 160 (``git add data/places_quota.json``).
+  * ``data/vor_request_count.json`` — ``update-vor-cache.yml`` line 97
+    (``file_pattern: data/vor_request_count.json``) and
+    ``update-stammstrecke-status.yml`` line 96 (same file_pattern).
+  * ``cache/vor*/last_run.json`` — ``update-vor-cache.yml`` line 96
+    (``file_pattern: cache/vor*/last_run.json``).
+
+They are operator-facing artefacts — ``cat`` / ``less`` / the GitHub
+web UI / IDE preview all honour BiDi formatting controls when
+displaying the file. Pre-fix every writer serialised the payload with
+``json.dump(..., ensure_ascii=False, ...)``. ``ensure_ascii=False``
+emits every non-ASCII code point as raw UTF-8 — including the
+CVE-2021-42574 "Trojan Source" BiDi formatting controls
+(``U+202A``-``U+202E`` / ``U+2066``-``U+2069``), zero-width primitives
+(``U+200B``-``U+200F``), Unicode line / paragraph separators
+(``U+2028`` / ``U+2029``), the BOM (``U+FEFF``), and the C1 terminal-
+escape primitives (``\\x9b`` CSI, ``\\x9d`` OSC, ``\\x90`` DCS).
+
+The state-cache writer (``_save_state``), the orchestrator heartbeat
+writer (``_write_heartbeat_file``), the auto-quarantine writer
+(``_write_quarantine_file``) and the stations-diff markdown writer
+(``_render_diff_markdown``) already closed this drift in PR #1434 and
+PR #1435 (journal Rounds 9 and 10). The three sibling writers below
+are the deferred siblings the Round-10 closing-checklist explicitly
+named.
+
+Attack path for ``MonthlyQuota.save_atomic``
+=============================================
+
+The current schema serialises ``month_key``, ``daily_key``,
+``counts`` (a ``dict[str, int]``), ``total`` and ``daily_total`` —
+``month_key`` and ``daily_key`` are *strings*. Today both fields are
+populated from internal helpers (``current_month_key`` /
+``current_daily_key`` return safe ASCII), but the dataclass itself
+accepts any string. A future schema-drift addition or an operator
+mis-edit of the on-disk file would slip a planted BiDi mark straight
+through to the next ``save_atomic`` write — the file is committed to
+``main`` by ``update-google-places-stations.yml`` and rendered via
+``cat`` / ``less`` / the GitHub web UI / IDE preview, where the BiDi
+reversal of the surrounding bytes hides the attack from review.
+
+Attack path for ``save_request_count``'s writer
+================================================
+
+The pre-fix inline write at ``src/providers/vor.py:1562`` used
+``json.dump(payload, handle, ensure_ascii=False)``. The current payload
+schema is ``{"date": <ISO date>, "requests": <int>}`` — both safe
+scalars — but the schema is dictionary-shaped and forward-compatible.
+A future field carrying station- / provider- / environment-controlled
+content (e.g. ``"last_user_agent"``, ``"last_error_token"``) would leak
+the canonical BiDi / line-separator / C1 union verbatim to ``cat`` /
+``less`` / the GitHub web UI.
+
+Attack path for ``write_status``
+=================================
+
+The pre-fix write at ``src/utils/cache.py:435`` used
+``json.dump(status, fh, ensure_ascii=False, indent=2, sort_keys=True)``.
+The current ``status`` schema is heartbeat-shaped (``"status"`` token,
+ISO timestamps, integers), but the callers can pass any dict — for
+example, ``scripts/update_vor_cache.py:_record_status`` constructs the
+payload from the run's runtime state, and a future field carrying a
+provider-controlled error fragment, station name, or request-id would
+slip through.
+
+To pin the invariant programmatically (the same shape the existing
+Round-9 / Round-10 PoCs use), each post-fix writer uses
+``ensure_ascii=True``. The PoCs below use a synthetic payload field
+(or, for ``MonthlyQuota``, the existing ``daily_key`` string field)
+carrying the canonical Trojan-Source primitive set to demonstrate the
+escape behaviour: every primitive lands as a literal ``\\uXXXX`` escape
+in the on-disk file rather than its raw UTF-8 byte sequence.
+
+Fix shape
+==========
+
+All three writers: switch from ``ensure_ascii=False`` to
+``ensure_ascii=True``. The VOR writer additionally extracts the inline
+``atomic_write`` block into a ``_write_request_count_file(path,
+payload)`` helper, mirroring the Round-10 ``_write_heartbeat_file``
+extraction so the canonical fix-shape lives in exactly one place per
+writer family.
+
+  * Forensic intent is preserved (``json.loads`` recovers the original
+    string from the literal ``\\uXXXX`` escape, so debugging / replay
+    is unaffected).
+  * No raw BiDi / line-separator / C1 byte reaches any byte viewer
+    (``cat`` / ``less`` / GitHub web UI / IDE preview).
+  * The closing-checklist's invariant is now uniform across every
+    committed operator-facing JSON sidecar writer in the
+    ``data/*.json`` and ``cache/<provider>/*.json`` family.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.places.quota import MonthlyQuota
+from src.providers.vor import _write_request_count_file
+from src.utils import cache
+from src.utils.files import sanitize_filename
+
+
+# Canonical Trojan-Source / zero-width / Unicode-line-terminator / C1
+# terminal-escape primitives — byte-exact mirror of the set pinned in
+# ``tests/test_sentinel_state_heartbeat_trojan_source.py`` so any future
+# widening of the canonical floor is enforced uniformly across the
+# committed-sidecar writer family.
+_TROJAN_SOURCE_PRIMITIVES = (
+    # BiDi formatting controls (CVE-2021-42574 first half).
+    "‪",  # LRE Left-To-Right Embedding
+    "‫",  # RLE Right-To-Left Embedding
+    "‬",  # PDF Pop Directional Formatting
+    "‭",  # LRO Left-To-Right Override
+    "‮",  # RLO Right-To-Left Override
+    # BiDi isolates (CVE-2021-42574 second half).
+    "⁦",  # LRI Left-To-Right Isolate
+    "⁧",  # RLI Right-To-Left Isolate
+    "⁨",  # FSI First Strong Isolate
+    "⁩",  # PDI Pop Directional Isolate
+    # Zero-width / left-right marks.
+    "​",  # ZWSP
+    "‌",  # ZWNJ
+    "‍",  # ZWJ
+    "‎",  # LRM
+    "‏",  # RLM
+    "؜",  # ALM
+    # Unicode line / paragraph separators (SIEM splitter primitive).
+    " ",  # LINE SEPARATOR
+    " ",  # PARAGRAPH SEPARATOR
+    # Byte Order Mark / ZWNBSP.
+    "﻿",
+    # C1 terminal escape primitives (8-bit colour/SGR start, OSC).
+    "\x9b",  # CSI
+    "\x9d",  # OSC
+    "\x90",  # DCS
+)
+
+
+# UTF-8 byte sequence each primitive encodes to. Pre-fix every byte
+# sequence appears in the on-disk file verbatim; post-fix none of them
+# do (the JSON encoder replaces each code point with the literal
+# ``\\uXXXX`` escape).
+_UTF8_BYTES = {primitive: primitive.encode("utf-8") for primitive in _TROJAN_SOURCE_PRIMITIVES}
+
+
+# ---------------------------------------------------------------------
+# PoC 1: ``MonthlyQuota.save_atomic`` — the ``daily_key`` / ``month_key``
+# string fields MUST NOT leak raw BiDi marks into the on-disk file.
+# ---------------------------------------------------------------------
+
+
+def test_quota_save_atomic_does_not_emit_raw_bidi_override(tmp_path: Path) -> None:
+    """A planted ``daily_key`` carrying U+202E reaches the on-disk
+    ``data/places_quota.json`` verbatim pre-fix. Operators viewing the
+    file via ``cat`` / ``less`` / GitHub web UI / IDE preview see the
+    BiDi-reversed display of the surrounding bytes, hiding the attack
+    from review.
+    """
+    quota = MonthlyQuota(
+        month_key="2026-05",
+        counts={"nearby": 1, "text": 0, "details": 0},
+        total=1,
+        daily_key="2026-05-10‮moc.live",
+        daily_total=1,
+    )
+    out_path = tmp_path / "places_quota.json"
+    quota.save_atomic(out_path)
+
+    raw_bytes = out_path.read_bytes()
+    # The smoking gun: U+202E encodes to the 3-byte UTF-8 sequence E2 80 AE.
+    # Its appearance in the on-disk file means BiDi reversal is now active
+    # for any cat / less / GitHub / IDE viewer of the file.
+    assert b"\xe2\x80\xae" not in raw_bytes, (
+        "U+202E (RLO) leaked verbatim into data/places_quota.json — "
+        "BiDi reversal is now active for any cat/less/GitHub viewer of the file."
+    )
+    # Defense-in-depth: the escaped form ``\\u202e`` MUST appear so the
+    # forensic intent (preserve which date / key was tracked) is not lost.
+    assert "\\u202e" in raw_bytes.decode("utf-8"), (
+        "The escaped sentinel ``\\u202e`` is missing — quota state lost."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_quota_save_atomic_escapes_every_trojan_source_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    """The escape behaviour MUST be uniform across the canonical
+    Trojan-Source / zero-width / line-terminator / C1 union — a single
+    primitive surviving in raw form reopens the attack via a future
+    field that carries operator-controlled or schema-drift content.
+    """
+    quota = MonthlyQuota(
+        month_key="2026-05",
+        daily_key=f"evil{primitive}.example",
+        daily_total=1,
+        total=1,
+    )
+    out_path = tmp_path / "places_quota.json"
+    quota.save_atomic(out_path)
+
+    raw_bytes = out_path.read_bytes()
+    raw_utf8 = _UTF8_BYTES[primitive]
+    assert raw_utf8 not in raw_bytes, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked into the "
+        f"places quota state file as raw UTF-8 bytes ({raw_utf8!r})."
+    )
+
+
+def test_quota_save_atomic_round_trips_legitimate_payload(tmp_path: Path) -> None:
+    """Regression: the canonical quota schema (ASCII-safe ISO keys + ints)
+    round-trips byte-stable through ``json.loads``. The ``MonthlyQuota.load``
+    path must continue to recover the in-memory state from the on-disk file
+    after the ``ensure_ascii=True`` switch — operators relying on the file
+    for monthly reconciliation see exactly the same parsed structure as
+    pre-fix runs.
+    """
+    quota = MonthlyQuota(
+        month_key="2026-05",
+        counts={"nearby": 3, "text": 2, "details": 1},
+        total=6,
+        daily_key="2026-05-10",
+        daily_total=4,
+    )
+    out_path = tmp_path / "places_quota.json"
+    quota.save_atomic(out_path)
+
+    parsed = json.loads(out_path.read_text(encoding="utf-8"))
+    assert parsed["month"] == "2026-05"
+    assert parsed["counts"] == {"nearby": 3, "text": 2, "details": 1}
+    assert parsed["total"] == 6
+    assert parsed["daily_key"] == "2026-05-10"
+    assert parsed["daily_total"] == 4
+
+
+# ---------------------------------------------------------------------
+# PoC 2: ``_write_request_count_file`` — the extracted VOR quota writer
+# helper MUST NOT leak raw BiDi marks into
+# ``data/vor_request_count.json``.
+# ---------------------------------------------------------------------
+
+
+def test_vor_request_count_does_not_emit_raw_bidi_override(tmp_path: Path) -> None:
+    """The VOR quota writer's structural fix shape: even with a payload
+    carrying U+202E in a synthetic field, the on-disk file MUST NOT
+    contain the raw UTF-8 byte sequence ``\\xe2\\x80\\xae``. The
+    ``cat data/vor_request_count.json`` view, the GitHub web UI render,
+    and any IDE preview MUST display the inert ``\\u202e`` escape rather
+    than triggering BiDi reversal of the trailing characters.
+    """
+    payload = {
+        "date": "2026-05-10‮moc.live",
+        "requests": 42,
+    }
+    out_path = tmp_path / "vor_request_count.json"
+    _write_request_count_file(out_path, payload)
+
+    raw_bytes = out_path.read_bytes()
+    assert b"\xe2\x80\xae" not in raw_bytes, (
+        "U+202E (RLO) leaked verbatim into data/vor_request_count.json — "
+        "BiDi reversal is now active for any cat/less/GitHub viewer of the file."
+    )
+    assert "\\u202e" in raw_bytes.decode("utf-8"), (
+        "The escaped sentinel ``\\u202e`` is missing — VOR quota forensic "
+        "data lost."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_vor_request_count_escapes_every_trojan_source_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    """The VOR quota writer's escape behaviour MUST be uniform across
+    the canonical Trojan-Source / zero-width / line-terminator / C1
+    union — a single primitive surviving in raw form reopens the
+    attack via a future field that carries station- / provider- /
+    environment-controlled content.
+    """
+    payload = {"date": f"evil{primitive}.example", "requests": 1}
+    out_path = tmp_path / "vor_request_count.json"
+    _write_request_count_file(out_path, payload)
+
+    raw_bytes = out_path.read_bytes()
+    raw_utf8 = _UTF8_BYTES[primitive]
+    assert raw_utf8 not in raw_bytes, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked into the "
+        f"VOR quota file as raw UTF-8 bytes ({raw_utf8!r})."
+    )
+
+
+def test_vor_request_count_round_trips_legitimate_payload(tmp_path: Path) -> None:
+    """Regression: the canonical VOR quota schema (``date`` + ``requests``)
+    round-trips byte-stable. The ASCII-only on-disk bytes parse via
+    ``json.loads`` back to the same dict — operators and downstream
+    parsers see the exact same structure as pre-fix runs.
+    """
+    payload = {"date": "2026-05-10", "requests": 7}
+    out_path = tmp_path / "vor_request_count.json"
+    _write_request_count_file(out_path, payload)
+
+    parsed = json.loads(out_path.read_text(encoding="utf-8"))
+    assert parsed == payload
+    # Trailing newline preserved.
+    assert out_path.read_text(encoding="utf-8").endswith("\n")
+
+
+# ---------------------------------------------------------------------
+# PoC 3: ``write_status`` — the cache heartbeat writer MUST NOT leak
+# raw BiDi marks into ``cache/<provider>/last_run.json``.
+# ---------------------------------------------------------------------
+
+
+def test_write_status_does_not_emit_raw_bidi_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A planted ``status`` payload carrying U+202E in a synthetic
+    field reaches ``cache/<provider>/last_run.json`` verbatim pre-fix.
+    Operators viewing the file via ``cat`` / ``less`` / GitHub web UI
+    / IDE preview see the BiDi-reversed display of the surrounding
+    bytes, hiding the attack from review.
+    """
+    base = tmp_path / "cache-root"
+    monkeypatch.setattr(cache, "_CACHE_DIR", base, raising=False)
+
+    payload = {
+        "last_run_at": "2026-05-10T12:00:00+00:00",
+        "status": "ok",
+        "error_token": "evil‮moc.live",
+    }
+    cache.write_status("vor", payload)
+
+    status_path = base / sanitize_filename("vor") / "last_run.json"
+    raw_bytes = status_path.read_bytes()
+    assert b"\xe2\x80\xae" not in raw_bytes, (
+        "U+202E (RLO) leaked verbatim into cache/<provider>/last_run.json — "
+        "BiDi reversal is now active for any cat/less/GitHub viewer of the file."
+    )
+    assert "\\u202e" in raw_bytes.decode("utf-8"), (
+        "The escaped sentinel ``\\u202e`` is missing — cache status "
+        "forensic data lost."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_write_status_escapes_every_trojan_source_primitive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, primitive: str
+) -> None:
+    """The cache status writer's escape behaviour MUST be uniform
+    across the canonical Trojan-Source / zero-width / line-terminator
+    / C1 union — a single primitive surviving in raw form reopens the
+    attack via a future field that carries station- / provider- /
+    environment-controlled content.
+    """
+    base = tmp_path / "cache-root"
+    monkeypatch.setattr(cache, "_CACHE_DIR", base, raising=False)
+
+    payload = {"status": "ok", "error_token": f"evil{primitive}.example"}
+    cache.write_status("vor", payload)
+
+    status_path = base / sanitize_filename("vor") / "last_run.json"
+    raw_bytes = status_path.read_bytes()
+    raw_utf8 = _UTF8_BYTES[primitive]
+    assert raw_utf8 not in raw_bytes, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked into the "
+        f"cache status file as raw UTF-8 bytes ({raw_utf8!r})."
+    )
+
+
+def test_write_status_round_trips_legitimate_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: the canonical heartbeat schema (status token, ISO
+    timestamps, integers) round-trips byte-stable. The ASCII-only
+    on-disk bytes parse via ``json.loads`` back to the same dict —
+    downstream ``read_status`` callers see the exact same structure
+    as pre-fix runs.
+    """
+    base = tmp_path / "cache-root"
+    monkeypatch.setattr(cache, "_CACHE_DIR", base, raising=False)
+
+    payload = {
+        "last_run_at": "2026-05-10T12:00:00+00:00",
+        "status": "ok",
+        "events_collected": 5,
+        "stations_queried": 2,
+    }
+    cache.write_status("vor", payload)
+
+    assert cache.read_status("vor") == payload
+
+
+def test_write_status_preserves_german_text_via_escape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A legitimate German string (``München``) in a synthetic status
+    field round-trips through ``json.loads`` unchanged. The on-disk
+    bytes are now the escape sequence (``M\\u00fcnchen``) but the
+    parsed value equals the original — forensic intent preserved.
+    """
+    base = tmp_path / "cache-root"
+    monkeypatch.setattr(cache, "_CACHE_DIR", base, raising=False)
+
+    payload = {"status": "ok", "location": "München Hbf"}
+    cache.write_status("vor", payload)
+
+    status_path = base / sanitize_filename("vor") / "last_run.json"
+    parsed = json.loads(status_path.read_text(encoding="utf-8"))
+    assert parsed["location"] == "München Hbf"
+    # The raw multi-byte ``ü`` (UTF-8 ``\xc3\xbc``) MUST NOT appear in
+    # the on-disk file; it lands as the literal ``ü`` escape.
+    assert b"\xc3\xbc" not in status_path.read_bytes()
+    assert "\\u00fc" in status_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Round 11 closes the **three** sibling JSON sidecar writers the Round-10 closing-checklist explicitly **named but deferred**. All three landed `ensure_ascii=False` JSON output into operator-facing files committed to `main` by the cron pipeline:

| Writer | On-disk path | Committed by |
| --- | --- | --- |
| `MonthlyQuota.save_atomic` (`src/places/quota.py`) | `data/places_quota.json` | `update-google-places-stations.yml:160` |
| `save_request_count` inline write (`src/providers/vor.py:1582-1588` pre-fix) — now `_write_request_count_file` helper | `data/vor_request_count.json` | `update-vor-cache.yml:97`, `update-stammstrecke-status.yml:96` |
| `write_status` (`src/utils/cache.py`) | `cache/<provider>/last_run.json` | `update-vor-cache.yml:96` |

## Vulnerability (CVE-2021-42574 Trojan-Source / BiDi-Mark Drift)

`ensure_ascii=False` emits every non-ASCII code point as raw UTF-8. The canonical attack-byte union — BiDi controls `U+202A`-`U+202E` / `U+2066`-`U+2069`, zero-width primitives `U+200B`-`U+200F`, Unicode line/paragraph separators `U+2028`-`U+2029`, BOM `U+FEFF`, and C1 terminal-escape primitives `\x9b` (CSI) / `\x9d` (OSC) / `\x90` (DCS) — would survive verbatim into the on-disk file. Operators reviewing the file via `cat` / `less` / `git diff` / GitHub web UI / IDE preview see the BiDi-reversed display of the surrounding bytes, hiding the attack from human eyes.

**Pre-fix repro** (verified locally): a planted `daily_key="2026-05-10‮moc.live"` produces `data/places_quota.json` with the raw 3-byte sequence `\xe2\x80\xae` (U+202E RLO) embedded between `0` and `moc.live`. Post-fix: the file holds the inert ASCII escape `‮` (6 ASCII bytes) — no BiDi trigger in any viewer.

The current payload schemas for all three writers carry only safe scalar values **today** (integers, ISO dates, hard-coded status tokens), but the writer-shape contract MUST be `ensure_ascii=True` regardless — the defence is forward-compatible against future schema-drift additions and mirrors the canonical fix shape pinned in PR #1434 / PR #1435 for the sibling writers (`_write_quarantine_file`, `_render_diff_markdown`, `_save_state`, `_write_heartbeat_file`).

## Fix

* `src/places/quota.py:MonthlyQuota.save_atomic` — `ensure_ascii=False` → `ensure_ascii=True` (one-line flip; method already centralised).
* `src/utils/cache.py:write_status` — same one-line flip (function already centralised).
* `src/providers/vor.py:save_request_count` — extracted the inline `atomic_write` block into a new `_write_request_count_file(path, payload)` helper using `ensure_ascii=True`, mirroring the Round-10 `_write_heartbeat_file` extraction pattern so the canonical fix-shape lives in exactly one place per writer family.

Forensic intent is preserved everywhere — `MonthlyQuota.load` / `load_request_count` / `read_status` all recover the original strings from the literal `\uXXXX` escape sequences via `json.loads`.

## Test plan

- [x] `tests/test_sentinel_quota_status_trojan_source.py` — **70 PoC tests**:
  - Quota: smoking-gun U+202E test + 21 parametrised primitives + 1 round-trip regression.
  - VOR: smoking-gun U+202E test + 21 parametrised primitives + 1 round-trip regression.
  - Status: smoking-gun U+202E test + 21 parametrised primitives + 1 round-trip regression + 1 German `ü` escape regression.
- [x] Full pytest suite: **3572 passed, 3 skipped** (82s).
- [x] `python scripts/run_static_checks.py`: Ruff ✓, Mypy ✓ (8 pre-existing errors in `src/utils/http.py` unrelated to this change), Bandit ✓, secret scan ✓, C901 gate ✓ (0 new violations), pip-audit ✓.

## Closing checklist — named but deferred

Out of scope, queued for a dedicated provider-cache sanitisation round:
* `cache/<provider>/events.json` (`src/utils/cache.py:write_cache`) — carries legitimate provider-fetched German titles + descriptions. A blanket `ensure_ascii=True` flag flip would massively bloat the committed cache diff; the next round MUST pair the flag flip with a Trojan-Source primitive scrubber at the ingestion boundary (`read_cache` / provider parsers) instead.

https://claude.ai/code/session_01Q6zyUVz55KWGZQqqTX7XRv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6zyUVz55KWGZQqqTX7XRv)_