### PR TITLE
security: BiDi/Trojan-Source leak in script-level station writers via scrubber-at-ingestion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,197 @@
+## 2026-05-11 - Trojan-Source BiDi Drift Round 14 (Script-Level Station Writers): Seven Sibling `json.dump(..., ensure_ascii=False, ...)` Sinks That Bypass `src/places/merge.py:write_stations` — All Closed Via The Round-12 `scrub_trojan_source_primitives` Helper
+
+**Vulnerability:** Round 13 (PR #1438) closed
+`src/places/merge.py:write_stations` / `load_stations`
+(`data/stations.json`) via the
+`scrub_trojan_source_primitives` helper added in Round 12
+(`src/utils/serialize.py`). The Round-13 closing checklist
+explicitly named **eight sibling script-level writer sinks**
+spread across **seven `scripts/` files** that bypass the
+canonical library function and write `data/stations.json` (or the
+sibling `data/vor-haltestellen.mapping.json`) via direct
+`json.dump(..., ensure_ascii=False, ...)` /
+`json.dumps(..., ensure_ascii=False, ...)` calls. Each is
+reached from the weekly `update-stations.yml` cron pipeline
+(via `scripts/update_all_stations.py`'s orchestrator) — the same
+threat surface that Rounds 10-13 closed at the library level
+but is reopened by every direct-`json.dump` call site that does
+not route through `src.places.merge.write_stations`.
+
+The eight closed sinks (mapped to `scripts/` files):
+
+  1. `scripts/fetch_google_places_stations.py:_write_if_changed`
+     (line ~288) — writes `{"stations": [...]}` to
+     `data/stations.json` during the manual Google-Places-only
+     escape-hatch path (`update-google-places-stations.yml`
+     line 154 `git add data/stations.json`).
+  2. `scripts/fetch_google_places_stations.py:_dump_changes`
+     (line ~273) — writes a `{"new": [...], "updated": [...]}`
+     per-run change-dump sidecar.
+  3. `scripts/update_all_stations.py:_write_stations_payload`
+     (line ~529) — writes `{"stations": [...]}` to the
+     orchestrator's temp file that is copy-back'd to
+     `data/stations.json` and committed by the weekly cron.
+  4. `scripts/enrich_station_aliases.py` (inline write at the
+     end of `main()`, line ~821) — writes
+     `{"stations": [...]}` to `data/stations.json` after alias
+     enrichment from VOR / GTFS / pendler-alternative-names
+     sources. Extracted into a new `_write_stations_payload`
+     helper so the scrubber can run uniformly at the
+     ingestion boundary.
+  5. `scripts/update_station_directory.py:write_json`
+     (line ~1762) — writes `{"stations": [...]}` after the
+     OEBB `Verzeichnis der Verkehrsstationen` Excel extraction.
+  6. `scripts/update_vor_stations.py:merge_into_stations`
+     (line ~1208 inline write) — writes
+     `{"stations": [...]}` after the VOR merge.
+  7. `scripts/update_wl_stations.py:merge_into_stations`
+     (line ~734 inline write) — writes `{"stations": [...]}`
+     after the Wien OGD CSV merge.
+  8. `scripts/fetch_vor_haltestellen.py` (inline write in
+     `main()`, line ~665) — writes
+     `data/vor-haltestellen.mapping.json` (the VAO
+     resolution-mapping sibling sidecar). Extracted into a new
+     `_write_mapping_payload` helper so the scrubber can run
+     uniformly at the ingestion boundary.
+
+**Threat model:**
+
+  1. Attacker compromises an upstream provider (Google Places
+     hijack, OSM Overpass cache poisoning, OEBB `Verzeichnis
+     der Verkehrsstationen` Excel response tampering, Wien OGD
+     CSV poisoning, VAO ReST station-resolution endpoint
+     hijack, leaked CI secret store) or an operator mis-edits
+     `data/stations.json` /
+     `data/vor-haltestellen.mapping.json` directly.
+  2. A planted station entry carrying U+202E (RIGHT-TO-LEFT
+     OVERRIDE) in a `name` / `aliases[]` /
+     `_formatted_address` / `station_name` / `resolved_name`
+     field — e.g. `name="Hauptbahnhof‮moc.live"` displays as
+     `Hauptbahnhofevil.com` — reaches one of the eight
+     script-level writers above.
+  3. Pre-fix each writer serialised the item via
+     `json.dump(..., ensure_ascii=False, ...)` or
+     `json.dumps(..., ensure_ascii=False, ...)`.
+     `ensure_ascii=False` emits U+202E as its raw UTF-8 byte
+     triplet `\xe2\x80\xae`, so the on-disk file carries the
+     BiDi-reversal trigger directly.
+  4. The `update-stations.yml` / `update-google-places-stations.yml`
+     workflow commits the poisoned file to `main`. The
+     malicious name is now visible in `git log -p` / `git show`
+     / the GitHub web UI / `cat` / `less` / IDE preview —
+     every viewer honours BiDi reversal.
+  5. Operator reviewing the weekly commit misreads the
+     BiDi-reversed display as the inverse of the actual
+     planted bytes. The attack hides in the operator's own
+     review pass.
+
+**Reproduced:** `tests/test_sentinel_script_station_writers_trojan_source.py`
+contains 184 PoC tests:
+
+  * 1 + 21 (parametrised) for each of the eight writer sinks
+    covering every primitive in the canonical CVE-2021-42574
+    attack-byte union.
+  * 1 German-content compact-diff regression per sink
+    (`ä`/`ü`/`ß` survive as raw UTF-8 — the bloated `\u00XX`
+    form does NOT appear), so we know `ensure_ascii=False` is
+    preserved and the scrubber is the ONLY change at the write
+    boundary.
+  * 1 inventory test that grep-pins
+    `scrub_trojan_source_primitives` is imported in every
+    target script — a future drift candidate (e.g. a 9th
+    script-level writer) that re-implements the primitive set
+    locally will trip the inventory check until it's wired to
+    the single-sourced helper.
+
+  Pre-fix repro for the canonical write-boundary case via
+  `scripts/fetch_google_places_stations.py:_write_if_changed`:
+  `name="Hauptbahnhof‮moc.live"` produced an on-disk file
+  with raw bytes `...Hauptbahnhof\xe2\x80\xaemoc.live...`.
+  Post-fix: the primitive is stripped at the ingestion
+  boundary; the on-disk file reads `Hauptbahnhofmoc.live`
+  (the malicious primitive is gone, the safe portion of the
+  name remains).
+
+**Fix:**
+
+  * Every script gains a `from src.utils.serialize import
+    scrub_trojan_source_primitives` import (mirroring
+    `src/places/merge.py`'s Round-13 wiring). The
+    canonical attack-byte union stays single-sourced across
+    the codebase.
+  * `_write_if_changed`, `_dump_changes`,
+    `_write_stations_payload`, `write_json`, and the inline
+    writes in `merge_into_stations` (VOR + WL) apply the
+    scrubber to the payload BEFORE `json.dump`/`json.dumps`.
+  * `enrich_station_aliases.py` and
+    `fetch_vor_haltestellen.py` get a new
+    `_write_stations_payload` / `_write_mapping_payload`
+    helper respectively that owns the
+    scrub-then-`json.dump` pair, replacing the inline writes
+    in `main()`. The helpers are package-private (underscored)
+    and importable by the PoC test suite.
+  * `ensure_ascii=False` is preserved at every writer so
+    legitimate German station names (umlauts ä/ö/ü/Ä/Ö/Ü +
+    sharp s ß) stay compact in the weekly commit diff.
+    Mirrors the Round-12/13 scrub-and-drop semantics chosen
+    for the high-cardinality content sinks.
+
+**Learning:** the Round-13 "Named but deferred" entry's
+prediction that the script-level writers were the next target
+AND that the single-sourced defence helper would carry the fix
+was correct. The drift family is now uniform across every
+committed operator-facing JSON sidecar in the project — nine
+rounds (Round 3 ValidationReport → Round 14 script-level
+station writers) of cumulative coverage on top of the
+channel/title/feed-XML/CSV/markdown sinks closed earlier. The
+closing-checklist drift-walker invariant continues to hold:
+every fix shape adopted in a previous round is mechanically
+reusable by the next round IF the helper was placed in a
+provider-neutral utility module
+(`src/utils/serialize.py:scrub_trojan_source_primitives` here).
+
+  * **Closed in this round:** eight script-level station
+    writers across seven `scripts/` files (see list above).
+  * **Already closed (Round 13):** `write_stations` /
+    `load_stations` (`data/stations.json`) via scrubber-at-
+    ingestion + flag preservation.
+  * **Already closed (Round 12):** `write_cache` / `read_cache`
+    (`cache/<provider>/events.json`).
+  * **Already closed (Round 11):** `MonthlyQuota.save_atomic`
+    (`data/places_quota.json`), `_write_request_count_file`
+    (`data/vor_request_count.json`), `write_status`
+    (`cache/<provider>/last_run.json`).
+  * **Already closed (earlier rounds):** `_save_state`
+    (`data/first_seen.json`, Round 10),
+    `_write_heartbeat_file` (`data/stations_last_run.json`,
+    Round 10), `_write_quarantine_file`
+    (`data/quarantine.json`, Round 9),
+    `_render_diff_markdown` (`docs/stations_diff.md`,
+    Round 9), `ValidationReport.to_markdown()` (Round 3),
+    `render_feed_health_markdown` / GitHub-Issue body
+    (Round 2), `docs/statistik.md` stats dashboard (Round 1),
+    `data/stats/*.csv` CSV writer, RSS XML writers, sitemap
+    writer, `_escape_env_value` `.env` writer.
+  * **Named but deferred** (out of scope for this round;
+    queued for follow-up sanitisation rounds): none currently
+    identified. Future drift candidates that would re-open the
+    family:
+    * A NEW provider script that grows an inline
+      `json.dump(..., ensure_ascii=False, ...)` write to a
+      `data/` JSON sidecar without routing through
+      `src.places.merge.write_stations` or
+      `src.utils.cache.write_cache`. The Round-14 inventory
+      test
+      (`test_all_script_writers_use_shared_scrubber_helper`)
+      pins the current set; the next walker MUST extend it
+      when a new sibling appears.
+    * A new utility helper (e.g. `src/utils/X.py`) that grows
+      its own `json.dump(..., ensure_ascii=False, ...)` site.
+      This is the recurring sibling-drift class — every
+      previous round identified one and the next round will
+      need to enumerate `grep -nE "ensure_ascii=False" src/`
+      one more time.
+
 ## 2026-05-11 - Trojan-Source BiDi Drift Round 13 (Canonical Stations Directory Sidecar): `write_stations` / `load_stations` (`data/stations.json`) Was the Round-12 Closing-Checklist Named-But-Deferred Sidecar — Closed Via The Round-12 `scrub_trojan_source_primitives` Helper (Single-Sourced Defence Shape)
 
 **Vulnerability:** Round 12 (PR #1437) closed

--- a/scripts/enrich_station_aliases.py
+++ b/scripts/enrich_station_aliases.py
@@ -38,8 +38,10 @@ if str(BASE_DIR) not in sys.path:
 
 try:
     from src.utils.files import atomic_write, read_capped_json, read_capped_text
+    from src.utils.serialize import scrub_trojan_source_primitives
 except ModuleNotFoundError:
     from utils.files import atomic_write, read_capped_json, read_capped_text  # type: ignore[no-redef]
+    from utils.serialize import scrub_trojan_source_primitives  # type: ignore[no-redef]
 
 DEFAULT_STATIONS = BASE_DIR / "data" / "stations.json"
 DEFAULT_VOR_STOPS = BASE_DIR / "data" / "vor-haltestellen.csv"
@@ -731,6 +733,25 @@ def _alias_candidates(
     return safe_aliases
 
 
+def _write_stations_payload(path: Path, stations: list[dict[str, object]]) -> None:
+    """Atomically rewrite *path* with the enriched stations wrapped in
+    the canonical ``{"stations": [...]}`` envelope.
+
+    Security (Trojan-Source / BiDi-Mark Drift Round 14, ingestion-boundary
+    defence): strip the canonical CVE-2021-42574 attack-byte union BEFORE
+    ``json.dump`` so a poisoned VOR / GTFS / pendler-alternative-names
+    source cannot leak raw BiDi marks into ``data/stations.json`` via
+    a planted alias. The file is committed to ``main`` by the weekly
+    ``update-stations.yml`` cron (when the orchestrator invokes this
+    script). Mirrors ``src/places/merge.py:write_stations`` (Round 13).
+    """
+    scrubbed = scrub_trojan_source_primitives(stations)
+    serialisable = scrubbed if isinstance(scrubbed, list) else stations
+    with atomic_write(path, mode="w", encoding="utf-8", permissions=0o644) as handle:
+        json.dump({"stations": serialisable}, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
+
 def _order_aliases(station: Mapping[str, object], aliases: Iterable[str]) -> list[str]:
     ordered: list[str] = []
 
@@ -817,9 +838,7 @@ def main() -> int:
         log.info("Dry run – not writing %s", args.stations)
         return 0
 
-    with atomic_write(args.stations, mode="w", encoding="utf-8", permissions=0o644) as handle:
-        json.dump({"stations": stations}, handle, ensure_ascii=False, indent=2)
-        handle.write("\n")
+    _write_stations_payload(args.stations, stations)
     log.info("Wrote enriched aliases to %s", args.stations)
     return 0
 

--- a/scripts/fetch_google_places_stations.py
+++ b/scripts/fetch_google_places_stations.py
@@ -47,6 +47,7 @@ from src.places.merge import BoundingBox, MergeConfig, merge_places, load_statio
 from src.places.tiling import Tile, iter_tiles, load_tiles_from_env, load_tiles_from_file
 from src.utils.env import load_default_env_files
 from src.utils.files import atomic_write, read_capped_text
+from src.utils.serialize import scrub_trojan_source_primitives
 from src.feed.config import InvalidPathError, validate_path
 
 LOGGER = logging.getLogger("places.cli")
@@ -270,11 +271,16 @@ def _dump_changes(
     new_entries: Sequence[Mapping[str, object]],
     updated_entries: Sequence[Mapping[str, object]],
 ) -> None:
+    # Security (Trojan-Source / BiDi-Mark Drift Round 14, ingestion-boundary
+    # defence): strip the canonical CVE-2021-42574 attack-byte union from
+    # provider-fetched Google Places ``new`` / ``updated`` entries BEFORE
+    # ``json.dumps``. Mirrors ``src/places/merge.py:write_stations``
+    # (Round 13) so the canonical attack-byte union stays single-sourced.
+    scrubbed = scrub_trojan_source_primitives(
+        {"new": list(new_entries), "updated": list(updated_entries)}
+    )
     payload = json.dumps(
-        {
-            "new": list(new_entries),
-            "updated": list(updated_entries),
-        },
+        scrubbed,
         ensure_ascii=False,
         indent=2,
         sort_keys=True,
@@ -285,7 +291,20 @@ def _dump_changes(
 
 
 def _write_if_changed(path: Path, stations: Sequence[Mapping[str, object]]) -> None:
-    payload = json.dumps({"stations": list(stations)}, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    # Security (Trojan-Source / BiDi-Mark Drift Round 14, ingestion-boundary
+    # defence): strip the canonical CVE-2021-42574 attack-byte union from
+    # the incoming stations BEFORE ``json.dumps``. This is the
+    # Google-Places-only manual escape hatch writer for
+    # ``data/stations.json`` — the file is pushed to ``main`` by
+    # ``update-google-places-stations.yml`` (line 154 ``git add
+    # data/stations.json``) so a planted U+202E in a provider-fetched
+    # ``name`` / ``aliases[]`` / ``_formatted_address`` field would
+    # otherwise leak into the operator-facing diff and the GitHub web
+    # UI rendering. ``ensure_ascii=False`` is preserved below so
+    # legitimate German station names stay compact in the diff.
+    scrubbed_stations = scrub_trojan_source_primitives(list(stations))
+    serialisable = scrubbed_stations if isinstance(scrubbed_stations, list) else list(stations)
+    payload = json.dumps({"stations": serialisable}, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
     if path.exists():
         # Security: ``read_capped_text`` enforces a TOCTOU-safe size cap
         # so a planted huge ``stations.json`` cannot exhaust memory and

--- a/scripts/fetch_vor_haltestellen.py
+++ b/scripts/fetch_vor_haltestellen.py
@@ -661,31 +661,40 @@ def main(argv: Sequence[str] | None = None) -> int:
         for pair in resolved_pairs
     ]
 
-    _write_mapping_payload(mapping_path, mapping_payload)
+    # Security (Trojan-Source / BiDi-Mark Drift Round 14, ingestion-boundary
+    # defence): scrub the canonical CVE-2021-42574 attack-byte union from the
+    # provider-fetched mapping BEFORE the json serialisation below. A poisoned
+    # VAO ReST station-resolution endpoint could plant U+202E in a
+    # ``station_name`` / ``resolved_name`` field —
+    # ``data/vor-haltestellen.mapping.json`` is the sibling station-directory
+    # sidecar that the cron pipeline commits to ``main``. Mirrors
+    # ``src/places/merge.py:write_stations`` (Round 13).
+    scrubbed_mapping = _scrub_mapping_for_serialisation(mapping_payload)
+
+    with atomic_write(mapping_path, mode="w", encoding="utf-8") as handle:
+        # codeql[py/clear-text-storage-sensitive-data] False Positive: Payload contains only public station data, no sensitive user data.
+        handle.write(json.dumps(scrubbed_mapping, ensure_ascii=False, indent=2) + "\n")
 
     log.info("Wrote station mapping to %s", mapping_path)
     return 0
 
 
-def _write_mapping_payload(path: Path, mapping: list[dict[str, object]]) -> None:
-    """Atomically rewrite *path* with the VAO resolution mapping.
+def _scrub_mapping_for_serialisation(
+    mapping: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    """Apply the canonical Trojan-Source scrubber to the VAO resolution mapping.
 
-    Security (Trojan-Source / BiDi-Mark Drift Round 14, ingestion-boundary
-    defence): strip the canonical CVE-2021-42574 attack-byte union from
-    the mapping BEFORE ``json.dumps``. A poisoned VAO ReST
-    station-resolution endpoint could plant U+202E in a
-    ``station_name`` / ``resolved_name`` field —
-    ``data/vor-haltestellen.mapping.json`` is the sibling
-    station-directory sidecar that the cron pipeline commits to
-    ``main``. Mirrors ``src/places/merge.py:write_stations`` (Round 13).
-    ``ensure_ascii=False`` is preserved so legitimate German names
-    stay compact in the commit diff.
+    Extracted as a helper so the scrub-and-drop semantics can be unit-tested
+    in isolation (the surrounding ``main()`` is hard to drive end-to-end).
+    Mirrors ``src/places/merge.py:write_stations`` (Round 13). The actual
+    ``json.dumps`` + ``atomic_write`` site stays inline at the original
+    location in ``main()`` so the data-flow shape (and the historical
+    CodeQL false-positive suppression for that line) does not move.
     """
-    scrubbed = scrub_trojan_source_primitives(mapping)
-    serialisable = scrubbed if isinstance(scrubbed, list) else mapping
-    with atomic_write(path, mode="w", encoding="utf-8") as handle:
-        # codeql[py/clear-text-storage-sensitive-data] False Positive: Payload contains only public station data, no sensitive user data.
-        handle.write(json.dumps(serialisable, ensure_ascii=False, indent=2) + "\n")
+    scrubbed = scrub_trojan_source_primitives(list(mapping))
+    if isinstance(scrubbed, list):
+        return [dict(entry) if isinstance(entry, Mapping) else entry for entry in scrubbed]
+    return [dict(entry) for entry in mapping]
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/scripts/fetch_vor_haltestellen.py
+++ b/scripts/fetch_vor_haltestellen.py
@@ -24,6 +24,7 @@ if str(BASE_DIR) not in sys.path:
 from src.feed.logging_safe import setup_script_logging  # noqa: E402
 from src.utils.files import atomic_write, read_capped_json  # noqa: E402
 from src.utils.http import read_response_safe, session_with_retries  # noqa: E402
+from src.utils.serialize import scrub_trojan_source_primitives  # noqa: E402
 
 
 DEFAULT_STATIONS_PATH = BASE_DIR / "data" / "stations.json"
@@ -660,12 +661,31 @@ def main(argv: Sequence[str] | None = None) -> int:
         for pair in resolved_pairs
     ]
 
-    with atomic_write(mapping_path, mode="w", encoding="utf-8") as handle:
-        # codeql[py/clear-text-storage-sensitive-data] False Positive: Payload contains only public station data, no sensitive user data.
-        handle.write(json.dumps(mapping_payload, ensure_ascii=False, indent=2) + "\n")
+    _write_mapping_payload(mapping_path, mapping_payload)
 
     log.info("Wrote station mapping to %s", mapping_path)
     return 0
+
+
+def _write_mapping_payload(path: Path, mapping: list[dict[str, object]]) -> None:
+    """Atomically rewrite *path* with the VAO resolution mapping.
+
+    Security (Trojan-Source / BiDi-Mark Drift Round 14, ingestion-boundary
+    defence): strip the canonical CVE-2021-42574 attack-byte union from
+    the mapping BEFORE ``json.dumps``. A poisoned VAO ReST
+    station-resolution endpoint could plant U+202E in a
+    ``station_name`` / ``resolved_name`` field —
+    ``data/vor-haltestellen.mapping.json`` is the sibling
+    station-directory sidecar that the cron pipeline commits to
+    ``main``. Mirrors ``src/places/merge.py:write_stations`` (Round 13).
+    ``ensure_ascii=False`` is preserved so legitimate German names
+    stay compact in the commit diff.
+    """
+    scrubbed = scrub_trojan_source_primitives(mapping)
+    serialisable = scrubbed if isinstance(scrubbed, list) else mapping
+    with atomic_write(path, mode="w", encoding="utf-8") as handle:
+        # codeql[py/clear-text-storage-sensitive-data] False Positive: Payload contains only public station data, no sensitive user data.
+        handle.write(json.dumps(serialisable, ensure_ascii=False, indent=2) + "\n")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/scripts/fetch_vor_haltestellen.py
+++ b/scripts/fetch_vor_haltestellen.py
@@ -649,7 +649,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     log.info("Wrote %d VOR stops to %s", len(resolved_unique), args.output)
 
     mapping_path = args.output.with_suffix(".mapping.json")
-    mapping_payload = [
+    mapping_payload = _scrub_mapping_for_serialisation(
         {
             "station_name": pair[0].name,
             "bst_id": pair[0].bst_id,
@@ -659,42 +659,33 @@ def main(argv: Sequence[str] | None = None) -> int:
             "longitude": pair[1].longitude,
         }
         for pair in resolved_pairs
-    ]
-
-    # Security (Trojan-Source / BiDi-Mark Drift Round 14, ingestion-boundary
-    # defence): scrub the canonical CVE-2021-42574 attack-byte union from the
-    # provider-fetched mapping BEFORE the json serialisation below. A poisoned
-    # VAO ReST station-resolution endpoint could plant U+202E in a
-    # ``station_name`` / ``resolved_name`` field —
-    # ``data/vor-haltestellen.mapping.json`` is the sibling station-directory
-    # sidecar that the cron pipeline commits to ``main``. Mirrors
-    # ``src/places/merge.py:write_stations`` (Round 13).
-    scrubbed_mapping = _scrub_mapping_for_serialisation(mapping_payload)
+    )
 
     with atomic_write(mapping_path, mode="w", encoding="utf-8") as handle:
         # codeql[py/clear-text-storage-sensitive-data] False Positive: Payload contains only public station data, no sensitive user data.
-        handle.write(json.dumps(scrubbed_mapping, ensure_ascii=False, indent=2) + "\n")
+        handle.write(json.dumps(mapping_payload, ensure_ascii=False, indent=2) + "\n")
 
     log.info("Wrote station mapping to %s", mapping_path)
     return 0
 
 
 def _scrub_mapping_for_serialisation(
-    mapping: Sequence[Mapping[str, object]],
+    mapping: Iterable[Mapping[str, object]],
 ) -> list[dict[str, object]]:
     """Apply the canonical Trojan-Source scrubber to the VAO resolution mapping.
 
-    Extracted as a helper so the scrub-and-drop semantics can be unit-tested
-    in isolation (the surrounding ``main()`` is hard to drive end-to-end).
-    Mirrors ``src/places/merge.py:write_stations`` (Round 13). The actual
-    ``json.dumps`` + ``atomic_write`` site stays inline at the original
-    location in ``main()`` so the data-flow shape (and the historical
-    CodeQL false-positive suppression for that line) does not move.
+    Wraps the call site's list-comprehension / generator so the on-disk
+    file cannot carry CVE-2021-42574 BiDi marks from a poisoned VAO
+    upstream. Mirrors ``src/places/merge.py:write_stations`` (Round 13).
+    The actual ``json.dumps`` + ``atomic_write`` site stays inline at the
+    original line position so CodeQL matches the historical
+    false-positive suppression for that location.
     """
-    scrubbed = scrub_trojan_source_primitives(list(mapping))
+    materialised = list(mapping)
+    scrubbed = scrub_trojan_source_primitives(materialised)
     if isinstance(scrubbed, list):
         return [dict(entry) if isinstance(entry, Mapping) else entry for entry in scrubbed]
-    return [dict(entry) for entry in mapping]
+    return [dict(entry) for entry in materialised]
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/scripts/update_all_stations.py
+++ b/scripts/update_all_stations.py
@@ -41,6 +41,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from src.feed.logging_safe import setup_script_logging  # noqa: E402
 from src.utils.files import atomic_write, read_capped_json  # noqa: E402  (import after path setup)
+from src.utils.serialize import scrub_trojan_source_primitives  # noqa: E402
 from src.utils.stations_validation import (  # noqa: E402
     StationValidationError,
     ValidationReport,
@@ -523,8 +524,18 @@ def _write_stations_payload(
     ``scripts/update_station_directory.py:write_json`` so a downstream
     consumer reading the merged temp file (and the final copy-back to
     ``data/stations.json``) sees the same format as a clean run.
+
+    Security (Trojan-Source / BiDi-Mark Drift Round 14, ingestion-boundary
+    defence): strip the canonical CVE-2021-42574 attack-byte union BEFORE
+    ``json.dump`` so a poisoned upstream provider (OEBB Excel / OSM
+    Overpass / Wien OGD CSV) cannot leak raw BiDi marks into the
+    orchestrator's temp file. The temp file is copy-back'd to
+    ``data/stations.json`` and the weekly ``update-stations.yml`` cron
+    commits it to ``main`` with ``add_options: "-A"``. Mirrors
+    ``src/places/merge.py:write_stations`` (Round 13).
     """
-    payload = {"stations": [dict(entry) for entry in stations]}
+    raw_payload = {"stations": [dict(entry) for entry in stations]}
+    payload = scrub_trojan_source_primitives(raw_payload)
     with atomic_write(path, mode="w", encoding="utf-8") as handle:
         json.dump(payload, handle, ensure_ascii=False, indent=2)
         handle.write("\n")

--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -52,6 +52,7 @@ try:  # pragma: no cover - convenience for module execution
         use_cached_polygon_result,
     )
     from src.utils.http import fetch_content_safe, session_with_retries
+    from src.utils.serialize import scrub_trojan_source_primitives
     from src.utils.stations import is_in_vienna as _is_point_in_vienna
 except ModuleNotFoundError:  # pragma: no cover - fallback when installed as package
     from utils.files import (  # type: ignore[no-redef]
@@ -65,6 +66,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when installed as pac
         use_cached_polygon_result,
     )
     from utils.http import fetch_content_safe, session_with_retries  # type: ignore[no-redef]
+    from utils.serialize import scrub_trojan_source_primitives  # type: ignore[no-redef]
     from utils.stations import is_in_vienna as _is_point_in_vienna  # type: ignore[no-redef]
 
 # Security cap against wide-but-flat JSON size-bomb attacks. Mirrors the
@@ -1760,7 +1762,19 @@ def load_pendler_name_candidates(path: Path) -> set[str]:
 
 
 def write_json(stations_list: list[dict[str, object]], output_path: Path) -> None:
-    payload = {"stations": stations_list}
+    # Security (Trojan-Source / BiDi-Mark Drift Round 14, ingestion-boundary
+    # defence): strip the canonical CVE-2021-42574 attack-byte union from
+    # the incoming stations BEFORE ``json.dump``. The OEBB
+    # ``Verzeichnis der Verkehrsstationen`` Excel response is the
+    # primary delivery vector — a hijacked OGD portal (DNS rebind or
+    # cache poisoning) could plant U+202E in a station ``name`` /
+    # ``aliases[]`` / ``alternative_names`` field. The weekly
+    # ``update-stations.yml`` cron commits ``data/stations.json`` to
+    # ``main``. ``ensure_ascii=False`` preserves compact German diffs.
+    # Mirrors ``src/places/merge.py:write_stations`` (Round 13).
+    scrubbed = scrub_trojan_source_primitives(stations_list)
+    serialisable = scrubbed if isinstance(scrubbed, list) else stations_list
+    payload = {"stations": serialisable}
     # Use atomic_write to prevent partial writes and reduce race conditions.
     with atomic_write(output_path, mode="w", encoding="utf-8", permissions=0o644) as handle:
         json.dump(payload, handle, ensure_ascii=False, indent=2)

--- a/scripts/update_vor_stations.py
+++ b/scripts/update_vor_stations.py
@@ -23,6 +23,7 @@ from src.feed.logging_safe import setup_script_logging  # noqa: E402
 from src.providers import vor as vor_provider  # noqa: E402
 from src.utils.files import atomic_write, read_capped_json, read_capped_text  # noqa: E402
 from src.utils.http import read_response_safe, session_with_retries  # noqa: E402
+from src.utils.serialize import scrub_trojan_source_primitives  # noqa: E402
 from src.utils.stations import is_in_vienna, is_pendler  # noqa: E402
 
 # Security cap against wide-but-flat JSON size-bomb attacks. Mirrors the
@@ -1205,8 +1206,19 @@ def merge_into_stations(stations_path: Path, vor_entries: list[dict[str, object]
     new_vor_entries.sort(key=lambda item: (str(item.get("name")), str(item.get("vor_id"))))
     merged_entries = existing + new_vor_entries
 
+    # Security (Trojan-Source / BiDi-Mark Drift Round 14, ingestion-boundary
+    # defence): strip the canonical CVE-2021-42574 attack-byte union from
+    # the merged stations BEFORE ``json.dump``. A planted VOR
+    # provider-fetched ``name`` / ``aliases[]`` field — e.g. via VAO
+    # ReST endpoint hijack or poisoned ``data/vor-haltestellen.csv``
+    # — would otherwise leak raw BiDi marks into ``data/stations.json``
+    # which the weekly cron commits to ``main``. ``ensure_ascii=False``
+    # is preserved so legitimate German station names stay compact.
+    # Mirrors ``src/places/merge.py:write_stations`` (Round 13).
+    scrubbed = scrub_trojan_source_primitives(merged_entries)
+    serialisable = scrubbed if isinstance(scrubbed, list) else merged_entries
     with atomic_write(stations_path, mode="w", encoding="utf-8", permissions=0o644) as handle:
-        output = {"stations": merged_entries}
+        output = {"stations": serialisable}
         json.dump(output, handle, ensure_ascii=False, indent=2)
         handle.write("\n")
     if skipped_unmerged_count:

--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -60,11 +60,20 @@ def _load_read_capped_text() -> Callable[..., Any]:
     return cast(Callable[..., Any], module.read_capped_text)
 
 
+def _load_scrub_trojan_source_primitives() -> Callable[..., Any]:
+    base_dir = _project_root()
+    if str(base_dir) not in sys.path:
+        sys.path.insert(0, str(base_dir))
+    module = import_module("src.utils.serialize")
+    return cast(Callable[..., Any], module.scrub_trojan_source_primitives)
+
+
 BASE_DIR = _project_root()
 is_in_vienna = _load_is_in_vienna()
 atomic_write = _load_atomic_write()
 read_capped_json = _load_read_capped_json()
 read_capped_text = _load_read_capped_text()
+scrub_trojan_source_primitives = _load_scrub_trojan_source_primitives()
 
 # Security cap against wide-but-flat JSON size-bomb attacks. Mirrors the
 # canonical ``MAX_*_FILE_BYTES`` contract from ``src/utils/cache.py`` /
@@ -731,8 +740,19 @@ def merge_into_stations(
 
     filtered.extend(unmatched)
 
+    # Security (Trojan-Source / BiDi-Mark Drift Round 14, ingestion-boundary
+    # defence): strip the canonical CVE-2021-42574 attack-byte union from
+    # the merged stations BEFORE ``json.dump``. A planted Wien OGD CSV
+    # (or hijacked ``data.wien.gv.at`` response) could plant U+202E in a
+    # WL station ``name`` / ``aliases[]`` field — the file is committed
+    # to ``main`` by the weekly cron via the orchestrator. Mirrors
+    # ``src/places/merge.py:write_stations`` (Round 13). ``ensure_ascii=
+    # False`` is preserved so legitimate German station names stay
+    # compact in the commit diff.
+    scrubbed = scrub_trojan_source_primitives(filtered)
+    serialisable = scrubbed if isinstance(scrubbed, list) else filtered
     with atomic_write(stations_path, mode="w", encoding="utf-8", permissions=0o644) as handle:
-        json.dump({"stations": filtered}, handle, ensure_ascii=False, indent=2)
+        json.dump({"stations": serialisable}, handle, ensure_ascii=False, indent=2)
         handle.write("\n")
     log.info("Wrote %d total stations", len(filtered))
 

--- a/tests/test_sentinel_script_station_writers_trojan_source.py
+++ b/tests/test_sentinel_script_station_writers_trojan_source.py
@@ -457,7 +457,7 @@ def test_update_station_directory_write_json_strips_every_primitive(
     from scripts.update_station_directory import write_json
 
     target = tmp_path / f"stations-{ord(primitive):04x}.json"
-    stations_list = [
+    stations_list: list[dict[str, object]] = [
         {
             "name": f"evil{primitive}.example",
             "bst_id": "100",
@@ -478,7 +478,7 @@ def test_update_station_directory_write_json_preserves_umlauts(tmp_path: Path) -
     from scripts.update_station_directory import write_json
 
     target = tmp_path / "stations.json"
-    stations_list = [{"name": "Wien Hütteldorf", "bst_id": "1"}]
+    stations_list: list[dict[str, object]] = [{"name": "Wien Hütteldorf", "bst_id": "1"}]
     write_json(stations_list, target)
 
     text = target.read_text(encoding="utf-8")
@@ -663,15 +663,16 @@ def test_update_wl_merge_into_stations_preserves_umlauts(tmp_path: Path) -> None
 # ---------------------------------------------------------------------
 
 
-def test_fetch_vor_haltestellen_mapping_no_rlo_leak(tmp_path: Path) -> None:
+def test_fetch_vor_haltestellen_mapping_no_rlo_leak() -> None:
     """The VAO resolution mapping sidecar
     ``data/vor-haltestellen.mapping.json`` is a sibling station-directory
-    artefact that gets committed by the same cron pipeline. Its inline
-    write is extracted into a ``_write_mapping_payload`` helper so the
-    scrubber can run uniformly at the ingestion boundary."""
-    from scripts.fetch_vor_haltestellen import _write_mapping_payload
+    artefact that gets committed by the same cron pipeline. Its scrubber
+    is extracted into a ``_scrub_mapping_for_serialisation`` helper so the
+    scrub-and-drop semantics can be unit-tested in isolation while the
+    actual ``json.dumps`` + ``atomic_write`` site stays inline at the
+    original location in ``main()``."""
+    from scripts.fetch_vor_haltestellen import _scrub_mapping_for_serialisation
 
-    target = tmp_path / "vor-haltestellen.mapping.json"
     mapping: list[dict[str, Any]] = [
         {
             "station_name": "Wien Mitte‮moc.live",
@@ -682,21 +683,22 @@ def test_fetch_vor_haltestellen_mapping_no_rlo_leak(tmp_path: Path) -> None:
             "longitude": 16.38,
         }
     ]
-    _write_mapping_payload(target, mapping)
-
-    raw = target.read_bytes()
+    scrubbed = _scrub_mapping_for_serialisation(mapping)
+    # The scrubbed payload must round-trip through json.dumps without
+    # emitting the RLO byte triplet — that is the exact data flow the
+    # main() function uses below the scrubber call.
+    raw = json.dumps(scrubbed, ensure_ascii=False, indent=2).encode("utf-8")
     assert _RLO_UTF8 not in raw, (
-        "U+202E leaked via fetch_vor_haltestellen._write_mapping_payload."
+        "U+202E leaked via fetch_vor_haltestellen._scrub_mapping_for_serialisation."
     )
 
 
 @pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
 def test_fetch_vor_haltestellen_mapping_strips_every_primitive(
-    tmp_path: Path, primitive: str
+    primitive: str,
 ) -> None:
-    from scripts.fetch_vor_haltestellen import _write_mapping_payload
+    from scripts.fetch_vor_haltestellen import _scrub_mapping_for_serialisation
 
-    target = tmp_path / f"mapping-{ord(primitive):04x}.json"
     mapping: list[dict[str, Any]] = [
         {
             "station_name": f"evil{primitive}.example",
@@ -707,20 +709,19 @@ def test_fetch_vor_haltestellen_mapping_strips_every_primitive(
             "longitude": 16.38,
         }
     ]
-    _write_mapping_payload(target, mapping)
-
-    raw = target.read_bytes()
+    scrubbed = _scrub_mapping_for_serialisation(mapping)
+    raw = json.dumps(scrubbed, ensure_ascii=False, indent=2).encode("utf-8")
     expected = _UTF8_BYTES[primitive]
     assert expected not in raw, (
         f"Trojan-Source primitive U+{ord(primitive):04X} leaked via "
-        f"fetch_vor_haltestellen._write_mapping_payload as raw UTF-8 bytes ({expected!r})."
+        f"fetch_vor_haltestellen._scrub_mapping_for_serialisation as raw "
+        f"UTF-8 bytes ({expected!r})."
     )
 
 
-def test_fetch_vor_haltestellen_mapping_preserves_umlauts(tmp_path: Path) -> None:
-    from scripts.fetch_vor_haltestellen import _write_mapping_payload
+def test_fetch_vor_haltestellen_mapping_preserves_umlauts() -> None:
+    from scripts.fetch_vor_haltestellen import _scrub_mapping_for_serialisation
 
-    target = tmp_path / "vor-haltestellen.mapping.json"
     mapping: list[dict[str, Any]] = [
         {
             "station_name": "Wien Hütteldorf",
@@ -731,9 +732,8 @@ def test_fetch_vor_haltestellen_mapping_preserves_umlauts(tmp_path: Path) -> Non
             "longitude": 16.26,
         }
     ]
-    _write_mapping_payload(target, mapping)
-
-    text = target.read_text(encoding="utf-8")
+    scrubbed = _scrub_mapping_for_serialisation(mapping)
+    text = json.dumps(scrubbed, ensure_ascii=False, indent=2)
     assert "Hütteldorf" in text
     assert "\\u00fc" not in text
 

--- a/tests/test_sentinel_script_station_writers_trojan_source.py
+++ b/tests/test_sentinel_script_station_writers_trojan_source.py
@@ -1,0 +1,769 @@
+"""Sentinel PoC: Trojan-Source / BiDi-Mark leakage at the **script-level**
+station-directory writers that the *BiDi-Mark Drift Round 13*
+closing-checklist named but deferred.
+
+Round 13 (PR #1438) closed the canonical library function
+``src/places/merge.py:write_stations`` / ``load_stations`` via the
+``scrub_trojan_source_primitives`` helper added in Round 12
+(``src/utils/serialize.py``). The Round-13 closing checklist explicitly
+named eight sibling script-level writers that bypass the canonical
+library function and write ``data/stations.json`` (or sibling
+``data/vor-haltestellen.mapping.json``) via direct
+``json.dump(..., ensure_ascii=False, ...)`` / ``json.dumps(...,
+ensure_ascii=False, ...)`` calls. Each of these is reached from the
+weekly ``update-stations.yml`` cron pipeline (via
+``scripts/update_all_stations.py``) which commits ``data/`` to ``main``
+with ``add_options: "-A"`` — exactly the same threat surface Rounds
+10-13 closed at the library level.
+
+Sinks pinned in this PoC
+=========================
+
+1. ``scripts/fetch_google_places_stations.py:_write_if_changed``
+   (line ~288) — writes ``{"stations": [...]}`` to ``data/stations.json``
+   during the manual Google-Places-only escape hatch path
+   (``update-google-places-stations.yml`` workflow).
+2. ``scripts/fetch_google_places_stations.py:_dump_changes``
+   (line ~273) — writes a ``{"new": [...], "updated": [...]}``
+   per-run change-dump sidecar.
+3. ``scripts/update_all_stations.py:_write_stations_payload``
+   (line ~529) — writes ``{"stations": [...]}`` to the orchestrator's
+   temp file which is then copy-back'd to ``data/stations.json``
+   (this is the file the weekly cron commits).
+4. ``scripts/enrich_station_aliases.py`` — extracts the inline
+   ``json.dump`` write into a new ``_write_stations_payload`` helper
+   so the scrubber can run uniformly at the ingestion boundary
+   (writes ``data/stations.json`` after alias enrichment).
+5. ``scripts/update_station_directory.py:write_json`` (line ~1762) —
+   writes ``{"stations": [...]}`` to ``data/stations.json`` after the
+   OEBB ``Verzeichnis der Verkehrsstationen`` Excel extraction.
+6. ``scripts/update_vor_stations.py:merge_into_stations``
+   (line ~1208) — writes ``{"stations": [...]}`` to
+   ``data/stations.json`` after the VOR merge.
+7. ``scripts/update_wl_stations.py:merge_into_stations``
+   (line ~734) — writes ``{"stations": [...]}`` to
+   ``data/stations.json`` after the WL OGD merge.
+8. ``scripts/fetch_vor_haltestellen.py`` — extracts the inline
+   ``json.dumps`` write into a new ``_write_mapping_payload`` helper
+   so the scrubber can run uniformly at the ingestion boundary
+   (writes ``data/vor-haltestellen.mapping.json`` after the VOR
+   station-name resolution).
+
+Threat model (identical to Round 13)
+=====================================
+
+1. Attacker compromises an upstream provider (Google Places hijack,
+   OSM Overpass cache poisoning, OEBB ``Verzeichnis der
+   Verkehrsstationen`` Excel response tampering, Wien OGD CSV
+   poisoning, VAO ReST station-resolution endpoint hijack, leaked CI
+   secret store) or an operator mis-edits ``data/stations.json`` /
+   ``data/vor-haltestellen.mapping.json`` directly.
+2. A planted station entry carrying U+202E (RIGHT-TO-LEFT OVERRIDE)
+   in a ``name`` / ``aliases[]`` / ``_formatted_address`` /
+   ``station_name`` / ``resolved_name`` field — e.g.
+   ``name="Hauptbahnhof<U+202E>moc.live"`` displays as
+   ``Hauptbahnhofevil.com`` — reaches one of the eight script-level
+   writers above.
+3. Pre-fix each writer serialised the item via
+   ``json.dump(..., ensure_ascii=False, ...)`` or
+   ``json.dumps(..., ensure_ascii=False, ...)``. ``ensure_ascii=False``
+   emits U+202E as its raw UTF-8 byte triplet ``\\xe2\\x80\\xae``, so
+   the on-disk file carries the BiDi-reversal trigger.
+4. The ``update-stations.yml`` / ``update-google-places-stations.yml``
+   workflow commits the poisoned file to ``main``. The malicious name
+   is now visible in ``git log -p`` / ``git show`` / the GitHub web UI
+   / ``cat`` / ``less`` / IDE preview — every viewer honours BiDi
+   reversal.
+5. Operator reviewing the weekly commit misreads the BiDi-reversed
+   display as the inverse of the actual planted bytes. The attack
+   hides in the operator's own review pass.
+
+Fix shape (identical to Round 13)
+==================================
+
+  * Reuse ``src/utils/serialize.py:scrub_trojan_source_primitives``
+    (added in Round 12) so the canonical attack-byte union stays
+    single-sourced across every operator-facing JSON sidecar writer in
+    the codebase.
+  * Each writer applies the scrubber to the incoming payload BEFORE
+    ``json.dump`` / ``json.dumps`` — ingestion-boundary defence so the
+    dangerous bytes never reach the serialiser.
+  * ``ensure_ascii=False`` is preserved at every writer so legitimate
+    German station names (umlauts ä/ö/ü/Ä/Ö/Ü + sharp s ß + every other
+    safe Unicode code point) stay compact in the weekly commit diff.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+# Canonical Trojan-Source / zero-width / Unicode-line-terminator / C1
+# terminal-escape primitives — byte-exact mirror of the set pinned in
+# ``tests/test_sentinel_places_stations_trojan_source.py`` (Round 13)
+# and ``tests/test_sentinel_cache_events_trojan_source.py`` (Round 12)
+# so any future widening of the canonical floor is enforced uniformly
+# across the committed-sidecar writer family.
+_TROJAN_SOURCE_PRIMITIVES = (
+    # BiDi formatting controls (CVE-2021-42574 first half).
+    "‪",  # LRE Left-To-Right Embedding
+    "‫",  # RLE Right-To-Left Embedding
+    "‬",  # PDF Pop Directional Formatting
+    "‭",  # LRO Left-To-Right Override
+    "‮",  # RLO Right-To-Left Override
+    # BiDi isolates (CVE-2021-42574 second half).
+    "⁦",  # LRI Left-To-Right Isolate
+    "⁧",  # RLI Right-To-Left Isolate
+    "⁨",  # FSI First Strong Isolate
+    "⁩",  # PDI Pop Directional Isolate
+    # Zero-width / left-right marks.
+    "​",  # ZWSP
+    "‌",  # ZWNJ
+    "‍",  # ZWJ
+    "‎",  # LRM
+    "‏",  # RLM
+    "؜",  # ALM
+    # Unicode line / paragraph separators (SIEM splitter primitive).
+    " ",  # LINE SEPARATOR
+    " ",  # PARAGRAPH SEPARATOR
+    # Byte Order Mark / ZWNBSP.
+    "﻿",
+    # C1 terminal escape primitives (8-bit colour/SGR start, OSC, DCS).
+    "\x9b",  # CSI
+    "\x9d",  # OSC
+    "\x90",  # DCS
+)
+
+# Mapping from each primitive to its raw UTF-8 byte sequence.
+# Pre-fix every byte sequence appears in the on-disk file verbatim
+# (ensure_ascii=False emits each as its raw UTF-8 form);
+# post-fix none of them do (the scrubber strips at the ingestion
+# boundary).
+_UTF8_BYTES = {p: p.encode("utf-8") for p in _TROJAN_SOURCE_PRIMITIVES}
+
+# Smoking-gun primitive: U+202E RLO. The 3-byte UTF-8 sequence
+# E2 80 AE drives the actual BiDi reversal that hides the attack
+# in any operator review pass.
+_RLO_UTF8 = b"\xe2\x80\xae"
+
+
+# ---------------------------------------------------------------------
+# Sink 1: ``scripts/fetch_google_places_stations.py:_write_if_changed``
+# ---------------------------------------------------------------------
+
+
+def test_fetch_google_places_write_if_changed_no_rlo_leak(tmp_path: Path) -> None:
+    """A planted station name with U+202E reaches ``data/stations.json``
+    pre-fix via the manual Google-Places escape-hatch workflow."""
+    from scripts.fetch_google_places_stations import _write_if_changed
+
+    target = tmp_path / "stations.json"
+    stations = [
+        {
+            "name": "Hauptbahnhof‮moc.live",
+            "source": "google_places",
+            "latitude": 48.18,
+            "longitude": 16.38,
+        }
+    ]
+    _write_if_changed(target, stations)
+
+    raw = target.read_bytes()
+    assert _RLO_UTF8 not in raw, (
+        "U+202E (RLO) leaked verbatim into data/stations.json via "
+        "_write_if_changed — BiDi reversal is now active for any "
+        "cat / less / GitHub / IDE viewer of the file."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_fetch_google_places_write_if_changed_strips_every_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    """Every canonical attack-byte primitive must be rejected at the
+    ingestion boundary — a single primitive surviving in raw form
+    reopens the attack via a future provider-controlled field."""
+    from scripts.fetch_google_places_stations import _write_if_changed
+
+    target = tmp_path / f"stations-{ord(primitive):04x}.json"
+    stations = [
+        {
+            "name": f"evil{primitive}.example",
+            "source": "google_places",
+            "latitude": 48.18,
+            "longitude": 16.38,
+            "aliases": [f"alias{primitive}evil"],
+        }
+    ]
+    _write_if_changed(target, stations)
+
+    raw = target.read_bytes()
+    expected = _UTF8_BYTES[primitive]
+    assert expected not in raw, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked into "
+        f"data/stations.json via _write_if_changed as raw UTF-8 bytes ({expected!r})."
+    )
+
+
+def test_fetch_google_places_write_if_changed_preserves_german_umlauts(
+    tmp_path: Path,
+) -> None:
+    """Legitimate German content (ä/ö/ü/Ä/Ö/Ü/ß) must survive the
+    scrubber so the weekly commit diff stays compact."""
+    from scripts.fetch_google_places_stations import _write_if_changed
+
+    target = tmp_path / "stations.json"
+    stations = [
+        {
+            "name": "Wien Hütteldorf",
+            "aliases": ["Hauptbahnhof", "Floridsdorfer Brücke", "Wien Heiligenstadt", "Praterstraße"],
+            "source": "google_places",
+            "latitude": 48.18,
+            "longitude": 16.38,
+        }
+    ]
+    _write_if_changed(target, stations)
+
+    text = target.read_text(encoding="utf-8")
+    assert "Hütteldorf" in text
+    assert "Floridsdorfer Brücke" in text
+    assert "Praterstraße" in text
+    # Sanity: the bloated \u00XX escape form must NOT appear — that
+    # would mean we accidentally switched to ensure_ascii=True and
+    # ballooned the diff size 4-6x.
+    assert "\\u00fc" not in text
+    assert "\\u00df" not in text
+
+
+# ---------------------------------------------------------------------
+# Sink 2: ``scripts/fetch_google_places_stations.py:_dump_changes``
+# ---------------------------------------------------------------------
+
+
+def test_fetch_google_places_dump_changes_no_rlo_leak(tmp_path: Path) -> None:
+    """The per-run change dump sidecar also gets committed via the
+    same workflow — same ingestion-boundary scrubbing required."""
+    from scripts.fetch_google_places_stations import _dump_changes
+
+    target = tmp_path / "places_changes.json"
+    new_entries = [
+        {"name": "EvilStation‮moc.live", "place_id": "abc"},
+    ]
+    updated_entries = [
+        {"name": "Hbf‮.evil", "place_id": "def"},
+    ]
+    _dump_changes(target, new_entries, updated_entries)
+
+    raw = target.read_bytes()
+    assert _RLO_UTF8 not in raw, (
+        "U+202E (RLO) leaked verbatim into the change-dump sidecar."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_fetch_google_places_dump_changes_strips_every_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    from scripts.fetch_google_places_stations import _dump_changes
+
+    target = tmp_path / f"changes-{ord(primitive):04x}.json"
+    new_entries = [{"name": f"evil{primitive}.example", "place_id": "abc"}]
+    _dump_changes(target, new_entries, [])
+
+    raw = target.read_bytes()
+    expected = _UTF8_BYTES[primitive]
+    assert expected not in raw, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked into change dump."
+    )
+
+
+# ---------------------------------------------------------------------
+# Sink 3: ``scripts/update_all_stations.py:_write_stations_payload``
+# ---------------------------------------------------------------------
+
+
+def test_update_all_stations_write_payload_no_rlo_leak(tmp_path: Path) -> None:
+    """The orchestrator's temp-file writer is the file that the
+    weekly ``update-stations.yml`` cron copies back to
+    ``data/stations.json`` and then commits to ``main``."""
+    from scripts.update_all_stations import _write_stations_payload
+
+    target = tmp_path / "stations.json"
+    stations = [
+        {
+            "name": "Westbahnhof‮moc.live",
+            "bst_id": "12345",
+            "latitude": 48.18,
+            "longitude": 16.38,
+        }
+    ]
+    _write_stations_payload(target, stations)
+
+    raw = target.read_bytes()
+    assert _RLO_UTF8 not in raw, (
+        "U+202E leaked via _write_stations_payload — the orchestrator's "
+        "temp file gets copy-back'd to data/stations.json and committed."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_update_all_stations_write_payload_strips_every_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    from scripts.update_all_stations import _write_stations_payload
+
+    target = tmp_path / f"stations-{ord(primitive):04x}.json"
+    stations = [
+        {
+            "name": f"evil{primitive}.example",
+            "bst_id": "12345",
+            "aliases": [f"alias{primitive}evil"],
+            "latitude": 48.18,
+            "longitude": 16.38,
+        }
+    ]
+    _write_stations_payload(target, stations)
+
+    raw = target.read_bytes()
+    expected = _UTF8_BYTES[primitive]
+    assert expected not in raw, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked via "
+        f"_write_stations_payload as raw UTF-8 bytes ({expected!r})."
+    )
+
+
+def test_update_all_stations_write_payload_preserves_umlauts(tmp_path: Path) -> None:
+    from scripts.update_all_stations import _write_stations_payload
+
+    target = tmp_path / "stations.json"
+    stations = [
+        {"name": "Wien Hütteldorf", "aliases": ["Floridsdorfer Brücke"], "bst_id": "1"}
+    ]
+    _write_stations_payload(target, stations)
+
+    text = target.read_text(encoding="utf-8")
+    assert "Hütteldorf" in text
+    assert "\\u00fc" not in text
+
+
+# ---------------------------------------------------------------------
+# Sink 4: ``scripts/enrich_station_aliases.py`` writer
+# ---------------------------------------------------------------------
+
+
+def test_enrich_station_aliases_writer_no_rlo_leak(tmp_path: Path) -> None:
+    """The alias enrichment script writes ``data/stations.json`` after
+    enrichment. Its inline ``json.dump`` write is extracted into a
+    ``_write_stations_payload`` helper so the scrubber can run uniformly
+    at the ingestion boundary."""
+    from scripts.enrich_station_aliases import _write_stations_payload
+
+    target = tmp_path / "stations.json"
+    stations: list[dict[str, Any]] = [
+        {
+            "name": "Westbahnhof‮moc.live",
+            "aliases": ["Hbf‮.evil"],
+            "bst_id": "12345",
+        }
+    ]
+    _write_stations_payload(target, stations)
+
+    raw = target.read_bytes()
+    assert _RLO_UTF8 not in raw, (
+        "U+202E leaked via enrich_station_aliases._write_stations_payload."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_enrich_station_aliases_writer_strips_every_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    from scripts.enrich_station_aliases import _write_stations_payload
+
+    target = tmp_path / f"stations-{ord(primitive):04x}.json"
+    stations: list[dict[str, Any]] = [
+        {
+            "name": f"evil{primitive}.example",
+            "aliases": [f"alias{primitive}evil"],
+            "bst_id": "12345",
+        }
+    ]
+    _write_stations_payload(target, stations)
+
+    raw = target.read_bytes()
+    expected = _UTF8_BYTES[primitive]
+    assert expected not in raw, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked via "
+        f"enrich_station_aliases as raw UTF-8 bytes ({expected!r})."
+    )
+
+
+def test_enrich_station_aliases_writer_preserves_umlauts(tmp_path: Path) -> None:
+    from scripts.enrich_station_aliases import _write_stations_payload
+
+    target = tmp_path / "stations.json"
+    stations: list[dict[str, Any]] = [
+        {"name": "Wien Hütteldorf", "aliases": ["Floridsdorfer Brücke"], "bst_id": "1"}
+    ]
+    _write_stations_payload(target, stations)
+
+    text = target.read_text(encoding="utf-8")
+    assert "Hütteldorf" in text
+    assert "\\u00fc" not in text
+
+
+# ---------------------------------------------------------------------
+# Sink 5: ``scripts/update_station_directory.py:write_json``
+# ---------------------------------------------------------------------
+
+
+def test_update_station_directory_write_json_no_rlo_leak(tmp_path: Path) -> None:
+    """The OEBB Excel-extraction writer feeds the canonical
+    ``data/stations.json``. A poisoned upstream Excel response (e.g.
+    via DNS hijack of the OEBB OGD portal) is the primary delivery
+    vector."""
+    from scripts.update_station_directory import write_json
+
+    target = tmp_path / "stations.json"
+    stations_list = [
+        {
+            "name": "Wien Hauptbahnhof‮moc.live",
+            "bst_id": "100",
+            "bst_code": "WHb",
+            "in_vienna": True,
+        }
+    ]
+    write_json(stations_list, target)
+
+    raw = target.read_bytes()
+    assert _RLO_UTF8 not in raw, (
+        "U+202E leaked via update_station_directory.write_json."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_update_station_directory_write_json_strips_every_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    from scripts.update_station_directory import write_json
+
+    target = tmp_path / f"stations-{ord(primitive):04x}.json"
+    stations_list = [
+        {
+            "name": f"evil{primitive}.example",
+            "bst_id": "100",
+            "bst_code": "WHb",
+        }
+    ]
+    write_json(stations_list, target)
+
+    raw = target.read_bytes()
+    expected = _UTF8_BYTES[primitive]
+    assert expected not in raw, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked via "
+        f"update_station_directory.write_json as raw UTF-8 bytes ({expected!r})."
+    )
+
+
+def test_update_station_directory_write_json_preserves_umlauts(tmp_path: Path) -> None:
+    from scripts.update_station_directory import write_json
+
+    target = tmp_path / "stations.json"
+    stations_list = [{"name": "Wien Hütteldorf", "bst_id": "1"}]
+    write_json(stations_list, target)
+
+    text = target.read_text(encoding="utf-8")
+    assert "Hütteldorf" in text
+    assert "\\u00fc" not in text
+
+
+# ---------------------------------------------------------------------
+# Sink 6: ``scripts/update_vor_stations.py:merge_into_stations``
+# ---------------------------------------------------------------------
+
+
+def test_update_vor_merge_into_stations_no_rlo_leak(tmp_path: Path) -> None:
+    """Integration test: a planted entry that already lives in
+    ``stations.json`` (e.g. inserted by a previous compromised cron
+    run) is read, processed, and re-written by ``merge_into_stations``.
+    The scrubber at the write boundary must strip the BiDi marks."""
+    from scripts.update_vor_stations import merge_into_stations
+
+    target = tmp_path / "stations.json"
+    poisoned = {
+        "stations": [
+            {
+                "name": "Wien Mitte‮moc.live",
+                "vor_id": "430001111",
+                "bst_id": "999000",
+                "bst_code": "WM",
+                "aliases": ["Hbf‮.evil", "999000", "WM"],
+                "source": "vor",
+                "latitude": 48.21,
+                "longitude": 16.38,
+            }
+        ]
+    }
+    target.write_text(json.dumps(poisoned, ensure_ascii=False), encoding="utf-8")
+    merge_into_stations(target, [])
+
+    raw = target.read_bytes()
+    assert _RLO_UTF8 not in raw, (
+        "U+202E from existing stations.json was not scrubbed at the "
+        "merge_into_stations write boundary."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_update_vor_merge_into_stations_strips_every_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    from scripts.update_vor_stations import merge_into_stations
+
+    target = tmp_path / f"stations-{ord(primitive):04x}.json"
+    poisoned = {
+        "stations": [
+            {
+                "name": f"evil{primitive}.example",
+                "vor_id": "430001111",
+                "bst_id": "999000",
+                "bst_code": "WM",
+                "aliases": [f"alias{primitive}evil", "999000", "WM"],
+                "source": "vor",
+                "latitude": 48.21,
+                "longitude": 16.38,
+            }
+        ]
+    }
+    target.write_text(json.dumps(poisoned, ensure_ascii=False), encoding="utf-8")
+    merge_into_stations(target, [])
+
+    raw = target.read_bytes()
+    expected = _UTF8_BYTES[primitive]
+    assert expected not in raw, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked via "
+        f"update_vor_stations.merge_into_stations as raw UTF-8 bytes ({expected!r})."
+    )
+
+
+def test_update_vor_merge_into_stations_preserves_umlauts(tmp_path: Path) -> None:
+    from scripts.update_vor_stations import merge_into_stations
+
+    target = tmp_path / "stations.json"
+    payload = {
+        "stations": [
+            {
+                "name": "Wien Hütteldorf",
+                "vor_id": "430001111",
+                "bst_id": "999000",
+                "bst_code": "WHd",
+                "aliases": ["Floridsdorfer Brücke", "999000", "WHd"],
+                "source": "vor",
+                "latitude": 48.21,
+                "longitude": 16.38,
+            }
+        ]
+    }
+    target.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    merge_into_stations(target, [])
+
+    text = target.read_text(encoding="utf-8")
+    assert "Hütteldorf" in text
+    assert "\\u00fc" not in text
+
+
+# ---------------------------------------------------------------------
+# Sink 7: ``scripts/update_wl_stations.py:merge_into_stations``
+# ---------------------------------------------------------------------
+
+
+def test_update_wl_merge_into_stations_no_rlo_leak(tmp_path: Path) -> None:
+    """Integration test: a planted WL entry reaches the on-disk
+    ``data/stations.json`` via the Wien OGD CSV merge path."""
+    from scripts.update_wl_stations import merge_into_stations
+
+    target = tmp_path / "stations.json"
+    target.write_text(json.dumps({"stations": []}), encoding="utf-8")
+    wl_entries: list[dict[str, Any]] = [
+        {
+            "name": "Karlsplatz‮moc.live",
+            "bst_id": "9000",
+            "aliases": ["U-Bahn‮.evil"],
+            "latitude": 48.20,
+            "longitude": 16.37,
+        }
+    ]
+    merge_into_stations(target, wl_entries)
+
+    raw = target.read_bytes()
+    assert _RLO_UTF8 not in raw, (
+        "U+202E leaked via update_wl_stations.merge_into_stations."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_update_wl_merge_into_stations_strips_every_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    from scripts.update_wl_stations import merge_into_stations
+
+    target = tmp_path / f"stations-{ord(primitive):04x}.json"
+    target.write_text(json.dumps({"stations": []}), encoding="utf-8")
+    wl_entries: list[dict[str, Any]] = [
+        {
+            "name": f"evil{primitive}.example",
+            "bst_id": "9000",
+            "aliases": [f"alias{primitive}evil"],
+            "latitude": 48.20,
+            "longitude": 16.37,
+        }
+    ]
+    merge_into_stations(target, wl_entries)
+
+    raw = target.read_bytes()
+    expected = _UTF8_BYTES[primitive]
+    assert expected not in raw, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked via "
+        f"update_wl_stations.merge_into_stations as raw UTF-8 bytes ({expected!r})."
+    )
+
+
+def test_update_wl_merge_into_stations_preserves_umlauts(tmp_path: Path) -> None:
+    from scripts.update_wl_stations import merge_into_stations
+
+    target = tmp_path / "stations.json"
+    target.write_text(json.dumps({"stations": []}), encoding="utf-8")
+    wl_entries: list[dict[str, Any]] = [
+        {
+            "name": "Wien Hütteldorf",
+            "bst_id": "9000",
+            "aliases": ["Floridsdorfer Brücke"],
+            "latitude": 48.20,
+            "longitude": 16.37,
+        }
+    ]
+    merge_into_stations(target, wl_entries)
+
+    text = target.read_text(encoding="utf-8")
+    assert "Hütteldorf" in text
+    assert "\\u00fc" not in text
+
+
+# ---------------------------------------------------------------------
+# Sink 8: ``scripts/fetch_vor_haltestellen.py`` mapping writer
+# ---------------------------------------------------------------------
+
+
+def test_fetch_vor_haltestellen_mapping_no_rlo_leak(tmp_path: Path) -> None:
+    """The VAO resolution mapping sidecar
+    ``data/vor-haltestellen.mapping.json`` is a sibling station-directory
+    artefact that gets committed by the same cron pipeline. Its inline
+    write is extracted into a ``_write_mapping_payload`` helper so the
+    scrubber can run uniformly at the ingestion boundary."""
+    from scripts.fetch_vor_haltestellen import _write_mapping_payload
+
+    target = tmp_path / "vor-haltestellen.mapping.json"
+    mapping: list[dict[str, Any]] = [
+        {
+            "station_name": "Wien Mitte‮moc.live",
+            "bst_id": "100",
+            "vor_id": "430001234",
+            "resolved_name": "Wien Mitte‮.evil",
+            "latitude": 48.21,
+            "longitude": 16.38,
+        }
+    ]
+    _write_mapping_payload(target, mapping)
+
+    raw = target.read_bytes()
+    assert _RLO_UTF8 not in raw, (
+        "U+202E leaked via fetch_vor_haltestellen._write_mapping_payload."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_fetch_vor_haltestellen_mapping_strips_every_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    from scripts.fetch_vor_haltestellen import _write_mapping_payload
+
+    target = tmp_path / f"mapping-{ord(primitive):04x}.json"
+    mapping: list[dict[str, Any]] = [
+        {
+            "station_name": f"evil{primitive}.example",
+            "bst_id": "100",
+            "vor_id": "430001234",
+            "resolved_name": f"resolved{primitive}.evil",
+            "latitude": 48.21,
+            "longitude": 16.38,
+        }
+    ]
+    _write_mapping_payload(target, mapping)
+
+    raw = target.read_bytes()
+    expected = _UTF8_BYTES[primitive]
+    assert expected not in raw, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked via "
+        f"fetch_vor_haltestellen._write_mapping_payload as raw UTF-8 bytes ({expected!r})."
+    )
+
+
+def test_fetch_vor_haltestellen_mapping_preserves_umlauts(tmp_path: Path) -> None:
+    from scripts.fetch_vor_haltestellen import _write_mapping_payload
+
+    target = tmp_path / "vor-haltestellen.mapping.json"
+    mapping: list[dict[str, Any]] = [
+        {
+            "station_name": "Wien Hütteldorf",
+            "bst_id": "100",
+            "vor_id": "430001234",
+            "resolved_name": "Hütteldorf Bahnhof",
+            "latitude": 48.20,
+            "longitude": 16.26,
+        }
+    ]
+    _write_mapping_payload(target, mapping)
+
+    text = target.read_text(encoding="utf-8")
+    assert "Hütteldorf" in text
+    assert "\\u00fc" not in text
+
+
+# ---------------------------------------------------------------------
+# Defensive invariants — single-sourced scrubber import
+# ---------------------------------------------------------------------
+
+
+def test_all_script_writers_use_shared_scrubber_helper() -> None:
+    """Every script-level station writer must import
+    ``scrub_trojan_source_primitives`` from ``src.utils.serialize`` so
+    the canonical attack-byte union stays single-sourced across the
+    project. A future script-level writer that re-implements the
+    primitive set would silently drift away from the canonical floor
+    pinned in ``src/utils/serialize.py``."""
+    targets = [
+        "scripts/fetch_google_places_stations.py",
+        "scripts/update_all_stations.py",
+        "scripts/enrich_station_aliases.py",
+        "scripts/update_station_directory.py",
+        "scripts/update_vor_stations.py",
+        "scripts/update_wl_stations.py",
+        "scripts/fetch_vor_haltestellen.py",
+    ]
+    for rel in targets:
+        path = REPO_ROOT / rel
+        text = path.read_text(encoding="utf-8")
+        assert "scrub_trojan_source_primitives" in text, (
+            f"{rel} does not import scrub_trojan_source_primitives — "
+            f"the canonical CVE-2021-42574 attack-byte union is no "
+            f"longer single-sourced across the project."
+        )


### PR DESCRIPTION
## Summary

Closes the **eight sibling script-level writer sinks** spread across **seven `scripts/` files** that the Round 13 (#1438) closing checklist explicitly named-but-deferred. Each sink bypasses the canonical `src/places/merge.py:write_stations` library function and writes `data/stations.json` (or sibling `data/vor-haltestellen.mapping.json`) via direct `json.dump(..., ensure_ascii=False, ...)` / `json.dumps(..., ensure_ascii=False, ...)` — reopening the same threat surface Rounds 10-13 closed at the library level. Each is reached from the weekly `update-stations.yml` cron pipeline (via `scripts/update_all_stations.py`'s orchestrator) which commits `data/` to `main` with `add_options: "-A"`.

**Threat model** (mirrors Round 13): a hijacked upstream provider (Google Places, OSM Overpass, OEBB `Verzeichnis der Verkehrsstationen` Excel, Wien OGD CSV, VAO ReST endpoint) or an operator mis-edit plants U+202E (RIGHT-TO-LEFT OVERRIDE) in a `name` / `aliases[]` / `_formatted_address` / `station_name` / `resolved_name` field. `ensure_ascii=False` emits the byte triplet `\xe2\x80\xae` directly into the on-disk file; the cron commits it to `main`; every `cat` / `less` / GitHub web UI / IDE preview honours BiDi reversal and shows the operator the inverse of the actual planted bytes.

**Fix** (mirrors Round 13's single-sourced shape): every writer imports `scrub_trojan_source_primitives` from `src.utils.serialize` (Round 12's helper) and applies it to the payload BEFORE `json.dump` / `json.dumps`. `ensure_ascii=False` is preserved at every writer so legitimate German station names (umlauts ä/ö/ü/Ä/Ö/Ü + sharp s ß) stay compact in the weekly commit diff. Two inline writes (in `enrich_station_aliases.py:main()` and `fetch_vor_haltestellen.py:main()`) are extracted into `_write_stations_payload` / `_write_mapping_payload` helpers so the scrubber runs uniformly at the ingestion boundary and the writers stay PoC-testable.

### Closed sinks

- `scripts/fetch_google_places_stations.py:_write_if_changed` — `data/stations.json` via Google-Places manual escape-hatch (`update-google-places-stations.yml`)
- `scripts/fetch_google_places_stations.py:_dump_changes` — per-run `{"new": [...], "updated": [...]}` change-dump sidecar
- `scripts/update_all_stations.py:_write_stations_payload` — orchestrator's temp file that is copy-back'd to `data/stations.json`
- `scripts/enrich_station_aliases.py` — `data/stations.json` after VOR / GTFS / pendler alias enrichment (new `_write_stations_payload` helper)
- `scripts/update_station_directory.py:write_json` — `data/stations.json` after OEBB Excel extraction
- `scripts/update_vor_stations.py:merge_into_stations` — `data/stations.json` after VOR merge
- `scripts/update_wl_stations.py:merge_into_stations` — `data/stations.json` after Wien OGD CSV merge
- `scripts/fetch_vor_haltestellen.py` — `data/vor-haltestellen.mapping.json` (VAO resolution-mapping sibling sidecar; new `_write_mapping_payload` helper)

### Tests

- 184 PoC tests in `tests/test_sentinel_script_station_writers_trojan_source.py`: 1 + 21 parametrised per sink covering every primitive in the canonical CVE-2021-42574 attack-byte union, plus per-sink German-content compact-diff regression, plus a grep-pinned inventory invariant (`test_all_script_writers_use_shared_scrubber_helper`) that future-proofs against a 9th drift candidate sneaking in without wiring to the single-sourced helper.

## Test plan

- [x] `python scripts/run_static_checks.py` — ruff, mypy strict, bandit, secret-scanner, C901 gate, pip-audit all pass
- [x] `pytest` — 3858 passed, 3 skipped (was 3674 + 184 new PoC tests)
- [x] PoC tests verified to fail pre-fix (158/184 fail) and pass post-fix (184/184 pass)
- [x] No new C901 violations; baseline preserved (1 pre-existing offender no longer >15)
- [x] `ensure_ascii=False` preserved at every writer (umlauts/sharp-s stay raw UTF-8 in the diff)
- [x] Sentinel journal entry added (`.jules/sentinel.md` Round 14)

https://claude.ai/code/session_016ok4GNgU7Fqh6ZLMBMbKfc

---
_Generated by [Claude Code](https://claude.ai/code/session_016ok4GNgU7Fqh6ZLMBMbKfc)_