### PR TITLE
security: BiDi/Trojan-Source leak in canonical stations directory writer via scrubber-at-ingestion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,185 @@
+## 2026-05-11 - Trojan-Source BiDi Drift Round 13 (Canonical Stations Directory Sidecar): `write_stations` / `load_stations` (`data/stations.json`) Was the Round-12 Closing-Checklist Named-But-Deferred Sidecar — Closed Via The Round-12 `scrub_trojan_source_primitives` Helper (Single-Sourced Defence Shape)
+
+**Vulnerability:** Round 12 (PR #1437) closed
+`write_cache` / `read_cache` (`cache/<provider>/events.json`) via
+the new `scrub_trojan_source_primitives` helper +
+`ensure_ascii=False` preservation. The Round-12 closing checklist's
+"Named but deferred" entry explicitly identified the SOLE remaining
+operator-facing JSON sidecar writer in the same family —
+`src/places/merge.py:write_stations` →
+`data/stations.json` — with the SAME fix shape requirement:
+
+  * `write_stations` serialises the canonical station directory
+    (`data/stations.json`) via
+    `json.dumps({"stations": ...}, ensure_ascii=False, indent=2,
+    sort_keys=True)`. The payload carries provider-fetched **German
+    station names + aliases + formatted addresses** from Google
+    Places, OSM Overpass, OEBB `Verzeichnis der
+    Verkehrsstationen` Excel, and Wien OGD CSVs.
+  * The committed sidecar contract is explicit: the file is pushed
+    to `main` by `update-stations.yml` (weekly cron, line ~152
+    `add_options: "-A"`) AND by
+    `update-google-places-stations.yml` (manual escape hatch,
+    line 154 `git add data/stations.json`).
+  * The fix shape MUST reuse the
+    `scrub_trojan_source_primitives` helper added in Round 12 so
+    the canonical CVE-2021-42574 attack-byte union stays
+    single-sourced across every operator-facing JSON sidecar
+    writer in the codebase.
+
+**Threat model:**
+
+  1. Attacker compromises an upstream provider (Google Places
+     hijack, OSM Overpass cache poisoning, OEBB `Verzeichnis der
+     Verkehrsstationen` Excel response tampering, Wien OGD CSV
+     poisoning, leaked CI secret store) or an operator mis-edits
+     `data/stations.json` directly.
+  2. A planted station entry carrying U+202E (RIGHT-TO-LEFT
+     OVERRIDE) in a `name`, `_formatted_address`, or `aliases[]`
+     field — e.g. `name="Hauptbahnhof‮moc.live"` displays as
+     `Hauptbahnhofevil.com` — reaches `write_stations` via one of
+     the upstream Google Places ingestion paths
+     (`scripts/fetch_google_places_stations.py` invoking
+     `merge_places` + `write_stations`,
+     `scripts/update_station_directory.py` invoking
+     `merge_places` from inside `update_all_stations.py`).
+  3. Pre-fix `write_stations` serialised the payload via
+     `json.dumps({"stations": ...}, ensure_ascii=False, indent=2,
+     sort_keys=True)`. `ensure_ascii=False` emits U+202E as its
+     raw UTF-8 byte triplet `\xe2\x80\xae` directly into the
+     on-disk `data/stations.json`.
+  4. The `update-stations.yml` cron commits the poisoned
+     `data/stations.json` to `main` (the workflow uses
+     `add_options: "-A"` so any change in `data/` gets staged).
+     The malicious name is now visible in `git log -p` /
+     `git show` / the GitHub web UI / `cat` / `less` / IDE
+     preview — every viewer honours BiDi reversal.
+  5. Operator reviewing the weekly commit / mis-edit alert
+     misreads the BiDi-reversed display as the inverse of the
+     actual planted bytes. The attack hides in the operator's own
+     review pass.
+
+**Reproduced:** `tests/test_sentinel_places_stations_trojan_source.py`
+contains 52 PoC tests (49 fail pre-fix, all 52 pass post-fix):
+
+  * 1 + 21 (parametrised) for the write boundary covering every
+    primitive in the canonical CVE-2021-42574 union.
+  * 4 for nested-shape coverage (dict KEY, `aliases` list,
+    `_formatted_address` string, `_types` list) so the recursive
+    walker is pinned over every plausible `StationEntry` field
+    type.
+  * 1 for the German-content compact-diff regression
+    (`ä`/`ü`/`ß` survive as raw UTF-8; the bloated `\u00XX` form
+    does NOT appear).
+  * 1 for the clean-payload round-trip regression
+    (`write_stations` → `load_stations` round-trips identically).
+  * 1 + 21 for the read-boundary defence-in-depth coverage
+    (every primitive is stripped from a planted on-disk
+    `data/stations.json`).
+  * 1 for the read-boundary German-content regression.
+  * 1 for the bare-list root shape (`load_stations` supports
+    both `{"stations": [...]}` and bare `[...]`).
+
+Pre-fix repro for the canonical write-boundary case:
+`name="Hauptbahnhof‮moc.live"` produced `data/stations.json`
+with raw bytes `...Hauptbahnhof\xe2\x80\xaemoc.live...`. Post-fix:
+the primitive is stripped at the ingestion boundary; the on-disk
+file reads `Hauptbahnhofmoc.live` (the malicious primitive is
+gone, the safe portion of the name remains).
+
+**Fix:**
+
+  * `src/places/merge.py`: import the shared
+    `scrub_trojan_source_primitives` helper from
+    `src.utils.serialize` (added in Round 12). No new helper —
+    reusing the single-sourced defence keeps the canonical
+    CVE-2021-42574 attack-byte union uniform across every
+    operator-facing JSON sidecar writer in the codebase.
+  * `src/places/merge.py:write_stations`: apply the scrubber to
+    the incoming `stations` BEFORE `json.dumps` —
+    ingestion-boundary defence so the dangerous bytes never reach
+    the writer. `ensure_ascii=False` is preserved at the writer
+    (compact German diff contract intact).
+  * `src/places/merge.py:load_stations`: apply the same scrubber
+    to the parsed payload BEFORE returning to callers —
+    defence-in-depth at the read boundary that retroactively
+    cleans any historic poisoned `data/stations.json` (planted
+    before this fix, surviving from a corrupted previous run, or
+    written by a future bypass of the write-side scrubber). The
+    scrubber sits AFTER the existing depth-bomb / size-bomb
+    guards so a malformed file still raises `ValueError`; only
+    well-formed but poisoned content reaches the cleanup pass.
+
+**Learning:** the Round-12 "Named but deferred" entry's prediction
+that `write_stations` was the next target AND that the
+single-sourced defence helper would carry the fix was correct.
+The drift family is now uniform across every committed
+operator-facing JSON sidecar in the project — eight rounds (Round
+3 ValidationReport → Round 13 stations) of cumulative coverage
+on top of the channel/title/feed-XML/CSV/markdown sinks closed
+earlier. The closing-checklist drift-walker invariant continues to
+hold: every fix shape adopted in a previous round is mechanically
+reusable by the next round IF the helper was placed in a
+provider-neutral utility module
+(`src/utils/serialize.py:scrub_trojan_source_primitives` here).
+
+  * **Closed in this round:** `write_stations` / `load_stations`
+    (`data/stations.json`) via scrubber-at-ingestion + flag
+    preservation. Both write and read boundaries carry the
+    defence so the in-memory payload handed to the merge /
+    validation step cannot carry raw BiDi marks regardless of
+    how the on-disk bytes got there.
+  * **Already closed (Round 12):** `write_cache` / `read_cache`
+    (`cache/<provider>/events.json`).
+  * **Already closed (Round 11):** `MonthlyQuota.save_atomic`
+    (`data/places_quota.json`), `_write_request_count_file`
+    (`data/vor_request_count.json`), `write_status`
+    (`cache/<provider>/last_run.json`) — all via
+    `ensure_ascii=True`.
+  * **Already closed (earlier rounds):** `_save_state`
+    (`data/first_seen.json`, Round 10), `_write_heartbeat_file`
+    (`data/stations_last_run.json`, Round 10),
+    `_write_quarantine_file` (`data/quarantine.json`, Round 9),
+    `_render_diff_markdown` (`docs/stations_diff.md`, Round 9),
+    `ValidationReport.to_markdown()` (Round 3),
+    `render_feed_health_markdown` / GitHub-Issue body (Round 2),
+    `docs/statistik.md` stats dashboard (Round 1),
+    `data/stats/*.csv` CSV writer, RSS XML writers, sitemap
+    writer, `_escape_env_value` `.env` writer.
+  * **Named but deferred** (out of scope for this round; queued
+    for follow-up sanitisation rounds): the script-level
+    stations-file writers that bypass the canonical
+    `src/places/merge.py` library function and write their own
+    payload via direct `json.dump(..., ensure_ascii=False, ...)`
+    calls:
+    * `scripts/fetch_google_places_stations.py:_write_if_changed`
+      (line 288, also `_dump_changes` line 273 for the
+      per-run change-dump sidecar) → writes
+      `data/stations.json` directly during the manual
+      Google-Places-only escape hatch path. Same fix shape:
+      apply `scrub_trojan_source_primitives` before
+      `json.dumps`.
+    * `scripts/update_all_stations.py:_write_stations_payload`
+      (line 529) → writes `data/stations.json` during the
+      weekly `update-stations.yml` cron. Same fix shape.
+    * `scripts/enrich_station_aliases.py` (line 821) and
+      `scripts/update_station_directory.py` (line 1766) —
+      both write to `data/stations.json` via direct
+      `json.dump(..., ensure_ascii=False)`. Same fix shape.
+    * `scripts/update_wl_stations.py` (line 735),
+      `scripts/update_vor_stations.py` (line 1210),
+      `scripts/fetch_vor_haltestellen.py` (line 665) — write
+      sibling station-directory CSV/JSON files via direct
+      `json.dump(..., ensure_ascii=False)` flows. Same fix
+      shape.
+
+The next round MUST close the script-level writers above by
+reusing the same `scrub_trojan_source_primitives` helper. The
+shape choice is dictated by cardinality and forensic-intent
+requirements (scrub-and-drop for high-cardinality content sinks,
+escape-and-preserve for low-cardinality state sinks) — see the
+Round-12 entry below for the full taxonomy.
+
 ## 2026-05-11 - Trojan-Source BiDi Drift Round 12 (Provider Cache Events Sidecar): `write_cache` (`cache/<provider>/events.json`) Was the Sole Round-11 Closing-Checklist Deferred Sidecar — Closed Via Scrubber-At-Ingestion (Not `ensure_ascii=True`) To Preserve Compact German Diffs
 
 **Vulnerability:** Round 11 (PR #1436) closed three sibling writers

--- a/src/places/merge.py
+++ b/src/places/merge.py
@@ -11,6 +11,7 @@ from typing import TypedDict, cast
 from collections.abc import Iterable, MutableMapping, Sequence
 
 from ..utils.files import atomic_write
+from ..utils.serialize import scrub_trojan_source_primitives
 from ..utils.stations import MAX_STATIONS_FILE_BYTES
 
 from .client import Place
@@ -116,11 +117,41 @@ def load_stations(path: Path) -> list[StationEntry]:
         if not isinstance(raw, MutableMapping):
             raise ValueError("stations entries must be objects")
         stations.append(cast(StationEntry, deepcopy(raw)))
+    # Security (Trojan-Source / BiDi-Mark Drift Round 13, defence-in-depth at
+    # the read boundary): retroactively scrub the canonical CVE-2021-42574
+    # attack-byte union from any historic poisoned ``data/stations.json``
+    # (planted before this fix, surviving from a corrupted previous run, or
+    # written by a future bypass of ``write_stations``'s ingestion-boundary
+    # scrubber). Mirrors the write-side defence so the in-memory payload
+    # handed to the merge / validation step cannot carry raw BiDi marks
+    # regardless of how the on-disk bytes got there. See
+    # ``src/utils/serialize.py:scrub_trojan_source_primitives`` for the
+    # canonical attack-byte union.
+    scrubbed = scrub_trojan_source_primitives(stations)
+    if isinstance(scrubbed, list):
+        return scrubbed
     return stations
 
 
 def write_stations(path: Path, stations: Sequence[StationEntry]) -> None:
-    serialisable = list(stations)
+    # Security (Trojan-Source / BiDi-Mark Drift Round 13, ingestion-boundary
+    # defence): strip the canonical CVE-2021-42574 attack-byte union (BiDi
+    # formatting controls, BiDi isolates, zero-width primitives + LRM/RLM/ALM,
+    # Unicode line / paragraph separators, the BOM / ZWNBSP, and the 8-bit
+    # C1 terminal-escape primitives) from every reachable string in the
+    # incoming stations BEFORE ``json.dumps``. ``data/stations.json`` is
+    # committed to ``main`` by the cron pipeline (``update-stations.yml``
+    # weekly + ``update-google-places-stations.yml`` manual escape hatch)
+    # and rendered via ``cat`` / ``less`` / the GitHub web UI / IDE preview.
+    # ``ensure_ascii=False`` is preserved at the writer below so legitimate
+    # German station names (umlauts ä/ö/ü/Ä/Ö/Ü + sharp s ß + every other
+    # safe Unicode code point) stay compact in the weekly commit diff;
+    # pairing it with the scrubber rejects the canonical attack-byte union
+    # before it reaches the serialiser. See
+    # ``src/utils/serialize.py:scrub_trojan_source_primitives`` for the
+    # canonical attack-byte union and the scrub-and-drop semantics rationale.
+    scrubbed = scrub_trojan_source_primitives(list(stations))
+    serialisable = scrubbed if isinstance(scrubbed, list) else list(stations)
     payload = json.dumps({"stations": serialisable}, ensure_ascii=False, indent=2, sort_keys=True)
     # Security: use atomic_write to avoid partial writes on crashes/power loss.
     with atomic_write(path, mode="w", encoding="utf-8", permissions=0o644) as handle:

--- a/tests/test_sentinel_places_stations_trojan_source.py
+++ b/tests/test_sentinel_places_stations_trojan_source.py
@@ -1,0 +1,510 @@
+"""Sentinel PoC: Trojan-Source / BiDi-Mark leakage at the
+``data/stations.json`` writer that the *BiDi-Mark Drift Round 12*
+closing-checklist named but deferred — ``src/places/merge.py:write_stations``.
+
+Round 12 (PR closing the ``write_cache`` cache-events sidecar) closed
+``src/utils/cache.py:write_cache`` / ``read_cache`` via the
+``scrub_trojan_source_primitives`` helper plus a preserved
+``ensure_ascii=False`` flag. The Round-12 closing checklist explicitly
+named ``src/places/merge.py:write_stations`` →
+``data/stations.json`` as the SOLE deferred sibling in the same
+operator-facing JSON family with the SAME fix shape requirement:
+
+  * ``write_stations`` serialises the canonical station directory
+    (``data/stations.json``) via
+    ``json.dumps(..., ensure_ascii=False, indent=2, sort_keys=True)``
+    today. The payload carries provider-fetched **German station
+    names + aliases + formatted addresses** (e.g. ``Wien
+    Hauptbahnhof``, ``Wien Hütteldorf``, ``Bahnhof Wien Floridsdorf``).
+    A blanket ``ensure_ascii=True`` flip would balloon every umlaut /
+    ``ß`` from its 2-byte UTF-8 form to the 6-byte ``\\u00XX``
+    escape, ~4-6x the byte size, and bloat the weekly
+    ``update-stations.yml`` commit diff.
+  * The committed sidecar contract is unambiguous: the file is
+    pushed to ``main`` by ``update-stations.yml`` (weekly cron)
+    AND by ``update-google-places-stations.yml`` (manual escape
+    hatch).
+
+The Round-12 "Named but deferred" entry pinned the fix shape:
+**pair an ingestion-boundary Trojan-Source primitive scrubber with
+the existing `ensure_ascii=False` flag** AND **reuse the
+``scrub_trojan_source_primitives`` helper from Round 12** so the
+defence shape stays single-sourced across every operator-facing JSON
+sidecar in the codebase.
+
+Attack path
+============
+
+1. Attacker compromises an upstream provider (Google Places hijack,
+   OSM Overpass cache poisoning, OEBB ``Verzeichnis der
+   Verkehrsstationen`` Excel response tampering, Wien OGD CSV
+   poisoning, leaked CI secret store) or an operator mis-edits
+   ``data/stations.json`` directly.
+2. A planted station entry carrying U+202E (RIGHT-TO-LEFT OVERRIDE)
+   in a ``name``, ``_formatted_address``, or ``aliases[]`` field —
+   e.g. ``name="Hauptbahnhof‮moc.live"`` displays as
+   ``Hauptbahnhofevil.com`` — reaches ``write_stations`` via one of
+   the upstream Google Places ingestion paths
+   (``scripts/fetch_google_places_stations.py``,
+   ``scripts/update_station_directory.py``).
+3. Pre-fix ``write_stations`` serialised the payload via
+   ``json.dumps({"stations": ...}, ensure_ascii=False, indent=2,
+   sort_keys=True)``. ``ensure_ascii=False`` emits U+202E as its raw
+   UTF-8 byte triplet ``\\xe2\\x80\\xae`` directly into the on-disk
+   ``data/stations.json``.
+4. The ``update-stations.yml`` cron commits the poisoned
+   ``data/stations.json`` to ``main`` (the workflow uses
+   ``add_options: "-A"`` so any change in ``data/`` gets staged).
+   The malicious name is now visible in ``git log -p`` /
+   ``git show`` / the GitHub web UI / ``cat`` / ``less`` /
+   IDE preview — every viewer honours BiDi reversal.
+5. Operator reviewing the commit / cache file for diff bloat /
+   suspicious upstream behaviour misreads the BiDi-reversed display
+   as the inverse of the actual planted bytes. The attack hides in
+   the operator's own review pass.
+
+Canonical attack-byte union
+============================
+
+Byte-exact mirror of the union pinned in
+``tests/test_sentinel_cache_events_trojan_source.py`` (Round 12) so
+any future widening of the canonical floor stays uniform across the
+committed-sidecar writer family:
+
+  * BiDi formatting controls (CVE-2021-42574 first half):
+    ``U+202A``-``U+202E`` (LRE/RLE/PDF/LRO/RLO).
+  * BiDi isolates (CVE-2021-42574 second half):
+    ``U+2066``-``U+2069`` (LRI/RLI/FSI/PDI).
+  * Zero-width primitives + LRM/RLM/ALM:
+    ``U+200B``-``U+200F``, ``U+061C``.
+  * Unicode line / paragraph separators:
+    ``U+2028``, ``U+2029``.
+  * Byte Order Mark / ZWNBSP: ``U+FEFF``.
+  * 8-bit C1 terminal-escape primitives:
+    ``\\x9b`` (CSI), ``\\x9d`` (OSC), ``\\x90`` (DCS).
+
+Fix shape
+==========
+
+  * Reuse ``src/utils/serialize.py:scrub_trojan_source_primitives``
+    (added in Round 12) so the canonical attack-byte union stays
+    single-sourced across every operator-facing JSON sidecar writer.
+  * ``src/places/merge.py:write_stations``: apply the scrubber to
+    the incoming ``stations`` BEFORE ``json.dumps`` —
+    ingestion-boundary defence so the dangerous bytes never reach
+    the writer.
+  * ``src/places/merge.py:load_stations``: apply the same scrubber
+    to the parsed payload BEFORE returning to callers —
+    defence-in-depth at the read boundary that retroactively cleans
+    any historic poisoned ``data/stations.json`` (planted before
+    this fix, surviving on disk through a corrupted previous run,
+    or written by a future bypass of the write-side scrubber).
+  * Keep ``ensure_ascii=False`` so legitimate German content
+    (ä/ö/ü/ß + every other safe Unicode code point) stays compact
+    in the on-disk diff. The scrubber removes ONLY the canonical
+    attack-byte union — every safe non-ASCII code point passes
+    through unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.places.merge import load_stations, write_stations
+
+
+# Canonical Trojan-Source / zero-width / Unicode-line-terminator / C1
+# terminal-escape primitives — byte-exact mirror of the set pinned in
+# ``tests/test_sentinel_cache_events_trojan_source.py`` (Round 12) so
+# any future widening of the canonical floor is enforced uniformly
+# across the committed-sidecar writer family.
+_TROJAN_SOURCE_PRIMITIVES = (
+    # BiDi formatting controls (CVE-2021-42574 first half).
+    "‪",  # LRE Left-To-Right Embedding
+    "‫",  # RLE Right-To-Left Embedding
+    "‬",  # PDF Pop Directional Formatting
+    "‭",  # LRO Left-To-Right Override
+    "‮",  # RLO Right-To-Left Override
+    # BiDi isolates (CVE-2021-42574 second half).
+    "⁦",  # LRI Left-To-Right Isolate
+    "⁧",  # RLI Right-To-Left Isolate
+    "⁨",  # FSI First Strong Isolate
+    "⁩",  # PDI Pop Directional Isolate
+    # Zero-width / left-right marks.
+    "​",  # ZWSP
+    "‌",  # ZWNJ
+    "‍",  # ZWJ
+    "‎",  # LRM
+    "‏",  # RLM
+    "؜",  # ALM
+    # Unicode line / paragraph separators (SIEM splitter primitive).
+    " ",  # LINE SEPARATOR
+    " ",  # PARAGRAPH SEPARATOR
+    # Byte Order Mark / ZWNBSP.
+    "﻿",
+    # C1 terminal escape primitives (8-bit colour/SGR start, OSC).
+    "\x9b",  # CSI
+    "\x9d",  # OSC
+    "\x90",  # DCS
+)
+
+# UTF-8 byte sequence each primitive encodes to. Pre-fix every byte
+# sequence appears in the on-disk file verbatim; post-fix none of them
+# do (the scrubber strips each code point at the ingestion boundary).
+_UTF8_BYTES = {
+    primitive: primitive.encode("utf-8") for primitive in _TROJAN_SOURCE_PRIMITIVES
+}
+
+
+# ---------------------------------------------------------------------
+# PoC 1: ``write_stations`` — the canonical RLO byte triplet MUST NOT
+# leak into the on-disk file.
+# ---------------------------------------------------------------------
+
+
+def test_write_stations_does_not_emit_raw_bidi_override(tmp_path: Path) -> None:
+    """A planted station entry carrying U+202E reaches the on-disk
+    ``data/stations.json`` verbatim pre-fix. Operators viewing the file
+    via ``cat`` / ``less`` / GitHub web UI / IDE preview see the
+    BiDi-reversed display of the surrounding bytes, hiding the attack
+    from review.
+    """
+    target = tmp_path / "stations.json"
+    stations = [
+        {
+            "name": "Hauptbahnhof‮moc.live",
+            "source": "google_places",
+            "latitude": 48.18,
+            "longitude": 16.38,
+        }
+    ]
+    write_stations(target, stations)  # type: ignore[arg-type]
+
+    raw_bytes = target.read_bytes()
+    # The smoking gun: U+202E encodes to the 3-byte UTF-8 sequence E2 80 AE.
+    # Its appearance in the on-disk file means BiDi reversal is now active
+    # for any cat / less / GitHub / IDE viewer of the file.
+    assert b"\xe2\x80\xae" not in raw_bytes, (
+        "U+202E (RLO) leaked verbatim into data/stations.json — "
+        "BiDi reversal is now active for any cat/less/GitHub viewer of the file."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_write_stations_strips_every_trojan_source_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    """The scrubber's reject-set MUST be uniform across the canonical
+    Trojan-Source / zero-width / line-terminator / C1 union — a single
+    primitive surviving in raw form reopens the attack via a future
+    name / aliases / formatted-address field carrying provider-fetched
+    content.
+    """
+    target = tmp_path / f"stations-{ord(primitive):04x}.json"
+    stations = [
+        {
+            "name": f"evil{primitive}.example",
+            "source": "google_places",
+            "latitude": 48.18,
+            "longitude": 16.38,
+        }
+    ]
+    write_stations(target, stations)  # type: ignore[arg-type]
+
+    raw_bytes = target.read_bytes()
+    raw_utf8 = _UTF8_BYTES[primitive]
+    assert raw_utf8 not in raw_bytes, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked into "
+        f"data/stations.json as raw UTF-8 bytes ({raw_utf8!r})."
+    )
+
+
+def test_write_stations_strips_primitive_in_aliases_list(tmp_path: Path) -> None:
+    """The ``aliases`` field is a ``list[str]`` — a critical attack
+    surface that the recursive scrubber MUST cover. A planted alias
+    landing in raw form on disk would still be rendered by the GitHub
+    diff view.
+    """
+    target = tmp_path / "stations.json"
+    stations = [
+        {
+            "name": "Hauptbahnhof",
+            "source": "google_places",
+            "latitude": 48.18,
+            "longitude": 16.38,
+            "aliases": ["Wien Hauptbahnhof", "Hbf‮moc.live"],
+        }
+    ]
+    write_stations(target, stations)  # type: ignore[arg-type]
+
+    raw_bytes = target.read_bytes()
+    assert b"\xe2\x80\xae" not in raw_bytes, (
+        "U+202E leaked from a nested aliases[] element into "
+        "data/stations.json."
+    )
+
+
+def test_write_stations_strips_primitive_in_formatted_address(tmp_path: Path) -> None:
+    """``_formatted_address`` is provider-fetched from Google Places —
+    a hijacked / cache-poisoned upstream could plant the primitive
+    there. The scrubber MUST cover string values regardless of key
+    name.
+    """
+    target = tmp_path / "stations.json"
+    stations = [
+        {
+            "name": "Hauptbahnhof",
+            "source": "google_places",
+            "latitude": 48.18,
+            "longitude": 16.38,
+            "_formatted_address": "Am Hauptbahnhof 1, 1100‮moc.live",
+        }
+    ]
+    write_stations(target, stations)  # type: ignore[arg-type]
+
+    raw_bytes = target.read_bytes()
+    assert b"\xe2\x80\xae" not in raw_bytes, (
+        "U+202E leaked from _formatted_address into data/stations.json."
+    )
+
+
+def test_write_stations_strips_primitive_in_dict_key(tmp_path: Path) -> None:
+    """Dict KEYS are an attack surface too — a future schema-drift
+    addition or operator mis-edit could plant the primitive in a key
+    name. The scrubber MUST cover keys as well as values.
+    """
+    target = tmp_path / "stations.json"
+    stations = [
+        {
+            "name‮_evil": "harmless",
+            "source": "google_places",
+            "latitude": 48.18,
+            "longitude": 16.38,
+        }
+    ]
+    write_stations(target, stations)  # type: ignore[arg-type]
+
+    raw_bytes = target.read_bytes()
+    assert b"\xe2\x80\xae" not in raw_bytes, (
+        "U+202E leaked into a dict KEY of data/stations.json — "
+        "BiDi reversal is now active for any viewer of the file."
+    )
+
+
+def test_write_stations_strips_primitive_in_types_list(tmp_path: Path) -> None:
+    """``_types`` is a Google Places provider-fetched ``list[str]``
+    field. Cache poisoning of the Places API response could plant a
+    primitive there. The scrubber MUST recurse into nested lists.
+    """
+    target = tmp_path / "stations.json"
+    stations = [
+        {
+            "name": "Hauptbahnhof",
+            "source": "google_places",
+            "latitude": 48.18,
+            "longitude": 16.38,
+            "_types": ["train_station", "transit_station‮moc.live"],
+        }
+    ]
+    write_stations(target, stations)  # type: ignore[arg-type]
+
+    raw_bytes = target.read_bytes()
+    assert b"\xe2\x80\xae" not in raw_bytes, (
+        "U+202E leaked from _types[] into data/stations.json."
+    )
+
+
+# ---------------------------------------------------------------------
+# Regression: legitimate German content stays compact (no diff bloat).
+# ---------------------------------------------------------------------
+
+
+def test_write_stations_preserves_german_umlauts_as_raw_utf8(tmp_path: Path) -> None:
+    """The fix-shape contract: ``ensure_ascii=False`` is preserved so
+    legitimate German station names (umlauts ä/ö/ü/Ä/Ö/Ü, sharp s ß)
+    stay as raw UTF-8 in the on-disk file — every weekly
+    ``update-stations.yml`` commit diff stays compact. A blanket
+    ``ensure_ascii=True`` flip would balloon each German character to
+    a 6-byte ``\\u00XX`` escape; the scrubber + flag-preservation
+    contract avoids that bloat.
+    """
+    target = tmp_path / "stations.json"
+    stations = [
+        {
+            "name": "Wien Hütteldorf — Großbahnhof Mariä-Empfängnis",
+            "source": "oebb",
+            "latitude": 48.19,
+            "longitude": 16.26,
+            "aliases": ["Hütteldorf", "Mariä-Empfängnis-Bahnhof"],
+        }
+    ]
+    write_stations(target, stations)  # type: ignore[arg-type]
+
+    raw_bytes = target.read_bytes()
+    # Every German character MUST land as raw UTF-8, not the 6-byte
+    # ``\\u00XX`` escape sequence.
+    assert "ß".encode() in raw_bytes, "ß lost as raw UTF-8 — diff bloat!"
+    assert "ü".encode() in raw_bytes, "ü lost as raw UTF-8 — diff bloat!"
+    assert "ä".encode() in raw_bytes, "ä lost as raw UTF-8 — diff bloat!"
+    # Defence in depth: the literal ``\\u00fc`` escape (the bloated
+    # form) MUST NOT appear in the on-disk file.
+    decoded = raw_bytes.decode("utf-8")
+    assert "\\u00fc" not in decoded, (
+        "ü was escaped as \\u00fc — ensure_ascii=False contract broken, "
+        "compact German diff lost."
+    )
+    assert "\\u00e4" not in decoded, (
+        "ä was escaped as \\u00e4 — ensure_ascii=False contract broken."
+    )
+
+
+def test_write_stations_preserves_clean_payload_round_trip(tmp_path: Path) -> None:
+    """Regression: a clean payload (no Trojan-Source primitives)
+    round-trips byte-stable through the scrubber. ``load_stations``
+    recovers exactly the same dict every caller saw pre-fix.
+    """
+    target = tmp_path / "stations.json"
+    stations = [
+        {
+            "name": "Wien Hauptbahnhof",
+            "source": "google_places,oebb",
+            "latitude": 48.18,
+            "longitude": 16.38,
+            "aliases": ["Hauptbahnhof", "Wien Hbf"],
+            "_google_place_id": "ChIJqaSC1234567890",
+            "_types": ["train_station", "transit_station"],
+        }
+    ]
+    write_stations(target, stations)  # type: ignore[arg-type]
+
+    parsed = load_stations(target)
+    assert parsed == stations
+
+
+# ---------------------------------------------------------------------
+# Defence in depth: ``load_stations`` strips primitives from a poisoned
+# on-disk stations file (planted before the fix, surviving from a
+# corrupted previous run, or written by a future bypass).
+# ---------------------------------------------------------------------
+
+
+def test_load_stations_strips_pre_existing_trojan_source_primitives(
+    tmp_path: Path,
+) -> None:
+    """A pre-existing ``data/stations.json`` carrying U+202E in raw
+    UTF-8 form (planted before this fix or written by a future bypass
+    of ``write_stations``'s scrubber) MUST NOT propagate the primitive
+    into the in-memory data structure handed to callers.
+    ``load_stations`` strips the canonical attack-byte union on the
+    way out.
+    """
+    target = tmp_path / "stations.json"
+    # Plant the poisoned bytes directly — bypasses ``write_stations``.
+    poisoned = json.dumps(
+        {
+            "stations": [
+                {
+                    "name": "Hauptbahnhof‮moc.live",
+                    "source": "google_places",
+                    "latitude": 48.18,
+                    "longitude": 16.38,
+                }
+            ]
+        },
+        ensure_ascii=False,
+    )
+    target.write_text(poisoned, encoding="utf-8")
+    # Sanity: the planted file actually contains the dangerous bytes.
+    assert b"\xe2\x80\xae" in target.read_bytes()
+
+    stations = load_stations(target)
+
+    assert isinstance(stations, list)
+    assert len(stations) == 1
+    name = stations[0]["name"]
+    assert "‮" not in name, (
+        "load_stations returned a string still carrying U+202E — "
+        "defence in depth at the read boundary failed."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_load_stations_strips_every_trojan_source_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    """The defence-in-depth read-boundary scrubber MUST cover the same
+    canonical union as the write-boundary scrubber.
+    """
+    target = tmp_path / f"stations-{ord(primitive):04x}.json"
+    poisoned = json.dumps(
+        {
+            "stations": [
+                {
+                    "name": f"evil{primitive}.example",
+                    "source": "google_places",
+                }
+            ]
+        },
+        ensure_ascii=False,
+    )
+    target.write_text(poisoned, encoding="utf-8")
+
+    stations = load_stations(target)
+
+    assert len(stations) == 1
+    name = stations[0]["name"]
+    assert primitive not in name, (
+        f"load_stations returned a string still carrying U+{ord(primitive):04X} "
+        f"— read-boundary scrubber drift."
+    )
+
+
+def test_load_stations_preserves_german_umlauts(tmp_path: Path) -> None:
+    """Regression: the read-boundary scrubber MUST NOT touch
+    legitimate German content. ä/ö/ü/ß round-trip identically.
+    """
+    target = tmp_path / "stations.json"
+    payload = {
+        "stations": [
+            {
+                "name": "Wien Hütteldorf",
+                "source": "oebb",
+                "latitude": 48.19,
+                "longitude": 16.26,
+                "aliases": ["Hütteldorf", "Großbahnhof"],
+            }
+        ]
+    }
+    target.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+    stations = load_stations(target)
+
+    assert stations == payload["stations"]
+
+
+def test_load_stations_handles_list_root_shape(tmp_path: Path) -> None:
+    """``load_stations`` supports both ``{"stations": [...]}`` and bare
+    ``[...]`` root shapes. The read-boundary scrubber MUST cover both.
+    """
+    target = tmp_path / "stations.json"
+    # Bare list root shape with planted U+202E.
+    poisoned = json.dumps(
+        [
+            {
+                "name": "Hauptbahnhof‮moc.live",
+                "source": "google_places",
+            }
+        ],
+        ensure_ascii=False,
+    )
+    target.write_text(poisoned, encoding="utf-8")
+    assert b"\xe2\x80\xae" in target.read_bytes()
+
+    stations = load_stations(target)
+
+    assert len(stations) == 1
+    name = stations[0]["name"]
+    assert "‮" not in name


### PR DESCRIPTION
## Summary

Closes the **Round-12 closing-checklist named-but-deferred** sidecar
writer: `src/places/merge.py:write_stations` →
`data/stations.json`. Reuses the
`scrub_trojan_source_primitives` helper from Round 12 (PR #1437)
to keep the canonical CVE-2021-42574 attack-byte union
single-sourced across every operator-facing JSON sidecar writer in
the codebase.

## Threat model

An attacker who compromises any upstream station-name provider
(Google Places, OSM Overpass, OEBB *Verzeichnis der
Verkehrsstationen* Excel, Wien OGD CSV) plants a station entry
carrying U+202E (RIGHT-TO-LEFT OVERRIDE) in its `name` /
`_formatted_address` / `aliases[]` / `_types[]` field — e.g.
`name="Hauptbahnhof‮moc.live"` displays as
`Hauptbahnhofevil.com`. Pre-fix `write_stations` serialised the
payload via `json.dumps(..., ensure_ascii=False, ...)`; the
dangerous bytes landed verbatim in `data/stations.json`, which is
committed to `main` by **two** workflows:

  * `update-stations.yml` (weekly cron, `add_options: "-A"`).
  * `update-google-places-stations.yml` (manual escape hatch,
    line 154 `git add data/stations.json`).

Every viewer (`git log -p`, `cat`, `less`, GitHub web UI, IDE
preview) renders the BiDi-reversed display, hiding the attack from
the operator's own review pass.

## Fix shape

Mirrors Round 12's cache-events fix exactly:

  * `src/places/merge.py:write_stations` — apply
    `scrub_trojan_source_primitives` to the incoming `stations`
    BEFORE `json.dumps`. **Ingestion-boundary defence.** The
    `ensure_ascii=False` flag is preserved so legitimate German
    station names (umlauts ä/ö/ü/Ä/Ö/Ü, sharp s ß) stay compact
    in the weekly commit diff.
  * `src/places/merge.py:load_stations` — apply the same scrubber
    to the parsed payload BEFORE returning to callers.
    **Defence-in-depth at the read boundary** that retroactively
    cleans any historic poisoned `data/stations.json` (planted
    before this fix, surviving from a corrupted previous run, or
    written by a future bypass of the write-side scrubber). The
    scrubber runs AFTER the existing depth-bomb / size-bomb guards
    so a malformed file still raises `ValueError`; only well-formed
    but poisoned content reaches the cleanup pass.

**No new helper added** — the Round-12 helper at
`src/utils/serialize.py:scrub_trojan_source_primitives` is reused
so the canonical attack-byte union stays single-sourced.

## PoC tests

`tests/test_sentinel_places_stations_trojan_source.py` — 52 tests
(49 fail pre-fix, all 52 pass post-fix):

  * 1 + 21 (parametrised) write-boundary tests covering every
    primitive in the canonical CVE-2021-42574 union.
  * 4 nested-shape tests (dict KEY, `aliases[]`,
    `_formatted_address`, `_types[]`) pin the recursive walker
    over every plausible `StationEntry` field type.
  * 1 German-content compact-diff regression
    (`ä`/`ü`/`ß` survive as raw UTF-8).
  * 1 clean-payload round-trip regression.
  * 1 + 21 read-boundary defence-in-depth tests.
  * 1 read-boundary German-content regression.
  * 1 bare-list root shape test (`load_stations` supports both
    `{"stations": [...]}` and bare `[...]`).

## Test plan

- [x] Run `pytest tests/test_sentinel_places_stations_trojan_source.py` — 52/52 passed
- [x] Run full `pytest` — 3674/3674 passed, 3 pre-existing skips
- [x] Run `python scripts/run_static_checks.py` — ruff/bandit/secret-scanner/C901/pip-audit all clean; the 8 mypy errors in `src/utils/http.py` are pre-existing (confirmed via `git stash`) and not caused by this change.
- [ ] CI green on all checks.

## Files

  * `src/places/merge.py` — added scrubber call at write + read boundaries; preserved `ensure_ascii=False`.
  * `tests/test_sentinel_places_stations_trojan_source.py` — 52 PoC tests.
  * `.jules/sentinel.md` — Round 13 journal entry with full threat model and named-but-deferred follow-up queue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgyW2sKAoVKfor4Djht5KG)_