### PR TITLE
feat(places): add HAFAS (ÖBB Scotty) coordinate fallback

### DIFF
--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -86,6 +86,16 @@ jobs:
         run: python scripts/check_overpass_status.py --allow-skip --verbose
         continue-on-error: true
 
+      - name: Synchronize HAFAS Profile
+        # Refresh data/hafas_profile.json from the upstream
+        # public-transport/hafas-client OEBB profile so the HAFAS
+        # fallback inside ``src/places/hafas_client.py`` picks up the
+        # current ``salt`` / ``ver`` / ``aid`` triple. ÖBB rotates
+        # these without notice; running the sync right before the
+        # station-directory refresh keeps the cached profile fresh
+        # without bloating the job runtime.
+        run: python scripts/sync_hafas_profile.py
+
       - name: Refresh station directory
         env:
           WIEN_OEPNV_OSM_ENRICH: ${{ steps.overpass-smoke.outcome == 'success' && '1' || '0' }}

--- a/docs/schema/stations.schema.json
+++ b/docs/schema/stations.schema.json
@@ -77,6 +77,11 @@
           "pattern": "^[0-9]+$",
           "description": "Wiener Linien DIVA-Nummer aus data/wienerlinien-ogd-haltestellen.csv (Wiener Linien OGD, www.wienerlinien.at/ogd_realtime/doku/ogd/, CC BY 4.0). Wird für WL-Provider-Lookups als IDENTITY-Alias geführt und trägt — gemeinsam mit bst_id/bst_code/vor_id — die strukturelle Eindeutigkeits-Garantie der Station."
         },
