### PR TITLE
feat(stations): derive specific display names from haltepunkte StopText

### DIFF
--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -374,6 +374,81 @@ def _derive_bst_code(name: str, identifier: str | None) -> str | None:
     return None
 
 
+# Haltestelle PlatformText values that carry no location information
+# on their own and are routinely shared across far-apart stops in the
+# OGD-Echtzeit data (e.g. ``Lokalbahn`` × 4 across 5.6 km of greater
+# Vienna, ``Bahnhof`` × 2 across 9.4 km). Whenever a station's
+# PlatformText is in this set, ``_derive_station_label`` overrides
+# it with the more specific haltepunkte ``StopText`` even when the
+# StopText does not contain the PlatformText as a substring (e.g.
+# PlatformText ``Bahnhof`` → StopText ``Tribuswinkel - Josefsthal``).
+_GENERIC_PLATFORM_TEXTS: frozenset[str] = frozenset(
+    {
+        "bahnhof",
+        "bahn",
+        "hauptbahnhof",
+        "lokalbahn",
+        "station",
+        "halt",
+        "bf",
+        "hbf",
+        "u-bahn",
+    }
+)
+
+# Bahnsteig-direction-/Bedarfshalt-Markers that should be stripped
+# from haltepunkte StopText before deriving the canonical label.
+# ``(Richtung X)`` describes which way the platform faces; ``(Bedarf)``
+# marks request stops. Neither is part of the stop's identity.
+_STOPTEXT_QUALIFIER_RE = re.compile(
+    r"\s*(?:\([^)]*Richtung[^)]*\)|\([^)]*Bedarf[^)]*\)|→.*|←.*)$"
+)
+
+
+def _derive_station_label(platform_text: str, stops: Iterable[Haltepunkt]) -> str:
+    """Override generic haltestelle ``PlatformText`` labels with the
+    more informative haltepunkte ``StopText``.
+
+    Wiener Linien's OGD-Echtzeit ``haltestellen.csv`` ``PlatformText``
+    field is sometimes a generic transport-typed token
+    (``Bahnhof``, ``Lokalbahn``, …) that gives the operator no useful
+    location context. The corresponding haltepunkte carry a much more
+    specific ``StopText`` value (e.g. ``Bahnhof`` →
+    ``Tribuswinkel - Josefsthal``). This helper picks the more
+    informative label **only** when the PlatformText is one of those
+    generic tokens; the much-larger common case (named haltestellen
+    like ``Karlsplatz``, ``Stephansplatz``, ``Bhf. Atzgersdorf``)
+    keeps the PlatformText untouched so ÖBB / VOR name-based joins
+    in ``merge_into_stations`` remain stable and the displayed label
+    does not silently rotate to the first haltepunkte StopText (which
+    may carry idiosyncratic suffixes like ``Bhf. Atzgersdorf S``).
+
+    Strategy:
+
+    * Strip Bahnsteig direction / Bedarfshalt qualifiers from each
+      haltepunkte StopText (``Karlsplatz U (Richtung Reumannplatz)``
+      → ``Karlsplatz U``).
+    * If ``platform_text`` is in :data:`_GENERIC_PLATFORM_TEXTS` and
+      the haltepunkte produce a single cleaned StopText, return the
+      StopText (overrides ``Bahnhof`` / ``Lokalbahn`` / …).
+    * Otherwise return ``platform_text`` unchanged.
+    """
+    if platform_text.casefold() not in _GENERIC_PLATFORM_TEXTS:
+        return platform_text
+
+    cleaned: set[str] = set()
+    for stop in stops:
+        if not isinstance(stop.name, str):
+            continue
+        normalized = _STOPTEXT_QUALIFIER_RE.sub("", stop.name).strip()
+        if normalized:
+            cleaned.add(normalized)
+
+    if len(cleaned) == 1:
+        return next(iter(cleaned))
+    return platform_text
+
+
 def _aggregate_coordinates(stops: Iterable[Haltepunkt]) -> tuple[float | None, float | None]:
     latitudes: list[float] = []
     longitudes: list[float] = []
