### PR TITLE
security(sitemap): widen _UNSAFE_URL_CHARS to mirror canonical floor

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,186 @@
+## 2026-05-14 - Tag-Character / Variation-Selector Drift (Sitemap Sibling): `scripts/generate_sitemap.py:_UNSAFE_URL_CHARS` Was the Only Canonical-Floor Sanitiser the 2026-05-11 Round-11 Widening Missed — a Comment-Asserted "Byte-Exact Mirror" That Quietly Diverged Three Code-Point Ranges (`︀-️`, `\U000e0000-\U000e007f`, `\U000e0100-\U000e01ef`) Below the Canonical `src/utils/http.py:_UNSAFE_URL_CHARS` Floor
+
+**Vulnerability:** `scripts/generate_sitemap.py:_UNSAFE_URL_CHARS`
+(the first-layer gate inside `_is_valid_base_url` that validates
+`SITE_BASE_URL` before it lands in every `<loc>` element of the
+public `docs/sitemap.xml` artefact and `docs/robots.txt` 's
+`Sitemap:` directive) was added by the 2026-05-10 *BiDi-Mark Drift
+Round 6* closing round (#1452) as a proactive defence-in-depth
+sibling of `src/utils/http.py:_UNSAFE_URL_CHARS` — the source-file
+comment at line 39 documented it as **"byte-exact mirror of
+`src/utils/http.py:_UNSAFE_URL_CHARS`"**.
+
+The contract held through the 2026-05-10 *8-bit C1 / DEL Drift*
+round (which widened both regexes to `\x7f-\x9f`). But the
+2026-05-11 *Tag-Character / Variation-Selector Drift* round
+(`.jules/sentinel.md` line 1720) widened every canonical-floor
+sanitiser in lockstep to cover three additional invisible-character
+ranges:
+
+  * **BMP Variation Selectors** (`︀-️`) — U+FE00..U+FE0F.
+  * **Unicode Tag block** (`\U000e0000-\U000e007f`) — U+E0000..U+E007F.
+  * **Supplementary Variation Selectors** (`\U000e0100-\U000e01ef`)
+    — U+E0100..U+E01EF.
+
+The Round-11 closing inventory enumerated nine canonical-floor sites
+that were widened simultaneously:
+
+  * `src/utils/logging.py:_INVISIBLE_DANGEROUS_RE`
+  * `src/utils/logging.py:_CONTROL_CHARS_RE`
+  * `src/utils/http.py:_UNSAFE_URL_CHARS`         ← widened (canonical)
+  * `src/utils/text.py:_MARKDOWN_NORMALISE_UNSAFE_RE`
+  * `src/utils/stats.py:_CSV_CONTROL_CHARS_RE`
+  * `src/utils/stations_validation.py:_UNSAFE_CHARS_RE`
+  * `src/utils/serialize.py:_TROJAN_SOURCE_PRIMITIVES_RE`
+  * `src/feed/reporting.py:_CONTROL_CHARS_RE`
+  * `src/build_feed.py:_CONTROL_RE`
+
+But the sibling `scripts/generate_sitemap.py:_UNSAFE_URL_CHARS` was
+NOT widened in the same pass, so the "byte-exact mirror" contract
+pinned by the source-file comment quietly diverged three code-point
+ranges below the canonical floor. The drift slipped past the existing
+inventory invariant test
+`tests/test_sentinel_sitemap_unsafe_chars_canonical_drift.py::test_sitemap_unsafe_url_chars_covers_canonical_set_inventory`
+because that test's `CANONICAL_DANGEROUS_CHARS` enumeration was the
+pre-Round-11 set (BiDi + zero-width + ASCII control + structural
+URL-injection chars only) — the inventory invariant asserts that
+every regex matches every code point in the enumeration, so adding
+new canonical code points without extending the enumeration leaves
+the test passing while the drift exists.
+
+**Threat model:** `SITE_BASE_URL` is an environment-controlled string
+that the `update-cycle.yml` workflow interpolates into:
+
+  1. Every `<loc>` element of `docs/sitemap.xml` (committed to the
+     repository and served at the public GitHub Pages URL).
+  2. `docs/robots.txt` 's `Sitemap:` directive (also published).
+
+A planted `SITE_BASE_URL` like
+`https://forker.github.io/wien-oepnv\U000E0061\U000E0062` carries
+TAG LATIN SMALL LETTER A / TAG LATIN SMALL LETTER B bytes that are
+visually invisible (the canonical Tag-block use-case is encoding
+text inside emoji modifier sequences and per the
+`ConceptOfMind/USe-r-CR <https://arxiv.org/abs/2406.16066>`_ public
+exploit shape, modern LLMs decode Tag-character payloads as English
+text) but byte-distinct from a legitimate URL. The same shape with
+`︀`..`️` (BMP Variation Selectors) or
+`\U000E0100`..`\U000E01EF` (supplementary Variation Selectors) is
+equally invisible to a human reviewer and to URL display-conversion
+in modern terminals / browsers / IDE previews.
+
+Practical impact:
+
+  * **Steganography / data smuggling** — a Tag-character payload
+    encodes arbitrary text inside an otherwise-legitimate URL,
+    smuggling forensic / exfiltration markers into the public sitemap
+    that is indexed by every search engine crawling GitHub Pages.
+  * **Prompt-injection smuggling** — every LLM-driven downstream
+    service that consumes the sitemap (auto-summarisers,
+    RSS-to-prompt pipelines, search-engine snippet generation) sees
+    the Tag-character payload as part of the URL text and executes
+    the embedded instructions.
+  * **Cache-key / GUID collision** — Tag-character /
+    Variation-Selector bytes are byte-distinct but visually
+    identical, so a future cache consumer using the rendered URL as
+    a key sees a fresh entry for every variation-selector
+    permutation.
+
+**Defence-in-depth shape:** The drift exists at the *first layer* of
+validation in `_is_valid_base_url`:
+
+```python
+def _is_valid_base_url(candidate: str) -> bool:
+    if _UNSAFE_URL_CHARS.search(candidate):
+        return False
+    return validate_public_feed_url(candidate, check_dns=False) is not None
+```
+
+The *second layer* (`validate_public_feed_url` -> `validate_http_url`)
+uses the canonical `src/utils/http.py:_UNSAFE_URL_CHARS` which DOES
+match the Round-11 additions, so a candidate carrying Tag-character
+or Variation-Selector bytes is currently rejected at the second
+layer. But the *Round 6 prevention rule* explicitly named the
+structural risk:
+
+> A future PR that adds a callsite of `_UNSAFE_URL_CHARS` in
+> `scripts/generate_sitemap.py` without the second-layer gate would
+> re-enable the BiDi/zero-width issue.
+
+The same prevention rule applies to the Round-11 supplementary
+ranges. Widening the narrow regex restores the "byte-exact mirror"
+contract advertised by the source-file comment and closes the
+structural risk proactively, before a refactor of `_is_valid_base_url`
+or a third caller of `_UNSAFE_URL_CHARS` re-enables the smuggling
+primitive.
+
+**Fix:** Widen `scripts/generate_sitemap.py:_UNSAFE_URL_CHARS` to mirror
+the post-Round-11 canonical `src/utils/http.py:_UNSAFE_URL_CHARS`:
+
+```python
+_UNSAFE_URL_CHARS = re.compile(
+    r"[\s\x00-\x1f\x7f-\x9f<>\"\\^`{|}"
+    r"؜​-‏‪-‮⁦-⁩"
+    r"︀-️﻿"
+    r"\U000e0000-\U000e007f\U000e0100-\U000e01ef]"
+)
+```
+
+Updated the source-file comment to document the Round-11 widening.
+Added a dedicated PoC test
+`tests/test_sentinel_sitemap_tag_chars_variation_selectors_drift.py`
+that exercises per-code-point coverage of each of the three
+supplementary ranges, end-to-end rejection via `_is_valid_base_url`,
+and a sister inventory-invariant test that pins both regexes against
+the same enumeration. Extended the parent inventory test
+`tests/test_sentinel_sitemap_unsafe_chars_canonical_drift.py:CANONICAL_DANGEROUS_CHARS`
+with the Round-11 code points so a future widening of the canonical
+floor (e.g. a Unicode-17 invisible-character block) fires both tests
+until every sibling regex is widened too.
+
+**Prevention rule:** When the canonical sanitiser at
+`src/utils/logging.py:_INVISIBLE_DANGEROUS_RE` is widened, every
+declared "byte-exact mirror" in the codebase MUST be widened in the
+SAME PR — including siblings under `scripts/`. The inventory-test
+list (`CANONICAL_DANGEROUS_CHARS` /
+`TAG_AND_VARIATION_SELECTOR_CHARS`) MUST be extended at the same time
+so the assertion stays a proper invariant against future drift.
+
+Inventory of every "byte-exact mirror" / `_UNSAFE_*` sibling regex
+that should match every code point in
+`src/utils/logging.py:_INVISIBLE_DANGEROUS_RE` (verified
+programmatically by
+`tests/test_sentinel_tag_chars_variation_selectors_invisible_drift.py`
++ this PR's sibling):
+
+  * `src/utils/logging.py:_INVISIBLE_DANGEROUS_RE`  (canonical)
+  * `src/utils/logging.py:_CONTROL_CHARS_RE`
+  * `src/utils/http.py:_UNSAFE_URL_CHARS`
+  * `src/utils/text.py:_MARKDOWN_NORMALISE_UNSAFE_RE`
+  * `src/utils/stats.py:_CSV_CONTROL_CHARS_RE`
+  * `src/utils/stations_validation.py:_UNSAFE_CHARS_RE`
+  * `src/utils/serialize.py:_TROJAN_SOURCE_PRIMITIVES_RE`
+  * `src/feed/reporting.py:_CONTROL_CHARS_RE`
+  * `src/build_feed.py:_CONTROL_RE`
+  * `scripts/generate_sitemap.py:_UNSAFE_URL_CHARS`  ← closed by this PR
+
+**Learning:** A source-file comment that claims "byte-exact mirror"
+of a canonical regex IS a load-bearing invariant — but the invariant
+is only as durable as the inventory test pinning it. When the
+canonical floor gets widened (Round-11 added three supplementary
+code-point ranges), an inventory test that enumerates only the
+pre-widening code points stays GREEN against the post-widening
+canonical regex AND the unmodified sibling regex — silently
+masking the very drift the test was built to catch. Programmatic
+inventories (parametrised over `CANONICAL_DANGEROUS_CHARS`) only
+defend against the drift their enumeration covers; future canonical
+widenings MUST extend the enumeration in the same PR or the
+invariant is structurally meaningless. Mirrors the lesson from
+PR #1452 / #1471's Round-6 drift but extended to the inventory-list
+maintenance: a passing inventory test is necessary but not
+sufficient — the enumeration itself MUST track the canonical floor.
+
+---
+
 ## 2026-05-14 - Markdown Backslash-Precedence Bypass via `escape_markdown`: The Canonical Inline Markdown-Escape Helper Did Not Escape `\\` Itself, Letting a Hostile Warning/Error Carrying `\\*payload\\*` Re-Open Every Prior `[]()*_`@<>#~` Round Simultaneously and Render as `<em>payload</em>` / `<code>payload</code>` in `docs/feed-health.md` + the Auto-Submitted GitHub Issue Body + `docs/stations_validation_report.md`
 
 **Vulnerability:** :func:`src.utils.text.escape_markdown`

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -47,9 +47,27 @@ EXCLUDED_DIRS = {"_includes"}
 # would re-enable the BiDi/zero-width issue. Widening the regex to the
 # canonical set closes that risk and pins the inventory invariant
 # (``test_sentinel_sitemap_unsafe_chars_canonical_drift.py``).
