### PR TITLE
ci(update-stations): drop redundant WL OGD curl step

### DIFF
--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -8,8 +8,10 @@ name: Update station directory
 #   directory.py`` downloads the workbook from data.oebb.at on every
 #   run; free open data, no auth.
 # * Wien OGD ``wienerlinien-ogd-haltestellen``/``-haltepunkte`` CSVs —
-#   the "Refresh Wiener Linien OGD CSVs" step below pulls the latest
-#   snapshot from data.wien.gv.at; free open data, no auth.
+#   ``update_wl_stations.py`` downloads the latest snapshot from
+#   data.wien.gv.at on every run (``--download`` default-on) with
+#   graceful fallback to the pinned local CSV on upstream outage;
+#   free open data, no auth.
 # * OSM Overpass — ``_enrich_with_osm`` queries Overpass via the
 #   ``WIEN_OEPNV_OSM_ENRICH=1`` env (toggled below by the Overpass
 #   smoke check); free open data, retried.
@@ -59,25 +61,6 @@ jobs:
 
       - name: Install dependencies
         uses: ./.github/actions/install-deps
-
-      # Wien OGD CSV refresh (free open data, no auth, no quota). The
-      # update_wl_stations.py script reads data/wienerlinien-ogd-
-      # haltestellen.csv + haltepunkte.csv from disk; without this step
-      # the weekly cron would re-merge the same pinned snapshot the
-      # operator last committed manually. The download is idempotent:
-      # ``--download`` overwrites only when the upstream byte-stream
-      # differs.
-      - name: Refresh Wiener Linien OGD CSVs
-        run: |
-          set -euo pipefail
-          curl -fsSL --max-time 60 \
-            -o data/wienerlinien-ogd-haltestellen.csv.tmp \
-            https://data.wien.gv.at/csv/wienerlinien-ogd-haltestellen.csv
-          curl -fsSL --max-time 60 \
-            -o data/wienerlinien-ogd-haltepunkte.csv.tmp \
-            https://data.wien.gv.at/csv/wienerlinien-ogd-haltepunkte.csv
-          mv data/wienerlinien-ogd-haltestellen.csv.tmp data/wienerlinien-ogd-haltestellen.csv
-          mv data/wienerlinien-ogd-haltepunkte.csv.tmp data/wienerlinien-ogd-haltepunkte.csv
 
       # VOR stop-list refresh removed 2026-05-09 to keep the project under
       # the VAO Start tier's 100/day quota — the Stammstrecke monitor


### PR DESCRIPTION
## Summary

The `Refresh Wiener Linien OGD CSVs` step in `.github/workflows/update-stations.yml` duplicated what `scripts/update_wl_stations.py` already does internally — but with brittle error handling. Removing it unblocks the weekly cron when `data.wien.gv.at` returns a transient 4xx/5xx.

## Why this is the right fix

`update_wl_stations.py` has had auto-download with graceful fallback since PR #1189 (CHANGELOG.md:247):

- `_download_ogd_csv` (scripts/update_wl_stations.py:158-191) downloads the same two URLs via `src.utils.http.fetch_content_safe`.
- On any HTTP failure it logs a warning, returns `False`, and the merge proceeds against the pinned local CSV.
- The orchestrator (`scripts/update_all_stations.py:65-75`) invokes the script without `--no-download`, so `download=True` is active.

The workflow's inline curl step ran with `set -euo pipefail` + `curl -fsSL`, so any upstream 404 short-circuited the orchestrator **before** the script's fallback could engage — that's exactly the failure seen in the most recent CI log (`curl: (22) The requested URL returned error: 404` immediately after `install-deps`).

## Effect

- `data.wien.gv.at` up → identical behaviour (script downloads, atomic-write, auto-commit pushes new CSV)
- `data.wien.gv.at` down → warning logged, pinned CSV used, pipeline proceeds (was: whole job red)
- Bandwidth halved (no double download)
- Aligns WL OGD with the soft-fail contract used by the other three sources (ÖBB / OSM / Google Places fallback)
- Removes a stale comment that described pre-#1189 read-from-disk behaviour

## Test plan

- [ ] CI green on this PR (install-deps step alone proves the pip-cap path is unaffected)
- [ ] Weekly `update-stations.yml` cron tick succeeds even if data.wien.gv.at is degraded (will materialise on the next Sunday 01:00 UTC run, or by manual `workflow_dispatch`)
- [ ] Existing regression tests still pass:
  - `tests/test_update_wl_stations_merge.py::test_download_ogd_csv_*` (network success + failure paths)
  - `tests/test_sentinel_csv_size_bomb.py::test_precondition_update_wl_stations_cap_exists`
- [ ] No other workflow or test references the removed step (verified via `grep -rln "Refresh Wiener Linien OGD CSVs"` → only the now-edited file matched)

## Scope note

The branch name (`claude/update-pip-constraint-ESRKD`) was originally created for the pip-cap bump, which has already landed on `main` — so this branch had no diff before this commit. The Workflow fix surfaced from the same CI run where the install-deps step was being verified. Title and body reflect the actual change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQdxfoiBCVYQ1bsQ4EKNWc)_