@@ -558,7 +633,22 @@ def build_wl_entries(
         # stale alias copy from a prior run trivially collides with
         # another entry's current ``wl_diva``.
         aliases.add(f"Wien {station.name}")
-        canonical = _canonical_name(station.name)
+        # The haltestelle ``PlatformText`` is sometimes a generic
+        # transport-typed label (``Bahnhof``, ``Lokalbahn``, …) that
+        # gives the operator no useful context — multiple haltestellen
+        # share it across all of Vienna's outskirts. The corresponding
+        # haltepunkte often carry a much more specific ``StopText``
+        # (e.g. ``Tribuswinkel - Josefsthal`` for one of the four
+        # WLB ``Lokalbahn`` stops). ``_derive_station_label`` picks
+        # the most informative label between PlatformText and the
+        # haltepunkte StopText, falling back to PlatformText when the
+        # StopText carries no additional information (Karlsplatz,
+        # Stephansplatz, … stay untouched so ÖBB / VOR name-based
+        # joins remain stable).
+        display_label = _derive_station_label(station.name, stops)
+        if display_label != station.name:
+            aliases.add(f"Wien {display_label}")
+        canonical = _canonical_name(display_label)
         aliases.add(canonical)
         latitude, longitude = _aggregate_coordinates(stops)
         # Compute ``in_vienna`` from the aggregate (mean) coordinates

--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -438,8 +438,6 @@ def _derive_station_label(platform_text: str, stops: Iterable[Haltepunkt]) -> st
 
     cleaned: set[str] = set()
     for stop in stops:
-        if not isinstance(stop.name, str):
-            continue
         normalized = _STOPTEXT_QUALIFIER_RE.sub("", stop.name).strip()
         if normalized:
             cleaned.add(normalized)

--- a/tests/test_update_wl_stations_merge.py
+++ b/tests/test_update_wl_stations_merge.py
@@ -583,10 +583,8 @@ def test_derive_station_label_overrides_generic_platform_text() -> None:
     when one is available. Non-generic PlatformText values are kept
     untouched so ÖBB / VOR name-based joins remain stable.
     """
-    Haltepunkt = update_wl_stations.Haltepunkt
-
-    def hp(name: str, stop_id: str = "1") -> object:
-        return Haltepunkt(
+    def hp(name: str, stop_id: str = "1") -> update_wl_stations.Haltepunkt:
+        return update_wl_stations.Haltepunkt(
             station_id="60200000",
             stop_id=stop_id,
             name=name,

--- a/tests/test_update_wl_stations_merge.py
+++ b/tests/test_update_wl_stations_merge.py
@@ -523,14 +523,22 @@ def test_build_wl_entries_does_not_suffix_far_apart_duplicate_names(
     haltestellen_path.write_text(
         "DIVA;PlatformText;Municipality;MunicipalityID;Longitude;Latitude\n"
         "60205022;Bahnhof;Wien;49000001;16.2697;48.0078\n"
-        "60205201;Bahnhof;Wien;49000001;16.3141;48.0870\n",
+        "60205201;Bahnhof;Wien;49000001;16.3141;48.0870\n"
+        "60200077;Arbeitergasse, Gürtel;Wien;49000001;16.3460;48.1841\n"
+        "60201880;Arbeitergasse, Gürtel;Wien;49000001;16.3449;48.1856\n",
         encoding="utf-8",
     )
     haltepunkte_path = tmp_path / "haltepunkte.csv"
     haltepunkte_path.write_text(
         "StopID;DIVA;StopText;Municipality;MunicipalityID;Longitude;Latitude\n"
-        "1;60205022;Bahnhof Süd;Wien;49000001;16.2697;48.0078\n"
-        "2;60205201;Bahnhof Nord;Wien;49000001;16.3141;48.0870\n",
+        # Generic PlatformText 'Bahnhof' + informative StopText →
+        # _derive_station_label overrides the generic label
+        "1;60205022;Tribuswinkel - Josefsthal;Wien;49000001;16.2697;48.0078\n"
+        "2;60205201;Wiener Neudorf;Wien;49000001;16.3141;48.0870\n"
+        # Non-generic PlatformText with identical StopText → keep
+        # PlatformText (multi-modal at one venue, no disambiguator)
+        "3;60200077;Arbeitergasse, Gürtel;Wien;49000001;16.3460;48.1841\n"
+        "4;60201880;Arbeitergasse, Gürtel;Wien;49000001;16.3449;48.1856\n",
         encoding="utf-8",
     )
 
@@ -538,15 +546,93 @@ def test_build_wl_entries_does_not_suffix_far_apart_duplicate_names(
     haltepunkte = update_wl_stations.load_haltepunkte(haltepunkte_path)
     entries = update_wl_stations.build_wl_entries(haltestellen, haltepunkte)
 
-    assert len(entries) == 2
-    names = sorted(str(e["name"]) for e in entries)
-    assert names == ["Wien Bahnhof (WL)", "Wien Bahnhof (WL)"], (
-        "Two physical stops sharing a PlatformText must keep the same "
-        "un-suffixed canonical display label. Their structured "
-        "wl_diva fields disambiguate them at the data layer."
+    assert len(entries) == 4
+    by_diva = {str(e["wl_diva"]): str(e["name"]) for e in entries}
+
+    # Generic PlatformText + informative StopText → derived label
+    # replaces the generic "Wien Bahnhof (WL)" with a real toponym.
+    assert by_diva["60205022"] == "Wien Tribuswinkel - Josefsthal (WL)", (
+        "Generic PlatformText 'Bahnhof' must be overridden by the "
+        "informative haltepunkte StopText so the RSS feed never "
+        "renders the meaningless 'Wien Bahnhof' label."
     )
-    divas = sorted(str(e["wl_diva"]) for e in entries)
-    assert divas == ["60205022", "60205201"]
+    # 'Wiener Neudorf' starts with 'Wien' so _canonical_name keeps it
+    # as-is without a redundant 'Wien' prefix.
+    # `Wiener Neudorf` starts with "Wien" so _canonical_name keeps it
+    # as-is without prepending a redundant "Wien" prefix — the
+    # generic `Bahnhof` PlatformText is replaced by the informative
+    # StopText.
+    assert by_diva["60205201"] in {"Wiener Neudorf (WL)", "Wien Wiener Neudorf (WL)"}
+
+    # Multi-modal duplicate with identical StopText: PlatformText
+    # carries the location info already, no override possible. Both
+    # entries keep the same canonical label — structured wl_diva
+    # disambiguates them at the data layer.
+    arbeiter_names = sorted(
+        n for d, n in by_diva.items() if d in {"60200077", "60201880"}
+    )
+    assert arbeiter_names == [
+        "Wien Arbeitergasse, Gürtel (WL)",
+        "Wien Arbeitergasse, Gürtel (WL)",
+    ]
+
+
+def test_derive_station_label_overrides_generic_platform_text() -> None:
+    """``_derive_station_label`` swaps generic transport-typed
+    ``PlatformText`` tokens for the informative haltepunkte StopText
+    when one is available. Non-generic PlatformText values are kept
+    untouched so ÖBB / VOR name-based joins remain stable.
+    """
+    Haltepunkt = update_wl_stations.Haltepunkt
+
+    def hp(name: str, stop_id: str = "1") -> object:
+        return Haltepunkt(
+            station_id="60200000",
+            stop_id=stop_id,
+            name=name,
+            latitude=48.2,
+            longitude=16.4,
+        )
+
+    # Generic PlatformText + single (orthogonal) StopText
+    # → trust the StopText even when it shares no substring.
+    assert update_wl_stations._derive_station_label(
+        "Bahnhof", [hp("Tribuswinkel - Josefsthal")]
+    ) == "Tribuswinkel - Josefsthal"
+    assert update_wl_stations._derive_station_label(
+        "Lokalbahn", [hp("Guntramsdorf Lokalbahn")]
+    ) == "Guntramsdorf Lokalbahn"
+
+    # Direction qualifiers are stripped before the cleaned-StopText
+    # set is computed; if all qualified StopTexts collapse to one
+    # cleaned value, that value wins.
+    assert update_wl_stations._derive_station_label(
+        "Bahnhof",
+        [
+            hp("Tribuswinkel - Josefsthal (Richtung A)", "1"),
+            hp("Tribuswinkel - Josefsthal (Richtung B)", "2"),
+        ],
+    ) == "Tribuswinkel - Josefsthal"
+
+    # Non-generic PlatformText keeps its label even when haltepunkte
+    # carry richer text. Preserves ÖBB / VOR merge-by-name stability.
+    assert update_wl_stations._derive_station_label(
+        "Schottenring", [hp("Schottenring, Herminengasse")]
+    ) == "Schottenring"
+    assert update_wl_stations._derive_station_label(
+        "Karlsplatz",
+        [hp("Karlsplatz U (Richtung Reumannplatz)", "1"),
+         hp("Karlsplatz U (Richtung Leopoldau)", "2")],
+    ) == "Karlsplatz"
+
+    # Generic PlatformText + multiple distinct StopTexts: nothing
+    # specific to pick → keep PlatformText.
+    assert update_wl_stations._derive_station_label(
+        "Bahnhof", [hp("Tribuswinkel", "1"), hp("Wiener Neudorf", "2")]
+    ) == "Bahnhof"
+
+    # No haltepunkte → keep PlatformText.
+    assert update_wl_stations._derive_station_label("Karlsplatz", []) == "Karlsplatz"
 
 
 def test_build_wl_entries_auto_promotes_outside_station_to_pendler() -> None:


### PR DESCRIPTION
## Summary

User feedback: `Wien Bahnhof (WL)` and `Wien Lokalbahn (WL)` are useless RSS-feed labels. Which Bahnhof? Welche Station der Wiener Lokalbahn?

Wiener Linien's OGD-Echtzeit data already carries the answer: the `haltepunkte.csv` `StopText` column has informative location labels that the haltestelle-level `PlatformText` flattens out.

## Forensic finding

| Haltestelle DIVA | PlatformText | StopText (informative) |
|---|---|---|
| 60205022 | `Bahnhof` | `Tribuswinkel - Josefsthal` |
| 60205201 | `Bahnhof` | `Wiener Neudorf` |
| 60203615 | `Lokalbahn` | `Guntramsdorf Lokalbahn` |
| 60204304 | `Lokalbahn` | `Möllersdorf` |
| 60204331 | `Lokalbahn` | `Neu Guntramsdorf` |
| 60205001 | `Lokalbahn` | `Traiskirchen Lokalbahn` |

## Design

`_derive_station_label(platform_text, stops)`:

1. **Scope to generic tokens only**. PlatformText must be in `_GENERIC_PLATFORM_TEXTS` (`Bahnhof`, `Lokalbahn`, `Hauptbahnhof`, `Station`, `Halt`, `Bf`, `Hbf`, `Bahn`, `U-Bahn`). All other haltestellen keep their PlatformText untouched.
2. **Strip direction qualifiers** from each haltepunkte StopText: `(Richtung X)`, `(Bedarf)`, `→...`, `←...`.
3. **Single cleaned StopText** → use it as the label. Otherwise → keep the generic PlatformText.

The conservative scope is deliberate. A broader rewrite would silently rotate `Wien Karlsplatz` to `Wien Karlsplatz U`, `Wien Schottenring` to `Wien Schottenring, Herminengasse`, `Wien Bhf. Atzgersdorf` to `Wien Bhf. Atzgersdorf S`, `Wien Betriebshof Ottakring` to `Wien Bhf.Otg.-Bedarf`, … breaking ÖBB / VOR name-based joins in `merge_into_stations` and introducing idiosyncratic suffixes to the operator-facing labels.

## Effect on `data/stations.json`

```diff
- Wien Bahnhof (WL)        (wl_diva: 60205022)
- Wien Bahnhof (WL)        (wl_diva: 60205201)
- Wien Lokalbahn (WL)      (wl_diva: 60203615)
- Wien Lokalbahn (WL)      (wl_diva: 60204304)
- Wien Lokalbahn (WL)      (wl_diva: 60204331)
- Wien Lokalbahn (WL)      (wl_diva: 60205001)
+ Wien Tribuswinkel - Josefsthal (WL)
+ Wiener Neudorf (WL)
+ Wien Guntramsdorf Lokalbahn (WL)
+ Wien Möllersdorf (WL)
+ Wien Neu Guntramsdorf (WL)
+ Wien Traiskirchen Lokalbahn (WL)
```

The 6 entries get an informative display name. The 7 remaining duplicate-name groups (`Arbeitergasse, Gürtel`, `Heinrich-von-Buol-Gasse`, `Heizwerkstraße`, `Lafitegasse`, `Märzstraße`, `Siebensterngasse`, `Skraupstraße`) are multi-modal venues where two DIVAs cover the same physical Knoten (Bus + Tram), the haltepunkte StopText is identical across DIVAs, and the duplicate display name is semantically correct.

## Backward compatibility

- **Aliases preserved**: the prior un-derived label stays in each entry's `aliases` list, so `station_info("Wien Bahnhof")` continues to resolve (`_station_lookup` strength-resolution picks one of the two via the identity-class `wl_diva` lookup).
- **ÖBB / VOR matches unchanged**: only generic-PlatformText entries (which by definition have no ÖBB / VOR counterpart that could match by name) get re-labelled.
- **Schema additive**: no new fields, no removed fields.

## Test plan

- [x] New unit-level regression `tests/test_update_wl_stations_merge.py::test_derive_station_label_overrides_generic_platform_text` pins all 5 decision branches (generic+single StopText → override; generic+direction qualifiers stripped → override; non-generic → keep; generic+multiple distinct StopTexts → keep; no haltepunkte → keep).
- [x] Existing `test_build_wl_entries_does_not_suffix_far_apart_duplicate_names` extended to cover both the generic-name override and the multi-modal duplicate-name retention in one test.
- [x] 3709 passed / 2 skipped on the full local suite.
- [x] `run_static_checks.py` (ruff + mypy + bandit + secret-scan + complexity + pip-audit) all green.
- [ ] After merge, observe `docs/feed.xml` next render: the 6 affected stations show informative labels.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQdxfoiBCVYQ1bsQ4EKNWc)_