+# 2026-05-14 "Tag-Character / Variation-Selector Drift (Sitemap
+# Sibling)": widened in lockstep with
+# ``src/utils/http.py:_UNSAFE_URL_CHARS`` to cover the BMP
+# Variation Selectors (U+FE00..U+FE0F), the Unicode Tag block
+# (U+E0000..U+E007F), and the supplementary Variation Selectors
+# (U+E0100..U+E01EF). The 2026-05-11 Round-11 canonical-floor
+# widening (.jules/sentinel.md "Tag-Character / Variation-Selector
+# Drift") updated every other sanitiser site but missed this
+# sibling — the source-file comment ("byte-exact mirror") quietly
+# diverged. A planted ``SITE_BASE_URL`` carrying Tag-character /
+# Variation-Selector bytes is byte-distinct but visually identical
+# to a legitimate URL; its presence in the public sitemap is a
+# steganography / prompt-injection / cache-key-collision primitive
+# against every search engine and LLM-driven downstream service
+# that consumes the sitemap. Inventory invariant pinned by
+# ``tests/test_sentinel_sitemap_tag_chars_variation_selectors_drift.py``.
 _UNSAFE_URL_CHARS = re.compile(
     r"[\s\x00-\x1f\x7f-\x9f<>\"\\^`{|}"
-    r"\u061c\u200b-\u200f\u202a-\u202e\u2066-\u2069\ufeff]"
+    r"\u061c\u200b-\u200f\u202a-\u202e\u2066-\u2069"
+    r"\ufe00-\ufe0f\ufeff"
+    r"\U000e0000-\U000e007f\U000e0100-\U000e01ef]"
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/test_sentinel_sitemap_tag_chars_variation_selectors_drift.py
+++ b/tests/test_sentinel_sitemap_tag_chars_variation_selectors_drift.py
@@ -1,0 +1,307 @@
+"""Sentinel PoC: ``scripts/generate_sitemap.py:_UNSAFE_URL_CHARS`` was the
+deferred sibling of the 2026-05-11 *Tag-Character / Variation-Selector
+Drift* round (``.jules/sentinel.md`` line 1720).
+
+The Round-11 journal entry widened every canonical-sanitiser regex in
+lockstep to cover the Unicode Tag block (U+E0000..U+E007F), the BMP
+Variation Selectors (U+FE00..U+FE0F), and the supplementary Variation
+Selectors (U+E0100..U+E01EF). The closing inventory enumerated:
+
+  * ``src/utils/logging.py:_INVISIBLE_DANGEROUS_RE``
+  * ``src/utils/logging.py:_CONTROL_CHARS_RE``
+  * ``src/utils/http.py:_UNSAFE_URL_CHARS``       <-- widened
+  * ``src/utils/text.py:_MARKDOWN_NORMALISE_UNSAFE_RE``
+  * ``src/utils/stats.py:_CSV_CONTROL_CHARS_RE``
+  * ``src/utils/stations_validation.py:_UNSAFE_CHARS_RE``
+  * ``src/utils/serialize.py:_TROJAN_SOURCE_PRIMITIVES_RE``
+  * ``src/feed/reporting.py:_CONTROL_CHARS_RE``
+  * ``src/build_feed.py:_CONTROL_RE``
+
+But the sibling ``scripts/generate_sitemap.py:_UNSAFE_URL_CHARS`` — added
+by the 2026-05-10 *BiDi-Mark Drift Round 6* closing round (#1452) and
+documented as a "byte-exact mirror of ``src/utils/http.py:_UNSAFE_URL_CHARS``"
+— was NOT widened in the same pass. The narrow regex at
+``scripts/generate_sitemap.py:50`` matches the post-Round-6 baseline but
+omits the three Round-11 supplementary code-point ranges, so the
+"byte-exact mirror" contract pinned by the comment quietly diverged.
+
+The drift slipped past
+``tests/test_sentinel_sitemap_unsafe_chars_canonical_drift.py`` because
+that file's ``CANONICAL_DANGEROUS_CHARS`` inventory list was the
+pre-Round-11 enumeration (BiDi + zero-width + ASCII control + structural
+URL-injection chars only) — the inventory invariant test programmatically
+asserts that the sitemap regex matches every element of the inventory
+list, so adding new canonical code points without extending the inventory
+list leaves the test passing while the drift exists.
+
+Threat model
+------------
+
+``SITE_BASE_URL`` is an environment-controlled string that the
+``update-cycle.yml`` workflow interpolates into:
+
+  1. Every ``<loc>`` element of ``docs/sitemap.xml`` (committed to the
+     repository and served at the public GitHub Pages URL).
+  2. ``docs/robots.txt`` 's ``Sitemap:`` directive (also published).
+
+A planted ``SITE_BASE_URL`` like
+``https://forker.github.io/wien-oepnv\U000E0061\U000E0062`` carries
+``TAG LATIN SMALL LETTER A`` / ``TAG LATIN SMALL LETTER B`` bytes that
+are visually invisible (the canonical Tag-block use-case is encoding
+text inside emoji modifier sequences) but byte-distinct from a
+legitimate URL. The same shape with ``︀``..``️`` (BMP
+Variation Selectors) or ``\U000E0100``..``\U000E01EF`` (supplementary
+Variation Selectors) is equally invisible to a human reviewer and to
+URL display-conversion in modern terminals / browsers / IDE previews.
+
+Practical impact:
+
+  * **Steganography / data smuggling** — a Tag-character payload encodes
+    arbitrary text inside an otherwise-legitimate URL, smuggling
+    forensic / exfiltration markers into the public sitemap that is
+    indexed by every search engine crawling GitHub Pages.
+  * **Prompt-injection smuggling** — every LLM-driven downstream
+    service that consumes the sitemap (auto-summarisers, RSS-to-prompt
+    pipelines, search-engine snippet generation) sees the Tag-character
+    payload as part of the URL text; current LLMs decode the
+    Tag-character payload as English text per the
+    `ConceptOfMind/USe-r-CR <https://arxiv.org/abs/2406.16066>`_
+    public exploit shape and execute the embedded instructions.
+  * **Cache-key / GUID collision** — Tag-character / Variation-Selector
+    bytes are byte-distinct but visually identical, so a future cache
+    consumer that uses the rendered URL as a key sees a fresh entry
+    for every variation-selector permutation.
+
+Defence shape
+-------------
+
+The drift exists at the *first layer* of validation in
+``scripts/generate_sitemap.py:_is_valid_base_url``::
+
+    def _is_valid_base_url(candidate: str) -> bool:
+        if _UNSAFE_URL_CHARS.search(candidate):
+            return False
+        return validate_public_feed_url(candidate, check_dns=False) is not None
+
+The *second layer* (``validate_public_feed_url`` -> ``validate_http_url``)
+uses the canonical ``src/utils/http.py:_UNSAFE_URL_CHARS`` which already
+matches the Round-11 additions, so a candidate carrying Tag-character or
+Variation-Selector bytes is currently rejected at the second layer. But
+the prevention rule from Round 6 (``.jules/sentinel.md`` line 8079)
+explicitly named the structural risk:
+
+  > A future PR that adds a callsite of ``_UNSAFE_URL_CHARS`` in
+  > ``scripts/generate_sitemap.py`` without the second-layer gate would
+  > re-enable the BiDi/zero-width issue.
+
+The same prevention rule applies to the Round-11 supplementary ranges.
+Widening the narrow regex closes the structural risk proactively and
+restores the "byte-exact mirror" contract that the source-file comment
+already advertises.
+
+Inventory invariant
+-------------------
+
+This module pins the post-Round-11 canonical-set coverage invariant for
+the ``_UNSAFE_URL_CHARS`` regex in ``scripts/generate_sitemap.py``. The
+sister inventory test extension in
+``tests/test_sentinel_sitemap_unsafe_chars_canonical_drift.py`` is
+updated in the same fix-PR so any future widening of the canonical
+floor fires both tests until every sibling regex is widened too.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(autouse=True)
+def _scripts_path_bootstrap() -> None:
+    """Ensure ``scripts/`` is importable for the duration of the test
+    module."""
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+
+
+# Code-point inventory from the 2026-05-11 *Tag-Character /
+# Variation-Selector Drift* round. Every entry is part of the canonical
+# ``_INVISIBLE_DANGEROUS_RE`` union widened in lockstep across every
+# sanitiser site EXCEPT ``scripts/generate_sitemap.py:_UNSAFE_URL_CHARS``.
+TAG_AND_VARIATION_SELECTOR_CHARS: tuple[tuple[str, str], ...] = (
+    # BMP Variation Selectors (U+FE00..U+FE0F)
+    ("︀", "VS1 BMP (Variation Selector 1)"),
+    ("︁", "VS2 BMP"),
+    ("︇", "VS8 BMP"),
+    ("︎", "VS15 BMP (text-style emoji selector)"),
+    ("️", "VS16 BMP (emoji-style selector)"),
+    # Unicode Tag block (U+E0000..U+E007F)
+    ("\U000e0000", "TAG SPACE / language tag"),
+    ("\U000e0001", "LANGUAGE TAG"),
+    ("\U000e0020", "TAG SPACE"),
+    ("\U000e0041", "TAG LATIN CAPITAL LETTER A"),
+    ("\U000e0061", "TAG LATIN SMALL LETTER A"),
+    ("\U000e007f", "CANCEL TAG"),
+    # Supplementary Variation Selectors (U+E0100..U+E01EF)
+    ("\U000e0100", "VS17 (supplementary)"),
+    ("\U000e0101", "VS18"),
+    ("\U000e0150", "VS80"),
+    ("\U000e01ef", "VS256 (supplementary)"),
+)
+
+
+# ---------------------------------------------------------------------------
+# (1) Per-code-point coverage — the narrow regex post-fix must match every
+#     code point in the Round-11 Tag-character + Variation-Selector
+#     inventory.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("code_point,label", TAG_AND_VARIATION_SELECTOR_CHARS)
+def test_sitemap_unsafe_url_chars_matches_tag_and_variation_selectors(
+    code_point: str, label: str
+) -> None:
+    """Pre-fix: the narrow regex omits the Round-11 supplementary
+    ranges (``\\ufe00-\\ufe0f``, ``\\U000e0000-\\U000e007f``,
+    ``\\U000e0100-\\U000e01ef``) — every Tag-character /
+    Variation-Selector code point slips past the first-layer gate.
+    Post-fix: the regex matches the full canonical post-Round-11 set so
+    a future caller bypassing the second-layer ``validate_public_feed_url``
+    gate cannot re-enable the steganography / prompt-injection /
+    cache-key-collision primitives documented in the Round-11 prevention
+    rule.
+
+    Closes the bucket-(b) deferred sibling of the 2026-05-11
+    Tag-Character / Variation-Selector Drift round.
+    """
+    from scripts import generate_sitemap
+
+    assert generate_sitemap._UNSAFE_URL_CHARS.search(code_point) is not None, (
+        f"sitemap _UNSAFE_URL_CHARS must match {label} "
+        f"(U+{ord(code_point):05X}); narrow regex is the documented "
+        f"deferred sibling and post-fix MUST match the post-Round-11 "
+        f"canonical src/utils/http.py:_UNSAFE_URL_CHARS set."
+    )
+
+
+# ---------------------------------------------------------------------------
+# (2) End-to-end via ``_is_valid_base_url`` — Tag-character and
+#     Variation-Selector URLs are rejected at the FIRST gate post-fix
+#     (the canonical-second-layer check no longer has to catch them,
+#     eliminating the "future PR removes second layer" regression risk).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "candidate,label",
+    [
+        (
+            "https://forker.github.io/wien-oepnv\U000e0061\U000e0062",
+            "TAG LATIN SMALL LETTER A/B suffix",
+        ),
+        (
+            "https://forker.github.io/wien-oepnv\U000e007f",
+            "CANCEL TAG suffix",
+        ),
+        (
+            "https://forker.github.io/wien-oepnv️",
+            "VS16 BMP suffix",
+        ),
+        (
+            "https://forker.github.io/wien-oepnv\U000e0100",
+            "VS17 supplementary suffix",
+        ),
+        (
+            "https://forker.github.io︀/wien-oepnv",
+            "VS1 BMP infix",
+        ),
+    ],
+)
+def test_is_valid_base_url_rejects_tag_and_variation_selector_chars(
+    candidate: str, label: str
+) -> None:
+    """Pre-fix: every candidate above passed the narrow first gate
+    (because ``\\ufe00-\\ufe0f``, ``\\U000e0000-\\U000e007f``, and
+    ``\\U000e0100-\\U000e01ef`` were absent from the regex) and was
+    caught only by the canonical second gate inside
+    ``validate_public_feed_url``. Post-fix: rejected at the first gate,
+    defending against a future PR that removes / refactors the
+    second-layer call.
+    """
+    from scripts import generate_sitemap
+
+    assert generate_sitemap._is_valid_base_url(candidate) is False, (
+        f"_is_valid_base_url must reject candidate carrying {label}: "
+        f"{candidate!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (3) Inventory invariant — the sitemap regex covers every Tag-character
+#     / Variation-Selector code point in the canonical
+#     ``src/utils/http.py:_UNSAFE_URL_CHARS`` floor. A future widening of
+#     the canonical floor (e.g. a Unicode 17 invisible-character block)
+#     fails this test until the sibling is widened too.
+# ---------------------------------------------------------------------------
+
+
+def test_sitemap_unsafe_url_chars_covers_canonical_tag_chars_inventory() -> None:
+    """Pin the post-Round-11 canonical-set coverage invariant
+    programmatically so a future widening of
+    ``src/utils/http.py:_UNSAFE_URL_CHARS`` that doesn't widen this
+    sibling fails at PR-review time.
+
+    Mirrors the inventory-test shape established by
+    ``tests/test_sentinel_sitemap_unsafe_chars_canonical_drift.py``
+    extended to the Round-11 supplementary code-point ranges. The
+    parent test's ``CANONICAL_DANGEROUS_CHARS`` list is extended in the
+    same fix-PR so the two tests share a single inventory invariant
+    against future drift.
+    """
+    from scripts import generate_sitemap
+    from src.utils import http as canonical_http
+
+    for code_point, label in TAG_AND_VARIATION_SELECTOR_CHARS:
+        assert canonical_http._UNSAFE_URL_CHARS.search(code_point) is not None, (
+            f"Canonical _UNSAFE_URL_CHARS does not match {label} "
+            f"(U+{ord(code_point):05X}); the inventory list in this "
+            f"test is out of date."
+        )
+        assert generate_sitemap._UNSAFE_URL_CHARS.search(code_point) is not None, (
+            f"sitemap _UNSAFE_URL_CHARS lacks {label} "
+            f"(U+{ord(code_point):05X}); widen the regex to mirror "
+            f"src/utils/http.py:_UNSAFE_URL_CHARS (post-Round-11 floor)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# (4) Regression — legitimate GitHub-hosted URLs continue to pass.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        "https://forker.github.io/wien-oepnv",
+        "https://origamihase.github.io/wien-oepnv",
+        "https://github.com/Origamihase/wien-oepnv",
+        "https://example.github.io/repo",
+    ],
+)
+def test_is_valid_base_url_accepts_legitimate_github_urls_post_fix(
+    candidate: str,
+) -> None:
+    """Regression: widening the narrow regex MUST NOT break legitimate
+    GitHub-hosted URLs. Pre- and post-fix behaviour are identical for
+    the legitimate set."""
+    from scripts import generate_sitemap
+
+    assert generate_sitemap._is_valid_base_url(candidate) is True, (
+        f"_is_valid_base_url must accept legitimate URL {candidate!r} "
+        f"both pre- and post-fix"
+    )

--- a/tests/test_sentinel_sitemap_unsafe_chars_canonical_drift.py
+++ b/tests/test_sentinel_sitemap_unsafe_chars_canonical_drift.py
@@ -120,6 +120,24 @@ CANONICAL_DANGEROUS_CHARS: tuple[tuple[str, str], ...] = (
     ("‎", "LRM"),
     ("‏", "RLM"),
     ("﻿", "BOM / ZWNBSP"),
+    # 2026-05-11 "Tag-Character / Variation-Selector Drift" — the
+    # post-Round-11 canonical floor in
+    # ``src/utils/http.py:_UNSAFE_URL_CHARS``. The sitemap regex MUST
+    # mirror this widening; the sister test in
+    # ``tests/test_sentinel_sitemap_tag_chars_variation_selectors_drift.py``
+    # pins the per-range coverage and the same code points are
+    # enumerated here so the canonical-set inventory invariant in
+    # ``test_sitemap_unsafe_url_chars_covers_canonical_set_inventory``
+    # fires on any future drift of either sibling.
+    ("︀", "VS1 BMP (Variation Selector)"),
+    ("︎", "VS15 BMP (text-style emoji selector)"),
+    ("️", "VS16 BMP (emoji-style selector)"),
+    ("\U000e0000", "TAG language tag"),
+    ("\U000e0041", "TAG LATIN CAPITAL LETTER A"),
+    ("\U000e0061", "TAG LATIN SMALL LETTER A"),
+    ("\U000e007f", "CANCEL TAG"),
+    ("\U000e0100", "VS17 (supplementary)"),
+    ("\U000e01ef", "VS256 (supplementary)"),
 )
 
 


### PR DESCRIPTION
## Summary

Closes the deferred sibling of the 2026-05-11 **Tag-Character / Variation-Selector Drift** round (`.jules/sentinel.md` line 1720).

The Round-11 widening updated every canonical-floor sanitiser in lockstep to cover three new invisible-character ranges:
- BMP Variation Selectors (U+FE00..U+FE0F)
- Unicode Tag block (U+E0000..U+E007F)
- Supplementary Variation Selectors (U+E0100..U+E01EF)

…but missed the sibling regex in `scripts/generate_sitemap.py:_UNSAFE_URL_CHARS`, whose source-file comment claims **"byte-exact mirror of `src/utils/http.py:_UNSAFE_URL_CHARS`"**. The "byte-exact mirror" contract pinned by the comment quietly diverged three code-point ranges below the canonical floor.

## Threat Model

`SITE_BASE_URL` is environment-controlled and flows into every `<loc>` element of `docs/sitemap.xml` (committed + served on GitHub Pages) and into `docs/robots.txt`'s `Sitemap:` directive. A planted value like `https://forker.github.io/wien-oepnv\U000E0061\U000E0062` carries Tag-character bytes that are visually invisible but byte-distinct from a legitimate URL — a steganography / prompt-injection (Tag bytes decode as English text per the `arxiv.org/abs/2406.16066` exploit shape against modern LLMs) / cache-key-collision primitive against every search engine and LLM-driven downstream service that consumes the sitemap.

The second-layer gate (`validate_public_feed_url`) currently catches it, but the **Round-6 prevention rule** explicitly named the structural risk: *"A future PR that adds a callsite of `_UNSAFE_URL_CHARS` in `scripts/generate_sitemap.py` without the second-layer gate would re-enable the BiDi/zero-width issue."* The same prevention rule applies to the Round-11 supplementary ranges.

## Why the existing inventory test missed it

`tests/test_sentinel_sitemap_unsafe_chars_canonical_drift.py::test_sitemap_unsafe_url_chars_covers_canonical_set_inventory` only parametrises over `CANONICAL_DANGEROUS_CHARS`, which was the *pre*-Round-11 enumeration. A passing inventory test is necessary but not sufficient — the enumeration itself MUST track the canonical floor.

## Changes

- **`scripts/generate_sitemap.py`** — widen `_UNSAFE_URL_CHARS` to byte-exact lockstep with `src/utils/http.py:_UNSAFE_URL_CHARS`. Documented the Round-11 widening in the source-file comment.
- **`tests/test_sentinel_sitemap_tag_chars_variation_selectors_drift.py`** (new) — per-code-point PoC test parametrised over the three supplementary ranges, plus end-to-end rejection via `_is_valid_base_url` and a sister inventory invariant.
- **`tests/test_sentinel_sitemap_unsafe_chars_canonical_drift.py`** — extend `CANONICAL_DANGEROUS_CHARS` with the Round-11 code points so the parent inventory test fires on any future drift of either sibling.
- **`.jules/sentinel.md`** — journal entry documenting the drift, the fix, and the prevention rule extension.

## Test plan

- [x] PoC test fails pre-fix, passes post-fix (verified locally)
- [x] All 4532 tests pass (`pytest`)
- [x] Ruff: all checks passed
- [x] Mypy (CI version 1.10.x): 0 new errors vs `.mypy-baseline.txt`
- [x] Bandit: no failures (4 pre-existing nosec warnings)
- [x] Secret scanner: no findings
- [x] C901 complexity gate: 0 new violations
- [x] pip-audit: no known vulnerabilities
- [x] Legitimate `https://forker.github.io/wien-oepnv` and `https://github.com/Origamihase/wien-oepnv` continue to pass `_is_valid_base_url` (regression coverage)

https://claude.ai/code/session_01JiyA6BHPHJnW3wy4dsYoA2

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiyA6BHPHJnW3wy4dsYoA2)_