+        "hafas_extId": {
+          "type": "string",
+          "pattern": "^[0-9A-Za-z._:@=-]+$",
+          "description": "HAFAS (ÖBB Scotty) extId aus der LocMatch-Anreicherung in src/places/hafas_client.py. Wird vom HAFAS-Fallback in scripts/update_station_directory.py gesetzt, wenn OSM Overpass keine Koordinaten liefert und HAFAS die Station auflöst. Typisch 7-9 Ziffern (z. B. '8100353' für Wien Hauptbahnhof); zulässig sind auch alphanumerische HAFAS-LIDs."
+        },
         "wl_stops": {
           "type": "array",
           "description": "WL-Einzelhaltepunkte (Bahnsteige/Richtungen) aus data/wienerlinien-ogd-haltepunkte.csv (Wiener Linien OGD, www.wienerlinien.at/ogd_realtime/doku/ogd/).",

--- a/scripts/sync_hafas_profile.py
+++ b/scripts/sync_hafas_profile.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Synchronise the ÖBB HAFAS (Scotty) Mgate profile from upstream.
+
+The HAFAS Mgate API of ÖBB requires up to three credential-shaped values
+to authenticate every request:
+
+* ``salt`` — optional HMAC ingredient for the ``mac`` query-parameter.
+  Not every HAFAS deployment uses it; ÖBB's current profile has none.
+* ``ver`` — HAFAS API client version pinned by ÖBB.
+* ``aid`` — deployment-scoped Application-ID inside the ``auth`` block.
+
+ÖBB rotates these values without notice, so a long-lived hardcoded
+triple in the repository would silently break the HAFAS fallback inside
+:mod:`src.places.hafas_client`. This helper extracts the live values
+from the upstream ``public-transport/hafas-client`` project (the
+canonical community mirror of ÖBB's web-app profile) and persists them
+atomically to ``data/hafas_profile.json``. The CI workflow runs this
+script directly before ``scripts/update_station_directory.py`` so the
+cron pipeline always picks up the freshest credentials.
+
+The upstream OEBB profile is split across two JavaScript modules — the
+entry point ``p/oebb/index.js`` and the imported ``p/oebb/base.js``
+(``index.js`` spreads ``baseProfile`` from ``./base.js``). The
+credential triple lives in ``base.js`` today; the sync resolves both
+files and merges the matches so a future upstream refactor that moves
+fields back into ``index.js`` does not silently break the cron job.
+
+The fetch routes through :func:`src.utils.http.request_safe` so the
+project's SSRF / DNS-rebinding / size-bomb defences apply uniformly.
+
+Exit codes:
+    0 — Profile fetched, parsed and written successfully.
+    1 — Upstream returned a non-2xx status, the response could not be
+        decoded as UTF-8, or one of the mandatory credential fields
+        (``ver`` / ``aid``) was missing from both source files.
+    2 — Network / DNS / connect-timeout failure or SSRF rejection by
+        :func:`request_safe`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Final
+
+import requests
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.feed.logging_safe import setup_script_logging
+from src.utils.files import atomic_write
+from src.utils.http import request_safe, session_with_retries
+from src.utils.logging import sanitize_log_arg
+from src.utils.serialize import scrub_trojan_source_primitives
+
+LOGGER = logging.getLogger("places.hafas.sync")
+
+_PROFILE_SOURCE_URL: Final[str] = (
+    "https://raw.githubusercontent.com/public-transport/hafas-client/main/p/oebb/index.js"
+)
+
+# Sibling module the entry-point imports via ``import baseProfile from
+# './base.js'``. We resolve it relative to the configured source URL so
+# a ``--source-url`` override applied at the entry-point automatically
+# inherits the correct base.
+_BASE_SUFFIX: Final[str] = "base.js"
+
+_USER_AGENT: Final[str] = (
+    "wien-oepnv-hafas-sync/1.0 "
+    "(+https://github.com/Origamihase/wien-oepnv; cron-pipeline)"
+)
+
+# The hafas-client source is hand-edited JavaScript; the credential
+# strings appear as quoted literals inside a ``profile`` / default-export
+# object. We extract each independently rather than parsing JavaScript
+# because the upstream layout (line breaks, key ordering, comments) is
+# not stable across releases.
+_SALT_RE: Final[re.Pattern[str]] = re.compile(
+    r"""salt\s*:\s*(?:Buffer\s*\.\s*from\s*\(\s*)?['"]([^'"\\]{8,256})['"]""",
+)
+_VER_RE: Final[re.Pattern[str]] = re.compile(
+    r"""\bver\s*:\s*['"]([0-9A-Za-z.\-_]{1,32})['"]""",
+)
+_AID_RE: Final[re.Pattern[str]] = re.compile(
+    r"""\baid\s*:\s*['"]([0-9A-Za-z.\-_]{1,128})['"]""",
+)
+
+# Tight wall-clock cap. The fetch happens at the very start of the
+# station-update workflow, so a slow upstream here directly delays the
+# whole cron tick.
+_FETCH_TIMEOUT_S: Final[float] = 15.0
+
+# Hard size cap. The upstream source files are < 4 KiB today; we cap an
+# order of magnitude above that to absorb future growth while keeping a
+# malicious / corrupted mirror from streaming megabytes through the
+# Slowloris-defence read budget.
+_MAX_RESPONSE_BYTES: Final[int] = 256 * 1024
+
+_DEFAULT_OUTPUT_PATH: Final[Path] = (
+    Path(__file__).resolve().parents[1] / "data" / "hafas_profile.json"
+)
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=_DEFAULT_OUTPUT_PATH,
+        help=(
+            "Destination JSON file (default: ./data/hafas_profile.json). "
+            "The write is atomic so a partial fetch cannot leave the "
+            "directory inconsistent."
+        ),
+    )
+    parser.add_argument(
+        "--source-url",
+        default=_PROFILE_SOURCE_URL,
+        help=(
+            "Override the upstream hafas-client entry-point URL. Must be "
+            "an https URL; routed through request_safe so SSRF guards apply."
+        ),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=_FETCH_TIMEOUT_S,
+        help=f"Per-request wall-clock cap in seconds (default: {_FETCH_TIMEOUT_S}).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Emit DEBUG-level logs.",
+    )
+    return parser.parse_args(argv)
+
+
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    setup_script_logging(level)
+
+
+def _sibling_url(entry_url: str, sibling_name: str) -> str:
+    """Derive the sibling URL by replacing the entry-point filename.
+
+    Pure string transform — no URL parsing, so the result is byte-exact
+    against the entry point's host / path / query and inherits whatever
+    allow-list ``request_safe`` already applied to the entry URL.
+    """
+    base, _slash, _filename = entry_url.rpartition("/")
+    if not base:
+        return entry_url
+    return f"{base}/{sibling_name}"
+
+
+def _fetch_source(
+    session: requests.Session, url: str, timeout_s: float
+) -> str | None:
+    """Download a single upstream source file.
+
+    Returns the decoded JavaScript source as a string, or ``None`` if
+    the upstream is unreachable / responded with a non-2xx / served an
+    undecodable body. The caller chains multiple files to assemble the
+    full ÖBB profile.
+    """
+    try:
+        response = request_safe(
+            session,
+            url,
+            method="GET",
+            max_bytes=_MAX_RESPONSE_BYTES,
+            timeout=timeout_s,
+            # raw.githubusercontent.com serves the file as text/plain.
+            # Some CDN paths return application/javascript or
+            # octet-stream — accept the canonical set so a future
+            # content-type negotiation tweak doesn't break the sync.
+            allowed_content_types=(
+                "text/plain",
+                "text/javascript",
+                "application/javascript",
+                "application/octet-stream",
+            ),
+            headers={
+                "Accept": "text/plain, text/javascript, */*;q=0.1",
+                "User-Agent": _USER_AGENT,
+            },
+        )
+    except requests.RequestException as exc:
+        LOGGER.error(
+            "HAFAS profile fetch failed (network): %s",
+            sanitize_log_arg(type(exc).__name__),
+        )
+        return None
+    except ValueError as exc:
+        LOGGER.error(
+            "HAFAS profile fetch rejected by request_safe: %s",
+            sanitize_log_arg(type(exc).__name__),
+        )
+        return None
+    try:
+        text: str = response.content.decode("utf-8")
+    except UnicodeDecodeError:
+        LOGGER.error("HAFAS profile source is not valid UTF-8")
+        return None
+    return text
+
+
+def _fetch_combined_source(entry_url: str, timeout_s: float) -> str | None:
+    """Fetch the entry-point source and its sibling ``base.js`` module.
+
+    Returns the concatenation of both bodies (separated by a newline)
+    so the field-extraction regexes can scan a single string. ``None``
+    if the primary fetch failed; a missing sibling is tolerated — the
+    extractor will fail the mandatory-field check later if any required
+    value cannot be found across the merged source.
+    """
+    session = session_with_retries(
+        user_agent=_USER_AGENT,
+        timeout=(min(5.0, timeout_s), timeout_s),
+    )
+    try:
+        primary = _fetch_source(session, entry_url, timeout_s)
+        if primary is None:
+            return None
+        sibling_url = _sibling_url(entry_url, _BASE_SUFFIX)
+        if sibling_url == entry_url:
+            return primary
+        sibling = _fetch_source(session, sibling_url, timeout_s)
+        if sibling is None:
+            LOGGER.info(
+                "Sibling base.js unavailable; falling back to entry-point source only"
+            )
+            return primary
+        return f"{primary}\n{sibling}"
+    finally:
+        session.close()
+
+
+def _extract_profile(source: str) -> dict[str, str] | None:
+    """Return the credential strings, or ``None`` if a required one is missing.
+
+    ``ver`` and ``aid`` are mandatory — without them no HAFAS request
+    can be built. ``salt`` is optional: ÖBB's current upstream profile
+    omits it (the API accepts unsigned requests). When ``salt`` is
+    absent the returned dict simply omits the key; the on-disk profile
+    then carries an empty string so downstream consumers can treat
+    "no salt" as a known state rather than a parse failure.
+    """
+    ver_match = _VER_RE.search(source)
+    aid_match = _AID_RE.search(source)
+
+    missing: list[str] = []
+    if ver_match is None:
+        missing.append("ver")
+    if aid_match is None:
+        missing.append("aid")
+    if missing or ver_match is None or aid_match is None:
+        LOGGER.error(
+            "HAFAS profile source is missing required fields: %s",
+            sanitize_log_arg(",".join(missing)),
+        )
+        return None
+
+    extracted: dict[str, str] = {
+        "ver": ver_match.group(1),
+        "aid": aid_match.group(1),
+    }
+    salt_match = _SALT_RE.search(source)
+    if salt_match is not None:
+        extracted["salt"] = salt_match.group(1)
+    else:
+        LOGGER.info(
+            "Upstream HAFAS profile carries no salt; storing empty value "
+            "(ÖBB does not currently require mac signing)"
+        )
+    return extracted
+
+
+def _build_profile_document(extracted: dict[str, str]) -> dict[str, object]:
+    """Render the canonical on-disk profile JSON.
+
+    The shape mirrors the structure :mod:`src.places.hafas_client`
+    expects: a flat ``salt`` / ``ver`` triple at the top level, an
+    ``auth`` block describing the authentication scheme, and a
+    ``client`` block carrying the ÖBB webapp's identifying handshake
+    fields.
+    """
+    return {
+        "salt": extracted.get("salt", ""),
+        "ver": extracted["ver"],
+        "auth": {"type": "AID", "aid": extracted["aid"]},
+        "client": {
+            "id": "OEBB",
+            "type": "WEB",
+            "name": "webapp",
+            "l": "vs_webapp",
+        },
+    }
+
+
+def _write_profile(profile: dict[str, object], output_path: Path) -> None:
+    """Persist the profile atomically with 0600 permissions.
+
+    The credentials are not literally secret (they ship in every public
+    web-app build of HAFAS) but treating them as low-sensitivity state
+    keeps the on-disk shape consistent with the project's other
+    auth-bearing sidecars.
+    """
+    scrubbed = scrub_trojan_source_primitives(profile)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with atomic_write(
+        output_path, mode="w", encoding="utf-8", permissions=0o600
+    ) as handle:
+        json.dump(
+            scrubbed,
+            handle,
+            ensure_ascii=True,
+            sort_keys=True,
+            indent=2,
+        )
+        handle.write("\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    _configure_logging(args.verbose)
+
+    source = _fetch_combined_source(args.source_url, max(1.0, float(args.timeout)))
+    if source is None:
+        return 2
+
+    extracted = _extract_profile(source)
+    if extracted is None:
+        return 1
+
+    profile = _build_profile_document(extracted)
+    try:
+        _write_profile(profile, args.output)
+    except OSError as exc:
+        LOGGER.error(
+            "Failed to write HAFAS profile: %s",
+            sanitize_log_arg(type(exc).__name__),
+        )
+        return 1
+
+    salt_value = extracted.get("salt", "")
+    LOGGER.info(
+        "HAFAS profile written (ver=%s, salt-bytes=%d, aid-bytes=%d)",
+        sanitize_log_arg(extracted["ver"]),
+        len(salt_value),
+        len(extracted["aid"]),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_hafas_profile.py
+++ b/scripts/sync_hafas_profile.py
@@ -41,10 +41,10 @@ from __future__ import annotations
 
 import argparse
 import json
-import logging
 import re
 import sys
 from collections.abc import Sequence
+from logging import DEBUG, INFO, getLogger
 from pathlib import Path
 from typing import Final
 
@@ -59,7 +59,7 @@ from src.utils.http import request_safe, session_with_retries
 from src.utils.logging import sanitize_log_arg
 from src.utils.serialize import scrub_trojan_source_primitives
 
-LOGGER = logging.getLogger("places.hafas.sync")
+LOGGER = getLogger("places.hafas.sync")
 
 _PROFILE_SOURCE_URL: Final[str] = (
     "https://raw.githubusercontent.com/public-transport/hafas-client/main/p/oebb/index.js"
@@ -145,7 +145,7 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
 
 
 def _configure_logging(verbose: bool) -> None:
-    level = logging.DEBUG if verbose else logging.INFO
+    level = DEBUG if verbose else INFO
     setup_script_logging(level)
 
 
@@ -352,10 +352,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         return 1
 
+    # Security: log only byte-length metadata, never the parsed credential
+    # values themselves. The ``ver`` / ``aid`` strings reach this log line
+    # via ``_extract_profile``'s dict — a credential-coded dataflow that
+    # CodeQL's clear-text-logging-sensitive-data taint analysis marks as
+    # secret-bearing end-to-end. Lengths give operators the "did the
+    # extractor find non-empty values?" signal they need without surfacing
+    # the bytes themselves. ``--verbose`` operators can inspect the
+    # on-disk JSON directly when they need the literal values.
     salt_value = extracted.get("salt", "")
     LOGGER.info(
-        "HAFAS profile written (ver=%s, salt-bytes=%d, aid-bytes=%d)",
-        sanitize_log_arg(extracted["ver"]),
+        "HAFAS profile written (ver-bytes=%d, salt-bytes=%d, aid-bytes=%d)",
+        len(extracted["ver"]),
         len(salt_value),
         len(extracted["aid"]),
     )

--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -129,6 +129,7 @@ try:  # pragma: no cover - convenience for module execution
         get_places_api_key,
     )
     from src.places.diagnostics import permission_hint
+    from src.places.hafas_client import enrich_station_with_hafas
     from src.places.merge import BoundingBox, MergeConfig, merge_places, StationEntry
     from src.places.osm_client import (
         OSMOverpassError,
@@ -151,6 +152,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when installed as pac
         get_places_api_key,
     )
     from places.diagnostics import permission_hint  # type: ignore[no-redef]
+    from places.hafas_client import enrich_station_with_hafas  # type: ignore[no-redef]
     from places.merge import BoundingBox, MergeConfig, merge_places, StationEntry  # type: ignore[no-redef]
     from places.osm_client import (  # type: ignore[no-redef]
         OSMOverpassError,
@@ -1018,6 +1020,54 @@ def _enrich_with_osm(
         len(outcome.skipped_places),
     )
     return True
+
+
+def _enrich_with_hafas(stations: list[Station]) -> list[Station]:
+    """Resolve coordinates for *stations* via the ÖBB HAFAS fallback.
+
+    Iterates over the strict subset of stations still missing
+    coordinates after the OSM pass and asks
+    :func:`src.places.hafas_client.enrich_station_with_hafas` for each.
+    The HAFAS hit is committed straight onto the station's extras —
+    matching the field shape produced by the OSM merge — and the
+    HAFAS ``extId`` is persisted as the top-level ``hafas_extId`` key
+    (parallel to ``vor_id`` / ``_google_place_id``) so downstream
+    consumers can resolve a station back to its HAFAS identifier
+    without re-querying the upstream.
+
+    Returns the residual list of stations *still* missing coordinates
+    after HAFAS ran, so the caller can hand only that subset to the
+    Google Places tier — protecting the monthly free-tier quota.
+    """
+    if not stations:
+        return []
+
+    updated = 0
+    residual: list[Station] = []
+    for station in stations:
+        hit = enrich_station_with_hafas(station.name)
+        if hit is None:
+            residual.append(station)
+            continue
+        station.extras["latitude"] = hit["lat"]
+        station.extras["longitude"] = hit["lon"]
+        station.extras["hafas_extId"] = hit["extId"]
+
+        existing_source = station.extras.get("source")
+        sources: set[str] = set()
+        if isinstance(existing_source, str):
+            sources.update(s.strip() for s in existing_source.split(",") if s.strip())
+        sources.add("hafas")
+        station.extras["source"] = ",".join(sorted(sources))
+        updated += 1
+
+    logger.info(
+        "HAFAS enrichment resolved coordinates for %d of %d stations; %d still missing",
+        updated,
+        len(stations),
+        len(residual),
+    )
+    return residual
 
 
 def _enrich_with_google_places(
@@ -2072,26 +2122,38 @@ def main() -> None:
                 len(stations),
             )
         else:
-            if osm_succeeded:
+            # HAFAS (ÖBB Scotty) is the second-tier fallback: it sits
+            # between the OSM Overpass primary and the Google Places
+            # last-resort. The HAFAS Mgate API has no per-month quota,
+            # so resolving coordinates here directly reduces the load
+            # on the Google free-tier budget tracked in
+            # data/places_quota.json.
+            missing = _enrich_with_hafas(missing)
+            if not missing:
                 logger.info(
-                    "Falling back to Google Places for %d stations still " "missing coordinates after OSM enrichment",
-                    len(missing),
+                    "HAFAS resolved every remaining station; skipping Google Places enrichment"
                 )
             else:
-                logger.info(
-                    "Falling back to Google Places for %d stations missing " "coordinates (OSM Overpass was unavailable)",
-                    len(missing),
+                if osm_succeeded:
+                    logger.info(
+                        "Falling back to Google Places for %d stations still " "missing coordinates after OSM + HAFAS enrichment",
+                        len(missing),
+                    )
+                else:
+                    logger.info(
+                        "Falling back to Google Places for %d stations missing " "coordinates (OSM Overpass was unavailable)",
+                        len(missing),
+                    )
+                # Pass the strict subset so Google never re-keys stations that
+                # OSM / HAFAS (or any earlier source) already resolved. The merge
+                # logic in src.places.merge would otherwise greedily match Google
+                # Places by name even when the existing entry is complete, giving
+                # the fallback authority it shouldn't have.
+                _enrich_with_google_places(
+                    stations,
+                    tiles_file=args.places_tiles_file,
+                    missing_subset=missing,
                 )
-            # Pass the strict subset so Google never re-keys stations that
-            # OSM (or any earlier source) already resolved. The merge logic
-            # in src.places.merge would otherwise greedily match Google
-            # Places by name even when the existing entry is complete,
-            # giving the fallback authority it shouldn't have.
-            _enrich_with_google_places(
-                stations,
-                tiles_file=args.places_tiles_file,
-                missing_subset=missing,
-            )
     else:
         logger.info("Skipping Google Places enrichment (--no-google-enrich)")
 

--- a/src/places/hafas_client.py
+++ b/src/places/hafas_client.py
@@ -126,11 +126,24 @@ _BREAKER: Final[CircuitBreaker] = CircuitBreaker(
 )
 
 _PROFILE_LOCK: Final[threading.Lock] = threading.Lock()
-_PROFILE_CACHE: HafasProfile | None = None
-# Sentinel: a previous load attempt failed and the failure was logged.
-# We avoid spamming the cron log with the same warning on every
-# subsequent station lookup in the same process.
-_PROFILE_LOAD_FAILED: bool = False
+
+
+class _ProfileState:
+    """Module-level cache for the lazily-loaded HAFAS profile.
+
+    The state lives on a class instead of bare module globals so
+    CodeQL's ``py/unused-global-variable`` analysis (which treats
+    ``global``-statement reads/writes inside a single function as
+    self-use and flags the variable as unused) sees clear
+    attribute-level reads and writes across the public entry point.
+    The ``cache`` slot holds the parsed profile after a successful
+    first load; the ``load_failed`` slot pins the "do not retry in
+    this process" decision so the cron log isn't spammed with the
+    same diagnostic on every subsequent station lookup.
+    """
+
+    cache: HafasProfile | None = None
+    load_failed: bool = False
 
 
 def _load_profile(path: Path = _PROFILE_PATH) -> HafasProfile:
@@ -202,22 +215,21 @@ def _get_profile() -> HafasProfile | None:
     in the same process short-circuit silently. The cache is thread-
     safe so a multi-threaded enrichment pass cannot race the load.
     """
-    global _PROFILE_CACHE, _PROFILE_LOAD_FAILED
     with _PROFILE_LOCK:
-        if _PROFILE_CACHE is not None:
-            return _PROFILE_CACHE
-        if _PROFILE_LOAD_FAILED:
+        if _ProfileState.cache is not None:
+            return _ProfileState.cache
+        if _ProfileState.load_failed:
             return None
         try:
-            _PROFILE_CACHE = _load_profile()
+            _ProfileState.cache = _load_profile()
         except HafasProfileError as exc:
-            _PROFILE_LOAD_FAILED = True
+            _ProfileState.load_failed = True
             LOGGER.warning(
                 "HAFAS enrichment disabled: %s",
                 sanitize_log_arg(str(exc)),
             )
             return None
-        return _PROFILE_CACHE
+        return _ProfileState.cache
 
 
 def _build_loc_match_payload(profile: HafasProfile, station_name: str) -> dict[str, object]:

--- a/src/places/hafas_client.py
+++ b/src/places/hafas_client.py
@@ -1,0 +1,472 @@
+"""Native HAFAS (ÖBB Scotty) Mgate client for coordinate fallback.
+
+This module is the third tier of the station-directory enrichment
+pipeline. After OSM Overpass and before Google Places, callers ask
+:func:`enrich_station_with_hafas` for a station's coordinates by name.
+A single HAFAS Mgate ``LocMatch`` request returns the canonical
+location row, which is normalised into a :class:`HafasLocation`
+TypedDict and returned to the caller.
+
+Resilience is layered to mirror the OSM Overpass client:
+
+* :func:`src.utils.http.session_with_retries` adds urllib3-level
+  retries with jitter for transient errors.
+* The module-level :class:`CircuitBreaker` protects the cron pipeline
+  from self-DDoS when HAFAS is down: five consecutive failures cool
+  the upstream for five minutes.
+* :func:`src.utils.http.request_safe` enforces SSRF / DNS-rebinding /
+  size / content-type guards.
+
+The HAFAS profile (``salt`` / ``ver`` / ``aid`` / ``client``) is loaded
+lazily from ``data/hafas_profile.json``. The companion
+``scripts/sync_hafas_profile.py`` refreshes the file from upstream
+before each cron tick. When the profile is absent (developer's local
+machine, first-time clone) :func:`enrich_station_with_hafas` returns
+``None`` instead of raising — the caller treats HAFAS as unavailable
+and falls through to the Google Places tier.
+
+No external HAFAS client library is used. The Mgate request payload is
+constructed directly and — when the upstream profile carries a salt —
+signed with an MD5 mac. ÖBB's current upstream profile carries no salt
+and accepts unsigned requests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+from pathlib import Path
+from typing import Any, Final, TypedDict, cast
+
+import requests
+
+from ..utils.circuit_breaker import CircuitBreaker, CircuitBreakerOpen
+from ..utils.files import read_capped_json
+from ..utils.http import request_safe, session_with_retries
+from ..utils.logging import sanitize_log_arg
+
+__all__ = [
+    "HafasLocation",
+    "HafasProfile",
+    "HafasProfileError",
+    "enrich_station_with_hafas",
+]
+
+LOGGER = logging.getLogger("places.hafas")
+
+
+class HafasLocation(TypedDict):
+    """Normalised HAFAS station location returned to enrichment callers."""
+
+    name: str
+    extId: str
+    lon: float
+    lat: float
+
+
+class HafasProfile(TypedDict):
+    """In-memory view of ``data/hafas_profile.json``.
+
+    Mirrors the on-disk JSON produced by
+    ``scripts/sync_hafas_profile.py``: a flat ``salt`` / ``ver`` pair,
+    plus the ``auth`` and ``client`` sub-objects that the Mgate request
+    envelope carries verbatim.
+    """
+
+    salt: str
+    ver: str
+    auth: dict[str, str]
+    client: dict[str, str]
+
+
+class HafasProfileError(RuntimeError):
+    """Raised when the on-disk HAFAS profile is missing or malformed.
+
+    The public :func:`enrich_station_with_hafas` entry point catches
+    this and returns ``None``; the error type is kept distinct from
+    other RuntimeErrors so callers that want to surface a profile
+    problem (the sync script before kicking off the enrichment) can
+    distinguish it from a transient upstream failure.
+    """
+
+
+_HAFAS_ENDPOINT: Final[str] = "https://fahrplan.oebb.at/bin/mgate.exe"
+
+# Per-call response cap. A LocMatch response with ``maxLoc=1`` weighs
+# ~2 KiB on the wire; 256 KiB is two orders of magnitude above
+# production state and well below ``MAX_PAYLOAD_SIZE`` (10 MiB).
+_MAX_RESPONSE_BYTES: Final[int] = 256 * 1024
+
+# Slowloris-defence ceiling for the whole request (connect + read).
+# A LocMatch round-trip completes in < 1 s under normal conditions;
+# 20 s absorbs a degraded upstream without stalling the cron tick.
+_REQUEST_TIMEOUT_S: Final[float] = 20.0
+
+# Coordinate scale used by HAFAS. The wire format carries lon/lat as
+# integers multiplied by 1e6 (e.g. ``x=16377778`` for longitude
+# 16.377778°). We normalise to floats at parse time so callers always
+# see WGS84 decimals.
+_HAFAS_COORD_SCALE: Final[float] = 1_000_000.0
+
+_USER_AGENT: Final[str] = (
+    "wien-oepnv-hafas/1.0 "
+    "(+https://github.com/Origamihase/wien-oepnv; cron-pipeline)"
+)
+
+_PROFILE_PATH: Final[Path] = (
+    Path(__file__).resolve().parents[2] / "data" / "hafas_profile.json"
+)
+
+_BREAKER: Final[CircuitBreaker] = CircuitBreaker(
+    "hafas_enrichment",
+    failure_threshold=5,
+    recovery_timeout=300.0,
+)
+
+_PROFILE_LOCK: Final[threading.Lock] = threading.Lock()
+_PROFILE_CACHE: HafasProfile | None = None
+# Sentinel: a previous load attempt failed and the failure was logged.
+# We avoid spamming the cron log with the same warning on every
+# subsequent station lookup in the same process.
+_PROFILE_LOAD_FAILED: bool = False
+
+
+def _load_profile(path: Path = _PROFILE_PATH) -> HafasProfile:
+    """Validate-and-narrow the on-disk profile JSON.
+
+    Raises :class:`HafasProfileError` if the file is missing, the
+    payload is not a JSON object, or any of the required fields is
+    missing / mistyped. The public entry point catches this and
+    short-circuits to ``None`` so the cron pipeline can fall through
+    to Google Places.
+    """
+    payload = read_capped_json(
+        path,
+        label="HAFAS profile",
+        logger=LOGGER,
+    )
+    if payload is None:
+        raise HafasProfileError(
+            f"HAFAS profile not found or unreadable at {path.name}"
+        )
+    if not isinstance(payload, dict):
+        raise HafasProfileError("HAFAS profile JSON must be an object")
+    payload_dict: dict[str, Any] = cast(dict[str, Any], payload)
+
+    salt_value = payload_dict.get("salt")
+    ver_value = payload_dict.get("ver")
+    auth_value = payload_dict.get("auth")
+    client_value = payload_dict.get("client")
+
+    if not isinstance(salt_value, str):
+        raise HafasProfileError("HAFAS profile is missing string field 'salt'")
+    if not isinstance(ver_value, str) or not ver_value:
+        raise HafasProfileError("HAFAS profile is missing string field 'ver'")
+    if not isinstance(auth_value, dict):
+        raise HafasProfileError("HAFAS profile is missing object field 'auth'")
+    if not isinstance(client_value, dict):
+        raise HafasProfileError("HAFAS profile is missing object field 'client'")
+
+    auth: dict[str, str] = {}
+    for key, value in auth_value.items():
+        if isinstance(key, str) and isinstance(value, str):
+            auth[key] = value
+    client: dict[str, str] = {}
+    for key, value in client_value.items():
+        if isinstance(key, str) and isinstance(value, str):
+            client[key] = value
+
+    if auth.get("type") != "AID" or not auth.get("aid"):
+        raise HafasProfileError(
+            "HAFAS profile 'auth' block is missing AID/aid fields"
+        )
+    if not client.get("id") or not client.get("type"):
+        raise HafasProfileError(
+            "HAFAS profile 'client' block is missing id/type fields"
+        )
+
+    return HafasProfile(
+        salt=salt_value,
+        ver=ver_value,
+        auth=auth,
+        client=client,
+    )
+
+
+def _get_profile() -> HafasProfile | None:
+    """Return the cached profile, loading it lazily on first call.
+
+    Returns ``None`` once a load attempt has failed so subsequent calls
+    in the same process short-circuit silently. The cache is thread-
+    safe so a multi-threaded enrichment pass cannot race the load.
+    """
+    global _PROFILE_CACHE, _PROFILE_LOAD_FAILED
+    with _PROFILE_LOCK:
+        if _PROFILE_CACHE is not None:
+            return _PROFILE_CACHE
+        if _PROFILE_LOAD_FAILED:
+            return None
+        try:
+            _PROFILE_CACHE = _load_profile()
+        except HafasProfileError as exc:
+            _PROFILE_LOAD_FAILED = True
+            LOGGER.warning(
+                "HAFAS enrichment disabled: %s",
+                sanitize_log_arg(str(exc)),
+            )
+            return None
+        return _PROFILE_CACHE
+
+
+def _build_loc_match_payload(profile: HafasProfile, station_name: str) -> dict[str, object]:
+    """Build the Mgate ``LocMatch`` request envelope for *station_name*.
+
+    The structure follows the canonical HAFAS Mgate contract used by
+    the public-transport/hafas-client community profile: a single
+    ``svcReqL`` entry asking for the top match of a station-typed
+    query. ``maxLoc=1`` keeps the response tiny — we only ever need
+    the first match for coordinate enrichment.
+    """
+    return {
+        "id": profile["client"].get("id", "OEBB"),
+        "ver": profile["ver"],
+        "lang": "de",
+        "auth": {
+            "type": profile["auth"].get("type", "AID"),
+            "aid": profile["auth"].get("aid", ""),
+        },
+        "client": dict(profile["client"]),
+        "formatted": False,
+        "svcReqL": [
+            {
+                "meth": "LocMatch",
+                "req": {
+                    "input": {
+                        "field": "S",
+                        "loc": {"name": station_name, "type": "S"},
+                        "maxLoc": 1,
+                    },
+                },
+            },
+        ],
+    }
+
+
+def _serialise_payload(payload: dict[str, object]) -> str:
+    """Render *payload* in HAFAS's canonical separator-free JSON form.
+
+    The mac signing protocol hashes the exact bytes that travel on the
+    wire, so the request body and the MD5 input must use the same
+    separators. ``json.dumps(payload, separators=(',', ':'))``
+    produces the same shape upstream hafas-client libraries use.
+    """
+    return json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+
+
+def _compute_mac(body: str, salt: str) -> str:
+    """Return the HAFAS Mgate ``mac`` query parameter or empty string.
+
+    HAFAS deployments without a salt accept unsigned requests; in that
+    case we return ``""`` and the caller omits the ``mac`` parameter
+    rather than sending an empty signature (which the upstream would
+    reject as malformed).
+
+    The hash itself is MD5 — non-cryptographic by design (HAFAS only
+    uses it as a tamper check, not for authentication). The
+    ``usedforsecurity=False`` keyword tells CodeQL / Bandit this is an
+    intentional non-security use and silences ``S324`` /
+    ``py/weak-cryptographic-algorithm``.
+    """
+    if not salt:
+        return ""
+    hasher = hashlib.md5(usedforsecurity=False)
+    hasher.update(body.encode("utf-8"))
+    hasher.update(salt.encode("utf-8"))
+    return hasher.hexdigest()
+
+
+def _build_request_url(mac: str) -> str:
+    """Return the endpoint URL with an optional ``?mac=...`` query."""
+    if not mac:
+        return _HAFAS_ENDPOINT
+    return f"{_HAFAS_ENDPOINT}?mac={mac}"
+
+
+def _extract_first_location(payload: object) -> HafasLocation | None:
+    """Walk the HAFAS response and return the first usable location.
+
+    The response shape is::
+
+        {
+          "svcResL": [
+            {
+              "meth": "LocMatch",
+              "err": "OK",
+              "res": {"match": {"locL": [{"name": …, "extId": …,
+                                          "crd": {"x": …, "y": …}}]}},
+            }
+          ]
+        }
+
+    Any deviation — missing key, wrong type, empty list, non-OK
+    service-level error code — returns ``None`` so callers can treat
+    HAFAS as having no match. The function is intentionally defensive:
+    a single upstream payload drift is a 0-cost soft failure, not a
+    pipeline crash.
+    """
+    if not isinstance(payload, dict):
+        return None
+    svc_res_list = payload.get("svcResL")
+    if not isinstance(svc_res_list, list) or not svc_res_list:
+        return None
+    first_service = svc_res_list[0]
+    if not isinstance(first_service, dict):
+        return None
+    if first_service.get("err") not in (None, "OK"):
+        return None
+    res = first_service.get("res")
+    if not isinstance(res, dict):
+        return None
+    match = res.get("match")
+    if not isinstance(match, dict):
+        return None
+    locations = match.get("locL")
+    if not isinstance(locations, list) or not locations:
+        return None
+    first_location = locations[0]
+    if not isinstance(first_location, dict):
+        return None
+
+    name = first_location.get("name")
+    ext_id = first_location.get("extId")
+    coords = first_location.get("crd")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    if not isinstance(ext_id, str) or not ext_id.strip():
+        return None
+    if not isinstance(coords, dict):
+        return None
+
+    x_raw = coords.get("x")
+    y_raw = coords.get("y")
+    if not isinstance(x_raw, int | float) or isinstance(x_raw, bool):
+        return None
+    if not isinstance(y_raw, int | float) or isinstance(y_raw, bool):
+        return None
+
+    lon = float(x_raw) / _HAFAS_COORD_SCALE
+    lat = float(y_raw) / _HAFAS_COORD_SCALE
+    return HafasLocation(name=name, extId=ext_id, lon=lon, lat=lat)
+
+
+def _fetch_hafas_location(station_name: str) -> HafasLocation | None:
+    """Issue a single Mgate ``LocMatch`` request and parse the response.
+
+    Returns ``None`` when the upstream replied with no match. Raises
+    :class:`requests.RequestException` /
+    :class:`~src.places.hafas_client.HafasProfileError` on
+    infrastructure-level failures so the surrounding
+    :class:`CircuitBreaker` records the failure.
+    """
+    profile = _get_profile()
+    if profile is None:
+        raise HafasProfileError("HAFAS profile not loaded")
+
+    payload = _build_loc_match_payload(profile, station_name)
+    body = _serialise_payload(payload)
+    mac = _compute_mac(body, profile["salt"])
+    url = _build_request_url(mac)
+
+    session = session_with_retries(
+        user_agent=_USER_AGENT,
+        timeout=(min(5.0, _REQUEST_TIMEOUT_S), _REQUEST_TIMEOUT_S),
+        allowed_methods=("GET", "POST"),
+    )
+    try:
+        response = request_safe(
+            session,
+            url,
+            method="POST",
+            max_bytes=_MAX_RESPONSE_BYTES,
+            timeout=_REQUEST_TIMEOUT_S,
+            allowed_content_types=("application/json",),
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json;charset=UTF-8",
+                "User-Agent": _USER_AGENT,
+            },
+            data=body.encode("utf-8"),
+        )
+    finally:
+        session.close()
+
+    try:
+        decoded = response.json()
+    except (ValueError, RecursionError) as exc:
+        # ``RecursionError`` defends against a JSON depth-bomb planted
+        # in a compromised / MITM'd HAFAS response. Treat both shapes
+        # as soft failures — the breaker counts the call as a failure
+        # via the outer RequestException-shaped path used by callers
+        # that want resilient behaviour.
+        LOGGER.warning(
+            "HAFAS returned non-JSON / depth-bomb payload for station: %s",
+            sanitize_log_arg(station_name),
+        )
+        raise requests.RequestException("HAFAS returned invalid JSON payload") from exc
+
+    return _extract_first_location(decoded)
+
+
+def enrich_station_with_hafas(station_name: str) -> HafasLocation | None:
+    """Return coordinates for *station_name* via HAFAS, or ``None``.
+
+    The call routes through the module-level :class:`CircuitBreaker`
+    so a recurring upstream failure short-circuits subsequent calls
+    for five minutes. ``CircuitBreakerOpen`` is caught and converted
+    to ``None`` so callers can simply branch on
+    ``coords is None``. Profile-loading failures and infrastructure
+    errors (network, SSRF rejection, malformed JSON) likewise resolve
+    to ``None`` after a log line — HAFAS is a best-effort tier whose
+    failures must never crash the cron pipeline.
+    """
+    trimmed = station_name.strip()
+    if not trimmed:
+        return None
+
+    try:
+        return _BREAKER.call(_fetch_hafas_location, trimmed)
+    except CircuitBreakerOpen:
+        LOGGER.info(
+            "HAFAS enrichment skipped (breaker open) for station: %s",
+            sanitize_log_arg(trimmed),
+        )
+        return None
+    except HafasProfileError as exc:
+        # The profile loader already logged the diagnostic the first
+        # time it failed; this catch is defensive against a later
+        # in-process eviction of the cached profile.
+        LOGGER.debug(
+            "HAFAS enrichment unavailable for station %s: %s",
+            sanitize_log_arg(trimmed),
+            sanitize_log_arg(str(exc)),
+        )
+        return None
+    except requests.RequestException as exc:
+        LOGGER.warning(
+            "HAFAS enrichment failed for station %s: %s",
+            sanitize_log_arg(trimmed),
+            sanitize_log_arg(type(exc).__name__),
+        )
+        return None
+    except ValueError as exc:
+        # ``request_safe`` raises ``ValueError`` for SSRF / size /
+        # content-type failures. Surface as a warning so operators can
+        # spot a misconfigured endpoint without crashing the cron.
+        LOGGER.warning(
+            "HAFAS enrichment rejected by request_safe for station %s: %s",
+            sanitize_log_arg(trimmed),
+            sanitize_log_arg(type(exc).__name__),
+        )
+        return None

--- a/tests/places/test_hafas_client.py
+++ b/tests/places/test_hafas_client.py
@@ -1,0 +1,345 @@
+"""Tests for the native HAFAS (ÖBB Scotty) Mgate enrichment client.
+
+Covers the profile loader, the Mgate payload / mac construction, the
+LocMatch response parser, the CircuitBreaker integration, and the
+public ``enrich_station_with_hafas`` happy / failure paths. The HTTP
+layer is mocked at ``request_safe`` so the suite runs with no real
+network IO.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from src.places import hafas_client
+from src.places.hafas_client import (
+    HafasLocation,
+    HafasProfile,
+    HafasProfileError,
+    enrich_station_with_hafas,
+)
+from src.utils.circuit_breaker import CircuitBreakerOpen
+
+
+# --------------------------------------------------------------------- fixtures
+
+
+@pytest.fixture
+def reset_module() -> Iterator[None]:
+    """Reset module-level cache + breaker so tests don't leak state."""
+    hafas_client._PROFILE_CACHE = None
+    hafas_client._PROFILE_LOAD_FAILED = False
+    hafas_client._BREAKER.reset()
+    yield
+    hafas_client._PROFILE_CACHE = None
+    hafas_client._PROFILE_LOAD_FAILED = False
+    hafas_client._BREAKER.reset()
+
+
+@pytest.fixture
+def profile_no_salt() -> HafasProfile:
+    return HafasProfile(
+        salt="",
+        ver="1.45",
+        auth={"type": "AID", "aid": "OWDL4fE4ixNiPBBm"},
+        client={"id": "OEBB", "type": "WEB", "name": "webapp", "l": "vs_webapp"},
+    )
+
+
+@pytest.fixture
+def profile_with_salt() -> HafasProfile:
+    return HafasProfile(
+        salt="abcdef0123456789",
+        ver="1.45",
+        auth={"type": "AID", "aid": "TESTAID"},
+        client={"id": "OEBB", "type": "WEB", "name": "webapp", "l": "vs_webapp"},
+    )
+
+
+def _mock_locmatch_response(name: str, ext_id: str, x: int, y: int) -> MagicMock:
+    response = MagicMock(spec=requests.Response)
+    response.status_code = 200
+    response.json.return_value = {
+        "ver": "1.45",
+        "lang": "de",
+        "id": "req",
+        "err": "OK",
+        "svcResL": [
+            {
+                "meth": "LocMatch",
+                "err": "OK",
+                "res": {
+                    "match": {
+                        "field": "S",
+                        "state": "S",
+                        "locL": [
+                            {
+                                "lid": f"A=1@O={name}@X={x}@Y={y}@L={ext_id}",
+                                "type": "S",
+                                "name": name,
+                                "extId": ext_id,
+                                "crd": {"x": x, "y": y},
+                            }
+                        ],
+                    }
+                },
+            }
+        ],
+    }
+    return response
+
+
+# --------------------------------------------------------------------- profile
+
+
+def test_load_profile_rejects_missing_file(tmp_path: Path) -> None:
+    missing = tmp_path / "nope.json"
+    with pytest.raises(HafasProfileError):
+        hafas_client._load_profile(missing)
+
+
+def test_load_profile_rejects_non_object(tmp_path: Path) -> None:
+    bad = tmp_path / "p.json"
+    bad.write_text("[]", encoding="utf-8")
+    with pytest.raises(HafasProfileError):
+        hafas_client._load_profile(bad)
+
+
+def test_load_profile_requires_aid(tmp_path: Path) -> None:
+    bad = tmp_path / "p.json"
+    bad.write_text(
+        json.dumps(
+            {
+                "salt": "",
+                "ver": "1.45",
+                "auth": {"type": "AID"},
+                "client": {"id": "OEBB", "type": "WEB"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(HafasProfileError):
+        hafas_client._load_profile(bad)
+
+
+def test_load_profile_accepts_well_formed(tmp_path: Path) -> None:
+    good = tmp_path / "p.json"
+    good.write_text(
+        json.dumps(
+            {
+                "salt": "abcd",
+                "ver": "1.45",
+                "auth": {"type": "AID", "aid": "TESTAID"},
+                "client": {"id": "OEBB", "type": "WEB", "name": "webapp", "l": "vs_webapp"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    profile = hafas_client._load_profile(good)
+    assert profile["salt"] == "abcd"
+    assert profile["ver"] == "1.45"
+    assert profile["auth"]["aid"] == "TESTAID"
+
+
+# --------------------------------------------------------------------- mac signing
+
+
+def test_compute_mac_returns_empty_when_salt_missing() -> None:
+    assert hafas_client._compute_mac("body", "") == ""
+
+
+def test_compute_mac_matches_md5_of_body_plus_salt() -> None:
+    body = '{"id":"OEBB"}'
+    salt = "abcdef"
+    expected = hashlib.md5(  # noqa: S324 - non-security use
+        (body + salt).encode("utf-8"), usedforsecurity=False
+    ).hexdigest()
+    assert hafas_client._compute_mac(body, salt) == expected
+
+
+def test_build_request_url_omits_mac_when_empty() -> None:
+    assert hafas_client._build_request_url("") == hafas_client._HAFAS_ENDPOINT
+
+
+def test_build_request_url_appends_mac_query() -> None:
+    url = hafas_client._build_request_url("abcd1234")
+    assert url.endswith("?mac=abcd1234")
+
+
+# --------------------------------------------------------------------- payload shape
+
+
+def test_loc_match_payload_carries_profile_fields(profile_no_salt: HafasProfile) -> None:
+    payload = hafas_client._build_loc_match_payload(profile_no_salt, "Wien Hauptbahnhof")
+    assert payload["ver"] == "1.45"
+    assert payload["auth"] == {"type": "AID", "aid": "OWDL4fE4ixNiPBBm"}
+    assert payload["lang"] == "de"
+    svc_req_list = payload["svcReqL"]
+    assert isinstance(svc_req_list, list)
+    first = svc_req_list[0]
+    assert isinstance(first, dict)
+    assert first["meth"] == "LocMatch"
+    req_field = first["req"]
+    assert isinstance(req_field, dict)
+    input_field = req_field["input"]
+    assert isinstance(input_field, dict)
+    loc = input_field["loc"]
+    assert isinstance(loc, dict)
+    assert loc["name"] == "Wien Hauptbahnhof"
+    assert input_field["maxLoc"] == 1
+
+
+# --------------------------------------------------------------------- parser
+
+
+def test_extract_first_location_normalises_coordinates() -> None:
+    location = hafas_client._extract_first_location(
+        _mock_locmatch_response("Wien Hauptbahnhof", "8100353", 16377778, 48185222).json()
+    )
+    assert location == HafasLocation(
+        name="Wien Hauptbahnhof",
+        extId="8100353",
+        lon=16.377778,
+        lat=48.185222,
+    )
+
+
+@pytest.mark.parametrize(
+    "broken_payload",
+    [
+        None,
+        {},
+        {"svcResL": []},
+        {"svcResL": [{"err": "FAIL", "res": {}}]},
+        {"svcResL": [{"err": "OK", "res": {"match": {"locL": []}}}]},
+        {"svcResL": [{"err": "OK", "res": {"match": {"locL": [{"name": "X"}]}}}]},
+        {
+            "svcResL": [
+                {
+                    "err": "OK",
+                    "res": {
+                        "match": {
+                            "locL": [
+                                {
+                                    "name": "X",
+                                    "extId": "1",
+                                    "crd": {"x": "not-a-number", "y": 1},
+                                }
+                            ]
+                        }
+                    },
+                }
+            ]
+        },
+    ],
+)
+def test_extract_first_location_returns_none_on_broken_payload(
+    broken_payload: object,
+) -> None:
+    assert hafas_client._extract_first_location(broken_payload) is None
+
+
+# --------------------------------------------------------------------- end-to-end
+
+
+def test_enrich_returns_none_for_blank_name(reset_module: None) -> None:
+    assert enrich_station_with_hafas("   ") is None
+
+
+def test_enrich_returns_coords_when_profile_loaded(
+    reset_module: None, profile_no_salt: HafasProfile
+) -> None:
+    response = _mock_locmatch_response("Wien Hauptbahnhof", "8100353", 16377778, 48185222)
+    with patch.object(hafas_client, "_get_profile", return_value=profile_no_salt):
+        with patch.object(hafas_client, "request_safe", return_value=response) as rs:
+            result = enrich_station_with_hafas("Wien Hauptbahnhof")
+    assert result == HafasLocation(
+        name="Wien Hauptbahnhof",
+        extId="8100353",
+        lon=16.377778,
+        lat=48.185222,
+    )
+    # When salt is empty the URL has no ``?mac=`` query.
+    call_args: Any = rs.call_args
+    url = call_args.args[1]
+    assert "mac=" not in url
+
+
+def test_enrich_signs_request_when_salt_present(
+    reset_module: None, profile_with_salt: HafasProfile
+) -> None:
+    response = _mock_locmatch_response("Wien Hauptbahnhof", "8100353", 16377778, 48185222)
+    with patch.object(hafas_client, "_get_profile", return_value=profile_with_salt):
+        with patch.object(hafas_client, "request_safe", return_value=response) as rs:
+            enrich_station_with_hafas("Wien Hauptbahnhof")
+    call_args: Any = rs.call_args
+    url = call_args.args[1]
+    body = call_args.kwargs["data"].decode("utf-8")
+    expected_mac = hashlib.md5(  # noqa: S324 - non-security use
+        (body + profile_with_salt["salt"]).encode("utf-8"), usedforsecurity=False
+    ).hexdigest()
+    assert f"mac={expected_mac}" in url
+
+
+def test_enrich_returns_none_when_profile_missing(reset_module: None) -> None:
+    with patch.object(hafas_client, "_get_profile", return_value=None):
+        assert enrich_station_with_hafas("Wien Hauptbahnhof") is None
+
+
+def test_enrich_returns_none_on_network_failure(
+    reset_module: None, profile_no_salt: HafasProfile
+) -> None:
+    def boom(*_args: Any, **_kwargs: Any) -> requests.Response:
+        raise requests.ConnectionError("boom")
+
+    with patch.object(hafas_client, "_get_profile", return_value=profile_no_salt):
+        with patch.object(hafas_client, "request_safe", side_effect=boom):
+            assert enrich_station_with_hafas("Wien Hauptbahnhof") is None
+
+
+def test_enrich_returns_none_when_breaker_open(
+    reset_module: None, profile_no_salt: HafasProfile
+) -> None:
+    def boom(*_args: Any, **_kwargs: Any) -> requests.Response:
+        raise requests.ConnectionError("boom")
+
+    with patch.object(hafas_client, "_get_profile", return_value=profile_no_salt):
+        with patch.object(hafas_client, "request_safe", side_effect=boom):
+            # Trip the breaker by exceeding the failure threshold.
+            for _ in range(hafas_client._BREAKER.failure_threshold):
+                assert enrich_station_with_hafas("Wien Hauptbahnhof") is None
+            assert hafas_client._BREAKER.state.value == "open"
+
+        # While the breaker is open, request_safe is not even called.
+        with patch.object(hafas_client, "request_safe") as never_called:
+            assert enrich_station_with_hafas("Wien Hauptbahnhof") is None
+            never_called.assert_not_called()
+
+
+def test_enrich_handles_invalid_json(
+    reset_module: None, profile_no_salt: HafasProfile
+) -> None:
+    response = MagicMock(spec=requests.Response)
+    response.status_code = 200
+    response.json.side_effect = ValueError("bad json")
+
+    with patch.object(hafas_client, "_get_profile", return_value=profile_no_salt):
+        with patch.object(hafas_client, "request_safe", return_value=response):
+            assert enrich_station_with_hafas("Wien Hauptbahnhof") is None
+
+
+def test_enrich_propagates_open_breaker_as_none(
+    reset_module: None, profile_no_salt: HafasProfile
+) -> None:
+    with patch.object(
+        hafas_client._BREAKER, "call", side_effect=CircuitBreakerOpen("open")
+    ):
+        assert enrich_station_with_hafas("Wien Hauptbahnhof") is None

--- a/tests/places/test_hafas_client.py
+++ b/tests/places/test_hafas_client.py
@@ -35,12 +35,12 @@ from src.utils.circuit_breaker import CircuitBreakerOpen
 @pytest.fixture
 def reset_module() -> Iterator[None]:
     """Reset module-level cache + breaker so tests don't leak state."""
-    hafas_client._PROFILE_CACHE = None
-    hafas_client._PROFILE_LOAD_FAILED = False
+    hafas_client._ProfileState.cache = None
+    hafas_client._ProfileState.load_failed = False
     hafas_client._BREAKER.reset()
     yield
-    hafas_client._PROFILE_CACHE = None
-    hafas_client._PROFILE_LOAD_FAILED = False
+    hafas_client._ProfileState.cache = None
+    hafas_client._ProfileState.load_failed = False
     hafas_client._BREAKER.reset()
 
 


### PR DESCRIPTION
## Summary

Slots a third coordinate-enrichment tier between OSM Overpass (primary) and Google Places (last-resort) so directory gaps OSM cannot fill are resolved via the ÖBB Mgate API without burning the Places monthly free-tier quota.

Implementation is purist — no `pyhafas` dependency. The Mgate LocMatch request is constructed directly, signed with `MD5(body + salt)` when the upstream profile carries a salt (ÖBB currently does not), and routed through `request_safe` so SSRF / DNS-rebinding / size / content-type guards apply uniformly with the rest of the codebase.

## Changes

* **`scripts/sync_hafas_profile.py`** (new) — refreshes `data/hafas_profile.json` from the upstream `public-transport/hafas-client` OEBB profile. Fetches both `p/oebb/index.js` (entry-point per the spec) **and** its imported sibling `p/oebb/base.js`, because the credential triple has migrated into the base module upstream. The three values are extracted via independent regexes; `salt` is tolerated as optional (ÖBB does not currently use mac signing). Persists via `atomic_write` with 0600 permissions.
* **`src/places/hafas_client.py`** (new) — native client with lazy profile load, module-level `CircuitBreaker("hafas_enrichment", failure_threshold=5, recovery_timeout=300.0)`, defensive Mgate response parser that divides `crd.x`/`crd.y` by `1_000_000.0`, and a public `enrich_station_with_hafas()` that converts `CircuitBreakerOpen` + `RequestException` + profile errors into `None` so callers can simply branch on `coords is None`.
* **`scripts/update_station_directory.py`** — `_enrich_with_hafas()` runs on the strict subset of stations still missing coordinates after the OSM pass; only the residual subset is forwarded to Google Places. The HAFAS `extId` is persisted on the top-level `hafas_extId` station field (paralleling the `vor_id` pattern — `aliases` is a `list[str]` by schema, not a dict).
* **`docs/schema/stations.schema.json`** — adds the optional top-level `hafas_extId` property with a permissive pattern covering both numeric (`"8100353"`) and alphanumeric HAFAS LIDs.
* **`.github/workflows/update-stations.yml`** — new `Synchronize HAFAS Profile` step runs `python scripts/sync_hafas_profile.py` immediately before the existing `Refresh station directory` step.
* **`tests/places/test_hafas_client.py`** (new) — 25 unit tests covering profile validation, mac signing (with and without salt), payload shape, response-parser robustness against 7 broken-payload shapes, network-failure paths, breaker integration, and the `None`-return contract.

## Deviations from the literal spec

1. **Upstream URL.** The user-specified `index.js` no longer carries `salt`/`ver`/`aid` — it spreads `baseProfile` from `./base.js`. The sync still fetches the specified entry-point URL but additionally resolves the sibling `base.js` so the merged source contains all three fields. Future restructures in either direction stay supported.
2. **`station["aliases"]["hafas_extId"]` vs. top-level field.** `aliases` is defined as `array<string>` in `docs/schema/stations.schema.json` and is treated as a flat list everywhere in the codebase (`src/utils/stations.py:_iter_aliases_with_strength`, `scripts/enrich_station_aliases.py`). Storing HAFAS `extId` as a top-level field (analogous to `vor_id`, `wl_diva`) preserves the user's intent (durable HAFAS ID on the station) without changing the schema's list-shape contract.
3. **`poetry run` → `python`.** The repo uses pip + `requirements.txt` (no `poetry.lock`, `install-deps` action calls `pip`), so the workflow step uses `python scripts/sync_hafas_profile.py` to match every sibling step. Functionally equivalent given how the GitHub Actions Python action is wired here.

## Test plan

- [x] `mypy --strict` clean on all changed files (3 scripts/src + 1 test file)
- [x] `ruff check` clean on all changed files
- [x] New `tests/places/test_hafas_client.py` — 25 tests pass
- [x] Full pytest suite — 4898 passed, 2 skipped (no regressions)
- [x] Manual smoke test: `scripts/sync_hafas_profile.py` fetches the real upstream, extracts `ver=1.45` / `aid=OWDL4fE4ixNiPBBm`, and writes the expected JSON shape
- [x] Mocked end-to-end: `_enrich_with_hafas` sets `latitude` / `longitude` / `hafas_extId` / `source=hafas` on a synthetic station and returns the residual list intact when HAFAS has no match
- [ ] Live cron run (will be exercised by the next scheduled `update-stations` workflow)

https://claude.ai/code/session_016YxAmGCjfTHNqMmnxfzus9

---
_Generated by [Claude Code](https://claude.ai/code/session_016YxAmGCjfTHNqMmnxfzus9)_