### PR TITLE
Support canonical OGD-Echtzeit CSV schema in WL station loader

### DIFF
--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -288,8 +288,14 @@ def _dict_reader(path: Path) -> Iterator[NormalizedRow]:
 def load_haltestellen(path: Path) -> dict[str, Haltestelle]:
     mapping: dict[str, Haltestelle] = {}
     for row in _dict_reader(path):
-        station_id = row.get("HALTESTELLEN_ID", "ID")
-        name = row.get("NAME")
+        # The legacy data.wien.gv.at proxy CSV used HALTESTELLEN_ID /
+        # NAME; the canonical wienerlinien.at OGD-Echtzeit CSV that
+        # replaced it (post PR #1442) collapses station_id and diva
+        # onto a single DIVA column and renames NAME → PlatformText.
+        # Accept both via the fuzzy-key lookup so the loader survives
+        # either upstream shape.
+        station_id = row.get("HALTESTELLEN_ID", "ID", "DIVA")
+        name = row.get("NAME", "PlatformText")
         diva = row.get("DIVA", "DIVANR") or None
         if not station_id or not name:
             continue
@@ -304,11 +310,17 @@ def load_haltestellen(path: Path) -> dict[str, Haltestelle]:
 def load_haltepunkte(path: Path) -> list[Haltepunkt]:
     haltepunkt_records: list[Haltepunkt] = []
     for row in _dict_reader(path):
