### PR TITLE
ci(wl-ogd): migrate WL OGD CSVs to canonical wienerlinien.at host

### DIFF
--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -9,9 +9,10 @@ name: Update station directory
 #   run; free open data, no auth.
 # * Wien OGD ``wienerlinien-ogd-haltestellen``/``-haltepunkte`` CSVs —
 #   ``update_wl_stations.py`` downloads the latest snapshot from
-#   data.wien.gv.at on every run (``--download`` default-on) with
-#   graceful fallback to the pinned local CSV on upstream outage;
-#   free open data, no auth.
+#   the canonical Wiener Linien OGD host
+#   (``www.wienerlinien.at/ogd_realtime/doku/ogd/``) on every run
+#   (``--download`` default-on) with graceful fallback to the pinned
+#   local CSV on upstream outage; free open data, no auth.
 # * OSM Overpass — ``_enrich_with_osm`` queries Overpass via the
 #   ``WIEN_OEPNV_OSM_ENRICH=1`` env (toggled below by the Overpass
 #   smoke check); free open data, retried.

--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -96,8 +96,14 @@ DEFAULT_HALTESTELLEN = BASE_DIR / "data" / "wienerlinien-ogd-haltestellen.csv"
 DEFAULT_STATIONS = BASE_DIR / "data" / "stations.json"
 DEFAULT_VOR_MAPPING = BASE_DIR / "data" / "vor-haltestellen.mapping.json"
 
-OGD_HALTESTELLEN_URL = "https://data.wien.gv.at/csv/wienerlinien-ogd-haltestellen.csv"
-OGD_HALTEPUNKTE_URL = "https://data.wien.gv.at/csv/wienerlinien-ogd-haltepunkte.csv"
+# Canonical OGD endpoint hosted by Wiener Linien themselves (documented in
+# ``wienerlinien_ogd_Beschreibung.pdf``). The ``data.wien.gv.at/csv/...``
+# proxy that this project used previously was retired during the 60th OGD
+# phase (September 2025): haltepunkte.csv started returning HTTP 404 and
+# haltestellen.csv was the last surviving proxy CSV. The wienerlinien.at
+# host has served the same files under a URL pattern stable since 2022.
+OGD_HALTESTELLEN_URL = "https://www.wienerlinien.at/ogd_realtime/doku/ogd/wienerlinien-ogd-haltestellen.csv"
+OGD_HALTEPUNKTE_URL = "https://www.wienerlinien.at/ogd_realtime/doku/ogd/wienerlinien-ogd-haltepunkte.csv"
 OGD_DOWNLOAD_TIMEOUT_SECONDS = 30
 USER_AGENT = (
     "wien-oepnv station updater "


### PR DESCRIPTION
## Summary

Follow-up to #1441. That PR made the workflow resilient to a `data.wien.gv.at` 404 on `wienerlinien-ogd-haltepunkte.csv`; this one fixes the underlying URL by pointing both WL OGD CSVs at the canonical Wiener Linien-hosted endpoint.

## Findings from the post-merge cron log

The `update-stations.yml` run after #1441 confirmed:

| URL | Status |
|---|---|
| `https://data.wien.gv.at/csv/wienerlinien-ogd-haltestellen.csv` | HTTP 200 (167067 bytes) |
| `https://data.wien.gv.at/csv/wienerlinien-ogd-haltepunkte.csv` | **HTTP 404** |

`data.wien.gv.at` was the City of Vienna proxy mirror. The [Digitales Wien changelog](https://digitales.wien.gv.at/changelog/) and the [60th OGD phase notes](https://digitales.wien.gv.at/60-ogd-phase/) describe a September 2025 dataset retirement that explains the 404. `haltestellen.csv` is the last surviving CSV from that proxy batch; treating it as load-bearing is borrowed time.

The canonical source — referenced from the official [Beschreibung der OGD-Dateien (©2022)](https://www.wienerlinien.at/ogd_realtime/doku/ogd/wienerlinien_ogd_Beschreibung.pdf) and the search result trail in [WebSearch metadata](https://www.wienerlinien.at/open-data) — is `https://www.wienerlinien.at/ogd_realtime/doku/ogd/wienerlinien-ogd-{haltestellen,haltepunkte}.csv`. Same files, same publisher, URL pattern stable since at least 2022.

## What this PR does

- Migrates both `OGD_HALTESTELLEN_URL` and `OGD_HALTEPUNKTE_URL` in `scripts/update_wl_stations.py` to the wienerlinien.at host.
- Updates the workflow header bullet in `.github/workflows/update-stations.yml` to name the new canonical host.
- Adds a short comment block above the URL constants explaining the migration so a future reader doesn't second-guess the deviation from the city-portal URL pattern.

No other changes. No code-path edits, no schema changes, no test rewrites.

## Heads-up: expected one-time behavioural change

The pinned `data/wienerlinien-ogd-haltepunkte.csv` is a **6-row legacy stub** with the pre-2018 4-digit `HALTESTELLEN_ID` schema (`1001`..`1004`). It cannot join against the current `wienerlinien-ogd-haltestellen.csv` (10-digit IDs like `1085613576`). The most recent cron log proves the consequence:

```
update_wl_stations: Found 6 haltepunkte
update_wl_stations: Prepared 0 WL station entries
update_wl_stations: Keeping 196 existing non-WL stations
update_wl_stations: Wrote 196 total stations
```

The WL OGD branch has been a silent no-op for an indeterminate period. The first cron tick after this merge will download a real haltepunkte.csv (schema-compatible with haltestellen.csv) from the new host — **reactivating the WL OGD path for the first time in a long time**.

Expected concrete impact: the next `chore(data): refresh station directory` auto-commit will likely add hundreds to ~1500 WL stations to `data/stations.json`. The diff is a one-time correction of a long-standing data deficit, after which daily drifts return to normal size. The auto-commit pattern surfaces the diff before any human consumes it, and `docs/stations_validation_report.md` is regenerated in the same job to flag any schema regressions.

Three alternatives were considered and rejected:

1. **URL swap only** (without acknowledging the reactivation) — risks surprising the next reviewer of the diff.
2. **URL swap + still-gate the WL OGD path** — codifies a silently broken state as intentional; future maintainer cost.
3. **Drop the WL OGD path entirely** — removes a documented architectural commitment (the workflow header lists Wien OGD as one of the four merge sources) without evidence the data is unreliable.

The chosen path (URL swap + accept reactivation) is the only option that restores the pipeline to its documented intent.

## Test plan

- [x] `tests/test_update_wl_stations_merge.py` — 7/7 pass after the URL change (tests mock the HTTP layer; URL value is irrelevant to the assertions, but kept as a regression net).
- [x] `tests/test_update_wl_stations_wrapped.py` — pass.
- [x] `tests/test_sentinel_csv_size_bomb.py` — 17/17 pass; the byte-cap and the post-write filename sentinels are unchanged.
- [ ] Manual `workflow_dispatch` on `update-stations.yml` after merge to inspect the resulting `stations.json` diff before the next scheduled cron rewrites it.
- [ ] If the regenerated `docs/stations_validation_report.md` flags new regressions, follow up with a separate PR.

## Scope note

This PR is the follow-up to my earlier offer in PR #1441 to investigate the data.wien.gv.at catalog for the new canonical endpoint. New branch `claude/wl-ogd-canonical-endpoint` — the original `claude/update-pip-constraint-ESRKD` is already merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQdxfoiBCVYQ1bsQ4EKNWc)_