### PR TITLE
security: BiDi/Trojan-Source leak in cache events writer (Round 12, scrubber-at-ingestion)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,175 @@
+## 2026-05-11 - Trojan-Source BiDi Drift Round 12 (Provider Cache Events Sidecar): `write_cache` (`cache/<provider>/events.json`) Was the Sole Round-11 Closing-Checklist Deferred Sidecar — Closed Via Scrubber-At-Ingestion (Not `ensure_ascii=True`) To Preserve Compact German Diffs
+
+**Vulnerability:** Round 11 (PR #1436) closed three sibling writers
+(`MonthlyQuota.save_atomic` → `data/places_quota.json`,
+`_write_request_count_file` → `data/vor_request_count.json`,
+`write_status` → `cache/<provider>/last_run.json`). The Round-11
+closing checklist explicitly named `write_cache`
+(`src/utils/cache.py:335`) as the SOLE deferred sidecar in the same
+operator-facing JSON family — but with a DIFFERENT fix shape than
+the prior rounds:
+
+  * The sibling writers carried only safe scalar values (ISO dates,
+    integers, hard-coded status tokens). Switching to
+    `ensure_ascii=True` had a negligible diff cost.
+  * `write_cache` carries provider-fetched **German titles +
+    descriptions** — every cache update flushes ~hundreds of items
+    where each title averages 30-80 characters and the description
+    100-300 characters, with umlauts (`ä`/`ö`/`ü`/`Ä`/`Ö`/`Ü`) and
+    sharp s (`ß`) sprinkled through both. A blanket
+    `ensure_ascii=True` flip would have ballooned every umlaut from
+    its 2-byte UTF-8 form (e.g. `\xc3\xbc` for `ü`) to the 6-byte
+    `ü` literal, multiplying the on-disk byte size of every
+    German cache file by ~4-6x and bloating the cron commit diff
+    that `update-vor-cache.yml` / `update-wl-cache.yml` /
+    `update-oebb-cache.yml` / `update-baustellen-cache.yml`
+    publishes back to `main` after every refresh.
+
+The Round-11 "Named but deferred" entry pinned the fix shape:
+**pair an ingestion-boundary Trojan-Source primitive scrubber with
+the existing `ensure_ascii=False` flag** so the committed diff stays
+compact for legitimate German content while the canonical
+CVE-2021-42574 attack-byte union is rejected before reaching the
+serialiser.
+
+**Threat model:**
+
+  1. Attacker compromises an upstream provider (WL / OEBB / VOR
+     cache poisoning, malicious title flowing through the
+     `update_*_cache.py` scripts, DNS hijack of an unpinned upstream,
+     leaked CI secret store) or an operator mis-edits the on-disk
+     cache file.
+  2. A planted feed item carrying U+202E (RIGHT-TO-LEFT OVERRIDE)
+     — e.g. `Westbahnhof‮moc.live` displays as `Westbahnhofevil.com`
+     — reaches `write_cache` via one of the four `update_*_cache.py`
+     call sites:
+       * `scripts/update_wl_cache.py:59`
+       * `scripts/update_oebb_cache.py:67`
+       * `scripts/update_vor_cache.py:234`
+       * `scripts/update_baustellen_cache.py:570`
+  3. Pre-fix `write_cache` serialised the item via
+     `json.dump(items, fh, ensure_ascii=False, ...)`.
+     `ensure_ascii=False` emits U+202E as its raw UTF-8 byte triplet
+     `\xe2\x80\xae`, so the on-disk
+     `cache/<provider>/events.json` carries the BiDi-reversal trigger.
+  4. The respective workflow commits `cache/<provider>/events.json`
+     to `main` (`update-vor-cache.yml` lists `cache/vor/events.json`
+     in its `file_pattern`; the WL / OEBB / Baustellen workflows
+     mirror this contract). The malicious title is now visible in
+     `git log -p` / `git show` / the GitHub web UI / `cat` /
+     `less` / IDE preview — every viewer honours BiDi reversal.
+  5. Operator reviewing the commit / cache file for diff bloat /
+     suspicious upstream behaviour misreads the BiDi-reversed
+     display as the inverse of the actual planted bytes. The
+     attack hides in the operator's own review pass.
+
+**Reproduced:** `tests/test_sentinel_cache_events_trojan_source.py`
+contains 50 PoC tests:
+
+  * 1 + 21 (parametrised) for the write boundary covering every
+    primitive in the canonical CVE-2021-42574 union.
+  * 3 for nested-shape coverage (dict KEY, nested list element,
+    nested dict value) so the recursive walker is pinned.
+  * 1 for the German-content compact-diff regression
+    (`ä`/`ü`/`ß`/`Ö` survive as raw UTF-8, the bloated
+    `\u00XX` form does NOT appear).
+  * 1 for the clean-payload round-trip regression.
+  * 1 + 21 for the read-boundary defence-in-depth coverage
+    (every primitive is stripped from a planted on-disk file).
+  * 1 for the read-boundary German-content regression.
+
+Pre-fix repro for the canonical write-boundary case:
+`title="Westbahnhof‮moc.live"` produced
+`cache/<provider>/events.json` with raw bytes
+`...Westbahnhof\xe2\x80\xaemoc.live...`. Post-fix: the primitive is
+stripped at the ingestion boundary; the on-disk file reads
+`Westbahnhofmoc.live` (the malicious primitive is gone, the safe
+portion of the title remains).
+
+**Fix:**
+
+  * `src/utils/serialize.py`: add `scrub_trojan_source_primitives` —
+    a recursive walker over JSON-shaped structures
+    (`str` / `dict` / `list` / `tuple`) that strips the canonical
+    CVE-2021-42574 attack-byte union from every reachable string
+    AND every dict KEY. The regex `_TROJAN_SOURCE_PRIMITIVES_RE`
+    is byte-exact mirror of `_INVISIBLE_DANGEROUS_RE` in
+    `src/utils/logging.py` and `_MARKDOWN_NORMALISE_UNSAFE_RE` in
+    `src/utils/text.py`. The pattern is built from ASCII-only
+    `\xNN` / `\uNNNN` escape sequences so the source file itself
+    contains no Trojan-Source primitives — reviewing the regex via
+    `cat` / `less` / the GitHub web UI / IDE preview cannot itself
+    trigger BiDi reversal (a self-defeating implementation would
+    have leaked the attack into the defence). Recursion is
+    depth-limited (`max_depth=50`) — defence-in-depth against
+    pathological inputs that bypass the upstream JSON-parser
+    depth-bomb guard.
+  * `src/utils/cache.py:write_cache`: apply the scrubber to the
+    incoming `items` BEFORE the data-degradation guard count, sort,
+    and `json.dump` — ingestion-boundary defence so the dangerous
+    bytes never reach the writer. `ensure_ascii=False` is preserved
+    at the writer (compact German diff contract intact).
+  * `src/utils/cache.py:read_cache`: apply the same scrubber to the
+    parsed payload BEFORE returning to callers — defence-in-depth
+    at the read boundary that retroactively cleans any historic
+    poisoned cache file (planted before this fix, surviving from a
+    corrupted previous run, written by a future bypass of the
+    write-side scrubber, or persisted across the staging-window
+    while a poisoned commit is still on `main`).
+
+**Learning:** the Round-11 closing-checklist's "Named but deferred"
+entry correctly predicted the cache-events writer was the next
+target AND correctly identified that the fix shape diverged from
+the sibling-writer pattern. The drift family is now uniform across
+every committed operator-facing JSON sidecar in the project:
+
+  * **Closed in this round:** `write_cache`
+    (`cache/<provider>/events.json`) via scrubber-at-ingestion +
+    `ensure_ascii=False` preservation. `read_cache` carries the
+    same defence-in-depth at the read boundary.
+  * **Already closed (Round 11):** `MonthlyQuota.save_atomic`
+    (`data/places_quota.json`), `_write_request_count_file`
+    (`data/vor_request_count.json`), `write_status`
+    (`cache/<provider>/last_run.json`) — all via
+    `ensure_ascii=True`.
+  * **Already closed (earlier rounds):** `_save_state`
+    (`data/first_seen.json`, Round 10), `_write_heartbeat_file`
+    (`data/stations_last_run.json`, Round 10),
+    `_write_quarantine_file` (`data/quarantine.json`, Round 9),
+    `_render_diff_markdown` (`docs/stations_diff.md`, Round 9),
+    `ValidationReport.to_markdown()` (Round 3),
+    `render_feed_health_markdown` / GitHub-Issue body (Round 2),
+    `docs/statistik.md` stats dashboard (Round 1),
+    `data/stats/*.csv` CSV writer, RSS XML writers, sitemap
+    writer, `_escape_env_value` `.env` writer.
+  * **Named but deferred** (out of scope for this round; queued
+    for a dedicated stations-file sanitisation round):
+    * `src/places/merge.py:write_stations` →
+      `data/stations.json` (committed by
+      `update-google-places-stations.yml`). Same
+      `ensure_ascii=False` shape; the payload carries
+      provider-fetched German station names. Same fix shape as
+      this round (scrubber-at-ingestion + flag preservation). The
+      next round MUST reuse the
+      `scrub_trojan_source_primitives` helper added in this
+      round so the defence shape stays single-sourced.
+
+The two structural fix shapes are now codified:
+  * **Scrub-and-drop semantics** (`scrub_trojan_source_primitives`
+    + `ensure_ascii=False`): high-cardinality content sinks where
+    forensic re-construction would bloat the diff and the safe
+    portion of the value is meaningful (cache content, station
+    descriptions, log messages).
+  * **Escape-and-preserve semantics** (`ensure_ascii=True`):
+    low-cardinality state sinks where each row is a unique
+    sentinel and forensic re-construction matters (heartbeat,
+    quota, request count, first-seen state, quarantine entries).
+
+The drift-walker invariant: any future operator-facing JSON
+sidecar writer added to the codebase MUST adopt one of the two
+shapes above. The shape choice is dictated by cardinality and
+forensic-intent requirements, not by writer convenience.
+
 ## 2026-05-11 - Trojan-Source BiDi Drift Round 11 (Places Quota + VOR Request Count + Cache Heartbeat Sidecars): `MonthlyQuota.save_atomic` (`data/places_quota.json`), `save_request_count`'s Atomic Write (`data/vor_request_count.json`), and `write_status` (`cache/<provider>/last_run.json`) Were the Three Sibling Writers the Round-10 Closing-Checklist Named But Deferred
 
 **Vulnerability:** Round 10 (PR #1435) closed `_save_state`

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -15,6 +15,7 @@ from collections.abc import Callable
 from .env import get_bool_env
 from .files import atomic_write, safe_path_join, sanitize_filename
 from .logging import sanitize_log_arg
+from .serialize import scrub_trojan_source_primitives
 
 _CACHE_DIR = Path("cache")
 _CACHE_FILENAME = "events.json"
@@ -244,7 +245,21 @@ def read_cache(provider: str) -> list[Any]:
         _emit_cache_alert(provider, f"Leseproblem ({sanitized_exc})")
     else:
         if isinstance(payload, list):
-            return payload
+            # Security (Trojan-Source / BiDi-Mark Drift Round 12,
+            # defence-in-depth at the read boundary): retroactively scrub
+            # the canonical CVE-2021-42574 attack-byte union from any
+            # historic poisoned cache file (planted before this fix,
+            # surviving from a corrupted previous run, or written by a
+            # future bypass of ``write_cache``'s ingestion-boundary
+            # scrubber). Mirrors the write-side defence so the in-memory
+            # payload handed to the feed builder cannot carry raw BiDi
+            # marks regardless of how the on-disk bytes got there. See
+            # ``src/utils/serialize.py:scrub_trojan_source_primitives``
+            # for the canonical attack-byte union.
+            scrubbed = scrub_trojan_source_primitives(payload)
+            if isinstance(scrubbed, list):
+                return scrubbed
+            return []
         log.warning(
             "Cache for provider '%s' at %s does not contain a JSON array (found %s)",
             provider,
@@ -339,6 +354,25 @@ def write_cache(provider: str, items: list[Any], *, pretty: bool | None = None) 
     reduce cache size for large datasets set ``pretty`` to ``False`` or define
     the environment variable ``WIEN_OEPNV_CACHE_PRETTY=0``.
     """
+
+    # Security (Trojan-Source / BiDi-Mark Drift Round 12, ingestion-boundary
+    # defence): strip the canonical CVE-2021-42574 attack-byte union (BiDi
+    # formatting controls, BiDi isolates, zero-width primitives + LRM/RLM/ALM,
+    # Unicode line / paragraph separators, the BOM / ZWNBSP, and the 8-bit
+    # C1 terminal-escape primitives) from every reachable string in the
+    # incoming items BEFORE the data-degradation guard count, sort, and
+    # ``json.dump``. ``cache/<provider>/events.json`` is committed to ``main``
+    # by the cron pipeline (``update-vor-cache.yml``,
+    # ``update-wl-cache.yml``, ``update-oebb-cache.yml``,
+    # ``update-baustellen-cache.yml``) and rendered via ``cat`` / ``less`` /
+    # the GitHub web UI / IDE preview. ``ensure_ascii=False`` is preserved at
+    # the writer below so legitimate German content (umlauts ä/ö/ü/Ä/Ö/Ü +
+    # sharp s ß + every other safe Unicode code point) stays compact in the
+    # diff; pairing it with the scrubber rejects the canonical attack-byte
+    # union before it reaches the serialiser. See
+    # ``src/utils/serialize.py:scrub_trojan_source_primitives`` for the
+    # canonical attack-byte union and the scrub-and-drop semantics rationale.
+    items = scrub_trojan_source_primitives(items)
 
     prune_cache()
 

--- a/src/utils/serialize.py
+++ b/src/utils/serialize.py
@@ -2,16 +2,104 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Any
 
 
-__all__ = ["serialize_for_cache"]
+__all__ = ["scrub_trojan_source_primitives", "serialize_for_cache"]
 
 
 import logging
 
 log = logging.getLogger(__name__)
+
+
+# Security (Trojan-Source / BiDi-Mark Drift Round 12): canonical attack-byte
+# union covering the CVE-2021-42574 BiDi formatting controls, BiDi isolates,
+# zero-width primitives + LRM/RLM/ALM, Unicode line / paragraph separators,
+# the BOM / ZWNBSP, and the 8-bit C1 terminal-escape primitives (CSI, OSC,
+# DCS). Byte-exact mirror of ``_INVISIBLE_DANGEROUS_RE`` in
+# ``src/utils/logging.py`` and ``_MARKDOWN_NORMALISE_UNSAFE_RE`` in
+# ``src/utils/text.py`` so any future widening of the canonical floor stays
+# uniform across the codebase. See the comment at
+# ``_INVISIBLE_DANGEROUS_RE`` for the full threat-model narrative.
+#
+# The character-class union is built from ASCII-only escape sequences
+# (``\xNN`` / ``\uNNNN``) so the source file itself contains no
+# Trojan-Source primitives — reviewing this regex via ``cat`` / ``less``
+# / the GitHub web UI / IDE preview cannot itself trigger BiDi reversal.
+_TROJAN_SOURCE_PRIMITIVES_RE = re.compile(
+    r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f"
+    r"\u061c\u200b-\u200f\u2028-\u202e\u2066-\u2069\ufeff]"
+)
+
+
+def scrub_trojan_source_primitives(
+    value: Any,
+    *,
+    _depth: int = 0,
+    max_depth: int = 50,
+) -> Any:
+    """Recursively strip Trojan-Source / BiDi / zero-width / line-terminator
+    / 8-bit C1 primitives from a JSON-shaped structure.
+
+    Walks ``str`` / ``dict`` / ``list`` / ``tuple`` values and removes the
+    canonical CVE-2021-42574 attack-byte union from every reachable string
+    (values AND dict keys). Legitimate non-ASCII content - German umlauts,
+    CJK, emoji, every other Unicode code point that is NOT in the
+    Trojan-Source union - passes through unchanged.
+
+    This is the ingestion-boundary defence for operator-facing JSON sidecar
+    sinks (currently ``cache/<provider>/events.json`` via
+    :func:`src.utils.cache.write_cache`) where the on-disk file is committed
+    to ``main`` by the cron pipeline and rendered via ``cat`` / ``less`` /
+    the GitHub web UI / IDE preview. ``ensure_ascii=False`` is preserved at
+    the writer so legitimate German content stays compact in the diff;
+    pairing it with this scrubber rejects the canonical attack-byte union
+    before it reaches the serialiser.
+
+    The scrub-and-drop semantics deliberately differ from the
+    ``ensure_ascii=True`` escape-and-preserve semantics used by the sibling
+    state writers (``MonthlyQuota.save_atomic``,
+    ``_write_request_count_file``, ``write_status``,
+    ``_write_heartbeat_file``, ``_write_quarantine_file``, ``_save_state``).
+    Cache content is a forward-flowing data feed with high cardinality
+    (thousands of items per refresh); per-item forensic re-construction
+    would just bloat the diff. State sinks carry unique sentinels where
+    forensic re-construction matters.
+
+    A ``RecursionError`` is raised if the structure depth exceeds
+    ``max_depth`` - defence-in-depth against pathological inputs that
+    bypass the upstream depth-bomb guard at the JSON parser.
+    """
+    if _depth > max_depth:
+        raise RecursionError(f"Maximum recursion depth {max_depth} exceeded")
+    if isinstance(value, str):
+        return _TROJAN_SOURCE_PRIMITIVES_RE.sub("", value)
+    if isinstance(value, dict):
+        return {
+            (
+                _TROJAN_SOURCE_PRIMITIVES_RE.sub("", key)
+                if isinstance(key, str)
+                else key
+            ): scrub_trojan_source_primitives(
+                val, _depth=_depth + 1, max_depth=max_depth
+            )
+            for key, val in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            scrub_trojan_source_primitives(item, _depth=_depth + 1, max_depth=max_depth)
+            for item in value
+        ]
+    if isinstance(value, tuple):
+        return tuple(
+            scrub_trojan_source_primitives(item, _depth=_depth + 1, max_depth=max_depth)
+            for item in value
+        )
+    return value
+
 
 def serialize_for_cache(
     value: Any,

--- a/tests/test_sentinel_cache_events_trojan_source.py
+++ b/tests/test_sentinel_cache_events_trojan_source.py
@@ -1,0 +1,478 @@
+"""Sentinel PoC: Trojan-Source / BiDi-Mark leakage at the
+``cache/<provider>/events.json`` writer that the *BiDi-Mark Drift
+Round 11* closing-checklist named but deferred —
+``src/utils/cache.py:write_cache``.
+
+Round 11 (PR #1436) closed the three sibling writers
+(``MonthlyQuota.save_atomic`` → ``data/places_quota.json``,
+``_write_request_count_file`` → ``data/vor_request_count.json``,
+``write_status`` → ``cache/<provider>/last_run.json``). The Round-11
+closing checklist explicitly named ``write_cache`` as the sole
+deferred sidecar in the same operator-facing JSON family — but with a
+DIFFERENT fix shape than the prior rounds:
+
+  * The other writers carried only safe scalar values (ISO dates,
+    integers, hard-coded status tokens). Switching to
+    ``ensure_ascii=True`` had a negligible diff cost.
+  * ``write_cache`` carries provider-fetched **German titles +
+    descriptions** (umlauts ä/ö/ü/ß ≡ U+00E4/U+00F6/U+00FC/U+00DF,
+    plus the German sharp s ß ≡ U+00DF, plus capitalised forms).
+    A blanket ``ensure_ascii=True`` flip would massively bloat the
+    committed cache diff — every ``ü`` becomes ``\\u00fc``, every
+    description sentence balloons to 4-6x its original size in the
+    on-disk byte representation.
+
+The closing checklist therefore pinned the fix shape: pair a
+**Trojan-Source primitive scrubber at the ingestion boundary** with
+the existing ``ensure_ascii=False`` flag so the committed diff stays
+compact for legitimate German content while the canonical
+CVE-2021-42574 attack-byte union is rejected before reaching the
+writer.
+
+Attack path
+============
+
+1. Attacker compromises an upstream provider (WL / OEBB / VOR cache
+   poisoning, malicious title flowing through ``update_*_cache.py``,
+   DNS hijack of an unpinned upstream, leaked CI secret store) or an
+   operator mis-edits the on-disk cache file.
+2. A planted item carrying U+202E (RIGHT-TO-LEFT OVERRIDE) — e.g.
+   ``Westbahnhof‮moc.live`` displays as ``Westbahnhofevil.com`` —
+   reaches ``write_cache`` via one of the four ``update_*_cache.py``
+   call sites:
+     * ``scripts/update_wl_cache.py`` line 59
+     * ``scripts/update_oebb_cache.py`` line 67
+     * ``scripts/update_vor_cache.py`` line 234
+     * ``scripts/update_baustellen_cache.py`` line 570
+3. Pre-fix ``write_cache`` serialised the item via
+   ``json.dump(items, fh, ensure_ascii=False, ...)``.
+   ``ensure_ascii=False`` emits U+202E as its raw UTF-8 byte triplet
+   ``\\xe2\\x80\\xae``, so the on-disk
+   ``cache/<provider>/events.json`` carries the BiDi-reversal trigger.
+4. The respective workflow commits ``cache/<provider>/events.json`` to
+   ``main`` (e.g. ``update-vor-cache.yml`` line 96 lists
+   ``cache/vor/events.json`` in its ``file_pattern``). The malicious
+   title is now visible in ``git log -p`` / ``git show`` / the
+   GitHub web UI / ``cat`` / ``less`` / IDE preview — every viewer
+   honours BiDi reversal.
+
+Canonical attack-byte union
+============================
+
+Mirror of the union pinned in
+``tests/test_sentinel_quota_status_trojan_source.py``:
+
+  * BiDi formatting controls (CVE-2021-42574 first half):
+    ``U+202A``-``U+202E`` (LRE/RLE/PDF/LRO/RLO).
+  * BiDi isolates (CVE-2021-42574 second half):
+    ``U+2066``-``U+2069`` (LRI/RLI/FSI/PDI).
+  * Zero-width primitives + LRM/RLM/ALM:
+    ``U+200B``-``U+200F``, ``U+061C``.
+  * Unicode line / paragraph separators:
+    ``U+2028``, ``U+2029``.
+  * Byte Order Mark / ZWNBSP: ``U+FEFF``.
+  * 8-bit C1 terminal-escape primitives:
+    ``\\x9b`` (CSI), ``\\x9d`` (OSC), ``\\x90`` (DCS).
+
+Fix shape
+==========
+
+  * ``src/utils/serialize.py``: add a recursive
+    ``scrub_trojan_source_primitives`` helper that walks JSON-shaped
+    structures (dict / list / tuple / scalar) and strips the canonical
+    union from every string value AND every dict KEY.
+  * ``src/utils/cache.py:write_cache``: apply the scrubber to the
+    incoming ``items`` BEFORE the data-degradation guard count, sort,
+    and ``json.dump`` — ingestion-boundary defence so the dangerous
+    bytes never reach the writer.
+  * ``src/utils/cache.py:read_cache``: apply the same scrubber to the
+    parsed payload BEFORE returning to callers — defence-in-depth at
+    the read boundary that retroactively cleans any historic poisoned
+    cache file (planted before this fix, surviving on disk through
+    a corrupted previous run, or written by a future bypass of the
+    write-side scrubber).
+  * Keep ``ensure_ascii=False`` so legitimate German content (ä/ö/ü/ß
+    + CJK + every other non-ASCII code point that is NOT in the
+    Trojan-Source union) stays compact in the on-disk diff. The
+    scrubber removes ONLY the canonical attack-byte union — every
+    safe non-ASCII code point passes through unchanged.
+
+The scrubber returns the input structure with all Trojan-Source
+primitives REMOVED (not escaped). Forensic intent is intentionally
+not preserved at the cache-content layer because:
+
+  * Cache content is a forward-flowing data feed — the scrub-and-drop
+    semantics match the pattern used at every other text-content
+    sink (``normalise_markdown_text``, the CSV C0 stripper, the
+    log-injection regex). Operators reading the cache file see the
+    safe portion of the title; the dangerous bytes are gone.
+  * The ``ensure_ascii=True`` escape-and-preserve semantics used by
+    the sibling state writers fits *state* sinks (heartbeat, quota,
+    request count) where each row is a unique sentinel and forensic
+    re-construction matters. Cache content has high cardinality
+    (thousands of items per refresh) and per-item forensic
+    re-construction would just bloat the diff.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.utils import cache
+from src.utils.files import sanitize_filename
+
+
+# Canonical Trojan-Source / zero-width / Unicode-line-terminator / C1
+# terminal-escape primitives — byte-exact mirror of the set pinned in
+# ``tests/test_sentinel_quota_status_trojan_source.py`` so any future
+# widening of the canonical floor is enforced uniformly across the
+# committed-sidecar writer family.
+_TROJAN_SOURCE_PRIMITIVES = (
+    # BiDi formatting controls (CVE-2021-42574 first half).
+    "‪",  # LRE Left-To-Right Embedding
+    "‫",  # RLE Right-To-Left Embedding
+    "‬",  # PDF Pop Directional Formatting
+    "‭",  # LRO Left-To-Right Override
+    "‮",  # RLO Right-To-Left Override
+    # BiDi isolates (CVE-2021-42574 second half).
+    "⁦",  # LRI Left-To-Right Isolate
+    "⁧",  # RLI Right-To-Left Isolate
+    "⁨",  # FSI First Strong Isolate
+    "⁩",  # PDI Pop Directional Isolate
+    # Zero-width / left-right marks.
+    "​",  # ZWSP
+    "‌",  # ZWNJ
+    "‍",  # ZWJ
+    "‎",  # LRM
+    "‏",  # RLM
+    "؜",  # ALM
+    # Unicode line / paragraph separators (SIEM splitter primitive).
+    " ",  # LINE SEPARATOR
+    " ",  # PARAGRAPH SEPARATOR
+    # Byte Order Mark / ZWNBSP.
+    "﻿",
+    # C1 terminal escape primitives (8-bit colour/SGR start, OSC).
+    "\x9b",  # CSI
+    "\x9d",  # OSC
+    "\x90",  # DCS
+)
+
+# UTF-8 byte sequence each primitive encodes to. Pre-fix every byte
+# sequence appears in the on-disk file verbatim; post-fix none of them
+# do (the scrubber strips each code point at the ingestion boundary).
+_UTF8_BYTES = {primitive: primitive.encode("utf-8") for primitive in _TROJAN_SOURCE_PRIMITIVES}
+
+
+def _prepare_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, provider: str
+) -> Path:
+    """Pin ``_CACHE_DIR`` under ``tmp_path`` and return the events file path."""
+    base = tmp_path / "cache-root"
+    monkeypatch.setattr(cache, "_CACHE_DIR", base, raising=False)
+    target = base / sanitize_filename(provider)
+    target.mkdir(parents=True, exist_ok=True)
+    return target / "events.json"
+
+
+# ---------------------------------------------------------------------
+# PoC 1: ``write_cache`` — the canonical RLO byte triplet MUST NOT
+# leak into the on-disk file.
+# ---------------------------------------------------------------------
+
+
+def test_write_cache_does_not_emit_raw_bidi_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A planted feed item carrying U+202E reaches the on-disk
+    ``cache/<provider>/events.json`` verbatim pre-fix. Operators
+    viewing the file via ``cat`` / ``less`` / GitHub web UI / IDE
+    preview see the BiDi-reversed display of the surrounding bytes,
+    hiding the attack from review.
+    """
+    cache_file = _prepare_cache(tmp_path, monkeypatch, "wl")
+
+    items = [
+        {
+            "title": "Westbahnhof‮moc.live",
+            "guid": "wl-001",
+            "source": "wl",
+        }
+    ]
+    cache.write_cache("wl", items)
+
+    raw_bytes = cache_file.read_bytes()
+    # The smoking gun: U+202E encodes to the 3-byte UTF-8 sequence E2 80 AE.
+    # Its appearance in the on-disk file means BiDi reversal is now active
+    # for any cat / less / GitHub / IDE viewer of the file.
+    assert b"\xe2\x80\xae" not in raw_bytes, (
+        "U+202E (RLO) leaked verbatim into cache/<provider>/events.json — "
+        "BiDi reversal is now active for any cat/less/GitHub viewer of the file."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_write_cache_strips_every_trojan_source_primitive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, primitive: str
+) -> None:
+    """The scrubber's reject-set MUST be uniform across the canonical
+    Trojan-Source / zero-width / line-terminator / C1 union — a single
+    primitive surviving in raw form reopens the attack via a future
+    title / description / GUID field carrying provider-fetched content.
+    """
+    cache_file = _prepare_cache(tmp_path, monkeypatch, f"poc-{ord(primitive):04x}")
+
+    items = [
+        {
+            "title": f"evil{primitive}.example",
+            "guid": f"id{primitive}-001",
+            "source": "poc",
+        }
+    ]
+    cache.write_cache(f"poc-{ord(primitive):04x}", items)
+
+    raw_bytes = cache_file.read_bytes()
+    raw_utf8 = _UTF8_BYTES[primitive]
+    assert raw_utf8 not in raw_bytes, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked into the "
+        f"cache events file as raw UTF-8 bytes ({raw_utf8!r})."
+    )
+
+
+def test_write_cache_strips_primitive_in_dict_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dict KEYS are an attack surface too — a future schema-drift
+    addition or operator mis-edit could plant the primitive in a key
+    name. The scrubber MUST cover keys as well as values.
+    """
+    cache_file = _prepare_cache(tmp_path, monkeypatch, "key-poc")
+
+    items = [
+        {
+            "title‮_evil": "harmless",
+            "guid": "id-001",
+            "source": "key-poc",
+        }
+    ]
+    cache.write_cache("key-poc", items)
+
+    raw_bytes = cache_file.read_bytes()
+    assert b"\xe2\x80\xae" not in raw_bytes, (
+        "U+202E leaked into a dict KEY of cache/<provider>/events.json — "
+        "BiDi reversal is now active for any viewer of the file."
+    )
+
+
+def test_write_cache_strips_primitive_in_nested_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nested ``list[str]`` shapes (e.g. ``stations``, ``lines``,
+    ``tags``) are common in feed-item schemas. The scrubber MUST
+    recurse into them.
+    """
+    cache_file = _prepare_cache(tmp_path, monkeypatch, "nested-list")
+
+    items = [
+        {
+            "title": "harmless",
+            "guid": "id-001",
+            "source": "nested-list",
+            "stations": ["Westbahnhof", "Hauptbahnhof‮moc.live"],
+        }
+    ]
+    cache.write_cache("nested-list", items)
+
+    raw_bytes = cache_file.read_bytes()
+    assert b"\xe2\x80\xae" not in raw_bytes, (
+        "U+202E leaked from a nested list element into "
+        "cache/<provider>/events.json."
+    )
+
+
+def test_write_cache_strips_primitive_in_nested_dict(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Nested ``dict`` shapes (e.g. ``metadata``, ``location``) are
+    common in feed-item schemas. The scrubber MUST recurse into them.
+    """
+    cache_file = _prepare_cache(tmp_path, monkeypatch, "nested-dict")
+
+    items = [
+        {
+            "title": "harmless",
+            "guid": "id-001",
+            "source": "nested-dict",
+            "metadata": {
+                "agency": "OEBB‮moc.live",
+                "ref": "12345",
+            },
+        }
+    ]
+    cache.write_cache("nested-dict", items)
+
+    raw_bytes = cache_file.read_bytes()
+    assert b"\xe2\x80\xae" not in raw_bytes, (
+        "U+202E leaked from a nested dict value into "
+        "cache/<provider>/events.json."
+    )
+
+
+# ---------------------------------------------------------------------
+# Regression: legitimate German content stays compact (no diff bloat).
+# ---------------------------------------------------------------------
+
+
+def test_write_cache_preserves_german_umlauts_as_raw_utf8(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fix-shape contract: ``ensure_ascii=False`` is preserved so
+    legitimate German content (umlauts ä/ö/ü/Ä/Ö/Ü, sharp s ß) stays
+    as raw UTF-8 in the on-disk file — every cache-update commit diff
+    stays compact. A blanket ``ensure_ascii=True`` flip would balloon
+    each German character to a 6-byte ``\\u00XX`` escape; the scrubber
+    + flag-preservation contract avoids that bloat.
+    """
+    cache_file = _prepare_cache(tmp_path, monkeypatch, "german")
+
+    items = [
+        {
+            "title": "Großbaustelle Wien Hütteldorf — Bahnübergang Mariä-Empfängnis",
+            "guid": "g-001",
+            "source": "german",
+            "description": "Schienenersatzverkehr für Reisende — Öffnungszeiten!",
+        }
+    ]
+    cache.write_cache("german", items)
+
+    raw_bytes = cache_file.read_bytes()
+    # Every German character MUST land as raw UTF-8, not the 6-byte
+    # ``\\u00XX`` escape sequence.
+    assert "ß".encode() in raw_bytes, "ß lost as raw UTF-8 — diff bloat!"
+    assert "ü".encode() in raw_bytes, "ü lost as raw UTF-8 — diff bloat!"
+    assert "ä".encode() in raw_bytes, "ä lost as raw UTF-8 — diff bloat!"
+    assert "Ö".encode() in raw_bytes, "Ö lost as raw UTF-8 — diff bloat!"
+    # Defence in depth: the literal ``ü`` escape (the bloated
+    # form) MUST NOT appear in the on-disk file.
+    decoded = raw_bytes.decode("utf-8")
+    assert "\\u00fc" not in decoded, (
+        "ü was escaped as \\u00fc — ensure_ascii=False contract broken, "
+        "compact German diff lost."
+    )
+    assert "\\u00e4" not in decoded, (
+        "ä was escaped as \\u00e4 — ensure_ascii=False contract broken."
+    )
+
+
+def test_write_cache_preserves_clean_payload_round_trip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: a clean payload (no Trojan-Source primitives)
+    round-trips byte-stable through the scrubber. ``read_cache``
+    recovers exactly the same dict every caller saw pre-fix.
+    """
+    cache_file = _prepare_cache(tmp_path, monkeypatch, "clean")
+
+    items = [
+        {
+            "title": "Großbaustelle Hauptbahnhof",
+            "guid": "clean-001",
+            "source": "wl",
+            "stations": ["Hauptbahnhof", "Praterstern"],
+            "metadata": {"agency": "WL", "ref": "42"},
+        }
+    ]
+    cache.write_cache("clean", items)
+
+    parsed = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert parsed == items
+
+
+# ---------------------------------------------------------------------
+# Defence in depth: ``read_cache`` strips primitives from a poisoned
+# on-disk cache file (planted before the fix, surviving from a
+# corrupted previous run, or written by a future bypass).
+# ---------------------------------------------------------------------
+
+
+def test_read_cache_strips_pre_existing_trojan_source_primitives(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pre-existing ``cache/<provider>/events.json`` carrying U+202E
+    in raw UTF-8 form (planted before this fix or written by a future
+    bypass of ``write_cache``'s scrubber) MUST NOT propagate the
+    primitive into the in-memory data structure handed to the feed
+    builder. ``read_cache`` strips the canonical attack-byte union
+    on the way out.
+    """
+    cache_file = _prepare_cache(tmp_path, monkeypatch, "wl")
+    # Plant the poisoned bytes directly — bypasses ``write_cache``.
+    poisoned = json.dumps(
+        [{"title": "Westbahnhof‮moc.live", "guid": "wl-001", "source": "wl"}],
+        ensure_ascii=False,
+    )
+    cache_file.write_text(poisoned, encoding="utf-8")
+    # Sanity: the planted file actually contains the dangerous bytes.
+    assert b"\xe2\x80\xae" in cache_file.read_bytes()
+
+    items = cache.read_cache("wl")
+
+    assert isinstance(items, list)
+    assert len(items) == 1
+    title = items[0]["title"]
+    assert "‮" not in title, (
+        "read_cache returned a string still carrying U+202E — defence "
+        "in depth at the read boundary failed."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_read_cache_strips_every_trojan_source_primitive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, primitive: str
+) -> None:
+    """The defence-in-depth read-boundary scrubber MUST cover the same
+    canonical union as the write-boundary scrubber.
+    """
+    cache_file = _prepare_cache(
+        tmp_path, monkeypatch, f"read-{ord(primitive):04x}"
+    )
+    poisoned = json.dumps(
+        [{"title": f"evil{primitive}.example", "guid": "x", "source": "x"}],
+        ensure_ascii=False,
+    )
+    cache_file.write_text(poisoned, encoding="utf-8")
+
+    items = cache.read_cache(f"read-{ord(primitive):04x}")
+
+    assert len(items) == 1
+    title = items[0]["title"]
+    assert primitive not in title, (
+        f"read_cache returned a string still carrying U+{ord(primitive):04X} "
+        f"— read-boundary scrubber drift."
+    )
+
+
+def test_read_cache_preserves_german_umlauts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: the read-boundary scrubber MUST NOT touch
+    legitimate German content. ä/ö/ü/ß round-trip identically.
+    """
+    cache_file = _prepare_cache(tmp_path, monkeypatch, "read-german")
+    payload = [
+        {
+            "title": "Großbaustelle Hütteldorf",
+            "guid": "g-1",
+            "source": "wl",
+            "description": "Schienenersatzverkehr für Reisende",
+        }
+    ]
+    cache_file.write_text(
+        json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+    )
+
+    items = cache.read_cache("read-german")
+
+    assert items == payload


### PR DESCRIPTION
## Summary

Round 12 of the Trojan-Source / BiDi-Mark drift family. Round 11 (PR #1436) closed the three sibling state writers (`MonthlyQuota.save_atomic`, `_write_request_count_file`, `write_status`) and explicitly named `write_cache` (`cache/<provider>/events.json`) as the **sole** deferred sidecar in the same operator-facing JSON family — but with a different fix shape.

### Why the fix shape differs

The sibling state writers carried only safe scalar values (ISO dates, integers, hard-coded status tokens). Switching to `ensure_ascii=True` had a negligible diff cost.

`write_cache`, by contrast, carries provider-fetched **German titles + descriptions** — every cache update flushes hundreds of items where each title averages 30-80 characters and the description 100-300 characters, with umlauts (`ä`/`ö`/`ü`/`Ä`/`Ö`/`Ü`) and sharp s (`ß`) sprinkled through both. A blanket `ensure_ascii=True` flip would have ballooned every umlaut from its 2-byte UTF-8 form to a 6-byte `\u00XX` literal, multiplying the on-disk byte size of every German cache file by ~4-6x and bloating the cron commit diff that `update-vor-cache.yml` / `update-wl-cache.yml` / `update-oebb-cache.yml` / `update-baustellen-cache.yml` publishes back to `main` after every refresh.

### Fix shape: scrubber-at-ingestion + `ensure_ascii=False` preservation

* **`src/utils/serialize.py`**: add `scrub_trojan_source_primitives` — a recursive walker over JSON-shaped structures (`str` / `dict` / `list` / `tuple`) that strips the canonical CVE-2021-42574 attack-byte union (BiDi formatting controls + isolates, zero-width primitives + LRM/RLM/ALM, Unicode line/paragraph separators, BOM/ZWNBSP, 8-bit C1 terminal-escape primitives) from every reachable string AND every dict KEY. The regex is built from ASCII-only `\xNN` / `\uNNNN` escape sequences so the source file itself contains no Trojan-Source primitives — reviewing the regex via `cat` / `less` / GitHub web UI / IDE preview cannot itself trigger BiDi reversal.
* **`src/utils/cache.py:write_cache`**: apply the scrubber to incoming `items` BEFORE the data-degradation guard, sort, and `json.dump`. `ensure_ascii=False` is preserved at the writer.
* **`src/utils/cache.py:read_cache`**: apply the same scrubber to the parsed payload before returning to callers — defence-in-depth at the read boundary that retroactively cleans any historic poisoned cache file (planted before this fix, surviving from a corrupted previous run, or written by a future bypass of the write-side scrubber).

### Two structural fix shapes are now codified

| Shape | Use when | Sites |
|-------|----------|-------|
| **Scrub-and-drop** (`scrub_trojan_source_primitives` + `ensure_ascii=False`) | High-cardinality content sinks; safe portion of the value is meaningful | cache content (this round) |
| **Escape-and-preserve** (`ensure_ascii=True`) | Low-cardinality state sinks; each row is a unique sentinel | heartbeat, quota, request count, first-seen state, quarantine entries |

## Test plan

PoC suite (`tests/test_sentinel_cache_events_trojan_source.py`, 50 tests):

- [x] PoC 1: `write_cache` does not emit raw `\xe2\x80\xae` (RLO) into `cache/<provider>/events.json`
- [x] Parametrised: every primitive in the canonical CVE-2021-42574 union (21 primitives: 5 BiDi formatting + 4 BiDi isolates + 6 zero-width/marks + ALM + 2 line/paragraph separators + BOM + 3 C1 escapes) is stripped at the write boundary
- [x] Nested-shape coverage: dict KEY, nested list element, nested dict value
- [x] German-content compact-diff regression: `ä`/`ü`/`ß`/`Ö` survive as raw UTF-8; the bloated `\u00XX` form does NOT appear
- [x] Clean-payload round-trip regression
- [x] Defence-in-depth at the read boundary: every primitive is stripped from a planted on-disk file (parametrised over the same 21 primitives)
- [x] Read-boundary German-content regression

Validation:

- [x] All 50 PoC tests pass post-fix
- [x] Full suite passes: 3622 passed, 3 skipped
- [x] Static checks: ruff / bandit / secret-scanner / C901 complexity gate / pip-audit all clean
- [x] mypy state preserved (no new errors vs baseline)

https://claude.ai/code/session_01YEDCxPi6872wdeu7TdFvfJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEDCxPi6872wdeu7TdFvfJ)_