### PR TITLE
security(scripts): install stdlib-only SafeFormatter in preflight quota check

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,112 @@
+## 2026-05-14 - Clear-Text-Logging Drift (Preflight `basicConfig` Closure): Last Remaining `logging.basicConfig` Caller In `scripts/` — The Pre-Install-Deps Cron-Gate That Inherited The Unsanitised Root-Formatter
+
+**Vulnerability:** ``scripts/preflight_quota_check.py`` was the only
+remaining script in ``scripts/`` that called ``logging.basicConfig(
+format=...)`` instead of routing through
+:func:`src.feed.logging_safe.setup_script_logging` (the Round-1 closure
+of the Clear-Text-Logging Drift family). ``basicConfig`` installs a
+default :class:`logging.Formatter` that does NOT sanitise the rendered
+record — meaning every ``%s`` interpolated value flows verbatim into
+the workflow stdout/stderr captured by
+``.github/workflows/update-cycle.yml`` (the cron tick that fires every
+~30 minutes on :00 / :30 and runs ``python scripts/
+preflight_quota_check.py --check vor --margin 2`` as the budget-gating
+preflight before any VAO ``/trip`` request).
+
+The deferred migration was deliberate: ``setup_script_logging``
+transitively imports ``src.feed.config`` -> ``src.utils.http`` ->
+``requests`` / ``urllib3`` / ``dns.resolver``, all third-party
+packages installed in the workflow AFTER this preflight runs. The
+preflight's docstring pins the contract: "zero non-stdlib runtime
+dependencies so it works in the early Actions step ... before
+``install-deps`` has run." The Round-1 closure named the script as a
+deferred sibling but left the gap open.
+
+**Attack surface:** The ``_emit_outputs`` helper writes the
+GitHub-Actions output file at the path declared by ``$GITHUB_OUTPUT``.
+When ``open(target, "a")`` fails an :class:`OSError` is raised whose
+``__str__`` echoes the path bytes back into a WARNING log line::
+
+    LOGGER.warning("preflight: konnte $GITHUB_OUTPUT nicht schreiben: %s", exc)
+
+A poisoned ``GITHUB_OUTPUT`` value (compromised CI runner, hostile
+third-party Action that pollutes the env, leaked secret store with
+non-ASCII bytes) carrying any of the canonical CVE-2021-42574 /
+log-injection / 8-bit-C1 / Tag-block / Variation-Selector / ANSI-ESC
+/ log-forgery primitives flows verbatim into the workflow log.
+
+**Threat model:** Same as the Path-Log Sibling Drift family — a
+single ``%s`` interpolation surface against an env-controlled path
+in a cron-pipeline script. The pre-fix WARNING line emits the raw
+OSError text via ``%s`` (no formatter-layer defence), so:
+
+  * ``‮`` (U+202E RIGHT-TO-LEFT OVERRIDE) — visually reverses
+    subsequent text on any Unicode-aware terminal / SIEM viewer.
+  * ``​`` (U+200B ZERO WIDTH SPACE) — invisible cache-key
+    poisoning primitive.
+  * ``\x9b`` (U+009B 8-bit CSI) — survives the 7-bit
+    ``_ANSI_ESCAPE_RE`` defence, triggers SGR colour
+    interpretation on 8-bit-C1-honouring terminals.
+  * ``\x1b`` (U+001B ESC) — ANSI prefix, terminal-escape
+    primitive.
+  * ``\r\n`` — log-record forgery into any line-based consumer
+    (SIEM splitters, journald, Promtail).
+
+**Reproduced:** ``tests/test_sentinel_preflight_basicconfig_drift.py``
+contains 6 PoC tests:
+
+  * 1 unit-level PoC against ``_emit_outputs`` ``OSError`` warning.
+  * 1 formatter-layer PoC: an attack payload round-tripped through
+    the inline ``_PreflightSafeFormatter`` must come out scrubbed.
+  * 2 structural invariants on the new ``_build_safe_formatter`` /
+    ``_configure_safe_logging`` helpers.
+  * 1 end-to-end PoC invoking ``main()`` with a hostile OSError
+    fault-injected into ``open()``.
+  * 1 closing-checklist invariant: walk every ``*.py`` in
+    ``scripts/`` and assert no remaining ``logging.basicConfig``
+    outside comments/docstrings.
+
+Pre-fix: every PoC fails (the attack bytes survive into ``caplog.text``
+verbatim). Post-fix: all 6 tests pass; the full 4397-test suite passes;
+static checks (ruff, mypy 1.10 against ``.mypy-baseline.txt``, bandit,
+secret scanner, C901 gate, pip-audit) are clean.
+
+**Fix shape:** Two defense-in-depth layers + auto-discoverable gate:
+
+  1. **Inline ``_PreflightSafeFormatter``** mirroring
+     :class:`src.feed.logging_safe.SafeFormatter` byte-for-byte but
+     defined inside the preflight script so its stdlib-only invariant
+     is preserved (``src.utils.logging.sanitize_log_message`` itself
+     imports only ``re`` and ``typing``).
+  2. **Call-site sanitiser** at the ``_emit_outputs`` ``OSError``
+     warning: route the bound ``exc`` through
+     :func:`src.utils.logging.sanitize_log_arg` so the log line is
+     sanitised even if a future maintainer drops the formatter-layer
+     defence.
+  3. **Closing-checklist invariant** (``test_no_basicconfig_in_
+     scripts``): walks every ``*.py`` in ``scripts/`` and asserts
+     ``logging.basicConfig`` does not appear outside comments /
+     docstrings. Any future regression — a new script being added
+     with ``logging.basicConfig``, an existing script regressing
+     from ``setup_script_logging`` — fails the test at PR-review
+     time.
+
+**Learning:** When a Round-1 (or any earlier) closure of a drift
+family is scoped to "most callers" with a deferred sibling, the
+deferred-list cell in the closing checklist MUST carry a
+self-discovering invariant test rather than relying on a future
+journal reader noticing the gap. The pre-flight script was named in
+the Round-1 deferred list (``src/feed/logging_safe.py``'s docstring
+explicitly calls out the third-party-deps constraint) but no
+inventory test pinned the eventual closure — only this Round-2
+closure added that gate. Whenever a future round defers a sibling
+for a structural reason (third-party deps, layering constraint, API
+back-compat) the gate MUST be added on the SAME PR as the deferred
+deferral, with the gate failing today (FAIL-LOUD) so the closure
+PR is auto-prompted when the constraint goes away.
+
+---
+
 ## 2026-05-14 - Path-Log Sibling Drift Round 3 (Cron-Pipeline `scripts/` Closure): 5 Operator-Facing ERROR/WARNING/INFO Sinks In `scripts/update_baustellen_cache.py` — The Named-But-Deferred Cron-Pipeline Sub-Landscape Of The 2026-05-13 Round 2 Closure
 
 **Vulnerability:** The 2026-05-13 Round 2 closure (PR #1468) enumerated 28

--- a/scripts/preflight_quota_check.py
+++ b/scripts/preflight_quota_check.py
@@ -44,7 +44,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Final, cast
+from typing import Any, Final, cast
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -60,7 +60,95 @@ if str(REPO_ROOT) not in sys.path:
 # ``install-deps`` has run, exactly like the rest of this script.
 from src.utils.files import read_capped_json  # noqa: E402
 
+# Project import: ``sanitize_log_arg`` / ``sanitize_log_message`` are
+# the canonical log-injection / Trojan-Source defences. ``src.utils.
+# logging`` is stdlib-only (imports ``re`` + ``typing``) so the
+# preflight's "no non-stdlib runtime deps" invariant is preserved.
+# We avoid ``src.feed.logging_safe.setup_script_logging`` because its
+# transitive imports pull ``src.feed.config`` -> ``src.utils.http`` ->
+# ``requests``/``urllib3``/``dns.resolver`` which are third-party
+# packages installed AFTER this preflight runs in the workflow.
+from src.utils.logging import sanitize_log_arg, sanitize_log_message  # noqa: E402
+
 LOGGER = logging.getLogger("preflight_quota_check")
+
+
+class _PreflightSafeFormatter(logging.Formatter):
+    """Stdlib-only mirror of :class:`src.feed.logging_safe.SafeFormatter`.
+
+    Sentinel (Clear-Text-Logging Drift, preflight closure): the
+    historical ``logging.basicConfig(format=...)`` call installed a
+    default :class:`logging.Formatter` that does NOT sanitise the
+    rendered record. A hostile exception text (e.g. an :class:`OSError`
+    raised when ``open(GITHUB_OUTPUT, "a")`` rejects an env-poisoned
+    path carrying any of the canonical CVE-2021-42574 / log-injection
+    / 8-bit-C1 / ANSI-ESC / log-forgery primitives) leaks unmodified
+    into the workflow stdout/stderr captured by
+    ``.github/workflows/update-cycle.yml`` (visible in the GitHub
+    Actions UI and ingested by any downstream SIEM forwarder).
+
+    Mirrors the canonical SafeFormatter byte-for-byte but defined
+    inline so the preflight's docstring invariant ("zero non-stdlib
+    runtime dependencies so it works in the early Actions step ...
+    before ``install-deps`` has run") is preserved.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        # Clone the record so concurrent handlers don't see the
+        # mutated msg/args. ``logging.makeLogRecord`` is the
+        # canonical idiom (mirrors SafeFormatter.format).
+        record = logging.makeLogRecord(record.__dict__)
+        original_msg = record.getMessage()
+        sanitized_msg = sanitize_log_message(original_msg)
+        record.msg = sanitized_msg
+        record.args = ()
+        formatted = super().format(record)
+        return formatted.replace("\n", "\\n").replace("\r", "\\r")
+
+    def formatException(self, ei: Any) -> str:
+        # Sanitize the rendered traceback but preserve newlines for
+        # readability — same contract as SafeFormatter.formatException.
+        return sanitize_log_message(
+            super().formatException(ei), strip_control_chars=False
+        )
+
+
+def _build_safe_formatter() -> logging.Formatter:
+    """Factory for the inline SafeFormatter.
+
+    Exposed as a module-level helper so tests can round-trip an
+    attack payload through the formatter to verify the sanitiser
+    contract.
+    """
+    return _PreflightSafeFormatter(
+        "%(asctime)s %(levelname)s %(name)s: %(message)s"
+    )
+
+
+def _configure_safe_logging(level: int = logging.INFO) -> None:
+    """Install the inline SafeFormatter on the root logger.
+
+    Replaces the historical ``logging.basicConfig(format=...)`` call.
+    Idempotent: a sanitising handler is added exactly once per
+    process so repeated invocations from tests / re-entry don't
+    duplicate handlers. Mirrors the idempotency contract of
+    :func:`src.feed.logging_safe.setup_script_logging`.
+
+    Foreign handlers (most importantly pytest's ``caplog`` capture
+    handler) are preserved — they predate our installation and
+    clearing them would invalidate test fixtures that capture log
+    records via the standard pytest mechanism.
+    """
+    root = logging.getLogger()
+    has_safe = any(
+        isinstance(h.formatter, _PreflightSafeFormatter)
+        for h in root.handlers
+    )
+    if not has_safe:
+        handler = logging.StreamHandler()
+        handler.setFormatter(_build_safe_formatter())
+        root.addHandler(handler)
+    root.setLevel(level)
 
 # Hard-coded contractual ceilings. Mirrors the *defaults* in the
 # respective modules; the env-overridable ``MAX_*`` constants in
@@ -215,7 +303,21 @@ def _emit_outputs(quota_ok: bool, projected: int, limit: int, kind: str) -> None
                 for line in lines:
                     handle.write(line + "\n")
         except OSError as exc:
-            LOGGER.warning("preflight: konnte $GITHUB_OUTPUT nicht schreiben: %s", exc)
+            # Security (Clear-Text-Logging Drift, preflight closure):
+            # route the bound exception text through
+            # :func:`sanitize_log_arg` so a hostile ``GITHUB_OUTPUT``
+            # env value carrying any of the canonical CVE-2021-42574
+            # / log-injection / 8-bit-C1 / ANSI-ESC primitives cannot
+            # smuggle attack bytes into the workflow log captured by
+            # ``.github/workflows/update-cycle.yml``. The
+            # :class:`_PreflightSafeFormatter` on the root logger is
+            # the secondary defence layer; this call-site sanitiser
+            # is the primary one so a future maintainer who replaces
+            # the formatter cannot regress the contract silently.
+            LOGGER.warning(
+                "preflight: konnte $GITHUB_OUTPUT nicht schreiben: %s",
+                sanitize_log_arg(str(exc)),
+            )
     for line in lines:
         print(line)
 
@@ -255,7 +357,14 @@ def main(argv: list[str] | None = None) -> int:
         LOGGER.error("preflight: --margin muss >= 0 sein, war %d.", args.margin)
         return 2
 
-    logging.basicConfig(format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    # Security (Clear-Text-Logging Drift, preflight closure): replace
+    # the pre-fix ``logging.basicConfig(...)`` call (which installed
+    # a default :class:`logging.Formatter` that does NOT sanitise the
+    # rendered record) with the inline :class:`_PreflightSafeFormatter`
+    # shim. Mirrors :func:`src.feed.logging_safe.setup_script_logging`
+    # but stays stdlib-only so the preflight's "no non-stdlib runtime
+    # deps" invariant is preserved.
+    _configure_safe_logging(logging.INFO)
     LOGGER.setLevel(logging.INFO)
 
     if args.check == "vor":

--- a/tests/test_sentinel_preflight_basicconfig_drift.py
+++ b/tests/test_sentinel_preflight_basicconfig_drift.py
@@ -1,0 +1,423 @@
+"""Sentinel PoC: ``scripts/preflight_quota_check.py`` — Clear-Text-Logging
+Drift via ``logging.basicConfig`` instead of the canonical ``SafeFormatter``
+shim.
+
+Threat model
+------------
+
+``scripts/preflight_quota_check.py`` runs as the budget-gating preflight
+of ``.github/workflows/update-cycle.yml`` (every ~30 min cron tick)::
+
+    - name: Preflight VOR quota
+      run: python scripts/preflight_quota_check.py --check vor --margin 2
+
+Every other script in ``scripts/`` migrated to
+``src.feed.logging_safe.setup_script_logging`` (Round 1 of the
+Clear-Text-Logging Drift family) which installs a :class:`SafeFormatter`
+that sanitises every log message before it is written. The pre-flight
+deliberately could NOT pull that helper in because
+``src.feed.logging_safe`` transitively imports
+``src.feed.config`` -> ``src.utils.http`` -> ``requests``/``urllib3``/
+``dns.resolver`` (all third-party), and the script's docstring pins
+the invariant "zero non-stdlib runtime dependencies so it works in
+the early Actions step ... before ``install-deps`` has run."
+
+The pre-fix shape::
+
+    logging.basicConfig(format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+installs a default :class:`logging.Formatter` that does NOT sanitise.
+
+Attack surface
+~~~~~~~~~~~~~~
+
+The ``_emit_outputs`` helper writes the GitHub-Actions output file at
+the path declared by ``$GITHUB_OUTPUT``. When the open() fails (the
+file is missing, has restrictive permissions, or — in the threat
+model — the env var carries non-canonical bytes that the OS rejects),
+an :class:`OSError` is raised whose ``__str__`` echoes the path bytes
+back into a WARNING log line::
+
+    LOGGER.warning("preflight: konnte $GITHUB_OUTPUT nicht schreiben: %s", exc)
+
+A poisoned ``GITHUB_OUTPUT`` value (compromised CI runner, hostile
+third-party Action that pollutes the env, leaked secret store with
+non-ASCII bytes, BiDi-carrying repository name on a fork build)
+carrying any of the canonical CVE-2021-42574 / log-injection /
+8-bit-C1 / Tag-block / Variation-Selector / ANSI-ESC / log-forgery
+primitives flows verbatim into the workflow stdout/stderr captured
+by ``update-cycle.yml`` (visible in the GitHub Actions UI, ingested
+by any downstream SIEM forwarder that scrapes the run log) and into
+any ``LogRecord`` consumer that reads ``record.args``.
+
+Severity
+~~~~~~~~
+
+MEDIUM — log-injection / Trojan-Source primitive smuggling into the
+operator-facing cron-pipeline log. Same family that the existing
+``test_sentinel_clear_text_logging_drift_utils.py`` tests pin for
+``src/utils/cache.py``, ``src/utils/locking.py``, ``src/utils/http.py``
+and ``src/build_feed.py``. No credential leak; no remote code
+execution; but the operator log is the canonical incident-response
+surface and any control-byte smuggling there blinds the IR
+playbook.
+
+Fix shape
+---------
+
+1. **Inline ``_PreflightSafeFormatter``** that mirrors
+   :class:`src.feed.logging_safe.SafeFormatter` byte-for-byte, but
+   defined inside the preflight script so the "stdlib-only" invariant
+   is preserved (``src.utils.logging.sanitize_log_message`` is itself
+   stdlib-only — imports just ``re`` and ``typing``).
+2. **``_configure_safe_logging()``** installs the inline formatter on
+   the root logger's :class:`StreamHandler`, replacing the historical
+   ``logging.basicConfig(format=...)`` call.
+3. **Call-site sanitisation** at the ``_emit_outputs`` ``OSError``
+   warning — route the bound ``exc`` through
+   :func:`src.utils.logging.sanitize_log_arg` so the log line is
+   sanitised even if a future maintainer accidentally regresses the
+   formatter-layer defence.
+
+Closing-checklist invariant
+---------------------------
+
+The inventory test ``test_no_basicconfig_in_scripts`` walks every
+``*.py`` in ``scripts/`` and asserts that ``logging.basicConfig`` does
+NOT appear outside comments / docstrings. After this fix the preflight
+is the last remaining ``basicConfig`` caller in ``scripts/`` — once
+migrated, the grep is clean.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _scripts_path_bootstrap() -> None:
+    """Ensure ``scripts/`` is importable. The script's own ``sys.path``
+    manipulation runs at script invocation, not at import."""
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+
+
+# Canonical attack payload exercising the four classes of control-text
+# sneak-bys that :func:`sanitize_log_arg` / :func:`sanitize_log_message`
+# are documented to defeat. Mirrors ``ATTACK_BYTES`` in
+# ``tests/test_sentinel_clear_text_logging_drift_utils.py`` so the
+# invariant is uniform across the Clear-Text-Logging Drift family.
+ATTACK_BYTES = "\x1b[31mEVIL\x1b[0m\r\nINJECTED-LOG-LINE‮RTL-OVERRIDE​ZWS"
+
+# Substrings that must NOT appear in the captured log MESSAGE, individually,
+# so a partially-applied fix still fails the test. Note: bare ``\n`` / ``\r``
+# are NOT in this set because :class:`logging.StreamHandler` appends a record
+# terminator after the formatted message — checking for them would yield a
+# false positive on every log line. The log-forging primitive that matters
+# is the EMBEDDED ``\r\n`` pair inside the rendered message; ``sanitize_
+# log_message`` escapes it to literal ``\\r\\n`` so the assertion below
+# catches a regression deterministically.
+FORBIDDEN_FRAGMENTS = (
+    "\x1b[",      # ANSI CSI introducer
+    "\r\n",       # Embedded CR+LF log-forging primitive
+    "‮",     # BiDi RIGHT-TO-LEFT OVERRIDE
+    "​",     # Zero-width space
+)
+
+
+def _assert_no_attack_bytes(text: str, *, where: str) -> None:
+    """Assert *text* does not carry any of the canonical attack fragments.
+
+    Strips the trailing record terminator (``\\n`` / ``\\r\\n``) before
+    scanning so a natural :class:`logging.StreamHandler` line break is
+    not flagged as a log-injection primitive.
+    """
+    scrub = text.rstrip("\r\n")
+    for fragment in FORBIDDEN_FRAGMENTS:
+        assert fragment not in scrub, (
+            f"clear-text-logging drift: attack fragment {fragment!r} "
+            f"survived sanitisation in {where}.\nCaptured: {text!r}"
+        )
+
+
+# ============================================================================
+# Layer 1 — unit-level PoC against the ``_emit_outputs`` OSError log site.
+# ============================================================================
+
+
+def test_emit_outputs_oserror_sanitises_logged_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A hostile ``OSError`` carrying control bytes raised by
+    ``open(GITHUB_OUTPUT, "a")`` must not flow raw into the WARNING
+    log line emitted by ``_emit_outputs``.
+
+    Threat model: ``GITHUB_OUTPUT`` is normally set by the GH Actions
+    runner to a well-known tmp path, but a compromised CI runner / a
+    hostile third-party Action / a leaked / mistyped env can plant a
+    path carrying any of the canonical CVE-2021-42574 / log-injection
+    / 8-bit-C1 / ANSI-ESC / log-forgery primitive bytes. The pre-fix
+    shape interpolates the raw OSError text into ``%s``, leaking the
+    attack bytes verbatim into the cron-pipeline log captured by
+    ``.github/workflows/update-cycle.yml``.
+    """
+    from scripts import preflight_quota_check
+
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "out.txt"))
+
+    class HostileOSError(OSError):
+        def __init__(self, msg: str) -> None:
+            super().__init__(msg)
+            self._msg = msg
+
+        def __str__(self) -> str:
+            return self._msg
+
+    import builtins
+    real_open = builtins.open
+
+    def fake_open(target: Any, *args: Any, **kwargs: Any) -> Any:
+        if isinstance(target, str) and target.endswith("out.txt"):
+            raise HostileOSError(ATTACK_BYTES)
+        return real_open(target, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+
+    caplog.set_level(logging.WARNING, logger="preflight_quota_check")
+    preflight_quota_check._emit_outputs(True, 7, 100, "vor")
+
+    _assert_no_attack_bytes(
+        caplog.text, where="_emit_outputs OSError warning log"
+    )
+
+
+def test_emit_outputs_oserror_via_formatter_sanitises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defense-in-depth: the *formatter* installed by
+    ``_configure_safe_logging`` must itself sanitise the rendered log
+    record so a future maintainer who accidentally drops the
+    call-site ``sanitize_log_arg`` cannot regress.
+
+    Verifies the install-then-render path end-to-end: install the
+    preflight's SafeFormatter on a fresh :class:`StreamHandler`,
+    capture its output to an in-memory buffer, and assert the attack
+    bytes do not survive the formatter.
+    """
+    from scripts import preflight_quota_check
+
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "out.txt"))
+
+    # Capture formatter output to an in-memory stream.
+    buffer = io.StringIO()
+    handler = logging.StreamHandler(buffer)
+    # The preflight ships a stdlib-only SafeFormatter; the fix MUST
+    # expose the installer so this test can assert it round-trips
+    # the attack bytes through the formatter sink.
+    handler.setFormatter(preflight_quota_check._build_safe_formatter())
+
+    logger = logging.getLogger("preflight_quota_check.test_isolation")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.WARNING)
+
+    try:
+        logger.warning(
+            "preflight: konnte $GITHUB_OUTPUT nicht schreiben: %s", ATTACK_BYTES
+        )
+    finally:
+        handler.close()
+
+    rendered = buffer.getvalue()
+    _assert_no_attack_bytes(
+        rendered, where="_PreflightSafeFormatter rendered output"
+    )
+
+
+# ============================================================================
+# Layer 2 — structural invariants on the preflight module.
+# ============================================================================
+
+
+def test_build_safe_formatter_returns_log_formatter() -> None:
+    """The inline SafeFormatter factory must return a
+    :class:`logging.Formatter` instance — the contract every handler
+    expects."""
+    from scripts import preflight_quota_check
+
+    fmt = preflight_quota_check._build_safe_formatter()
+    assert isinstance(fmt, logging.Formatter)
+
+
+def test_configure_safe_logging_installs_safe_formatter() -> None:
+    """Calling ``_configure_safe_logging`` once must install a handler
+    whose formatter sanitises log records. Subsequent calls must be
+    idempotent (no duplicate handlers)."""
+    from scripts import preflight_quota_check
+
+    root = logging.getLogger()
+    pre_handlers = list(root.handlers)
+    try:
+        preflight_quota_check._configure_safe_logging(logging.INFO)
+        first_count = len(root.handlers)
+        preflight_quota_check._configure_safe_logging(logging.INFO)
+        second_count = len(root.handlers)
+        assert second_count == first_count, (
+            "_configure_safe_logging must be idempotent — "
+            f"first={first_count}, second={second_count}"
+        )
+        # Every handler newly added must use a sanitising formatter.
+        new_handlers = [h for h in root.handlers if h not in pre_handlers]
+        assert new_handlers, "_configure_safe_logging did not install a handler"
+        for handler in new_handlers:
+            fmt = handler.formatter
+            assert fmt is not None, "Handler installed without a formatter"
+            # Round-trip ATTACK_BYTES through the formatter to verify
+            # it sanitises.
+            record = logging.LogRecord(
+                name="preflight_quota_check",
+                level=logging.WARNING,
+                pathname=__file__,
+                lineno=0,
+                msg="%s",
+                args=(ATTACK_BYTES,),
+                exc_info=None,
+            )
+            rendered = fmt.format(record)
+            _assert_no_attack_bytes(
+                rendered, where="_configure_safe_logging handler formatter"
+            )
+    finally:
+        # Restore root handlers so we don't pollute later tests.
+        root.handlers = pre_handlers
+
+
+# ============================================================================
+# Layer 3 — closing-checklist invariant: no remaining ``logging.basicConfig``
+# in ``scripts/``. Pins the post-fix contract auto-discoverably.
+# ============================================================================
+
+
+_BASICCONFIG_RE = re.compile(r"\blogging\.basicConfig\b")
+# Strip Python comments (``# ...`` to end-of-line) AND triple-quoted
+# string blocks before scanning so the inventory test ignores docstring
+# references to ``logging.basicConfig`` (e.g. the
+# ``src/feed/logging_safe.py`` docstring that documents what it
+# replaces).
+_TRIPLE_QUOTED_RE = re.compile(r'"""(?:.|\n)*?"""|\'\'\'(?:.|\n)*?\'\'\'')
+_LINE_COMMENT_RE = re.compile(r"#[^\n]*")
+
+
+def _strip_comments_and_docstrings(source: str) -> str:
+    no_docs = _TRIPLE_QUOTED_RE.sub("", source)
+    return _LINE_COMMENT_RE.sub("", no_docs)
+
+
+def test_no_basicconfig_in_scripts() -> None:
+    """Auto-discoverable invariant: walk every ``*.py`` in
+    ``scripts/`` and assert that ``logging.basicConfig`` does NOT
+    appear outside comments / docstrings.
+
+    Every script must route through :func:`setup_script_logging` (or
+    the stdlib-only :func:`_configure_safe_logging` shim in the
+    preflight) so the SafeFormatter is installed uniformly. The pre-
+    flight is the LAST remaining ``basicConfig`` site closed by this
+    PR — once migrated, the grep stays clean."""
+    scripts_dir = REPO_ROOT / "scripts"
+    offenders: list[str] = []
+    for path in sorted(scripts_dir.glob("*.py")):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:  # pragma: no cover - defensive
+            continue
+        scrubbed = _strip_comments_and_docstrings(source)
+        if _BASICCONFIG_RE.search(scrubbed):
+            offenders.append(path.name)
+    assert not offenders, (
+        "Clear-Text-Logging Drift: ``logging.basicConfig`` still present "
+        f"in scripts/ outside comments/docstrings: {offenders}. "
+        "Migrate to ``setup_script_logging`` (or, when third-party deps "
+        "are forbidden, the stdlib-only ``_configure_safe_logging`` "
+        "shim used by ``scripts/preflight_quota_check.py``)."
+    )
+
+
+# ============================================================================
+# Layer 4 — end-to-end PoC: hostile env-var path lands in WARNING log line.
+# ============================================================================
+
+
+def test_main_emit_outputs_path_with_attack_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Integration: invoke ``main(["--check", "vor", "--margin", "0"])``
+    with ``GITHUB_OUTPUT`` set to a path that the OS rejects (NUL
+    byte) and assert no attack fragment survives in the log.
+
+    The state file is missing, so the preflight projects a count of
+    margin=0 against the 100/day cap, the quota is OK, and
+    ``_emit_outputs`` is invoked with the poisoned path.
+    """
+    from scripts import preflight_quota_check
+
+    monkeypatch.setenv("VAO_DAILY_COUNT_FILE", str(tmp_path / "vor.json"))
+    monkeypatch.setattr(
+        preflight_quota_check, "VOR_QUOTA_FILE", tmp_path / "vor.json"
+    )
+
+    # Plant a "/proc/<garbage>" style path that the OS will reject
+    # with OSError on open(). The :class:`OSError` ``__str__`` echoes
+    # the path back via its ``.filename`` attribute — which is how
+    # the canonical Errno message ``[Errno N] <strerror>: <path>``
+    # builds. Path bytes carrying BiDi / ANSI / zero-width primitives
+    # land in the OSError text verbatim.
+    #
+    # The env path itself must be syntactically representable in
+    # ``os.environ`` (no NUL bytes); pytest's ``monkeypatch.setenv``
+    # rejects NUL via :class:`ValueError`. We instead exercise the
+    # log-injection surface via the synthetic ``HostileOSError``
+    # below — the same shape the upstream unit-level PoC above
+    # exercises but routed through the full ``main()`` entry point.
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "out.txt"))
+
+    import builtins
+    real_open = builtins.open
+
+    class _HostileOSError(OSError):
+        def __init__(self, msg: str) -> None:
+            super().__init__(msg)
+            self._msg = msg
+
+        def __str__(self) -> str:
+            return self._msg
+
+    def fake_open(target: Any, *args: Any, **kwargs: Any) -> Any:
+        if isinstance(target, str) and target.endswith("out.txt"):
+            raise _HostileOSError(ATTACK_BYTES)
+        return real_open(target, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+
+    caplog.set_level(logging.WARNING, logger="preflight_quota_check")
+    rc = preflight_quota_check.main(["--check", "vor", "--margin", "0"])
+    # quota OK (0 + 0 <= 100); exit 0 regardless of output-write failure.
+    assert rc == 0
+
+    _assert_no_attack_bytes(
+        caplog.text, where="main() OSError WARNING log"
+    )


### PR DESCRIPTION
## Summary

`scripts/preflight_quota_check.py` was the **last** caller in `scripts/`
still using `logging.basicConfig(format=...)` — every other script
migrated to `setup_script_logging` (Round 1 of the Clear-Text-Logging
Drift family). `basicConfig` installs a default `logging.Formatter`
that does **NOT** sanitise the rendered record, so a `%s`-interpolated
attacker-controlled value flows verbatim into the workflow log
captured by `.github/workflows/update-cycle.yml`.

The deferred migration was deliberate: `setup_script_logging`
transitively imports `requests` / `urllib3` / `dns.resolver`, and the
preflight runs in `update-cycle.yml` **before** `install-deps` has run
(docstring invariant: "zero non-stdlib runtime dependencies").

### Attack surface

`_emit_outputs` writes the GitHub-Actions output file at the path
declared by `$GITHUB_OUTPUT`. When `open()` fails an `OSError`
is raised whose `__str__` echoes the path bytes back into a WARNING:

```python
LOGGER.warning("preflight: konnte $GITHUB_OUTPUT nicht schreiben: %s", exc)
```

A poisoned `GITHUB_OUTPUT` value (compromised CI runner, hostile
third-party Action, leaked env) carrying CVE-2021-42574 / log-injection
/ 8-bit-C1 / ANSI-ESC / log-forgery primitives lands verbatim in the
cron-pipeline log.

### Fix shape (defense-in-depth)

1. **Inline `_PreflightSafeFormatter`** mirroring
   `src.feed.logging_safe.SafeFormatter` byte-for-byte — stdlib-only
   (`src.utils.logging.sanitize_log_message` imports just `re` + `typing`)
   so the preflight's "no non-stdlib deps before `install-deps`"
   invariant is preserved.
2. **`_configure_safe_logging()`** idempotent installer replacing
   `logging.basicConfig(...)`.
3. **Call-site `sanitize_log_arg(str(exc))`** at the `_emit_outputs`
   OSError warning — primary defence so a future maintainer can't
   regress the contract by replacing the formatter.
4. **Closing-checklist invariant** (`test_no_basicconfig_in_scripts`)
   walks every `scripts/*.py` and asserts no remaining
   `logging.basicConfig` outside comments / docstrings.

### Severity

MEDIUM — log-injection / Trojan-Source primitive smuggling into the
operator-facing cron-pipeline log. Same family closed by the existing
`test_sentinel_clear_text_logging_drift_utils.py` invariants for
`src/utils/{cache,locking,http}.py` and `src/build_feed.py`.

## Test plan

- [x] PoC: pre-fix the 6 new tests fail (attack bytes survive into
      `caplog.text` verbatim).
- [x] PoC: post-fix all 6 tests pass.
- [x] Full pytest suite: 4397 passed, 2 skipped (no regressions).
- [x] Ruff: clean.
- [x] Mypy (1.10, CI version): clean.
- [x] Bandit: clean.
- [x] Secret scanner: clean.
- [x] C901 complexity gate: clean.
- [x] pip-audit: clean.

## Files changed

- `scripts/preflight_quota_check.py` — inline `_PreflightSafeFormatter`
  + `_configure_safe_logging()` + call-site `sanitize_log_arg`.
- `tests/test_sentinel_preflight_basicconfig_drift.py` — 6 new PoC
  tests (unit, formatter, structural, end-to-end, inventory).
- `.jules/sentinel.md` — journal entry documenting the Round-1
  deferred-sibling closure pattern.

https://claude.ai/code/session_014FaBLTtXsNNW2fPCGWmnTT

---
_Generated by [Claude Code](https://claude.ai/code/session_014FaBLTtXsNNW2fPCGWmnTT)_