### PR TITLE
refactor(stations): name is a display label, not a primary key

### DIFF
--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -661,7 +661,15 @@ def build_wl_entries(
         entries.append(entry)
     entries.sort(key=lambda item: (str(item.get("name")), str(item.get("wl_diva"))))
     entries = _merge_colocated_duplicates(entries)
-    _disambiguate_duplicate_names(entries)
+    # ``_disambiguate_duplicate_names`` retired 2026-05-12. The
+    # stations validator no longer enforces canonical-name uniqueness
+    # (PR after #1451) — structured identifiers (``wl_diva``,
+    # ``bst_id``, ``vor_id``) carry the project's
+    # eindeutigkeits-Garantie. The canonical display name stays
+    # ``Wien <PlatformText> (WL)`` for every WL haltestelle, even when
+    # the same PlatformText is shared by another DIVA, so the RSS
+    # feed renders ``Wien Bahnhof (WL)`` cleanly instead of the
+    # ``Wien Bahnhof (WL 60205022)`` DIVA suffix that pre-existed.
     return entries
 
 
@@ -857,63 +865,6 @@ def _merge_entry_group(group: list[dict[str, object]]) -> dict[str, object]:
         merged["pendler"] = not bool(merged["in_vienna"])
 
     return merged
-
-
-def _disambiguate_duplicate_names(entries: list[dict[str, object]]) -> None:
-    """Append the wl_diva to ``name`` whenever two or more entries would
-    otherwise share the same canonical name.
-
-    Wiener Linien's OGD-Echtzeit ``PlatformText`` is not a globally
-    unique identifier: 21 names (e.g. ``Lokalbahn`` × 4, ``Bahnhof`` × 2,
-    ``Berggasse`` × 2 separated by 12.7 km) appear on more than one
-    haltestelle DIVA. The stations validator's
-    ``_find_naming_issues`` correctly flags these as canonical-name
-    duplicates and the auto-quarantine path would otherwise eject them
-    from ``data/stations.json`` — losing real Wiener Linien stops that
-    happen to share a generic PlatformText.
-
-    This pass disambiguates **in place** by appending the DIVA inside
-    the existing ``(WL)`` suffix (so the canonical name reads
-    ``Wien Bahnhof (WL 60205022)`` rather than the verbose
-    ``Wien Bahnhof (WL) [60205022]``). The original un-suffixed name is
-    preserved in the entry's ``aliases`` list so name-based lookups
-    (``station_info``, free-text extraction) continue to work — the
-    alias may legitimately match more than one station, and the
-    existing ``_station_lookup`` strength-resolution rules handle that.
-
-    The pass is a no-op for entries whose name is already unique, so
-    the common case (1782 of 1803 entries on the current OGD CSV) is
-    unaffected — only the 21 multi-DIVA names pick up the DIVA suffix.
-    """
-    from collections import Counter
-
-    name_counts = Counter(
-        str(entry.get("name") or "")
-        for entry in entries
-    )
-    for entry in entries:
-        original_name = str(entry.get("name") or "")
-        if not original_name or name_counts[original_name] <= 1:
-            continue
-        diva = str(entry.get("wl_diva") or "").strip()
-        if not diva:
-            continue
-        # Replace a trailing ``(WL)`` with ``(WL <diva>)``; if the
-        # suffix is absent (defensive: every WL canonical name carries
-        # it via ``_canonical_name``), append the disambiguator inline.
-        disambiguated = re.sub(
-            r"\s*\(WL\)\s*$", f" (WL {diva})", original_name
-        )
-        if disambiguated == original_name:
-            disambiguated = f"{original_name} (WL {diva})"
-        entry["name"] = disambiguated
-        # Preserve the un-disambiguated name in aliases so existing
-        # free-text and name-based lookups still resolve the entry.
-        aliases_obj = entry.get("aliases")
-        if isinstance(aliases_obj, list):
-            if original_name not in aliases_obj:
-                aliases_obj.append(original_name)
-            aliases_obj.sort()
 
 
 def _normalize_sources(value: object | None) -> list[str]:

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -762,44 +762,35 @@ def _find_provider_issues(
 def _find_naming_issues(
     stations: Sequence[Mapping[str, object]]
 ) -> Iterator[NamingIssue]:
-    """Validate canonical-name policy and flag-consistency invariants.
+    """Validate flag-consistency invariants.
 
-    Three checks:
+    Two checks (was three pre-2026-05-12):
 
-    1. **Uniqueness** – the ``name`` field is the canonical display label
-       for a station and must not be shared between two distinct entries.
-    2. **Source-field formatting** – the comma-separated provider source
+    1. **Source-field formatting** – the comma-separated provider source
        string must not contain whitespace inside tokens (e.g.
        ``"google_places, vor"``). Whitespace breaks naive ``==``-based
        lookup branches and signals an unnormalized write path.
-    3. **Vienna/pendler mutual exclusivity** – ``in_vienna`` and ``pendler``
+    2. **Vienna/pendler mutual exclusivity** – ``in_vienna`` and ``pendler``
        partition the directory: every entry is *either* inside the city
        limits *or* a commuter-belt station outside, never both. The
        exceptions are ``type: manual_foreign_city`` (München, Roma) and
        ``type: manual_distant_at`` (Salzburg, Graz, Linz etc.) where
        both flags may legitimately be ``false``.
-    """
-    name_to_identifiers: dict[str, list[str]] = defaultdict(list)
-    for entry in stations:
-        name_obj = entry.get("name")
-        if not isinstance(name_obj, str):
-            continue
-        name = name_obj.strip()
-        if not name:
-            continue
-        name_to_identifiers[name].append(_format_identifier(entry))
 
-    for name, identifiers in name_to_identifiers.items():
-        if len(identifiers) > 1:
-            for identifier in identifiers:
-                yield NamingIssue(
-                    identifier=identifier,
-                    name=name,
-                    reason=(
-                        f"canonical name {name!r} is not unique "
-                        f"(also used by {', '.join(other for other in identifiers if other != identifier)})"
-                    ),
-                )
+    The pre-2026-05-12 canonical-name uniqueness check has been
+    removed. ``name`` is the operator-facing display label, not a
+    primary key; structured identifiers (``wl_diva``, ``bst_id``,
+    ``vor_id``, ``bst_code``) carry the project's eindeutigkeits-
+    Garantie. Wiener Linien's OGD-Echtzeit ``PlatformText`` is
+    legitimately duplicated for the ten remaining non-mergeable
+    multi-DIVA groups (Lokalbahn × 4, Bahnhof × 2, etc.); blocking
+    them on name-uniqueness produced exactly the RSS feed clutter
+    (``Wien Bahnhof (WL 60205022)``) that the disambiguation work
+    in PR #1448 had to introduce. Removing the gate lets the
+    upstream ``_disambiguate_duplicate_names`` step retire too, so
+    the published feed shows ``Wien Bahnhof (WL)`` without a DIVA
+    suffix.
+    """
 
     for entry in stations:
         source = entry.get("source")

--- a/tests/test_station_validation.py
+++ b/tests/test_station_validation.py
@@ -258,8 +258,20 @@ def test_markdown_rendering_contains_cross_station_id_section() -> None:
     assert "No issues detected." not in markdown
 
 
-def test_naming_validation_detects_duplicate_canonical_names(tmp_path: Path) -> None:
-    """Two entries with the same ``name`` field must trigger a NamingIssue."""
+def test_naming_validation_allows_duplicate_canonical_names(tmp_path: Path) -> None:
+    """Two entries sharing a ``name`` field must NOT trigger a naming
+    issue.
+
+    The canonical-name uniqueness check was removed on 2026-05-12.
+    Wiener Linien's OGD-Echtzeit ``PlatformText`` is legitimately
+    duplicated for non-mergeable multi-DIVA groups (``Lokalbahn`` × 4
+    spread across 5.6 km, ``Bahnhof`` × 2 at 9.4 km, …); structured
+    identifiers (``wl_diva``, ``bst_id``, ``vor_id``, ``bst_code``)
+    carry the project's eindeutigkeits-Garantie. Without this
+    relaxation the operator-facing display label has to carry a
+    disambiguating ``(WL <diva>)`` suffix that clutters the published
+    RSS feed.
+    """
     stations = [
         {
             "bst_id": 100,
@@ -284,12 +296,14 @@ def test_naming_validation_detects_duplicate_canonical_names(tmp_path: Path) -> 
     path.write_text(json.dumps(stations), encoding="utf-8")
 
     report = validate_stations(path)
-    naming_reasons = {issue.reason for issue in report.naming_issues}
-    assert any("not unique" in reason for reason in naming_reasons)
-    assert {issue.identifier for issue in report.naming_issues} == {
-        "bst:100 / code:X1 / source:oebb",
-        "bst:200 / code:X2 / source:wl",
-    }
+    duplicate_name_issues = [
+        issue for issue in report.naming_issues if "not unique" in issue.reason
+    ]
+    assert duplicate_name_issues == [], (
+        "Duplicate canonical names must no longer surface as naming "
+        "issues. Structured identifiers carry the eindeutigkeits-"
+        "Garantie; ``name`` is a display label only."
+    )
 
 
 def test_format_identifier_distinguishes_wl_only_entries() -> None:

--- a/tests/test_update_wl_stations_merge.py
+++ b/tests/test_update_wl_stations_merge.py
@@ -505,13 +505,19 @@ def test_build_wl_entries_merges_colocated_haltestellen(tmp_path: Path) -> None:
     assert "(WL 6" not in str(merged["name"])
 
 
-def test_build_wl_entries_keeps_disambiguated_far_apart_haltestellen(
+def test_build_wl_entries_does_not_suffix_far_apart_duplicate_names(
     tmp_path: Path,
 ) -> None:
     """Two haltestellen with the same canonical name but haltepunkte
-    >150 m apart stay as two entries (multi-modal at venue or
-    generic-name coincidence). The DIVA-suffix disambiguation kicks
-    in instead.
+    >150 m apart stay as two SEPARATE entries — and (after 2026-05-12)
+    keep the un-suffixed ``Wien <PlatformText> (WL)`` display label.
+
+    The DIVA suffix disambiguation introduced by PR #1448 was retired
+    together with the validator's canonical-name uniqueness check:
+    structured identifiers (``wl_diva``) carry the eindeutigkeits-
+    Garantie, so the operator-facing display label can stay clean for
+    the RSS feed even when the same ``PlatformText`` legitimately
+    appears at two physical locations.
     """
     haltestellen_path = tmp_path / "haltestellen.csv"
     haltestellen_path.write_text(
@@ -534,56 +540,13 @@ def test_build_wl_entries_keeps_disambiguated_far_apart_haltestellen(
 
     assert len(entries) == 2
     names = sorted(str(e["name"]) for e in entries)
-    assert names == [
-        "Wien Bahnhof (WL 60205022)",
-        "Wien Bahnhof (WL 60205201)",
-    ]
-
-
-def test_build_wl_entries_disambiguates_duplicate_canonical_names(
-    tmp_path: Path,
-) -> None:
-    """When two WL haltestellen share the same ``PlatformText`` (real-world
-    Wiener Linien data shape — 21 such cases including ``Lokalbahn`` × 4,
-    ``Bahnhof`` × 2, ``Berggasse`` × 2 separated by 12.7 km), the canonical
-    name is disambiguated by appending the DIVA inside the ``(WL)`` suffix.
-    The un-disambiguated natural name stays in ``aliases`` so free-text
-    name lookups continue to work.
-    """
-    haltestellen_path = tmp_path / "haltestellen.csv"
-    haltestellen_path.write_text(
-        "DIVA;PlatformText;Municipality;MunicipalityID;Longitude;Latitude\n"
-        "60205022;Bahnhof;Wien;49000001;16.269738;48.007784\n"
-        "60205201;Bahnhof;Wien;49000001;16.314052;48.087007\n"
-        "60200657;Karlsplatz;Wien;49000001;16.368948;48.200955\n",
-        encoding="utf-8",
+    assert names == ["Wien Bahnhof (WL)", "Wien Bahnhof (WL)"], (
+        "Two physical stops sharing a PlatformText must keep the same "
+        "un-suffixed canonical display label. Their structured "
+        "wl_diva fields disambiguate them at the data layer."
     )
-    haltepunkte_path = tmp_path / "haltepunkte.csv"
-    haltepunkte_path.write_text(
-        "StopID;DIVA;StopText;Municipality;MunicipalityID;Longitude;Latitude\n"
-        "1;60205022;Bahnhof;Wien;49000001;16.269738;48.007784\n"
-        "2;60205201;Bahnhof;Wien;49000001;16.314052;48.087007\n"
-        "3;60200657;Karlsplatz;Wien;49000001;16.368948;48.200955\n",
-        encoding="utf-8",
-    )
-
-    haltestellen = update_wl_stations.load_haltestellen(haltestellen_path)
-    haltepunkte = update_wl_stations.load_haltepunkte(haltepunkte_path)
-    entries = update_wl_stations.build_wl_entries(haltestellen, haltepunkte)
-
-    assert len(entries) == 3
-    by_diva = {str(e["wl_diva"]): e for e in entries}
-
-    # Both "Bahnhof" entries get disambiguated names containing their DIVA
-    assert by_diva["60205022"]["name"] == "Wien Bahnhof (WL 60205022)"
-    assert by_diva["60205201"]["name"] == "Wien Bahnhof (WL 60205201)"
-    # The un-disambiguated natural name is preserved in aliases for search
-    bahnhof_1_aliases = cast(list[str], by_diva["60205022"]["aliases"])
-    bahnhof_2_aliases = cast(list[str], by_diva["60205201"]["aliases"])
-    assert "Wien Bahnhof (WL)" in bahnhof_1_aliases
-    assert "Wien Bahnhof (WL)" in bahnhof_2_aliases
-    # Unique names (Karlsplatz) are left untouched
-    assert by_diva["60200657"]["name"] == "Wien Karlsplatz (WL)"
+    divas = sorted(str(e["wl_diva"]) for e in entries)
+    assert divas == ["60205022", "60205201"]
 
 
 def test_build_wl_entries_auto_promotes_outside_station_to_pendler() -> None:


### PR DESCRIPTION
## Summary

Closes backlog item **#5**: `name` is a display label, not a primary key.

After the seven-PR WL-OGD reactivation chain the canonical-name uniqueness contract had two cosmetic side effects:

1. `_find_naming_issues` flagged duplicate-name groups as blocking validation issues → auto-quarantine.
2. `_disambiguate_duplicate_names` worked around #1 by suffixing the display label with the wl_diva, producing 30 names like `Wien Bahnhof (WL 60205022)` in the published RSS feed.

The disambiguation suffixes reach `docs/feed.xml` through `build_feed.py` → `canonical_name` → stations directory and clutter the operator-facing event titles. Wiener Linien's OGD-Echtzeit `PlatformText` is **legitimately** shared across multi-modal stops at one venue and across generic-name coincidences (`Lokalbahn` × 4, `Bahnhof` × 2 at 9.4 km, …) — for these 10 non-mergeable groups the suffix was the symptom of treating `name` as a primary key.

## Design principle

The eindeutigkeits-Garantie moves to where it belongs: the structured identifier fields.

| Field | Eindeutigkeit |
|---|---|
| `wl_diva` | unique per WL haltestelle |
| `bst_id`, `bst_code` | unique per ÖBB station |
| `vor_id` | unique per VOR stop |
| `_format_identifier(entry)` | internal validator key (uses all of the above) |
| **`name`** | **operator-facing display label only** |
| `aliases` | lookup-text, not unique by design |

## Changes

* **`_find_naming_issues`** (`src/utils/stations_validation.py`) drops the canonical-name uniqueness check. The other two invariants (source-field formatting, in_vienna/pendler mutual exclusivity) remain.
* **`_disambiguate_duplicate_names`** (`scripts/update_wl_stations.py`) is **removed entirely** — `build_wl_entries` no longer rewrites canonical names; every WL haltestelle keeps the natural `Wien <PlatformText> (WL)` label.
* **`data/stations.json`** has its 30 DIVA-suffixed names stripped in place (`Wien Bahnhof (WL 60205022)` → `Wien Bahnhof (WL)`). First cron tick after merge regenerates under the new rule.
* **Tests**:
  * `test_naming_validation_detects_duplicate_canonical_names` → renamed to `test_naming_validation_allows_duplicate_canonical_names` with inverted assertion.
  * `test_build_wl_entries_disambiguates_duplicate_canonical_names` → **removed** (the disambiguator no longer exists).
  * `test_build_wl_entries_keeps_disambiguated_far_apart_haltestellen` → renamed to `test_build_wl_entries_does_not_suffix_far_apart_duplicate_names` and inverted to pin the new contract.

## Effect on the published feed

```diff
- Wien Bahnhof (WL 60205022)
- Wien Bahnhof (WL 60205201)
- Wien Lokalbahn (WL 60203615)
- Wien Lokalbahn (WL 60204304)
…
+ Wien Bahnhof (WL)
+ Wien Bahnhof (WL)
+ Wien Lokalbahn (WL)
+ Wien Lokalbahn (WL)
…
```

30 entries get a cleaner display label. The structured `wl_diva` field on each entry continues to disambiguate them at the data layer — two `Wien Bahnhof (WL)` rows have distinct `wl_diva` values (`60205022`, `60205201`) so any downstream consumer that needs the exact stop reads it from the structured field, not by parsing the display label.

## Downstream-compatibility

* `station_info(name)` / `canonical_name(name)` over a duplicate-name input continue to return a **single** `StationInfo` via `_station_lookup`'s existing strength-based conflict resolution. The path itself is unchanged — only the population of `_station_lookup` differs (no more synthetic DIVA-suffixed names dominate the alias set).
* `build_feed.py` renderers read `entry["name"]` as a string — no API change.
* `_extract_location_name` free-text → directory lookup: same single-match contract.

## Test plan

- [x] 3707 passed / 3 skipped on the full local suite.
- [x] `run_static_checks.py` (ruff + mypy + bandit + secret-scan + complexity + pip-audit) all green (the 61 pre-existing mypy errors in `src/utils/http.py` re `Retry` / `HTTPSConnection` subclassing are unrelated to this PR).
- [ ] After merge, observe the first `update-stations.yml` cron tick: `stations.json` regenerates with 30 entries on un-suffixed names, `docs/feed.xml` next build shows clean labels.

## Backlog disposition

| # | Item | Status |
|---|---|---|
| 1 | ÖBB-CMS-URL Brüchigkeit | mitigated (#1450) |
| 2 | ÖBB-Soft-Fail | done (#1450) |
| 3 | VOR-Snapshot-Drift Doku | deferred (doku-only) |
| 4 | Auto-Commit-Race-Fenster | deferred (unobserved) |
| **5** | **`name` als PK Refactor** | **This PR** |
| 6 | Multi-DIVA-Merge <150m | done (#1451) |

After this PR: only the two deferred items (doku-only / unobserved) remain on the backlog.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQdxfoiBCVYQ1bsQ4EKNWc)_