-        station_id = row.get("HALTESTELLEN_ID", "ID")
-        stop_id = row.get("STOP_ID", "STOPID", "RBL_NUMMER", "RBLNR")
-        name = row.get("NAME", "HALTEPUNKTNAME")
-        lat = _coerce_float(row.get("WGS84_LAT", "LAT", "GEO_LAT"))
-        lon = _coerce_float(row.get("WGS84_LON", "LON", "GEO_LON", "LONG"))
+        # Legacy proxy CSV joined on HALTESTELLEN_ID with a separate
+        # STOP_ID / RBL_NUMMER per platform. The canonical
+        # wienerlinien.at OGD-Echtzeit CSV exposes a StopID primary
+        # key, joins haltestellen via DIVA, names the platform via
+        # StopText, and uses Longitude / Latitude column headers.
+        # Accept both shapes via fuzzy-key fallback.
+        station_id = row.get("HALTESTELLEN_ID", "ID", "DIVA")
+        stop_id = row.get("STOP_ID", "STOPID", "RBL_NUMMER", "RBLNR", "StopID")
+        name = row.get("NAME", "HALTEPUNKTNAME", "StopText")
+        lat = _coerce_float(row.get("WGS84_LAT", "LAT", "GEO_LAT", "Latitude"))
+        lon = _coerce_float(row.get("WGS84_LON", "LON", "GEO_LON", "LONG", "Longitude"))
         if not station_id or not stop_id:
             continue
         haltepunkt_records.append(

--- a/tests/test_update_wl_stations_merge.py
+++ b/tests/test_update_wl_stations_merge.py
@@ -159,6 +159,115 @@ def test_unmatched_wl_entry_is_appended(stations_path: Path) -> None:
     assert entry["aliases"] == ["Neue Station"]
 
 
+def test_load_haltestellen_parses_legacy_proxy_schema(tmp_path: Path) -> None:
+    """The pre-2026-05 ``data.wien.gv.at`` proxy CSV used the
+    ``HALTESTELLEN_ID;TYP;DIVA;NAME;…WGS84_LAT;WGS84_LON`` column
+    layout. The fuzzy-key loader must keep parsing it so a future
+    operator can still feed a pinned legacy snapshot through the
+    pipeline without modification.
+    """
+    csv_path = tmp_path / "haltestellen-legacy.csv"
+    csv_path.write_text(
+        "﻿\"HALTESTELLEN_ID\";\"TYP\";\"DIVA\";\"NAME\";"
+        "\"GEMEINDE\";\"WGS84_LAT\";\"WGS84_LON\"\n"
+        "1085613576;\"stop\";60200120;\"Belvederegasse\";\"Wien\";"
+        "48.1901468;16.3719577\n",
+        encoding="utf-8",
+    )
+
+    haltestellen = update_wl_stations.load_haltestellen(csv_path)
+
+    assert len(haltestellen) == 1
+    halt = haltestellen["1085613576"]
+    assert halt.name == "Belvederegasse"
+    assert halt.diva == "60200120"
+
+
+def test_load_haltestellen_parses_realtime_ogd_schema(tmp_path: Path) -> None:
+    """The canonical ``wienerlinien.at/ogd_realtime/doku/ogd/`` CSV
+    (post PR #1442) collapses station_id and diva onto a single
+    ``DIVA`` column and renames ``NAME`` → ``PlatformText``. Without
+    this lookup path, the production cron run on 2026-05-11 logged
+    ``Found 0 haltestellen`` and emitted zero WL entries despite a
+    successful 126 KiB download.
+    """
+    csv_path = tmp_path / "haltestellen-realtime.csv"
+    csv_path.write_text(
+        "DIVA;PlatformText;Municipality;MunicipalityID;Longitude;Latitude\n"
+        "60200001;Schrankenberggasse;Wien;49000001;16.3898073;48.1738011\n",
+        encoding="utf-8",
+    )
+
+    haltestellen = update_wl_stations.load_haltestellen(csv_path)
+
+    assert len(haltestellen) == 1
+    halt = haltestellen["60200001"]
+    assert halt.name == "Schrankenberggasse"
+    assert halt.diva == "60200001"
+
+
+def test_load_haltepunkte_parses_realtime_ogd_schema(tmp_path: Path) -> None:
+    """The canonical OGD-Echtzeit haltepunkte CSV exposes
+    ``StopID;DIVA;StopText;…;Longitude;Latitude`` instead of the
+    legacy ``HALTESTELLEN_ID;…;STOP_ID;NAME;…;WGS84_*`` layout. The
+    fuzzy-key fallback wires ``StopText`` → ``name`` and ``DIVA`` →
+    ``station_id`` so build_wl_entries can join against
+    ``load_haltestellen`` on the new canonical key.
+    """
+    csv_path = tmp_path / "haltepunkte-realtime.csv"
+    csv_path.write_text(
+        "StopID;DIVA;StopText;Municipality;MunicipalityID;Longitude;Latitude\n"
+        "2;60201421;Venediger Au;Wien;49000001;16.3965357;48.2179090\n",
+        encoding="utf-8",
+    )
+
+    haltepunkte = update_wl_stations.load_haltepunkte(csv_path)
+
+    assert len(haltepunkte) == 1
+    halt = haltepunkte[0]
+    assert halt.station_id == "60201421"
+    assert halt.stop_id == "2"
+    assert halt.name == "Venediger Au"
+    assert halt.latitude == pytest.approx(48.2179090)
+    assert halt.longitude == pytest.approx(16.3965357)
+
+
+def test_build_wl_entries_joins_realtime_schema(tmp_path: Path) -> None:
+    """End-to-end smoke: hand the realtime schema to load_haltestellen
+    and load_haltepunkte, then call build_wl_entries with the resulting
+    dataclasses. The DIVA-on-DIVA join must produce a real entry —
+    pre-fix this returned 0 because the legacy
+    ``HALTESTELLEN_ID``-only lookup failed silently on the new schema.
+    """
+    haltestellen_path = tmp_path / "haltestellen.csv"
+    haltestellen_path.write_text(
+        "DIVA;PlatformText;Municipality;MunicipalityID;Longitude;Latitude\n"
+        "60201076;Karlsplatz;Wien;49000001;16.369450;48.198680\n",
+        encoding="utf-8",
+    )
+    haltepunkte_path = tmp_path / "haltepunkte.csv"
+    haltepunkte_path.write_text(
+        "StopID;DIVA;StopText;Municipality;MunicipalityID;Longitude;Latitude\n"
+        "1;60201076;Karlsplatz U (Richtung Reumannplatz);Wien;49000001;"
+        "16.369450;48.198680\n",
+        encoding="utf-8",
+    )
+
+    haltestellen = update_wl_stations.load_haltestellen(haltestellen_path)
+    haltepunkte = update_wl_stations.load_haltepunkte(haltepunkte_path)
+    entries = update_wl_stations.build_wl_entries(haltestellen, haltepunkte)
+
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["wl_diva"] == "60201076"
+    assert entry["in_vienna"] is True
+    assert entry["pendler"] is False
+    from typing import cast
+    stops = cast(list[dict[str, object]], entry["wl_stops"])
+    assert len(stops) == 1
+    assert stops[0]["stop_id"] == "1"
+
+
 def test_build_wl_entries_auto_promotes_outside_station_to_pendler() -> None:
     """An unmatched WL station outside the Vienna polygon must reach the
     merge step with ``pendler=True`` so it does not trip


### PR DESCRIPTION
## Beschreibung der Änderung

The Wiener Linien station loader (`update_wl_stations.py`) previously only recognized the legacy `data.wien.gv.at` proxy CSV schema with columns like `HALTESTELLEN_ID`, `NAME`, `STOP_ID`, and `WGS84_LAT/LON`. 

After PR #1442, the canonical `wienerlinien.at/ogd_realtime/` CSV endpoint changed its schema to:
- Collapse `HALTESTELLEN_ID` and `DIVA` into a single `DIVA` column (used as the primary key)
- Rename `NAME` → `PlatformText` (for haltestellen)
- Rename `STOP_ID` → `StopID` and `NAME` → `StopText` (for haltepunkte)
- Use `Latitude`/`Longitude` instead of `WGS84_LAT`/`WGS84_LON`

This caused the production cron run on 2026-05-11 to log "Found 0 haltestellen" despite a successful 126 KiB download, because the loader silently skipped all rows when the expected columns were missing.

**Changes:**
1. Updated `load_haltestellen()` to accept both `HALTESTELLEN_ID` and `DIVA` as station identifiers, and both `NAME` and `PlatformText` as station names
2. Updated `load_haltepunkte()` to accept the new column names (`StopID`, `StopText`, `Latitude`, `Longitude`) alongside legacy variants
3. Both functions now use fuzzy-key fallback via the existing `row.get()` multi-argument pattern to survive either upstream schema shape

The loader now handles:
- Legacy proxy CSV: `HALTESTELLEN_ID;NAME;STOP_ID;WGS84_LAT;WGS84_LON`
- Canonical OGD-Echtzeit CSV: `DIVA;PlatformText;StopID;StopText;Latitude;Longitude`

## Ticket-Referenz

Related to production incident on 2026-05-11 where the canonical OGD-Echtzeit schema was not recognized.

## Out-of-scope debt I'm deliberately NOT tackling

None identified.

---

## Seven-discipline review checklist

### 🛡 Sentinel — Security
- [x] No new HTTP request bypasses `request_safe`
- [x] No new `# nosec` markers
- [x] No new SSRF / redirect / DNS-rebinding surface
- [x] No new external hosts contacted

### ⚡ Apex — Performance
- [x] No `copy.deepcopy()` on hot paths
- [x] No new O(n²) patterns
- [x] No `wait()`-mocked test loops

### 💧 Purist — Static analysis
- [x] `ruff check src/ tests/` is clean
- [x] `mypy --no-pretty src tests` is clean
- [x] No `# type: ignore` or `# noqa` added
- [x] No new mypy-allowlist entries

### 🥼 Surgeon — Complexity
- [x] No function exceeds C901 = 15
- [x] Changes are localized to parameter handling in two functions
- [x] No new helpers needed

### Ω Omega — Joint Sentinel + Surgeon
- [x] No security gates touched
- [x] N/A

### 🧨 Saboteur — Resilience
- [x] Hostile-payload paths return `None` (existing `continue` on missing keys)
- [x] No new parser added
- [x] No new provider added
- [x] Provider-level bulkhead preserved

### 🪶 Scribe — Developer experience
- [x] Functions already have docstrings; updated with schema context
- [x] No architectural changes requiring `docs/architecture.md` update
- [x] Pattern documented inline via

https://claude.ai/code/session_01LQdxfoiBCVYQ1bsQ4EKNWc