### PR TITLE
fix(wl-merge): auto-promote outside-Vienna WL stations to pendler=true

### DIFF
--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -528,10 +528,19 @@ def build_wl_entries(
                     latitude = round(float(lat_val), 6)
                     longitude = round(float(lon_val), 6)
         aliases.update(_alias_variants(station.name, canonical, resolved_name or None))
+        # Mirror the legacy WL-auto-promote heuristic from
+        # ``update_station_directory._annotate_station_flags`` (a WL-sourced
+        # station outside Vienna becomes pendler=True; see the regression
+        # test ``test_wl_outside_station_becomes_pendler``). Without this,
+        # unmatched WL entries from ``build_wl_entries`` reach
+        # ``merge_into_stations`` with ``in_vienna=False, pendler=False``
+        # and trip ``_find_naming_issues`` → auto-quarantine. ÖBB-mirrored
+        # WL stations are unaffected because ``_merge_wl_payload`` does
+        # not overwrite the existing entry's flag pair.
         entry = {
             "name": canonical,
             "in_vienna": in_vienna,
-            "pendler": False,
+            "pendler": not in_vienna,
             "wl_diva": station_identifier,
             "wl_stops": sorted(
                 stops_payload,

--- a/tests/test_update_wl_stations_merge.py
+++ b/tests/test_update_wl_stations_merge.py
@@ -159,6 +159,63 @@ def test_unmatched_wl_entry_is_appended(stations_path: Path) -> None:
     assert entry["aliases"] == ["Neue Station"]
 
 
+def test_build_wl_entries_auto_promotes_outside_station_to_pendler() -> None:
+    """An unmatched WL station outside the Vienna polygon must reach the
+    merge step with ``pendler=True`` so it does not trip
+    ``_find_naming_issues`` → auto-quarantine. Mirrors the legacy
+    ``test_wl_outside_station_becomes_pendler`` heuristic from
+    ``test_update_station_directory_flags`` for the
+    ``build_wl_entries`` boundary.
+    """
+    haltestellen = {
+        "9999": update_wl_stations.Haltestelle(
+            station_id="9999", name="Eisenstadt Domplatz", diva="60299999"
+        )
+    }
+    haltepunkte = [
+        update_wl_stations.Haltepunkt(
+            station_id="9999",
+            stop_id="60299999",
+            name="Eisenstadt Domplatz",
+            latitude=47.846,
+            longitude=16.522,
+        )
+    ]
+
+    entries = update_wl_stations.build_wl_entries(haltestellen, haltepunkte)
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["in_vienna"] is False
+    assert entry["pendler"] is True
+
+
+def test_build_wl_entries_keeps_vienna_station_as_non_pendler() -> None:
+    """Inside-Vienna WL stations stay ``pendler=False`` — the auto-promote
+    only fires when the polygon check says ``in_vienna=False``."""
+    haltestellen = {
+        "1001": update_wl_stations.Haltestelle(
+            station_id="1001", name="Karlsplatz", diva="60201076"
+        )
+    }
+    haltepunkte = [
+        update_wl_stations.Haltepunkt(
+            station_id="1001",
+            stop_id="60201076",
+            name="Karlsplatz U (Richtung Reumannplatz)",
+            latitude=48.200888,
+            longitude=16.368907,
+        )
+    ]
+
+    entries = update_wl_stations.build_wl_entries(haltestellen, haltepunkte)
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["in_vienna"] is True
+    assert entry["pendler"] is False
+
+
 def test_merge_sources_emits_alphabetical_order() -> None:
     """``_merge_sources`` must produce a deterministic alphabetical
     ordering so two callers with the same set of providers (in any


### PR DESCRIPTION
## Summary

Pre-emptive fix in front of the WL OGD reactivation that PR #1442 set up. Mirrors an existing legacy heuristic from `update_station_directory.py` into `update_wl_stations.py` so the unmatched-WL-entry path produces a flag pair the validator accepts.

## Why

After #1442's URL migration lands a fresh full `wienerlinien-ogd-haltepunkte.csv` on the next cron tick, `build_wl_entries` will produce real entries for the first time in a long time. The path through the merger splits in two:

1. **Matched** entries (existing ÖBB/VOR station gets `wl_diva`/`wl_stops` attached) — `_merge_wl_payload` does **not** overwrite the existing entry's `in_vienna`/`pendler` pair, so these are safe.
2. **Unmatched** entries (WL-only stations, e.g. U-Bahn/Tram-only stops that have no ÖBB counterpart) — `merge_into_stations` appends them verbatim from `build_wl_entries`. Today the entry is hard-wired with `pendler: False` and a polygon-based `in_vienna`. If the polygon check returns `False` (border-area stops: U6 northern termini, bus lines crossing into Niederösterreich, etc.), the entry reaches `_find_naming_issues` with `in_vienna=False, pendler=False`:

```python
# src/utils/stations_validation.py:826-840
elif (
    not in_vienna
    and not pendler
    and entry_type not in ("manual_foreign_city", "manual_distant_at")
):
    yield NamingIssue(
        ...,
        reason=(
            "in_vienna and pendler are both false — entry should "
            "either be classified as a Vienna station, a commuter "
            "station, or marked with type='manual_foreign_city' "
            "or type='manual_distant_at'"
        ),
    )
```

The orchestrator's auto-quarantine path (`scripts/update_all_stations.py:656-703`) then partitions these into `data/quarantine.json` instead of merging — diagnostic noise on every reactivated cron tick, even though the classification of "WL station outside the city limits = commuter station" is correct.

The legacy ÖBB-side path **already** does the right thing here. `_annotate_station_flags` (`scripts/update_station_directory.py:1640-1641`):

```python
if info and not station.in_vienna and "wl" in info.sources:
    pendler_candidate = True
```

…with the pinned contract in `tests/test_update_station_directory_flags.py:58-68` (`test_wl_outside_station_becomes_pendler`).

This PR mirrors the heuristic at the `build_wl_entries` boundary so the same semantics apply to WL-only entries.

## What changes

One line of behavioural change in `scripts/update_wl_stations.py:build_wl_entries`:

```diff
 entry = {
     "name": canonical,
     "in_vienna": in_vienna,
-    "pendler": False,
+    "pendler": not in_vienna,
     "wl_diva": station_identifier,
```

Plus a header comment block above the assignment that documents the heuristic and references the legacy test pinning the contract, so a future reader doesn't independently re-derive it.

## Test plan

- [x] New regressions in `tests/test_update_wl_stations_merge.py`:
  - `test_build_wl_entries_auto_promotes_outside_station_to_pendler` — Eisenstadt (47.846, 16.522) → `in_vienna=False, pendler=True`
  - `test_build_wl_entries_keeps_vienna_station_as_non_pendler` — Karlsplatz (48.201, 16.369) → `in_vienna=True, pendler=False`
- [x] Existing tests stay green: 34/34 across `test_update_wl_stations_merge`, `test_update_wl_stations_wrapped`, `test_update_station_directory_flags`, `test_sentinel_csv_size_bomb`.
- [ ] After merge, observe the next `update-stations.yml` cron tick (or manual `workflow_dispatch`): the WL reactivation should land in `stations.json` with the appropriate `pendler` flags and minimal-to-empty `quarantine.json` growth.

## Scope / non-goals

- Does not change `_merge_wl_payload` (matched-entry path stays untouched — existing flag pair already correct).
- Does not retroactively reclassify existing WL entries that the validator may have caught in earlier cron ticks; only affects newly-built entries from `build_wl_entries`.
- Does not address the deeper architectural observations from today's audit (ÖBB CMS-URL brittleness, ÖBB lack of soft-fail, race window in auto-commit) — those were explicitly tagged "low priority" and out of scope for this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQdxfoiBCVYQ1bsQ4EKNWc)_