### PR TITLE
security(text): escape '#' in escape_markdown to defang ATX heading injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,104 @@
+## 2026-05-14 - Markdown ATX-Heading Injection via `escape_markdown`: The Canonical Inline Markdown-Escape Helper Did Not Cover `#`, Letting a Hostile Warning/Error Starting With `# evil` Promote a Bullet List Item to `<ul><li><h1>evil</h1></li></ul>` in `docs/feed-health.md` + the Auto-Submitted GitHub Issue Body
+
+**Vulnerability:** :func:`src.utils.text.escape_markdown` escaped only
+``[]()*_`@<>`` pre-fix. The ``#`` character was missing from the escape
+set, so a string starting with ``# ...`` survived the helper unchanged.
+The helper is consumed by :func:`src.feed.reporting.render_feed_health_markdown`
+and :func:`src.feed.reporting._build_github_issue_body` via the
+bullet-list interpolation pattern::
+
+    lines.append(f"- {escape_markdown(warning)}")
+    lines.append(f"- {escape_markdown(error)}")
+
+CommonMark and GFM parse ``- # heading`` as a list item whose content
+is an ATX heading — ``<ul><li><h1>heading</h1></li></ul>`` (verified
+empirically via the ``commonmark`` Python reference parser). A hostile
+warning / error / exception message therefore landed a fresh ``<h1>``
+… ``<h6>`` inside the public ``docs/feed-health.md`` artefact and the
+auto-submitted GitHub Issue body.
+
+**Threat model:** Warning / error strings originate from every
+provider's error path (``provider_error``, ``add_warning``,
+``add_error_message``), which forward upstream / network-derived text
+through :func:`src.feed.reporting.clean_message`. ``clean_message``
+collapses whitespace and strips invisible Trojan-Source primitives but
+does **not** strip ASCII ``#``. A compromised provider, MITM, hostile
+DNS response, or any of the prior-round env-override leak surfaces can
+plant a warning / error starting with ``# evil heading payload`` and
+have it render as a heading in two public sinks:
+
+ 1. ``docs/feed-health.md`` — committed to the repo by the
+    ``update-cycle.yml`` cron job, rendered on the public GitHub
+    Pages site. Heading injection corrupts the document outline,
+    manipulates GitHub's auto-generated anchors (which feed
+    cross-linking and the TOC sidebar), and produces a misleading
+    large-font heading inside a bullet list.
+ 2. ``submit_auto_issue`` GitHub Issue body — opened on every failed
+    feed build, visible to every repo watcher.
+
+Severity: MEDIUM. No JS execution (HTML metacharacters are entity-
+encoded by the leading ``html.escape``), no phishing (``[]()`` are
+already backslash-escaped, so ``[link](url)`` becomes literal text).
+The attack is visual deception + document-structure manipulation +
+anchor spoofing — the same threat class as PR #1473 / #1472 / #1471
+which closed sibling Markdown / clear-text-logging drifts.
+
+**Fix shape:** Add ``#`` to the escape set in :func:`escape_markdown`
+in ``src/utils/text.py``. Mirrors the canonical backslash-escape
+pattern (``\\[``, ``\\]``, ``\\(``, ``\\)``, ``\\*``, ``\\_``,
+``\\``\\``, ``\\@``, ``\\<``, ``\\>``). The backslash-escaped ``\\#``
+renders as literal ``#`` in CommonMark / GFM so legitimate text
+("issue #123", "C# code", "Track #5") is visually unchanged on the
+rendered page. ``escape_markdown_cell`` composes ``escape_markdown``
+and inherits the fix automatically; the heading injection is not
+directly exploitable inside GFM table cells (cells parse inline-only
+content) but the cell helper's contract is documented as a superset
+of the inline contract.
+
+**Reproduced:** ``tests/test_sentinel_escape_markdown_heading_injection.py``
+contains 19 PoC tests:
+
+ * 4 unit-level PoCs on the helper itself (leading ``#``, every level
+   h1..h6, ``#`` anywhere, legitimate text preserved).
+ * 1 unit-level PoC on ``escape_markdown_cell`` (inheritance through
+   composition).
+ * 2 integration PoCs on ``render_feed_health_markdown`` (warning
+   path + error path) asserting the rendered Markdown source contains
+   the backslash-escaped form and **not** the raw ``- # …``
+   construction that CommonMark parses as a heading.
+ * 6 parametrised integration PoCs covering every heading depth
+   (h1..h6) at the renderer boundary.
+ * 1 inventory invariant asserting the canonical helper defangs the
+   full minimum escape set ``[]()*_`@<>#``, accepting either
+   backslash escape or HTML-entity encoding (the ``<``/``>`` chars
+   are handled via ``&lt;``/``&gt;`` from the leading
+   ``html.escape``).
+
+Pre-fix: at least the four unit-level PoCs + every parametrised
+integration PoC fail (the ``#`` survives ``escape_markdown``). Post-
+fix: all 19 pass.
+
+**Learning:** The Markdown-injection drift family pinned across
+Rounds 1-3 closed per-sink applications of the canonical helpers
+(``escape_markdown``, ``escape_markdown_cell``, ``safe_markdown_codespan``)
+at specific renderer boundaries (stats dashboard, code-span / fenced-
+code-block, stations-validation report). The structural gap the
+present round closes is **at the canonical helper itself**: the
+inline-escape contract documented as "Markdown specials" omitted
+``#``, which is **the** structural metacharacter that promotes
+inline content to block-level inside a bullet-list item — every
+caller pattern of the shape ``f"- {escape_markdown(x)}"`` therefore
+inherited a defence-in-depth gap. The prevention rule: any future
+widening of the ``# / + / - / ~ / !`` family at the canonical helper
+boundary must verify that **all** structural metacharacters that can
+appear at the start of a list-item content (and promote it block-
+level) are covered. The inventory invariant test
+``test_canonical_escape_set_includes_hash`` pins the contract
+programmatically — a future regression that drops ``#`` from the
+defang set fails the walker. Same closing-rule pattern as the
+``_INVISIBLE_DANGEROUS_RE`` widening rounds, applied to the inline
+escape contract.
+
 ## 2026-05-14 - Clear-Text-Logging Drift (Google Places `OUT_PATH_STATIONS` Resolver): `scripts/fetch_google_places_stations.py:_resolve_stations_out_path` Was the Last `LOGGER.warning(..., env_str)` Callsite In `scripts/` That Interpolated the Env-Controlled `OUT_PATH_STATIONS` Value Via Bare `%s` Without `sanitize_log_arg`
 
 **Vulnerability:** The InvalidPathError branch of

--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -408,9 +408,31 @@ def normalise_markdown_text(text: str, *, max_len: int = 200) -> str:
 def escape_markdown(text: str) -> str:
     """Escape HTML and Markdown characters to prevent injection/XSS."""
     text = html.escape(text)
-    # Escape Markdown characters that could create links or formatting
-    # We backslash-escape: [ ] ( ) * _ ` @ < >
-    for char in "[]()*_`@<>":
+    # Escape Markdown characters that could create links or formatting.
+    # We backslash-escape: [ ] ( ) * _ ` @ < > #
+    #
+    # Security: ``#`` was missing pre-Sentinel ``escape_markdown`` ATX-
+    # heading-injection round. Callers in :mod:`src.feed.reporting`
+    # interpolate the result directly after a list-item marker
+    # (``f"- {escape_markdown(warning)}"`` /
+    # ``f"- {escape_markdown(error)}"`` at lines 637/647/1100/1107).
+    # A hostile warning / error string starting with ``# evil`` then
+    # produces ``- # evil`` in the rendered Markdown, which CommonMark
+    # and GFM parse as ``<ul><li><h1>evil</h1></li></ul>`` —
+    # a fresh ATX heading inside a bullet list. The same payload at
+    # ``## evil`` … ``###### evil`` reaches every heading level
+    # (h1..h6). Sinks: the public ``docs/feed-health.md`` artefact
+    # (committed by ``update-cycle.yml`` and rendered on GitHub
+    # Pages) and the auto-submitted GitHub Issue body
+    # (``submit_auto_issue`` — visible to every repo watcher).
+    # ``clean_message`` collapses whitespace before the value reaches
+    # here, but ``#`` is a printable ASCII character that survives
+    # every prior round of sanitisation. The backslash-escaped
+    # ``\\#`` renders as literal ``#`` in CommonMark / GFM so
+    # legitimate text ("issue #123", "C# code") is visually
+    # unchanged on the rendered page. Mirrors the canonical
+    # backslash-escape shape pinned for ``[]()*_```@<>``.
+    for char in "[]()*_`@<>#":
         text = text.replace(char, f"\\{char}")
     return text
 

--- a/tests/test_sentinel_escape_markdown_heading_injection.py
+++ b/tests/test_sentinel_escape_markdown_heading_injection.py
@@ -1,0 +1,285 @@
+"""Sentinel: Markdown ATX-heading injection via ``escape_markdown``.
+
+The canonical Markdown escape helper
+:func:`src.utils.text.escape_markdown` previously escaped only
+``[]()*_`@<>``. The ``#`` character was missing from the escape set,
+so a hostile string starting with ``# ...`` survived the helper
+unchanged. The helper is consumed by
+:func:`src.feed.reporting.render_feed_health_markdown` /
+:func:`src.feed.reporting._build_github_issue_body` via the
+bullet-list interpolation::
+
+    lines.append(f"- {escape_markdown(warning)}")
+    lines.append(f"- {escape_markdown(error)}")
+
+CommonMark and GFM parse ``- # heading`` as a list item whose
+content is an ATX heading — ``<ul><li><h1>heading</h1></li></ul>``.
+A hostile warning / error / exception message therefore lands a
+fresh ``<h1>`` … ``<h6>`` inside the public ``docs/feed-health.md``
+artefact and the auto-submitted GitHub Issue body.
+
+Threat model
+------------
+The warning / error strings originate from every provider's error
+path (``provider_error``, ``add_warning``, ``add_error_message``),
+which forward upstream / network-derived text through
+:func:`src.feed.reporting.clean_message`. ``clean_message`` collapses
+whitespace and strips invisible Trojan-Source primitives but does
+NOT strip ASCII ``#``. A compromised provider, MITM, or hostile DNS
+response can therefore plant a warning / error string that begins
+with ``# evil heading payload`` and have it render as a heading.
+
+Sinks
+-----
+1. ``docs/feed-health.md`` — committed to the repository by the
+   ``update-cycle.yml`` cron job and rendered on the public GitHub
+   Pages site. Heading injection corrupts the document outline,
+   manipulates GitHub's auto-generated anchors, and produces a
+   misleading large-font heading inside a bullet list.
+2. ``submit_auto_issue`` GitHub Issue body — opened on every failed
+   feed build, visible to every repo watcher via the notifications
+   channel. Same heading-injection blast radius.
+
+Severity: MEDIUM. No JS execution (HTML is entity-encoded), no
+phishing (links are already escaped via ``[]()``). The attack is
+visual deception + document-structure manipulation + anchor
+spoofing — the same threat class as PR #1473 / #1472 / #1471 etc.
+which closed sibling Markdown / clear-text-logging drifts.
+
+Fix shape
+---------
+Add ``#`` to the escape set in :func:`escape_markdown`. Mirrors the
+existing canonical pattern (``\\[``, ``\\]``, ``\\(``, ``\\)``,
+``\\*``, ``\\_``, ``\\``\\``, ``\\@``, ``\\<``, ``\\>``). The
+backslash-escaped ``\\#`` renders as literal ``#`` in CommonMark /
+GFM so legitimate text containing ``#`` (e.g. "C# code",
+"issue #123") is unchanged on the rendered page.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.feed.reporting import (
+    FeedHealthMetrics,
+    RunReport,
+    render_feed_health_markdown,
+)
+from src.utils.text import escape_markdown, escape_markdown_cell
+
+
+# ---------------------------------------------------------------------------
+# Unit-level PoCs on the canonical helper.
+# ---------------------------------------------------------------------------
+
+
+def test_escape_markdown_escapes_hash_at_start() -> None:
+    """A leading ``#`` must be backslash-escaped.
+
+    Pre-fix: ``escape_markdown("# heading")`` returns ``"# heading"``
+    (the ``#`` survives), so a downstream ``f"- {…}"`` interpolation
+    produces ``"- # heading"`` which renders as
+    ``<ul><li><h1>heading</h1></li></ul>``.
+    """
+    result = escape_markdown("# heading")
+    assert result == r"\# heading", (
+        f"ATX heading marker must be escaped (got {result!r})"
+    )
+
+
+@pytest.mark.parametrize("level", [1, 2, 3, 4, 5, 6])
+def test_escape_markdown_escapes_all_heading_levels(level: int) -> None:
+    """All six ATX heading levels (h1..h6) must be defanged.
+
+    A hostile warning ``"### evil"`` would render as ``<h3>`` inside
+    a list item pre-fix. Escaping the first ``#`` is sufficient to
+    break the ATX-heading parse, but we backslash-escape every
+    ``#`` for defense in depth (the rendered output is identical —
+    CommonMark renders ``\\#`` as literal ``#``).
+    """
+    payload = "#" * level + " evil"
+    result = escape_markdown(payload)
+    expected = ("\\#" * level) + " evil"
+    assert result == expected, (
+        f"ATX heading at level {level} must be escaped: "
+        f"expected {expected!r}, got {result!r}"
+    )
+
+
+def test_escape_markdown_escapes_hash_anywhere() -> None:
+    """Defense in depth: every ``#`` must be escaped, not just at start.
+
+    CommonMark only treats ``#`` as a heading marker at line start,
+    but escaping every occurrence keeps the helper's contract
+    uniform — callers cannot accidentally re-expose the heading
+    injection by concatenating text that places a previously-mid-
+    string ``#`` at line start (e.g. ``f"\\n{escape_markdown(x)}"``).
+    """
+    result = escape_markdown("foo # bar # baz")
+    assert result == r"foo \# bar \# baz", (
+        f"Every '#' must be escaped (got {result!r})"
+    )
+
+
+def test_escape_markdown_preserves_legitimate_text() -> None:
+    """The fix must NOT change rendering of legitimate text.
+
+    ``\\#`` renders as literal ``#`` in CommonMark / GFM, so the
+    operator-facing artefact's visible output stays unchanged.
+    """
+    # Issue references, C#, hashtag-like content all still escape.
+    assert escape_markdown("issue #123") == r"issue \#123"
+    assert escape_markdown("C# code") == r"C\# code"
+    assert escape_markdown("no hash here") == "no hash here"
+
+
+def test_escape_markdown_cell_escapes_hash() -> None:
+    """``escape_markdown_cell`` composes ``escape_markdown`` so it
+    inherits the fix automatically.
+
+    GFM table cells parse inline content only (no block-level
+    headings), so the hash injection is not directly exploitable
+    via table cells. But the cell helper documents itself as a
+    superset of the inline escape contract, and the inventory
+    walker test below relies on the same character set being
+    escaped at both call sites.
+    """
+    assert escape_markdown_cell("# in cell") == r"\# in cell"
+
+
+# ---------------------------------------------------------------------------
+# Integration-level PoC via render_feed_health_markdown.
+# ---------------------------------------------------------------------------
+
+
+_HEADING_ATTACK_PAYLOAD = "# EVIL HEADING from hostile upstream"
+
+
+def _minimal_metrics() -> FeedHealthMetrics:
+    return FeedHealthMetrics(
+        raw_items=0,
+        filtered_items=0,
+        deduped_items=0,
+        new_items=0,
+        duplicate_count=0,
+        duplicates=(),
+    )
+
+
+def test_warning_starting_with_hash_does_not_become_heading() -> None:
+    """Render a feed-health report with a warning carrying a hash
+    payload; assert the rendered Markdown source neutralises the
+    heading marker.
+
+    Pre-fix, the rendered Markdown contained the substring
+    ``- # EVIL HEADING …`` verbatim, which CommonMark / GFM parses
+    as a list item containing an ATX-1 heading. Post-fix, the ``#``
+    is backslash-escaped (``- \\# EVIL HEADING …``), which renders
+    as a plain bullet item with literal ``#`` text.
+    """
+    report = RunReport(statuses=[("provider", True)])
+    report.add_warning(_HEADING_ATTACK_PAYLOAD)
+    markdown = render_feed_health_markdown(report, _minimal_metrics())
+
+    # Must NOT contain the raw ``- # …`` form that CommonMark parses
+    # as ``<li><h1>…</h1></li>``.
+    assert (
+        f"- {_HEADING_ATTACK_PAYLOAD}" not in markdown
+    ), (
+        "Markdown source contains unescaped '- # ...' which renders "
+        "as an embedded heading"
+    )
+
+    # Must contain the backslash-escaped form. The leading ``#`` of
+    # the payload becomes ``\#`` so the line is ``- \# EVIL …``.
+    expected = "- \\" + _HEADING_ATTACK_PAYLOAD
+    assert expected in markdown, (
+        "Markdown source must contain the backslash-escaped form "
+        f"(expected {expected!r} in output)"
+    )
+
+
+def test_error_starting_with_hash_does_not_become_heading() -> None:
+    """Sibling assertion on the error rendering path
+    (``render_feed_health_markdown`` line 647)."""
+    report = RunReport(statuses=[("provider", True)])
+    report.add_error_message(_HEADING_ATTACK_PAYLOAD)
+    markdown = render_feed_health_markdown(report, _minimal_metrics())
+
+    assert (
+        f"- {_HEADING_ATTACK_PAYLOAD}" not in markdown
+    ), (
+        "Markdown source contains unescaped '- # ...' which renders "
+        "as an embedded heading"
+    )
+    expected = "- \\" + _HEADING_ATTACK_PAYLOAD
+    assert expected in markdown
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "# Level 1",
+        "## Level 2",
+        "### Level 3",
+        "#### Level 4",
+        "##### Level 5",
+        "###### Level 6",
+    ],
+)
+def test_all_heading_levels_neutralised_at_renderer_boundary(payload: str) -> None:
+    """Every ATX heading depth (h1..h6) reachable inside a list
+    item must be defanged at the renderer boundary."""
+    report = RunReport(statuses=[("provider", True)])
+    report.add_warning(payload)
+    markdown = render_feed_health_markdown(report, _minimal_metrics())
+
+    # The raw ``- # ...`` / ``- ## ...`` / ... form would create a
+    # heading inside the list item.
+    assert f"- {payload}" not in markdown
+
+
+# ---------------------------------------------------------------------------
+# Audit walker: the canonical inline escape MUST cover '#'.
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_escape_set_includes_hash() -> None:
+    """Inventory invariant: the canonical Markdown-escape helper
+    must defang the full set of structural metacharacters that can
+    appear at the START of a bullet-list item's content and
+    promote that content to a block-level structure.
+
+    The minimum set is::
+
+        [ ] ( ) * _ ` @ < > #
+
+    Bracket/paren = link/image syntax; ``*``/``_`` = emphasis;
+    ``` ` ``` = inline code; ``@`` = mention; ``<``/``>`` = HTML
+    autolink + blockquote marker; ``#`` = ATX heading marker.
+
+    The defang mechanism is either:
+      * backslash escape (``\\X``) — applied by the for-loop, OR
+      * HTML-entity encoding (``&lt;`` / ``&gt;``) — applied by the
+        leading ``html.escape`` call for ``<`` and ``>``.
+
+    Both renderings produce literal characters in HTML output, so
+    either is a sufficient defence. Removal of any element from the
+    defang set fails the invariant.
+    """
+    # ``<`` and ``>`` are HTML-entity-encoded by ``html.escape``; the
+    # rest are backslash-escaped by the for-loop.
+    html_entity_chars = {"<": "&lt;", ">": "&gt;"}
+    required = set("[]()*_`@<>#")
+    for ch in required:
+        out = escape_markdown(ch)
+        if ch in html_entity_chars:
+            assert html_entity_chars[ch] in out, (
+                f"Canonical Markdown-escape helper dropped {ch!r} from the "
+                f"defang set (got {out!r})"
+            )
+        else:
+            assert "\\" + ch in out, (
+                f"Canonical Markdown-escape helper dropped {ch!r} from the "
+                f"defang set (got {out!r})"
+            )


### PR DESCRIPTION
## Summary

The canonical inline Markdown-escape helper `src.utils.text.escape_markdown` escaped only `[]()*_\`@<>` pre-fix. **`#` was missing from the escape set.** A warning / error string starting with `# evil` therefore flowed unchanged through `src/feed/reporting.py`'s bullet-list interpolation pattern:

```python
lines.append(f"- {escape_markdown(warning)}")  # lines 637, 647, 1100, 1107
```

CommonMark and GFM parse `- # heading` as **`<ul><li><h1>heading</h1></li></ul>`** — a fresh ATX heading promoted from bullet-list content. Verified empirically against the `commonmark` reference parser; the same payload at every depth `## ... ######` produces `<h2>` … `<h6>`.

### Sinks
1. **`docs/feed-health.md`** — committed by the `update-cycle.yml` cron job, rendered on the public GitHub Pages site. Heading injection corrupts the document outline, manipulates GitHub's auto-generated anchors, and produces a misleading large-font heading inside a bullet list.
2. **Auto-submitted GitHub Issue body** (`submit_auto_issue`) — opened on every failed feed build, visible to every repo watcher.

### Threat model
Warning / error strings originate from every provider's error path (`provider_error`, `add_warning`, `add_error_message`). `clean_message` collapses whitespace and strips invisible Trojan-Source primitives but does **not** strip ASCII `#`. A compromised provider, MITM, hostile DNS response, or env-override leak can plant a payload starting with `# evil heading` and have it render as a heading.

**Severity: MEDIUM.** No JS execution (HTML metacharacters are entity-encoded by the leading `html.escape`), no phishing (`[]()` are already backslash-escaped). The attack is visual deception + document-structure manipulation + anchor spoofing — same threat class as the prior Markdown / clear-text-logging drift rounds.

### Fix
Add `#` to the escape set so the canonical helper mirrors the existing backslash-escape pattern. `\#` renders as literal `#` in CommonMark / GFM, so legitimate text like `issue #123` or `C# code` is visually unchanged on the rendered page.

### PoC + inventory invariant
`tests/test_sentinel_escape_markdown_heading_injection.py` adds **19 tests**:
- 4 unit-level PoCs on the helper (leading `#`, every level h1..h6, anywhere, legitimate text preserved)
- 1 unit-level PoC on `escape_markdown_cell` (composition inheritance)
- 2 integration PoCs on `render_feed_health_markdown` (warning path + error path)
- 6 parametrised integration PoCs covering every heading depth (h1..h6) at the renderer boundary
- 1 inventory invariant asserting the canonical helper defangs `[]()*_\`@<>#`

Pre-fix at least 11 tests fail (the `#` survives `escape_markdown`). Post-fix all 19 pass.

## Test plan
- [x] `pytest` — 4466 passed, 2 skipped
- [x] `python -m mypy` — Success: no issues found in 45 source files
- [x] `python -m ruff check` — All checks passed
- [x] `python scripts/scan_secrets.py` — No potential secrets
- [x] `python scripts/check_complexity.py` — C901 gate passed (0 new violations)
- [x] Empirical verification via `commonmark` reference parser — `- # heading` → `<ul><li><h1>heading</h1></li></ul>`; `- \# heading` → `<ul><li># heading</li></ul>` (defanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_015fQTXjADLTnFFAkvQvdv82)_