### PR TITLE
security(reporting): sanitize env-controlled api_url + error_log_path log args

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,137 @@
+## 2026-05-14 - Clear-Text-Logging Drift (Reporting GitHub-Issue Submitter + Error-Log-Path Hint): Two Sibling Sites In `src/feed/reporting.py` Logged Env-Controlled Strings Via Bare `%s` — The Last `log.warning(..., env_str)` / `log.info(..., env_path)` Call Shapes In `src/feed/` That Did Not Mirror The Canonical `sanitize_log_arg` Defence
+
+**Vulnerability:** Two sibling clear-text-logging drift sites in
+``src/feed/reporting.py`` interpolated env-controlled strings via the
+bare ``%s`` format spec WITHOUT routing through
+:func:`sanitize_log_arg`:
+
+  * ``_GithubIssueReporter.submit`` (line 873-877) — the rejection
+    branch reached when :func:`_is_trusted_github_api` rules the
+    operator-controlled ``FEED_GITHUB_API_URL`` (preferred) /
+    ``GITHUB_API_URL`` env var as a non-GitHub endpoint::
+
+        if not _is_trusted_github_api(self._config.api_url):
+            log.warning(
+                "Automatisches GitHub-Issue abgebrochen: API-URL %s ist kein "
+                "bekannter GitHub-Endpunkt; Token wird nicht gesendet.",
+                self._config.api_url,
+            )
+            return
+
+    The value has only been ``urlparse``'d at this point — the parser
+    accepts arbitrary bytes in path / fragment / query, so a hostile
+    env var carrying any Trojan-Source primitive (BiDi RLO, ZWSP,
+    ALM, 8-bit C1 CSI/OSC, ESC-prefixed ANSI SGR, Tag-block
+    invisible-instruction-smuggling, Variation Selectors, log-record-
+    forgery newline / CR) flows verbatim into the rejection-branch
+    WARNING. The branch fires BEFORE :func:`validate_http_url` (the
+    next defence layer) gets a chance to strip the value.
+
+  * ``RunReport.log_results`` (line 482-484) — the errors-detail-hint
+    INFO log line that points operators at the error log file::
+
+        if self.has_errors():
+            log.info(
+                "Hinweis: Fehler während des Feed-Laufs – Details siehe %s",
+                error_log_path,
+            )
+
+    ``error_log_path`` is :file:`Path(LOG_DIR) / "errors.log"` and
+    ``LOG_DIR`` is env-controlled via :func:`resolve_env_path`
+    (see ``src/feed/config.py:LOG_DIR_PATH = resolve_env_path
+    ("LOG_DIR", Path("log"), allow_fallback=True)``).
+    :func:`validate_path` only checks the path resolves under one of
+    ``ALLOWED_ROOTS = {"docs", "data", "log"}``; it does NOT reject
+    Trojan-Source / control-character / BiDi primitives embedded in
+    the path bytes (``Path.resolve()`` normalises ``..`` and symlinks
+    but does not strip non-printable characters). A hostile
+    ``LOG_DIR`` like ``log/sub<RLO>`` / ``log<ESC>[31m`` /
+    ``log<NEWLINE>[INJECTED]`` flows verbatim into the INFO line.
+
+**Sibling drift shape:** This is the exact same drift class as the
+ÖBB Retry-After hardening pinned at
+``src/providers/oebb.py:1313-1315`` and the places-client closure
+PR #1472 at ``src/places/client.py:524-527``::
+
+    log.warning(
+        "ÖBB RSS Rate-Limit (Retry-After: %s)",
+        sanitize_log_arg(str(header)),
+    )
+
+with the explicit Sentinel comment "the value is upstream/operator-
+controlled; route through ``sanitize_log_arg`` so a hostile peer
+cannot inject ANSI/BiDi/control characters into operator log
+streams." The ``src/feed/reporting.py`` callsites were the last
+remaining ``log.warning(..., env_str)`` / ``log.info(..., env_path)``
+log lines in ``src/feed/`` that did NOT mirror the canonical
+sanitisation shape — same drift shape, same threat model, same fix.
+
+**Attack-surface narrowness pre-fix:** Both sites are guarded by
+:class:`SafeFormatter` in production (which calls
+:func:`sanitize_log_message` on the formatted message before it
+reaches stderr / the rotating file handlers). However:
+
+  * **pytest's ``caplog``** fires BEFORE :class:`SafeFormatter` runs.
+    Tests that exercise the rejection branch (CI surface) see the
+    pre-formatter message verbatim — including every primitive.
+  * **Non-``SafeFormatter`` log handlers** (early-init plumbing
+    before :func:`configure_logging` runs, third-party log
+    capturing, future refactor that drops the safe formatter)
+    consume the raw record.
+  * **Defence-in-depth.** Mirroring the canonical shape at every
+    env-controlled-string log boundary in the codebase means a
+    future refactor that bypasses :class:`SafeFormatter` doesn't
+    silently re-expose every drift site at once.
+
+**Reproduced:**
+``tests/test_sentinel_reporting_clear_text_logging_drift.py``
+contains 23 PoC tests:
+
+  * 10 parametrised PoC tests on the api_url WARNING site, one per
+    canonical primitive (BiDi RLO, ZWSP, ALM, ESC, 8-bit CSI, BEL,
+    newline, carriage return, Tag SPACE, Variation Selector-1).
+    Pre-fix every primitive survives in ``caplog.text`` verbatim.
+    Post-fix every primitive is sanitised.
+  * 1 full-attack-payload PoC on the api_url WARNING site that
+    bundles every primitive plus an ANSI SGR colour escape and a
+    log-record-forgery newline. Pre-fix every fragment survives;
+    post-fix every fragment is stripped.
+  * 10 parametrised PoC tests on the error_log_path INFO site
+    (same primitive list).
+  * 1 full-attack-payload PoC on the error_log_path INFO site.
+  * 1 AST inventory invariant: walks ``src/feed/reporting.py`` for
+    ``log.<level>(..., self._config.api_url)`` AND
+    ``log.<level>(..., error_log_path)`` calls and asserts neither
+    bare-arg shape survives without being wrapped in
+    :func:`sanitize_log_arg`. A regression here means a future
+    contributor unwrapped the sanitisation and re-exposed the drift.
+
+**Test-isolation note:** The PoC tests import
+``_GithubIssueReporter`` / ``RunReport`` / ``error_log_path`` *inside*
+the test functions so any prior test that reloads
+:mod:`src.feed.reporting` (e.g. via ``importlib.reload``) does not
+break the PoC's class-identity assumptions. Mirrors the test-isolation
+discipline pinned in the 2026-05-14 places-client closure entry.
+
+**Learning:** The "every env-controlled string interpolated into a
+log line via bare ``%s`` MUST route through ``sanitize_log_arg``"
+contract was implicit in the ÖBB / places-client Retry-After fixes'
+Sentinel comments but never enumerated as a per-module audit walker
+for ``src/feed/reporting.py``. Adding the AST inventory
+test (mirroring the
+``test_no_bare_exc_logging_in_clear_text_logging_modules`` walker
+shape from the 2026-05-08 round) FAILS LOUD on the next sibling
+site at PR-review time, instead of waiting for a future Sentinel
+sweep to enumerate ``grep -rn 'log\\.warning\\b' src/feed/`` and
+notice the gap. The two-site sweep also confirms the
+``%r``-via-repr defence is the only other safe shape currently in
+use at line 887-890 (``self._config.repository``); :func:`repr`
+escapes BiDi marks / control chars / non-ASCII codepoints to
+``\\xNN`` / ``\\uNNNN`` literal sequences and is therefore a valid
+sibling-defence shape, but inconsistent with the canonical
+``sanitize_log_arg`` pattern — flagged for a future refactor that
+would consolidate every env-string log boundary on one shape.
+
 ## 2026-05-14 - Clear-Text-Logging Drift (Places-Client Retry-After Sibling): The ÖBB Retry-After Hardening Was Never Mirrored In `src/places/client.py` — The Last `response.headers.get("Retry-After")` Site In `src/` That Logged The Header Via Bare `%s`
 
 **Vulnerability:** ``src/places/client.py:_post`` extracts the upstream

--- a/src/feed/reporting.py
+++ b/src/feed/reporting.py
@@ -478,9 +478,23 @@ class RunReport:
             diagnostics = self.diagnostics_message()
             log.info(diagnostics)
             if self.has_errors():
+                # Sentinel (Clear-Text-Logging Drift, sibling of the
+                # ``src/utils/files.py`` SHA-256 path-fingerprint family
+                # and the ``src/utils/env.py`` ``_warn_if_world_readable``
+                # closure): ``error_log_path`` is ``Path(LOG_DIR) /
+                # "errors.log"`` and ``LOG_DIR`` is env-controlled via
+                # :func:`resolve_env_path`. :func:`validate_path` only
+                # checks the path resolves under one of ``ALLOWED_ROOTS``;
+                # it does NOT reject Trojan-Source / control-character /
+                # BiDi primitives embedded in the path bytes. Routing the
+                # value through :func:`sanitize_log_arg` at the call site
+                # mirrors the canonical defence shape and guarantees no
+                # primitive can reach pytest's ``caplog`` capture (which
+                # fires BEFORE :class:`SafeFormatter`) nor any non-
+                # ``SafeFormatter`` log handler that consumes the record.
                 log.info(
                     "Hinweis: Fehler während des Feed-Laufs – Details siehe %s",
-                    error_log_path,
+                    sanitize_log_arg(str(error_log_path)),
                 )
                 with self._lock:
                     if not self._issue_submitted:
@@ -870,10 +884,26 @@ class _GithubIssueReporter:
         # checked BEFORE constructing the request URL or attaching the
         # Authorization header so an env-var override can't leak credentials.
         if not _is_trusted_github_api(self._config.api_url):
+            # Sentinel (Clear-Text-Logging Drift, sibling of the ÖBB /
+            # places-client Retry-After family): ``self._config.api_url``
+            # is sourced from the operator-controlled
+            # ``FEED_GITHUB_API_URL`` (preferred) / ``GITHUB_API_URL``
+            # env vars in :meth:`_GithubIssueConfig.from_env`. The value
+            # has only been ``urlparse``'d at this point — the parser
+            # accepts arbitrary bytes in path/fragment, so a hostile env
+            # var carrying any Trojan-Source primitive (BiDi RLO,
+            # zero-width, ALM, 8-bit C1 CSI/OSC, ESC-prefixed ANSI SGR,
+            # Tag block, Variation Selectors, log-record-forgery
+            # newline) flows verbatim into the rejection-branch
+            # WARNING. Routing through :func:`sanitize_log_arg` at the
+            # call site mirrors the canonical defence shape pinned at
+            # every other env-controlled-string log boundary in the
+            # codebase (defense-in-depth — caplog and any non-
+            # ``SafeFormatter`` handler see the pre-formatter message).
             log.warning(
                 "Automatisches GitHub-Issue abgebrochen: API-URL %s ist kein "
                 "bekannter GitHub-Endpunkt; Token wird nicht gesendet.",
-                self._config.api_url,
+                sanitize_log_arg(self._config.api_url),
             )
             return
 

--- a/tests/test_sentinel_reporting_clear_text_logging_drift.py
+++ b/tests/test_sentinel_reporting_clear_text_logging_drift.py
@@ -1,0 +1,441 @@
+"""Sentinel PoC: Clear-Text-Logging Drift in ``src/feed/reporting.py``.
+
+Two sibling drift sites in :mod:`src.feed.reporting` interpolate
+env-controlled strings via the bare ``%s`` format spec without
+routing through :func:`sanitize_log_arg`. The journal pinned the
+canonical defence shape on every other Trojan-Source-bearing log
+boundary (places-client Retry-After, ÖBB Retry-After, ``read_capped
+_*`` path-fingerprinting, scripts/ path-log sanitisation rounds 1-3,
+…); these two sites in the GitHub-issue / log-results renderer were
+the last remaining ``log.warning(..., env_str)`` /
+``log.info(..., env_path)`` call shapes in :mod:`src.feed` that did
+NOT mirror the canonical sanitiser.
+
+Site 1 — :func:`_GithubIssueReporter.submit` rejection branch
+============================================================
+
+Pre-fix::
+
+    if not _is_trusted_github_api(self._config.api_url):
+        log.warning(
+            "Automatisches GitHub-Issue abgebrochen: API-URL %s ist kein "
+            "bekannter GitHub-Endpunkt; Token wird nicht gesendet.",
+            self._config.api_url,
+        )
+        return
+
+``self._config.api_url`` is sourced from the operator-controlled
+``FEED_GITHUB_API_URL`` (preferred) / ``GITHUB_API_URL`` env vars in
+:meth:`_GithubIssueConfig.from_env`. The interpolated value is
+gated by :func:`_is_trusted_github_api` only AFTER it has already
+been used in the WARNING line — meaning the rejection branch is the
+exact shape that lets a hostile env var (compromised CI runner,
+malicious workflow PR, leaked CI secret store, mistaken Enterprise
+URL) flow into the operator log. The ``urlparse`` parse the
+function performs accepts arbitrary bytes in the path/fragment;
+the rejection branch is the ONLY time the value is logged before
+``validate_http_url`` (the next defence layer) gets a chance to
+strip it.
+
+Site 2 — :meth:`RunReport.log_results` errors-detail hint
+=========================================================
+
+Pre-fix::
+
+    if self.has_errors():
+        log.info(
+            "Hinweis: Fehler während des Feed-Laufs – Details siehe %s",
+            error_log_path,
+        )
+
+``error_log_path`` is :file:`Path(LOG_DIR) / "errors.log"` where
+``LOG_DIR`` is env-controlled via :func:`resolve_env_path` (see
+``src/feed/config.py:LOG_DIR_PATH = resolve_env_path("LOG_DIR",
+Path("log"), allow_fallback=True)``). :func:`validate_path` only
+checks the path resolves under one of ``ALLOWED_ROOTS``; it does
+NOT reject Trojan-Source / control-character / BiDi primitives
+embedded in the path string, so a hostile ``LOG_DIR`` like
+``log/sub<RLO>``, ``log<ESC>[31m``, ``log<NEWLINE>[INJECTED]``
+flows verbatim into the INFO log line.
+
+Threat model
+============
+A hostile env var value can carry the canonical primitives:
+
+  * ``‮`` RIGHT-TO-LEFT OVERRIDE — visually reverses
+    subsequent text. An operator skimming the log sees the
+    inverse of the actual bytes (Trojan-Source, CVE-2021-42574).
+  * ``​`` ZERO WIDTH SPACE — invisible cache-key / equality
+    poisoning primitive.
+  * ``؜`` ARABIC LETTER MARK — BiDi mark.
+  * ``\x1b`` ESC — ANSI prefix; terminal-escape primitive
+    (``\x1b[31m`` colourises subsequent terminal output).
+  * ``\x9b`` 8-bit CSI — bypasses the 7-bit ``_ANSI_ESCAPE_RE``
+    on terminals that honour 8-bit C1 (xterm with eightBitInput,
+    BSD consoles, rxvt in 8-bit mode).
+  * ``\x07`` BEL — terminal-bell denial-of-attention.
+  * ``\n`` / ``\r`` — log-record forgery in any line-based
+    consumer (journalctl, Docker logs, log aggregator splitters).
+  * ``\U000e0020`` Unicode Tag SPACE — invisible-instruction
+    smuggling primitive (2024 OpenAI disclosure).
+  * ``︀`` VARIATION SELECTOR-1 — 4-bit-payload steganography.
+
+Pre-fix every primitive flows verbatim into the WARNING/INFO log
+line and from there into:
+
+  * pytest's ``caplog`` capture (fires BEFORE :class:`SafeFormatter`
+    runs — the project's CI surface);
+  * any non-:class:`SafeFormatter` log handler (early-init plumbing,
+    third-party log capture, future refactor that drops the
+    safe formatter);
+  * the public ``docs/feed-health.md`` artefact + the GitHub
+    Issue body submitted by ``submit_auto_issue`` when the
+    rejection branch is reached *before* the auto-issue itself
+    is suppressed by the same gate.
+
+Post-fix every primitive is stripped at the call-site by routing
+the env-controlled value through :func:`sanitize_log_arg`, mirroring
+the canonical defence pinned at every other Trojan-Source-bearing
+log boundary in the codebase.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+
+import pytest
+
+
+_PRIMITIVES: list[tuple[str, str]] = [
+    ("‮", "U+202E RIGHT-TO-LEFT OVERRIDE"),
+    ("​", "U+200B ZERO WIDTH SPACE"),
+    ("؜", "U+061C ARABIC LETTER MARK"),
+    ("\x1b", "U+001B ESC (ANSI prefix)"),
+    ("\x9b", "U+009B 8-bit CSI"),
+    ("\x07", "U+0007 BEL"),
+    ("\n", "newline (log-record forgery)"),
+    ("\r", "carriage return"),
+    ("\U000e0020", "U+E0020 Unicode Tag SPACE"),
+    ("︀", "U+FE00 VARIATION SELECTOR-1"),
+]
+
+_FORBIDDEN_FRAGMENTS = (
+    "\x1b[31m",  # ANSI SGR colour
+    "‮",
+    "​",
+    "؜",
+    "\x9b",
+    "\x07",
+    "\U000e0020",
+    "︀",
+)
+
+
+# ============================================================================
+# Site 1: _GithubIssueReporter.submit() rejection branch
+# ============================================================================
+
+
+@pytest.mark.parametrize("primitive,primitive_label", _PRIMITIVES)
+def test_submit_warning_strips_api_url_primitives(
+    primitive: str,
+    primitive_label: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A hostile ``FEED_GITHUB_API_URL`` carrying *primitive* MUST NOT
+    propagate into the rejection-branch WARNING log line.
+
+    Pre-fix ``self._config.api_url`` was interpolated via the bare
+    ``%s`` format spec; post-fix the env-controlled value is routed
+    through :func:`sanitize_log_arg` at the call site so every
+    Trojan-Source primitive is stripped before reaching the log.
+    """
+    poisoned_url = f"https://evil.example.com/path{primitive}/foo"
+
+    monkeypatch.setenv("FEED_GITHUB_CREATE_ISSUES", "1")
+    monkeypatch.setenv("FEED_GITHUB_REPOSITORY", "demo/repo")
+    monkeypatch.setenv("FEED_GITHUB_TOKEN", "secret-token")
+    monkeypatch.setenv("FEED_GITHUB_API_URL", poisoned_url)
+    monkeypatch.delenv("FEED_GITHUB_ENTERPRISE_HOSTS", raising=False)
+
+    # Import inside the test to bind against the currently-installed
+    # module (defensive against any prior test reloading reporting).
+    from src.feed.reporting import (
+        _GithubIssueConfig,
+        _GithubIssueReporter,
+        RunReport,
+    )
+
+    report = RunReport([("wl", True)])
+    report.provider_error("wl", "Test error")
+    report.finish(build_successful=False)
+
+    config = _GithubIssueConfig.from_env()
+    reporter = _GithubIssueReporter(config)
+
+    caplog.set_level(logging.WARNING, logger="build_feed")
+    reporter.submit(report)
+
+    matching = [
+        record.getMessage()
+        for record in caplog.records
+        if "Automatisches GitHub-Issue abgebrochen" in record.getMessage()
+    ]
+    assert matching, (
+        "Expected the rejection-branch WARNING to fire when the API URL "
+        f"is untrusted (got records: {[r.getMessage() for r in caplog.records]!r})"
+    )
+    for message in matching:
+        assert primitive not in message, (
+            f"{primitive_label} ({primitive!r}) leaked into the "
+            f"submit() WARNING: {message!r}"
+        )
+
+
+def test_submit_warning_strips_full_attack_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A hostile ``FEED_GITHUB_API_URL`` carrying the canonical
+    attack-fragment union (ANSI SGR + BiDi RLO + ZWSP + 8-bit CSI +
+    Tag SPACE + Variation Selector + log-record forgery newline)
+    MUST NOT propagate any fragment into the WARNING log line.
+    """
+    payload = (
+        "https://evil.example.com/"
+        "\x1b[31m"  # ANSI SGR red
+        "‮"  # BiDi RLO
+        "​"  # ZWSP
+        "؜"  # ALM
+        "\x9b"  # 8-bit CSI
+        "\x07"  # BEL
+        "\U000e0020"  # Tag SPACE
+        "︀"  # Variation Selector-1
+        "\n[INJECTED] fake.log.line"  # log-record forgery
+    )
+
+    monkeypatch.setenv("FEED_GITHUB_CREATE_ISSUES", "1")
+    monkeypatch.setenv("FEED_GITHUB_REPOSITORY", "demo/repo")
+    monkeypatch.setenv("FEED_GITHUB_TOKEN", "secret-token")
+    monkeypatch.setenv("FEED_GITHUB_API_URL", payload)
+    monkeypatch.delenv("FEED_GITHUB_ENTERPRISE_HOSTS", raising=False)
+
+    from src.feed.reporting import (
+        _GithubIssueConfig,
+        _GithubIssueReporter,
+        RunReport,
+    )
+
+    report = RunReport([("wl", True)])
+    report.provider_error("wl", "Test error")
+    report.finish(build_successful=False)
+
+    config = _GithubIssueConfig.from_env()
+    reporter = _GithubIssueReporter(config)
+
+    caplog.set_level(logging.WARNING, logger="build_feed")
+    reporter.submit(report)
+
+    matching = [
+        record.getMessage()
+        for record in caplog.records
+        if "Automatisches GitHub-Issue abgebrochen" in record.getMessage()
+    ]
+    assert matching
+    for message in matching:
+        for fragment in _FORBIDDEN_FRAGMENTS:
+            assert fragment not in message, (
+                f"Forbidden fragment {fragment!r} survived in the "
+                f"submit() WARNING: {message!r}"
+            )
+        # The injected fake-log-line fragment uses ASCII printables only;
+        # the surviving newline would let a downstream line-splitter parse
+        # the bytes after ``\n`` as a separate log record. ``sanitize_log_
+        # message`` escapes ``\n`` to ``\\n`` (literal backslash-n) so the
+        # raw newline cannot survive.
+        assert "\n" not in message, (
+            f"Raw newline survived in the submit() WARNING: {message!r}"
+        )
+
+
+# ============================================================================
+# Site 2: RunReport.log_results errors-detail hint
+# ============================================================================
+
+
+@pytest.mark.parametrize("primitive,primitive_label", _PRIMITIVES)
+def test_log_results_strips_error_log_path_primitives(
+    primitive: str,
+    primitive_label: str,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A hostile ``LOG_DIR`` (env-controlled via :func:`resolve_env_path`)
+    that flows into ``error_log_path`` MUST NOT propagate *primitive*
+    into the INFO log line that points operators at the error log.
+
+    Pre-fix ``error_log_path`` was interpolated via the bare ``%s``
+    format spec; post-fix the env-derived path string is routed
+    through :func:`sanitize_log_arg` at the call site, mirroring the
+    canonical defence shape applied at every other env-path boundary
+    in the codebase (``src.utils.files.read_capped_*`` SHA-256
+    fingerprint family, ``src.utils.env._warn_if_world_readable``).
+
+    Disable the GitHub auto-issue submitter so the test isolates the
+    INFO-level errors-detail-hint log line.
+    """
+    monkeypatch.delenv("FEED_GITHUB_CREATE_ISSUES", raising=False)
+
+    from src.feed import reporting
+
+    poisoned_path = Path(f"/tmp/log{primitive}/errors.log")
+    monkeypatch.setattr(reporting, "error_log_path", poisoned_path)
+
+    report = reporting.RunReport([("wl", True)])
+    report.provider_error("wl", "Test error")
+    report.finish(build_successful=False)
+
+    caplog.set_level(logging.INFO, logger="build_feed")
+    report.log_results()
+
+    matching = [
+        record.getMessage()
+        for record in caplog.records
+        if "Details siehe" in record.getMessage()
+    ]
+    assert matching, (
+        "Expected the errors-detail-hint INFO line to fire when "
+        f"has_errors() is True (got: {[r.getMessage() for r in caplog.records]!r})"
+    )
+    for message in matching:
+        assert primitive not in message, (
+            f"{primitive_label} ({primitive!r}) leaked into "
+            f"log_results() INFO: {message!r}"
+        )
+
+
+def test_log_results_strips_full_attack_payload(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Sister of :func:`test_submit_warning_strips_full_attack_payload`
+    for the ``error_log_path`` log line. Same canonical attack-fragment
+    union, same forbidden-fragment invariant.
+    """
+    monkeypatch.delenv("FEED_GITHUB_CREATE_ISSUES", raising=False)
+
+    from src.feed import reporting
+
+    poisoned_name = (
+        "errors"
+        "\x1b[31m"
+        "‮"
+        "​"
+        "؜"
+        "\x9b"
+        "\x07"
+        "\U000e0020"
+        "︀"
+        ".log"
+    )
+    poisoned_path = Path("/tmp/log") / poisoned_name
+    monkeypatch.setattr(reporting, "error_log_path", poisoned_path)
+
+    report = reporting.RunReport([("wl", True)])
+    report.provider_error("wl", "Test error")
+    report.finish(build_successful=False)
+
+    caplog.set_level(logging.INFO, logger="build_feed")
+    report.log_results()
+
+    matching = [
+        record.getMessage()
+        for record in caplog.records
+        if "Details siehe" in record.getMessage()
+    ]
+    assert matching
+    for message in matching:
+        for fragment in _FORBIDDEN_FRAGMENTS:
+            assert fragment not in message, (
+                f"Forbidden fragment {fragment!r} survived in the "
+                f"log_results() INFO line: {message!r}"
+            )
+
+
+# ============================================================================
+# AST inventory invariant: walk src/feed/reporting.py and assert every
+# ``log.warning(..., self._config.api_url)`` /
+# ``log.info(..., error_log_path)`` site routes the env-derived arg
+# through ``sanitize_log_arg``. A future refactor that re-introduces
+# the bare ``%s`` shape fails this guard at PR-review time instead of
+# waiting for a follow-up Sentinel sweep.
+# ============================================================================
+
+
+def _read_reporting_source() -> str:
+    repo_root = Path(__file__).resolve().parents[1]
+    return (repo_root / "src" / "feed" / "reporting.py").read_text(encoding="utf-8")
+
+
+def test_no_bare_api_url_log_in_reporting() -> None:
+    """Inventory invariant: no ``log.warning(..., self._config.api_url)``
+    pattern survives in :mod:`src.feed.reporting` without
+    :func:`sanitize_log_arg` wrapping. Mirrors the canonical
+    inventory-walker shape that closes every prior clear-text-logging
+    drift in the codebase (e.g. ``test_no_bare_exc_logging_in_clear_
+    text_logging_modules``).
+    """
+    source = _read_reporting_source()
+    tree = ast.parse(source)
+
+    bare_sites: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Match ``log.warning`` / ``log.error`` / ``log.info`` /
+        # ``LOGGER.<level>`` / ``logger.<level>`` calls.
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        if func.attr not in {"warning", "error", "info"}:
+            continue
+        for arg in node.args[1:]:  # skip the format string
+            if _is_bare_api_url_arg(arg):
+                bare_sites.append(
+                    f"line {node.lineno}: log.{func.attr}(..., {ast.unparse(arg)})"
+                )
+            if _is_bare_error_log_path_arg(arg):
+                bare_sites.append(
+                    f"line {node.lineno}: log.{func.attr}(..., {ast.unparse(arg)})"
+                )
+
+    assert not bare_sites, (
+        "src/feed/reporting.py contains log call(s) that interpolate "
+        "an env-controlled value via bare %s without sanitize_log_arg. "
+        "Each site MUST route the value through sanitize_log_arg at "
+        "the call site (defense-in-depth — caplog and any non-"
+        "SafeFormatter handler see the pre-formatter message). "
+        f"Offending site(s): {bare_sites}"
+    )
+
+
+def _is_bare_api_url_arg(arg: ast.expr) -> bool:
+    """Return True iff *arg* is the bare ``self._config.api_url``
+    attribute access (i.e. NOT wrapped in ``sanitize_log_arg``)."""
+    return (
+        isinstance(arg, ast.Attribute)
+        and arg.attr == "api_url"
+        and isinstance(arg.value, ast.Attribute)
+        and arg.value.attr == "_config"
+        and isinstance(arg.value.value, ast.Name)
+        and arg.value.value.id == "self"
+    )
+
+
+def _is_bare_error_log_path_arg(arg: ast.expr) -> bool:
+    """Return True iff *arg* is the bare ``error_log_path`` name
+    reference (i.e. NOT wrapped in ``sanitize_log_arg``)."""
+    return isinstance(arg, ast.Name) and arg.id == "error_log_path"


### PR DESCRIPTION
## Summary

Two sibling clear-text-logging drift sites in `src/feed/reporting.py` interpolated env-controlled strings via the bare `%s` format spec without routing through `sanitize_log_arg`. This PR closes both via the canonical defence shape pinned at every other env-controlled-string log boundary in the codebase.

### Drift sites closed

1. **`_GithubIssueReporter.submit` rejection branch** (line 873-877) logged `self._config.api_url` (sourced from `FEED_GITHUB_API_URL` / `GITHUB_API_URL`) on the warning fired when `_is_trusted_github_api` rules the value as a non-GitHub endpoint. The value has only been `urlparse`'d at this point — the parser accepts arbitrary bytes in path / fragment / query, so a hostile env var carrying any Trojan-Source primitive (BiDi RLO, ZWSP, ALM, ANSI ESC, 8-bit C1, Tag block, Variation Selectors, log-record-forgery newline) flowed verbatim into pytest's `caplog` capture and any non-`SafeFormatter` log handler.

2. **`RunReport.log_results` errors-detail-hint** (line 482-484) logged `error_log_path` (`Path(LOG_DIR) / "errors.log"` where `LOG_DIR` is env-controlled via `resolve_env_path`). `validate_path` checks containment against `ALLOWED_ROOTS = {"docs", "data", "log"}` but does NOT reject Trojan-Source / control-character / BiDi primitives embedded in the path bytes (`Path.resolve()` normalises `..` and symlinks but does not strip non-printable characters), so a hostile `LOG_DIR` carried the same primitives into the INFO log line.

### Fix shape

Both sites now route the env-controlled value through `sanitize_log_arg` at the call site, mirroring the canonical defence pinned at:
- ÖBB Retry-After at `src/providers/oebb.py:1313-1315`
- Places-client Retry-After at `src/places/client.py:524-527` (PR #1472)
- The `read_capped_*` SHA-256 path-fingerprint family in `src/utils/files.py`
- Five caller-side path-log sites in `src/utils/{stations,env}.py` + `src/build_feed.py` (PR #1456)

### Defence-in-depth rationale

Both sites are guarded by `SafeFormatter` in production (which calls `sanitize_log_message` on the formatted message before it reaches stderr / the rotating file handlers). However:

- **pytest's `caplog`** fires BEFORE `SafeFormatter` runs. Tests that exercise the rejection branch (CI surface) see the pre-formatter message verbatim.
- **Non-`SafeFormatter` log handlers** (early-init plumbing before `configure_logging` runs, third-party log capturing, future refactor that drops the safe formatter) consume the raw record.
- Mirroring the canonical shape at every env-controlled-string log boundary means a future refactor that bypasses `SafeFormatter` doesn't silently re-expose every drift site at once.

### PoC tests

`tests/test_sentinel_reporting_clear_text_logging_drift.py` (NEW, 23 tests):

- 10 parametrised PoCs on the api_url WARNING site, one per canonical primitive (BiDi RLO, ZWSP, ALM, ESC, 8-bit CSI, BEL, newline, CR, Tag SPACE, Variation Selector-1). Pre-fix every primitive survives in `caplog.text` verbatim; post-fix every primitive is sanitised.
- 1 full-attack-payload PoC bundling every primitive plus an ANSI SGR colour escape and a log-record-forgery newline.
- 10 parametrised PoCs on the error_log_path INFO site (same primitive list).
- 1 full-attack-payload PoC on the error_log_path INFO site.
- 1 AST inventory invariant: walks `src/feed/reporting.py` for `log.<level>(..., self._config.api_url)` AND `log.<level>(..., error_log_path)` calls and asserts neither bare-arg shape survives without being wrapped in `sanitize_log_arg`. A regression here means a future contributor unwrapped the sanitisation and re-exposed the drift — fails LOUD at PR-review time instead of waiting for a future Sentinel sweep.

## Test plan

- [x] PoC tests fail pre-fix, pass post-fix (`tests/test_sentinel_reporting_clear_text_logging_drift.py` — 23/23 passed)
- [x] Existing reporting suite green (`test_reporting_*.py` + `test_sentinel_reporting_*.py` — 174/174 passed)
- [x] Full pytest suite green (4422 passed, 2 skipped)
- [x] `python scripts/run_static_checks.py` → ruff + mypy + bandit + secret scanner + C901 gate + pip-audit all pass (0 new C901 violations, 0 mypy errors with project-pinned mypy 1.10.x)


---
_Generated by [Claude Code](https://claude.ai/code/session_011U54rdSK32xQbDqL5hJBHP)_