### PR TITLE
docs: align documentation with the WL-OGD reactivation chain (PRs #1441-#1453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,88 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+* **Changed (WL OGD reactivation chain, PR #1441-#1453)**: thirteen
+  consolidated PRs fully reactivate the Wiener-Linien OGD merge path
+  against the canonical `www.wienerlinien.at/ogd_realtime/doku/ogd/`
+  endpoint (the previous `data.wien.gv.at/csv/` proxy was retired in
+  the 60th OGD phase, September 2025).
+  * **Endpoint + workflow (#1441, #1442)** — removed the redundant
+    inline curl step from `update-stations.yml`, migrated both
+    `OGD_HALTESTELLEN_URL` / `OGD_HALTEPUNKTE_URL` constants to the
+    canonical Wiener Linien host. Soft-fail to pinned local CSVs on
+    upstream outage.
+  * **Schema fuzzy-keys (#1444)** — added column aliases so the
+    loader parses both the legacy proxy CSV
+    (`HALTESTELLEN_ID`/`NAME`/`WGS84_*`) and the canonical
+    OGD-Echtzeit CSV (`DIVA`/`PlatformText`/`StopText`/`Latitude`).
+  * **WL-only entries im `wl_diva`-Namensraum (#1446)** — removed
+    synthetic `bst_id` (`9{DIVA}`) and synthetic `bst_code`
+    (`WL-{name[:3]}`) on WL-only entries; the canonical `wl_diva`
+    field is the sole structural identifier and cross-station-id
+    collisions / `WL-ABS`-style code duplicates are gone.
+  * **Pendler-Default für Border-Stops (#1443)** — unmatched WL
+    haltestellen outside the Wien polygon auto-promote to
+    `pendler=True`.
+  * **Validator identifier (#1447)** — `_format_identifier` now
+    includes `wl_diva` so WL-only entries get distinct keys instead
+    of collapsing onto `"source:wl"` (which had pulled 1759 stations
+    into auto-quarantine over 30 genuine naming groups).
+  * **StopID + direction-marker sanitisation (#1445)** — short
+    `StopID` counter values are filtered out of `aliases` (legacy
+    8-digit RBL stays); `<` and `>` direction markers in `StopText`
+    are replaced with `←` / `→` so they no longer hit
+    `_UNSAFE_CHARS_RE`.
+  * **`in_vienna` consistency (#1449)** — `build_wl_entries` now
+    derives `in_vienna` from the aggregate haltepunkt coordinates
+    instead of any-stop-wins, so boundary stations no longer carry
+    a flag that contradicts their persisted coords. Pinned by
+    `test_coordinates_match_in_vienna_flag`.
+  * **ÖBB workbook soft-fail (#1450)** — `download_workbook` atomic-
+    writes a snapshot to `data/oebb-verkehrsstationen.xlsx` on every
+    successful run and reads from the snapshot when `data.oebb.at`
+    returns a network error. Closes the asymmetric failure mode
+    where ÖBB was the only fail-fast upstream source. CodeQL config
+    (`.github/codeql/codeql-config.yml`) excludes the
+    `py/clear-text-storage-sensitive-data` false-positive that
+    matches every public-data cache writer in this project.
+  * **Multi-DIVA-Merge <150 m (#1451)** — `_merge_colocated_dupli
+    cates` folds same-name haltestellen with haltepunkte-mean
+    coordinates within 150 m of each other into a single entry
+    (lexicographically lowest DIVA wins, all haltepunkte and
+    aliases unioned). Removes 4 doublings from the current
+    `stations.json` (Stock im Weg, Vorgartenstraße, Lieblgasse,
+    Altmannsdorfer Straße).
+  * **`name` ist Display-Label, kein PK (#1452)** — the validator's
+    canonical-name uniqueness check is removed. Structural
+    uniqueness lives in `wl_diva` / `bst_id` / `vor_id` /
+    `bst_code`; `name` is operator-facing. The
+    `_disambiguate_duplicate_names` DIVA-suffix workaround
+    (`Wien Bahnhof (WL 60205022)`) is retired — duplicate display
+    labels are now legal and the RSS feed shows the clean
+    `Wien Bahnhof (WL)` form.
+  * **Aussagekräftige Display-Namen aus `StopText` (#1453)** —
+    `_derive_station_label` overrides generic transport-typed
+    haltestelle `PlatformText` tokens (`Bahnhof`, `Lokalbahn`,
+    `Hauptbahnhof`, `Station`, `Halt`, `Bf`, `Hbf`, `Bahn`,
+    `U-Bahn`) with the haltepunkte `StopText` when one is
+    available. Six entries got a real toponym:
+    `Wien Bahnhof (WL)` × 2 → `Wien Tribuswinkel - Josefsthal
+    (WL)`, `Wiener Neudorf (WL)`; `Wien Lokalbahn (WL)` × 4 →
+    `Wien Guntramsdorf Lokalbahn (WL)`, `Wien Möllersdorf (WL)`,
+    `Wien Neu Guntramsdorf (WL)`, `Wien Traiskirchen Lokalbahn
+    (WL)`. Non-generic PlatformText values stay untouched so
+    ÖBB / VOR name-based joins remain stable.
+  * **Test data refresh (#1449)** — three station-directory tests
+    hard-coded legacy DIVAs that Wiener Linien has since renumbered
+    (`60201076` was Karlsplatz pre-PR #1442 and is now
+    Ratzenhofergasse; `60201002` was Schottentor and is now
+    Pensionsversicherungsanstalt). Updated to current DIVAs.
+  * **Outcome on production data**: `stations.json` grew from 196
+    to 1951 entries (4 co-located doublings merged out of 1803 WL
+    entries), 0 DIVA suffixes in canonical names, 0 generic
+    `Wien Bahnhof (WL)` / `Wien Lokalbahn (WL)` labels, validator
+    reports 0 alias / naming / security issues, `quarantine.json`
+    stays empty across cron ticks.
 * **Changed (Auto-Quarantine für `update_all_stations.py`)**: Blockierende
   Validation-Issues (`provider_issues`, `cross_station_id_issues`,
   `naming_issues`, `security_issues`) brechen die Pipeline nicht mehr ab.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -362,6 +362,76 @@ The relevant CLI flags / env vars:
 | `OVERPASS_URL` | `overpass-api.de` | Trusted-mirror override; rejected unless on the allow-list |
 | `MERGE_MAX_DIST_M` | `150` | Distance threshold for the dedup match in `merge_places` |
 
+### 5a. Wiener Linien OGD merge (the fourth source)
+
+After the OSM / Google Places enrichment writes the ÖBB-rooted
+`stations.json`, the wrapper orchestrator runs
+`scripts/update_wl_stations.py` as a separate stage. This step folds
+Wiener Linien's OGD-Echtzeit station and stop data into the directory
+so the published feed knows about U-Bahn, Tram and Bus stops that
+have no ÖBB counterpart.
+
+**Source endpoint** (post-PR #1442): the canonical
+`www.wienerlinien.at/ogd_realtime/doku/ogd/wienerlinien-ogd-{halte
+stellen,haltepunkte}.csv`. The historical `data.wien.gv.at/csv/`
+proxy was retired during the 60th Wien OGD phase (September 2025)
+and `haltepunkte.csv` started returning HTTP 404 on the proxy host —
+the migration is documented in
+`scripts/update_wl_stations.py:OGD_HALTESTELLEN_URL`. Both files are
+downloaded fresh on every cron tick (`--download` default-on) and
+atomic-written to `data/wienerlinien-ogd-{haltestellen,haltepunkte}.
+csv`; on download failure the pipeline keeps the pinned local
+snapshot and continues.
+
+**Entry construction** (`build_wl_entries`):
+
+1. Group haltepunkte by their haltestelle DIVA.
+2. Per group, derive the canonical name via `_derive_station_label`:
+   if the haltestelle `PlatformText` is a generic transport-typed
+   token (`Bahnhof`, `Lokalbahn`, `Hauptbahnhof`, `Station`, `Halt`,
+   `Bf`, `Hbf`, `Bahn`, `U-Bahn`) and the haltepunkte produce a
+   single cleaned `StopText`, use the `StopText`. Otherwise keep
+   the `PlatformText`. This rule (PR #1453) turns operator-useless
+   labels like `Wien Bahnhof (WL)` into informative ones like
+   `Wien Tribuswinkel - Josefsthal (WL)`, while preserving the
+   common case (`Karlsplatz`, `Stephansplatz`, …).
+3. Resolve `in_vienna` from the aggregate (mean) haltepunkt
+   coordinates so the flag stays coherent with the persisted
+   `latitude`/`longitude` (invariant pinned by
+   `test_coordinates_match_in_vienna_flag` after PR #1449).
+4. Set `pendler = not in_vienna` to mirror the legacy WL-auto-
+   promote heuristic for border-area stops (PR #1443).
+5. Build the entry with `wl_diva`, `wl_stops`, `aliases` — but
+   without synthetic `bst_id` / `bst_code` (PR #1446 redesign).
+
+**Co-located haltestelle merge** (PR #1451): a post-build pass
+`_merge_colocated_duplicates` folds groups that share a canonical
+name **and** lie within 150 m of each other into a single entry.
+Wiener Linien's OGD-Echtzeit lists some physical stops twice
+(opposing-direction bahnsteige with distinct DIVAs); the merge
+collects all haltepunkte under one entry with the lexicographically
+lowest DIVA as `wl_diva`. Groups with at least one pair ≥150 m
+apart remain separate — they are multi-modal stops at one venue
+(Bus + Tram pair) or generic-PlatformText coincidences, and the
+shared display name is semantically correct.
+
+**Name uniqueness contract** (PR #1452): the stations validator no
+longer enforces canonical-name uniqueness. `name` is an
+operator-facing display label; structural uniqueness lives in
+`wl_diva` / `bst_id` / `vor_id` / `bst_code`. Wiener Linien
+legitimately ships duplicate `PlatformText` values across non-
+mergeable multi-DIVA groups (10 such groups on the May 2026 CSV
+snapshot, including `Lokalbahn` × 4 spread across 5.6 km and
+`Bahnhof` × 2 at 9.4 km separation) — the older
+`_disambiguate_duplicate_names` DIVA-suffix workaround
+(`Wien Bahnhof (WL 60205022)` etc.) cluttered the RSS feed and was
+retired together with the validator gate.
+
+**Resilience**: same `session_with_retries` + `fetch_content_safe`
+stack as the other sources, plus pinned snapshot fallback. Unlike
+the ÖBB workbook (until PR #1450) the WL CSVs have had a soft-fail
+path since the original `_download_ogd_csv` shape.
+
 ---
 
 ## 6. Statistics & Dashboard Pipeline

--- a/docs/development.md
+++ b/docs/development.md
@@ -313,7 +313,7 @@ verhindert Drift.
 
 | Feld | Pflicht | Beschreibung |
 | ---- | ------- | ------------ |
-| `name` | ✓ | Kanonischer Anzeige-Name (eindeutig, wird im Feed verwendet). |
+| `name` | ✓ | Operator-facing Anzeige-Name (wird im Feed verwendet). **Nicht unique**: zwischen mehreren Einträgen kann derselbe Name vorkommen, etwa bei multi-modalen Knoten, wo Bus- und Tram-Bahnsteige unter zwei DIVAs am selben Knoten geführt werden. Die strukturelle Eindeutigkeits-Garantie tragen `bst_id`/`bst_code`/`vor_id`/`wl_diva`; siehe PR #1452. |
 | `in_vienna` | ✓ | `true` wenn die Koordinaten innerhalb des LANDESGRENZEOGD-Polygons liegen. |
 | `pendler` | ✓ | `true` für Pendler-Knoten **außerhalb** Wiens (siehe `data/pendler_bst_ids.json`). **Exklusiv zu `in_vienna`**: jede Station ist entweder Wien-Station ODER Pendler, niemals beides. Ausnahmen sind manuell gepflegte Knoten außerhalb des Pendlergürtels: `type: manual_foreign_city` (z. B. München Hauptbahnhof, Roma Termini, Bratislava hl.st.) und `type: manual_distant_at` (z. B. Salzburg Hbf, Graz Hbf, Linz Hbf, Innsbruck Hbf) — bei beiden Sondertypen sind beide Flags `false`. Verstöße werden vom Validator als NamingIssue gemeldet und vom Updater automatisch korrigiert (in_vienna gewinnt). |
 | `aliases` | ✓ | Schreibvarianten und IDs zur Erkennung in Provider-Texten. |
@@ -333,8 +333,8 @@ damit kurze Stellencodes wie `Sue`/`Su` distinkt bleiben).
 
 | Quelle | Datei(en) | Lizenz | Pflicht-Attribution |
 |---|---|---|---|
-| **ÖBB-Verkehrsstationen** (`data.oebb.at`) | extrahiert aus dem Excel „Verzeichnis der Verkehrsstationen" + `data/gtfs/stops.txt` | [CC BY 3.0 AT](https://creativecommons.org/licenses/by/3.0/at/) | „Datenquelle: ÖBB-Infrastruktur AG" |
-| **Wiener Linien OGD** | `data/wienerlinien-ogd-haltestellen.csv`, `data/wienerlinien-ogd-haltepunkte.csv` | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) | „Datenquelle: Stadt Wien – data.wien.gv.at" |
+| **ÖBB-Verkehrsstationen** (`data.oebb.at`) | extrahiert aus dem Excel „Verzeichnis der Verkehrsstationen"; eine atomar-geschriebene Cache-Kopie liegt unter `data/oebb-verkehrsstationen.xlsx` (Soft-Fail-Snapshot seit PR #1450 — wird bei `data.oebb.at`-Outage automatisch verwendet). Zusätzlich `data/gtfs/stops.txt`. | [CC BY 3.0 AT](https://creativecommons.org/licenses/by/3.0/at/) | „Datenquelle: ÖBB-Infrastruktur AG" |
+| **Wiener Linien OGD** | `data/wienerlinien-ogd-haltestellen.csv`, `data/wienerlinien-ogd-haltepunkte.csv` (Quelle: `www.wienerlinien.at/ogd_realtime/doku/ogd/`, seit PR #1442; der vorherige `data.wien.gv.at/csv/`-Proxy wurde in der 60. OGD-Phase im September 2025 retired) | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) | „Datenquelle: Wiener Linien" |
 | **VOR (Verkehrsverbund Ost-Region)** | `data/vor-haltestellen.csv`, `data/vor-haltestellen.mapping.json` | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) | „Datenquelle: VOR Verkehrsverbund Ost-Region" |
 | **Wien-Stadtgrenzen-Polygon** | `data/LANDESGRENZEOGD.json` (Layer `ogdwien:LANDESGRENZEOGD` der MA 41 – Stadtvermessung, WFS-API von data.wien.gv.at, `srsName=EPSG:4326`, `outputFormat=json`) | [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) | **„Datenquelle: Stadt Wien – data.wien.gv.at"** |
 | **Google Places** (optional) | Enrichment | [Maps Platform-AGB](https://cloud.google.com/maps-platform/terms/) | – |
@@ -345,7 +345,7 @@ damit kurze Stellencodes wie `Sue`/`Su` distinkt bleiben).
 | ------ | -------- |
 | `python -m src.cli stations update all --verbose` | Führt alle Teilaktualisierungen (ÖBB, WL, VOR) in einem Lauf aus. |
 | `python -m src.cli stations update directory --verbose` | Aktualisiert das ÖBB-Basisverzeichnis und setzt `in_vienna`/`pendler`. |
-| `python scripts/update_wl_stations.py [--no-download] -v` | Lädt die WL-OGD-CSVs von `data.wien.gv.at` und führt sie zusammen. `--no-download` nutzt die lokalen Dateien (Sandbox/Offline-Modus). |
+| `python scripts/update_wl_stations.py [--no-download] -v` | Lädt die WL-OGD-CSVs vom kanonischen Wiener-Linien-OGD-Endpoint `www.wienerlinien.at/ogd_realtime/doku/ogd/` und führt sie mit `data/stations.json` zusammen. `--no-download` nutzt die lokal gepinnten CSVs (Sandbox/Offline-Modus). Beim Download-Erfolg wird die jeweilige CSV atomar geschrieben; bei Netzwerk-Fehlern wird das gepinnte Snapshot beibehalten. |
 | `python -m src.cli stations update vor --verbose` | Importiert VOR-Daten aus CSV oder API und reichert Stationen an. |
 
 
@@ -463,7 +463,7 @@ benötigt werden (z. B. `--no-download` für die WL-OGD-CSVs).
 | `update_all_stations.py` | Wrapper für den vollständigen Stationsverzeichnis-Refresh; ruft die folgenden Sub-Skripte gegen ein Temp-File auf und committet erst nach erfolgreicher Validierung. CLI: `python -m src.cli stations update all`. |
 | `update_station_directory.py` | Lädt das ÖBB-Excel und ergänzt OSM-/Google-Places-Koordinaten (OSM-First, siehe `docs/architecture.md` §5). |
 | `update_vor_stations.py` | Importiert VOR-Daten aus CSV oder API; live-Anreicherung via `location.name` ist auf `STAMMSTRECKE_VOR_IDS` begrenzt. |
-| `update_wl_stations.py` | Lädt `wienerlinien-ogd-haltestellen.csv` und `wienerlinien-ogd-haltepunkte.csv` von `data.wien.gv.at`. Mit `--no-download` werden die lokal gepinnten CSVs verwendet. |
+| `update_wl_stations.py` | Lädt `wienerlinien-ogd-haltestellen.csv` und `wienerlinien-ogd-haltepunkte.csv` vom kanonischen Endpoint `www.wienerlinien.at/ogd_realtime/doku/ogd/` und merged sie in `data/stations.json`. Soft-fail mit den gepinnten lokalen CSVs bei Upstream-Outage. Mit `--no-download` werden ausschließlich die lokal gepinnten CSVs verwendet. |
 | `enrich_station_aliases.py` | Sucht alternative Schreibweisen pro Station und schreibt sie ins Verzeichnis. |
 | `fetch_vor_haltestellen.py` | Holt die aktuelle Liste vom HAFAS-Endpoint `anachb.vor.at` und überschreibt `data/vor-haltestellen.csv`. |
 | `fetch_google_places_stations.py` | Optionaler Sekundär-Fallback für Stationen ohne OSM-Koordinaten; manueller Direktaufruf, nutzt das Quota-Stateful-Modul aus `src/places/`. Der OSM-first/Google-Fallback wird auch automatisch in `update-stations.yml` ausgeführt. |

--- a/docs/schema/stations.schema.json
+++ b/docs/schema/stations.schema.json
@@ -25,7 +25,7 @@
         "name": {
           "type": "string",
           "minLength": 1,
-          "description": "Kanonischer, eindeutiger Anzeige-Name. Wird im Feed verwendet. Muss über alle Einträge unique sein (validator-erzwungen)."
+          "description": "Operator-facing display label. Wird im Feed verwendet. Darf zwischen Einträgen wiederholt vorkommen — die Eindeutigkeits-Garantie liegt bei den strukturierten Identifier-Feldern (bst_id, bst_code, vor_id, wl_diva), nicht bei name. Bis PR #1452 (2026-05-12) hat _find_naming_issues Duplikate als blocking gewertet; seither ist diese Prüfung entfallen, weil Wiener Linien-PlatformText legitim über mehrere DIVAs geteilt wird (multi-modal venues mit Bus + Tram am gleichen Knoten)."
         },
         "in_vienna": {
           "type": "boolean",
@@ -75,11 +75,11 @@
         "wl_diva": {
           "type": "string",
           "pattern": "^[0-9]+$",
-          "description": "Wiener Linien DIVA-Nummer aus data/wienerlinien-ogd-haltestellen.csv (data.wien.gv.at, CC BY 4.0). Wird für WL-Provider-Lookups als IDENTITY-Alias geführt."
+          "description": "Wiener Linien DIVA-Nummer aus data/wienerlinien-ogd-haltestellen.csv (Wiener Linien OGD, www.wienerlinien.at/ogd_realtime/doku/ogd/, CC BY 4.0). Wird für WL-Provider-Lookups als IDENTITY-Alias geführt und trägt — gemeinsam mit bst_id/bst_code/vor_id — die strukturelle Eindeutigkeits-Garantie der Station."
         },
         "wl_stops": {
           "type": "array",
-          "description": "WL-Einzelhaltepunkte (Bahnsteige/Richtungen) aus data/wienerlinien-ogd-haltepunkte.csv.",
+          "description": "WL-Einzelhaltepunkte (Bahnsteige/Richtungen) aus data/wienerlinien-ogd-haltepunkte.csv (Wiener Linien OGD, www.wienerlinien.at/ogd_realtime/doku/ogd/).",
           "items": {
             "type": "object",
             "required": ["stop_id"],


### PR DESCRIPTION
## Summary

Thirteen merged PRs (#1441-#1453) in two days changed the WL-OGD merge path, canonical name contract, ÖBB cache fallback and station-validator gate. The documentation drifted on four axes; this PR closes the gap.

## Audit findings

### 1. Outdated URLs — `data.wien.gv.at` → `wienerlinien.at`

PR #1442 migrated both WL-OGD CSV downloads from the retired `data.wien.gv.at/csv/wienerlinien-ogd-*` proxy to the canonical `www.wienerlinien.at/ogd_realtime/doku/ogd/wienerlinien-ogd-*` endpoint. Four documentation references still pointed at the old proxy:

| File | Line | What it said |
|---|---|---|
| `docs/schema/stations.schema.json` | 78 | `wl_diva` "aus data.wien.gv.at" |
| `docs/schema/stations.schema.json` | 82 | `wl_stops` "aus data.wien.gv.at" |
| `docs/development.md` | 337 | Wiener Linien OGD source attribution |
| `docs/development.md` | 348 | `update_wl_stations.py` CLI row |
| `docs/development.md` | 466 | Script-overview table row |

All four now point to the canonical Wiener-Linien-OGD host, with a short note that the proxy was retired so a future reader does not re-introduce it.

### 2. Outdated `name`-uniqueness claim

PR #1452 dropped the canonical-name uniqueness check from `_find_naming_issues` and removed the `_disambiguate_duplicate_names` DIVA-suffix workaround. Two documentation entries still claimed `name` had to be unique:

| File | Line | Old | New |
|---|---|---|---|
| `docs/schema/stations.schema.json` | 28 | `name` "muss eindeutig sein" | `name` "darf zwischen Einträgen wiederholt vorkommen — Eindeutigkeit liegt bei den strukturierten Identifier-Feldern" |
| `docs/development.md` | 316 | `name` "(eindeutig, wird im Feed verwendet)" | `name` "Operator-facing Anzeige-Name. Nicht unique zwischen mehreren Einträgen ..." |

### 3. Missing feature documentation

The reactivation introduced three substantial new code paths, none of which had documentation. Architecture handbook now covers them in a new §5a "Wiener Linien OGD merge (the fourth source)":

* **WL OGD merge** — entry construction via `build_wl_entries`, ÖBB-WL join via `merge_into_stations`, resilience pattern symmetric to OSM / Google
* **`_derive_station_label`** (PR #1453) — heuristic for replacing generic haltestelle `PlatformText` (`Bahnhof`, `Lokalbahn`, …) with the more informative haltepunkte `StopText`
* **`_merge_colocated_duplicates`** (PR #1451) — distance-based merge for haltestellen that share a name and lie within 150 m of each other

Development handbook now also points at `data/oebb-verkehrsstationen.xlsx` as the ÖBB cache snapshot (PR #1450).

### 4. CHANGELOG gap

The 13 PRs landed without CHANGELOG entries. This PR adds one consolidated `Unreleased` bullet that lists every PR by number, structures them by intent (endpoint migration → schema → entry-construction → resilience → display-name cleanup), and summarises the production-data outcome:

```
stations.json: 196 → 1951 entries
0 DIVA suffixes in canonical names
0 generic 'Wien Bahnhof (WL)' / 'Wien Lokalbahn (WL)' labels
6 entries got informative toponyms (Tribuswinkel, Wiener Neudorf, ...)
Validator: 0 alias / naming / security issues
quarantine.json: empty across cron ticks
```

## Out of scope

| File | Why not touched |
|---|---|
| `docs/index.md`, `docs/how-to/*`, `docs/reference/*` | None refer to the WL OGD CSVs / station-directory schema in a way the reactivation invalidated. |
| `docs/archive/audits/*` | Historical audits document the state at the time of writing; rewriting them would erase the audit trail. |
| `README.md`, `AGENTS.md` | Describe the project shape at the use-case level, not the WL-OGD wiring; unchanged. |

## Smoke check

- [x] `python -c "import json; json.load(open('docs/schema/stations.schema.json'))"` exits 0 — schema syntactically valid after the description edits.
- [x] No code changes — pytest / mypy / ruff surfaces unchanged.

## Test plan

This is a documentation-only PR; the cron pipeline behaviour does not change. After merge, the next reader of `docs/development.md`, `docs/architecture.md`, `docs/schema/stations.schema.json` or `CHANGELOG.md` sees the actual current state of the WL-OGD merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQdxfoiBCVYQ1bsQ4EKNWc)_