### PR TITLE
docs(vor): purge stale references to removed VOR helper scripts + orphan cache

### DIFF
--- a/.github/workflows/manual-full-refresh.yml
+++ b/.github/workflows/manual-full-refresh.yml
@@ -9,13 +9,10 @@ name: Manual full refresh
 # Monitor beschränkt (Operator-Policy "VOR nur noch für die
 # Verspätungen der Stammstrecke"). Der Monitor läuft als Schritt
 # unten in diesem Workflow und in ``update-cycle.yml`` (~30 Min).
-# VOR-Cache- und VOR-Haltestellen-Refresh sind aus dem automatisierten
-# Stations-Pfad entfernt; das Stationsverzeichnis nutzt die gepinnte
-# ``data/vor-haltestellen.csv``. Bei Bedarf können die Helper-Scripts
-# (``scripts/update_vor_cache.py``, ``scripts/update_vor_stations.py``,
-# ``scripts/fetch_vor_haltestellen.py``) weiterhin als lokaler Direkt-
-# aufruf gestartet werden — der Operator akzeptiert dann bewusst den
-# Quota-Verbrauch außerhalb der 96 Stammstrecke-Calls/Tag.
+# Die früheren VOR-Helper-Scripts (``update_vor_cache.py``,
+# ``update_vor_stations.py``, ``fetch_vor_haltestellen.py``) wurden
+# 2026-05-11 aus ``scripts/`` entfernt; das Stationsverzeichnis nutzt
+# die gepinnte ``data/vor-haltestellen.csv``.
 
 on:
   workflow_dispatch:
@@ -72,11 +69,10 @@ jobs:
       - name: Refresh ÖBB cache
         run: python scripts/update_oebb_cache.py
 
-      # ``update_vor_cache.py`` was removed from the manual-full-refresh
-      # 2026-05-09 to keep the project under the VAO Start tier's
-      # 100/day quota. Stammstrecke (below) is now the only VOR-API
-      # consumer this workflow triggers; emergency station-disruption
-      # refreshes go through ``update-vor-cache.yml`` (workflow_dispatch).
+      # VOR-Cache-Refresh entfällt seit 2026-05-11 vollständig
+      # (Operator-Policy "VOR nur noch für die Stammstrecke"). Der
+      # Stammstrecke-Step (unten) ist damit der einzige VOR-API-
+      # Konsument in diesem Workflow.
 
       - name: Validate VOR secrets
         shell: bash
@@ -101,11 +97,11 @@ jobs:
         run: python scripts/update_stammstrecke_status.py
 
       # ----- 2) Stationsverzeichnis aktualisieren -----
-      # ``fetch_vor_haltestellen.py`` was removed 2026-05-09 — the
-      # station directory now uses the pinned ``data/vor-haltestellen.csv``.
-      # VOR station IDs change rarely (years); operator can refresh the
-      # snapshot manually with ``python scripts/fetch_vor_haltestellen.py``
-      # if needed.
+      # Die VOR-Stop-Liste wurde 2026-05-11 vollständig auf die
+      # gepinnte ``data/vor-haltestellen.csv``-Snapshot umgestellt;
+      # ein Live-Refresh-Skript existiert nicht mehr. VOR-Stop-IDs
+      # ändern sich nur selten — bei Bedarf wird die CSV redaktionell
+      # neu eingespielt.
 
       - name: Refresh station directory
         run: python scripts/update_all_stations.py --verbose

--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -67,14 +67,14 @@ jobs:
 
       # VOR stop-list refresh removed 2026-05-09 to keep the project under
       # the VAO Start tier's 100/day quota — the Stammstrecke monitor
-      # (``build-feed.yml``) is the project's only
-      # auto-running VOR API consumer and already owns 96 reqs/day. The
-      # station directory update now relies on the pinned
-      # ``data/vor-haltestellen.csv`` snapshot. To refresh the snapshot,
-      # run ``python scripts/fetch_vor_haltestellen.py`` manually — the
-      # operator then explicitly accepts the quota cost (a few extra
-      # requests; VOR station IDs change rarely so a many-month-old
-      # snapshot is operationally equivalent to a fresh fetch).
+      # (``update-cycle.yml``) is the project's only auto-running VOR
+      # API consumer and already owns 96 reqs/day. The station
+      # directory update now relies on the pinned
+      # ``data/vor-haltestellen.csv`` snapshot, which is redaktionell
+      # gepflegt; the former ``fetch_vor_haltestellen.py`` helper was
+      # removed from ``scripts/`` in the same pass. VOR station IDs
+      # change rarely (years) so a many-month-old snapshot is
+      # operationally equivalent to a fresh fetch.
 
       - name: Overpass smoke check (fail-fast / skip-OSM gate)
         id: overpass-smoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+* **Docs/Cleanup (VOR-Stammstrecke-only consolidation follow-up)** —
+  Doku- und Workflow-Drift nach der 2026-05-11-Konsolidierung (VOR
+  ist nur noch für den Stammstrecken-Monitor zuständig) bereinigt:
+  * Tote Skript-Verweise auf `update_vor_cache.py`,
+    `update_vor_stations.py` und `fetch_vor_haltestellen.py` aus
+    `docs/development.md`, `docs/architecture.md`,
+    `.github/workflows/manual-full-refresh.yml` und
+    `.github/workflows/update-stations.yml` entfernt; die Scripts
+    existieren seit 2026-05-11 nicht mehr.
+  * Verwaiste `cache/vor_929f1c/last_run.json` (kein aktiver Writer
+    nach der Konsolidierung; Status seit 2026-05-09 `api_unreachable`)
+    plus leeres Parent-Verzeichnis gelöscht.
+  * CLI-Help-Text `python -m src.cli cache update …` listet `vor`
+    nicht mehr als gültigen Provider-Identifier (der Handler hat es
+    ohnehin schon abgewiesen, jetzt ist die Hilfe konsistent).
+  * Stale `update-vor-cache.yml`-Workflow-Verweis in
+    `src/utils/cache.py` (`write_status`-Sicherheitskommentar) und in
+    `tests/test_sentinel_quota_status_trojan_source.py` als historisch
+    gekennzeichnet — die Trojan-Source-Defence im Writer bleibt
+    unverändert in Kraft.
 * **Changed (WL OGD reactivation chain, PR #1441-#1453)**: thirteen
   consolidated PRs fully reactivate the Wiener-Linien OGD merge path
   against the canonical `www.wienerlinien.at/ogd_realtime/doku/ogd/`

--- a/cache/vor_929f1c/last_run.json
+++ b/cache/vor_929f1c/last_run.json
@@ -1,8 +1,0 @@
-{
-  "daily_limit": 100,
-  "last_run_at": "2026-05-09T19:32:34.582322+00:00",
-  "last_run_at_local": "2026-05-09T21:32:34.582322+02:00",
-  "requests_used_today": 1,
-  "stations_queried": 2,
-  "status": "api_unreachable"
-}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -605,10 +605,12 @@ Die VOR/VAO ReST API erlaubt **100 Requests pro Tag** (`VAO Start`-
 Kontingent). Seit 2026-05-11 (Operator-Policy "VOR nur noch für die
 Verspätungen der Stammstrecke") ist der Stammstrecken-Monitor der
 **einzige** automatisierte VOR-Konsument im Projekt. Der frühere
-wöchentliche Station-Enrichment-Pfad
-(`scripts/update_vor_stations.py` via `update-stations.yml`) und das
-optionale Disruption-Polling sind aus den automatisierten Pfaden
-entfernt; VOR-Stop-IDs kommen jetzt ausschließlich aus der gepinnten
+wöchentliche Station-Enrichment-Pfad und das optionale
+Disruption-Polling sind aus den automatisierten Pfaden entfernt;
+die zugehörigen Helper-Scripts (`update_vor_cache.py`,
+`update_vor_stations.py`, `fetch_vor_haltestellen.py`) wurden
+2026-05-11 aus `scripts/` gelöscht. VOR-Stop-IDs kommen jetzt
+ausschließlich aus der gepinnten
 `data/vor-haltestellen.csv`-Snapshot. Siehe
 [`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md)
 für Details des Stammstrecken-Monitors.
@@ -616,8 +618,9 @@ für Details des Stammstrecken-Monitors.
 | Konsument | Default-Calls/Tag | Konfigurierbar |
 | :--- | ---: | :--- |
 | **Stammstrecke `/trip`** (~alle 30 Min × 2 Richtungen) | 96 | IFTTT-Cadence des `update-cycle.yml`-Triggers, `MAX_TRIPS_PER_QUERY` |
-| **Station-Enrichment `location.name`** | **0** (Pfad entfernt 2026-05-11) | Operator kann `scripts/update_vor_stations.py` manuell aufrufen; kostet dann bewusst Quota |
-| **Disruption-Polling `departureBoard`** | **0** (default; Pfad nicht mehr automatisiert) | Operator kann `scripts/update_vor_cache.py` mit `VOR_MONITOR_STATIONS_WHITELIST` manuell aufrufen |
+| **Station-Enrichment `location.name`** | **0** (Pfad und Script entfernt 2026-05-11) | — |
+| **Disruption-Polling `departureBoard`** | **0** (Pfad und Script entfernt 2026-05-11) | — |
+| **Auth-Diagnose** (`verify_vor_access_id.py`, `check_vor_auth.py`) | **0–2** | nur manueller Operator-Aufruf, einmalige Smoke-Tests |
 | **Tagesbudget gesamt** | **96 / 100** | — |
 
 Zwei zusammenwirkende Mechanismen schützen das Budget:
@@ -625,9 +628,10 @@ Zwei zusammenwirkende Mechanismen schützen das Budget:
 1. **Keine automatisierten Nicht-Stammstrecke-Pfade**: Weder
    `update-cycle.yml`, noch `update-stations.yml`, noch
    `manual-full-refresh.yml` rufen VOR-Disruption-Polling oder
-   VOR-Station-Enrichment auf. Helper-Scripts existieren noch unter
-   `scripts/`, werden aber nur durch explizite Operator-Aufrufe
-   getriggert.
+   VOR-Station-Enrichment auf. Die früheren Helper-Scripts existieren
+   nicht mehr; nur die Auth-Diagnose-Helfer
+   (`scripts/verify_vor_access_id.py`, `scripts/check_vor_auth.py`)
+   bleiben für gezielte manuelle Smoke-Tests verfügbar.
 
 2. **`_charge_one_request`** (`scripts/update_stammstrecke_status.py`).
    Vor jedem `/trip`-Call wird ein Quota-Slot via

--- a/docs/development.md
+++ b/docs/development.md
@@ -71,7 +71,7 @@ Der Feed-Build folgt einem klaren Ablauf:
 | `tests/`              | Umfangreiche Pytest-Suite (über 2000 Tests in ca. 390 Modulen) für Feed-Logik, Provider-Adapter und Utility-Funktionen. |
 
 
-> **Hinweis zu Cache-Pfaden:** Die tatsächlichen Verzeichnisse unter `cache/` tragen einen Hash-Suffix zur Cache-Versionierung (Stand Mai 2026: `cache/wl_9d709a/`, `cache/oebb_c40d21/`, `cache/vor_929f1c/`, `cache/baustellen_d438c3/`). In dieser Dokumentation werden aus Lesbarkeitsgründen verkürzte Schreibweisen wie `cache/wl/events.json` verwendet — sie verweisen jeweils auf das aktuelle Provider-Verzeichnis. Der **Stammstrecke-Monitor** persistiert nicht mehr in einer eigenen JSON-Cache-Datei; seit der 2026-05-09-Migration liest der Feed-Builder die Beobachtungen direkt aus dem CSV-Ledger `data/stats/stammstrecke_<YYYY>.csv` (siehe [`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md)).
+> **Hinweis zu Cache-Pfaden:** Die tatsächlichen Verzeichnisse unter `cache/` tragen einen Hash-Suffix zur Cache-Versionierung (Stand Mai 2026: `cache/wl_9d709a/`, `cache/oebb_c40d21/`, `cache/baustellen_d438c3/`). In dieser Dokumentation werden aus Lesbarkeitsgründen verkürzte Schreibweisen wie `cache/wl/events.json` verwendet — sie verweisen jeweils auf das aktuelle Provider-Verzeichnis. Ein eigenes VOR-Cache-Verzeichnis existiert seit der 2026-05-11-Migration nicht mehr (VOR ist auf den Stammstrecken-Monitor beschränkt). Der **Stammstrecke-Monitor** persistiert nicht in einer JSON-Cache-Datei; seit der 2026-05-09-Migration liest der Feed-Builder die Beobachtungen direkt aus dem CSV-Ledger `data/stats/stammstrecke_<YYYY>.csv` (siehe [`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md)).
 
 ## Installation & Setup
 
@@ -219,12 +219,9 @@ Der Meldungsfeed sammelt offizielle Störungs- und Hinweisinformationen der Wien
 
 ### Verkehrsverbund Ost-Region (VOR)
 
-- **Anforderung**: VAO-Tagesbudget (100 Requests/Tag) wird primär durch den S-Bahn-Stammstrecken-Monitor verbraucht (96 Calls/Tag); zusätzliches Disruption-Polling ist daher standardmäßig deaktiviert.
-- **Umsetzung**: Die Monitor-Whitelist `VOR_MONITOR_STATIONS_WHITELIST` ist seit der 2026-05-09-Migration auf einen leeren String voreingestellt (`DEFAULT_MONITOR_WHITELIST = ""` in `src/providers/vor.py`), das `departureBoard`-Polling läuft also per Default nicht.
-  - Operatoren, die das Legacy-Verhalten brauchen (z. B. nur „Wien Hauptbahnhof,Flughafen Wien"), setzen die Variable explizit als Umgebungsvariable.
-  - Weitere Stationen werden nur bei expliziter Konfiguration abgerufen — und auch nur unter Berücksichtigung des Tagesbudgets.
-- **Quelle**: VOR/VAO-ReST-API, authentifiziert über Access Token.
-- **Cache**: `cache/vor/events.json`.
+- **Anforderung**: VAO-Tagesbudget (100 Requests/Tag) wird seit 2026-05-11 ausschließlich vom S-Bahn-Stammstrecken-Monitor verbraucht (96 Calls/Tag = 48 Cycles × 2 Richtungen). Ein automatisiertes Disruption-Polling existiert nicht mehr (Operator-Policy "VOR nur für die Stammstrecke").
+- **Quelle**: VOR/VAO-ReST-API (`/trip`-Endpunkt), authentifiziert über Access Token.
+- **Persistenz**: keine eigene JSON-Cache-Datei mehr; der Stammstrecken-Monitor schreibt Beobachtungen direkt in den CSV-Ledger `data/stats/stammstrecke_<YYYY>.csv` (siehe [`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md)).
 
 ### Stadt Wien – Baustellen
 
@@ -345,25 +342,23 @@ damit kurze Stellencodes wie `Sue`/`Su` distinkt bleiben).
 
 | Skript | Funktion |
 | ------ | -------- |
-| `python -m src.cli stations update all --verbose` | Führt alle Teilaktualisierungen (ÖBB, WL, VOR) in einem Lauf aus. |
+| `python -m src.cli stations update all --verbose` | Führt alle Teilaktualisierungen (ÖBB, WL) in einem Lauf aus. |
 | `python -m src.cli stations update directory --verbose` | Aktualisiert das ÖBB-Basisverzeichnis und setzt `in_vienna`/`pendler`. |
 | `python scripts/update_wl_stations.py [--no-download] -v` | Lädt die WL-OGD-CSVs vom kanonischen Wiener-Linien-OGD-Endpoint `www.wienerlinien.at/ogd_realtime/doku/ogd/` und führt sie mit `data/stations.json` zusammen. `--no-download` nutzt die lokal gepinnten CSVs (Sandbox/Offline-Modus). Beim Download-Erfolg wird die jeweilige CSV atomar geschrieben; bei Netzwerk-Fehlern wird das gepinnte Snapshot beibehalten. |
-| `python -m src.cli stations update vor --verbose` | Importiert VOR-Daten aus CSV oder API und reichert Stationen an. |
 
 
 Die GitHub Action `.github/workflows/update-stations.yml` aktualisiert
 `data/stations.json` wöchentlich automatisch (Cron `0 1 * * 0`, Sonntag 01:00 UTC). Pipeline-Schritte:
 
 1. **VOR-Stop-Liste**: gepinnt in `data/vor-haltestellen.csv`. Seit
-   2026-05-11 wird `scripts/fetch_vor_haltestellen.py` **nicht mehr**
-   automatisch im Pipeline-Lauf aufgerufen (VOR-API ist auf den
-   Stammstrecken-Monitor beschränkt). VOR-Stop-IDs ändern sich nur
-   selten; ein manueller Refresh ist via lokalen Skript-Aufruf möglich.
+   2026-05-11 existiert kein automatisiertes VOR-Stop-Refresh-Skript
+   mehr; die CSV wird redaktionell gepflegt. VOR-Stop-IDs ändern sich
+   nur selten (Jahre).
 2. **Sub-Skripte** (`scripts/update_all_stations.py`) – `update_station_directory.py` →
    `update_wl_stations.py` → `enrich_station_aliases.py`,
    alle gegen ein Temp-File. Erst nach erfolgreicher Validierung wird per
-   `atomic_write` ins Repo zurückkopiert. `update_vor_stations.py` wurde
-   2026-05-11 aus dem automatisierten Pfad entfernt.
+   `atomic_write` ins Repo zurückkopiert. Ein VOR-Stations-Sub-Skript
+   gibt es seit 2026-05-11 nicht mehr.
 3. **Validation-Gate** – die Sub-Skript-Ausgabe wird vom selben Wrapper
    validiert. Vier Kategorien blockieren den Commit (Working Tree bleibt
    bytewise unverändert): `provider_issues`, `cross_station_id_issues`,
@@ -431,7 +426,7 @@ Nachnutzung zu gewährleisten.
 Die wichtigsten GitHub Actions:
 
 - `update-cycle.yml` – die zentrale Refresh-Pipeline. Trigger: `repository_dispatch: ifttt_feed_trigger` (ein externes IFTTT-Applet feuert ~alle 30 Minuten auf :00/:30 — zuverlässiger als der frühere GitHub-Cron `0,30 * * * *`, der am 2026-05-10 in Commit `55ca72f` entfernt wurde) sowie `workflow_dispatch` für manuelle Operator-Läufe. Einziger Job, der in einem Runner sequenziell die Provider-Cache-Fetcher (WL, ÖBB, Baustellen), den VAO-Pre-flight + die Stammstrecke-Abfrage, den Feed-Build (`docs/feed.xml`, `data/first_seen.json`, `data/stats/stoerungen_<YYYY>.csv`) sowie das README-/`docs/statistik.md`-Render ausführt und alles in einem Auto-Commit zusammenfasst. Hält die `external-api-fetch`-Concurrency-Lane, damit nie zwei API-Cycles parallel laufen.
-- VOR ist **ausschließlich** für den S-Bahn-Stammstrecke-Verspätungs-Monitor in `update-cycle.yml` eingesetzt (`/trip`-Endpunkt, ~96 Calls/Tag von 100 VAO-Start-Tier-Quota). Eine VOR-Disruption-Polling- bzw. Stations-Anreicherungs-Automatisierung gibt es nicht mehr (Entscheidung 2026-05-11). Operator-Direktaufrufe der Helper-Scripts (`scripts/update_vor_cache.py`, `scripts/update_vor_stations.py`, `scripts/fetch_vor_haltestellen.py`) bleiben verfügbar für gezielte manuelle Refreshes — kosten dann bewusst Quota.
+- VOR ist **ausschließlich** für den S-Bahn-Stammstrecke-Verspätungs-Monitor in `update-cycle.yml` eingesetzt (`/trip`-Endpunkt, ~96 Calls/Tag von 100 VAO-Start-Tier-Quota). Eine VOR-Disruption-Polling- bzw. Stations-Anreicherungs-Automatisierung gibt es nicht mehr (Entscheidung 2026-05-11); die zugehörigen Helper-Scripts (`update_vor_cache.py`, `update_vor_stations.py`, `fetch_vor_haltestellen.py`) wurden ebenfalls entfernt. Diagnose-Aufrufe gegen den VOR-Auth-Pfad bleiben via `scripts/verify_vor_access_id.py` und `scripts/check_vor_auth.py` möglich.
 - `build-feed.yml` – Code-Change-Verifikationspfad. Der reguläre Cron wurde 2026-05-09 in `update-cycle.yml` migriert; dieser Workflow läuft nur noch auf `push` (für `src/**`, `requirements.txt`, `pyproject.toml`, `.github/workflows/build-feed.yml`) sowie auf `workflow_dispatch` und baut den Feed aus den vorhandenen Caches neu — ohne neue API-Abfrage.
 - `update-stations.yml` – pflegt wöchentlich (Sonntag 01:00 UTC, Cron `0 1 * * 0`) `data/stations.json`. Die Anreicherung ist als **drei-stufige Kaskade** modelliert: OpenStreetMap (Overpass API) liefert die primären Koordinaten; der vorgeschaltete Smoke-Test (`scripts/check_overpass_status.py`) bricht den OSM-Schritt aber kontrolliert ab, falls der Mirror down ist. HAFAS (ÖBB Scotty) übernimmt seit 2026-05-14 als **Tier-2-Fallback** alle Stationen ohne OSM-Koordinaten — eingebettet in `request_safe` und durch einen eigenen `CircuitBreaker` abgesichert (siehe `docs/architecture.md` §5). Direkt davor läuft `scripts/sync_hafas_profile.py` als eigener Workflow-Step und aktualisiert das Mgate-Profil-Sidecar aus dem Open-Source-Projekt `public-transport/hafas-client`. Google Places bleibt der **Tier-3-Notausgang** für die strikte Restmenge, die weder OSM noch HAFAS auflösen konnten. VOR ist seit 2026-05-11 **nicht mehr** Teil des Stations-Refreshs (VOR-Stop-IDs aus gepinnter `data/vor-haltestellen.csv`). Die Stammstrecke-Abfrage und die tägliche `docs/statistik.md`-Regeneration laufen jeweils als Schritt in `update-cycle.yml`.
 - `manual-full-refresh.yml` – `workflow_dispatch`-only-Komplettlauf für Disaster-Recovery (führt alle Cache-Fetcher + Feed-Build hintereinander aus).
@@ -453,7 +448,6 @@ benötigt werden (z. B. `--no-download` für die WL-OGD-CSVs).
 | --- | --- |
 | `update_wl_cache.py` | Liest die Realtime-Störungen der Wiener Linien und schreibt `cache/wl/events.json`. CLI: `python -m src.cli cache update wl`. |
 | `update_oebb_cache.py` | Holt die ÖBB-Störungs-RSS-Feeds, filtert sie strikt auf Wien-Bezug (`_is_relevant`) und persistiert sie. CLI: `python -m src.cli cache update oebb`. |
-| `update_vor_cache.py` | Aktualisiert den VOR-Cache (`cache/vor/events.json`) inklusive `last_run.json`. CLI: `python -m src.cli cache update vor`. |
 | `update_baustellen_cache.py` | Lädt den Baustellen-Layer der Stadt Wien (oder den `data/samples/baustellen_sample.geojson`-Fallback) und legt Events ab. CLI: `python -m src.cli cache update baustellen`. |
 | `update_stammstrecke_status.py` | Refresh-Producer für den S-Bahn-Stammstrecke-Monitor (wird vom IFTTT-getriggerten `update-cycle.yml` ~alle 30 Min aufgerufen). Schreibt eine Beobachtungs-Zeile pro Lauf und Richtung in `data/stats/stammstrecke_<YYYY>.csv` (siehe [Reference](reference/stammstrecke_provider_logic.md)). |
 | `generate_markdown_stats.py` | Aggregiert die CSV-Ledger zu `docs/statistik.md` (30-Tage-Fenster) und patcht die `<!-- STATS:* -->`-Marker im README. |
@@ -465,13 +459,11 @@ benötigt werden (z. B. `--no-download` für die WL-OGD-CSVs).
 | `update_all_stations.py` | Wrapper für den vollständigen Stationsverzeichnis-Refresh; ruft die folgenden Sub-Skripte gegen ein Temp-File auf und committet erst nach erfolgreicher Validierung. CLI: `python -m src.cli stations update all`. |
 | `update_station_directory.py` | Lädt das ÖBB-Excel und ergänzt Koordinaten in drei Stufen: OSM (Primär) → HAFAS (Tier-2-Fallback) → Google Places (Tier-3-Notausgang). Details siehe `docs/architecture.md` §5. |
 | `sync_hafas_profile.py` | Holt `salt` / `ver` / `aid` des ÖBB-Mgate-Profils aus dem Open-Source-Projekt `public-transport/hafas-client` und persistiert sie atomar in `data/hafas_profile.json`. Läuft in `update-stations.yml` als eigener Schritt unmittelbar vor `update_station_directory.py`, damit ÖBB-seitige Credential-Rotation automatisch nachgezogen wird. |
-| `update_vor_stations.py` | Importiert VOR-Daten aus CSV oder API; live-Anreicherung via `location.name` ist auf `STAMMSTRECKE_VOR_IDS` begrenzt. |
 | `update_wl_stations.py` | Lädt `wienerlinien-ogd-haltestellen.csv` und `wienerlinien-ogd-haltepunkte.csv` vom kanonischen Endpoint `www.wienerlinien.at/ogd_realtime/doku/ogd/` und merged sie in `data/stations.json`. Soft-fail mit den gepinnten lokalen CSVs bei Upstream-Outage. Mit `--no-download` werden ausschließlich die lokal gepinnten CSVs verwendet. |
 | `enrich_station_aliases.py` | Sucht alternative Schreibweisen pro Station und schreibt sie ins Verzeichnis. |
-| `fetch_vor_haltestellen.py` | Holt die aktuelle Liste vom HAFAS-Endpoint `anachb.vor.at` und überschreibt `data/vor-haltestellen.csv`. |
 | `fetch_google_places_stations.py` | Optionaler Tier-3-Notausgang für Stationen, die weder OSM noch HAFAS auflösen konnten; manueller Direktaufruf, nutzt das Quota-Stateful-Modul aus `src/places/`. Die OSM/HAFAS/Google-Kaskade läuft auch automatisch in `update-stations.yml`. |
 | `validate_stations.py` | CLI-Front-end für `src.utils.stations_validation`; das gleiche Verhalten ist via `python -m src.cli stations validate` erreichbar. |
-| `validate_vor_mapping.py` | Prüft `data/vor-haltestellen.mapping.json` auf duplikate IDs und Format-Drift. |
+| `validate_vor_mapping.py` | Prüft die statische `data/vor-haltestellen.mapping.json` (VOR-ID ↔ Name) auf duplikate IDs und Format-Drift. Die Mapping-Datei wird seit 2026-05-11 redaktionell gepflegt. |
 
 ### Auth- & Diagnose-Helfer
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -158,7 +158,7 @@ def _configure_cache_commands(subparsers: argparse._SubParsersAction[argparse.Ar
         "providers",
         nargs="*",
         metavar="PROVIDER",
-        help="Provider identifiers (wl, oebb, vor, baustellen). Ohne Angabe werden alle Caches aktualisiert.",
+        help="Provider identifiers (wl, oebb, baustellen). Ohne Angabe werden alle Caches aktualisiert.",
     )
     update_parser.add_argument(
         "--all",

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -479,10 +479,14 @@ def write_status(provider: str, status: dict[str, Any]) -> None:
 
     try:
         # Security (Trojan-Source / BiDi-Mark Drift Round 11): the file
-        # is operator-facing diagnostic state, committed to ``main`` by
-        # the cron pipeline (``update-vor-cache.yml`` line 96 lists
-        # ``cache/vor*/last_run.json`` in its ``file_pattern``) and
-        # reviewed via ``cat`` / ``less`` / the GitHub web UI / IDE
+        # is operator-facing diagnostic state. Historically committed
+        # to ``main`` by the per-provider cache cron pipelines (e.g.
+        # the former ``update-vor-cache.yml`` listed
+        # ``cache/vor*/last_run.json`` in its ``file_pattern`` until
+        # the 2026-05-11 VOR-Stammstrecke-only consolidation); the
+        # helper remains in the public surface for any future provider
+        # heartbeat that may again land in a committed cache dir.
+        # Reviewed via ``cat`` / ``less`` / the GitHub web UI / IDE
         # preview. ``ensure_ascii=True`` escapes every non-ASCII code
         # point as a literal ``\uXXXX`` sequence, so a future status
         # payload field carrying station- / provider- / environment-

--- a/tests/test_sentinel_quota_status_trojan_source.py
+++ b/tests/test_sentinel_quota_status_trojan_source.py
@@ -6,17 +6,22 @@ Drift Round 10* closing-checklist named but deferred —
 (``data/vor_request_count.json``), and ``write_status``
 (``cache/<provider>/last_run.json``).
 
-All three files are committed to ``main`` by the automated pipeline:
+These files are committed to ``main`` by the automated pipeline:
 
   * ``data/places_quota.json`` — by the weekly ``update-stations.yml``
     cron job (the OSM-first / Google-Places-fallback step charges
     against this quota and writes the persisted counter).
   * ``data/vor_request_count.json`` — by the IFTTT-triggered
-    ``update-cycle.yml`` (Stammstrecke step) and by the
-    ``update-vor-cache.yml`` operator-only escape hatch
-    (``file_pattern: data/vor_request_count.json``).
-  * ``cache/vor*/last_run.json`` — by ``update-vor-cache.yml``
-    (``file_pattern: cache/vor*/last_run.json``).
+    ``update-cycle.yml`` (Stammstrecke step). The former
+    ``update-vor-cache.yml`` operator-only escape hatch that also
+    persisted this counter was retired with the 2026-05-11
+    VOR-Stammstrecke-only consolidation.
+  * ``cache/<provider>/last_run.json`` — historically by the per-
+    provider cache crons (e.g. ``update-vor-cache.yml`` listed
+    ``cache/vor*/last_run.json`` in its ``file_pattern``); the
+    ``write_status`` helper remains in the public surface for any
+    future provider heartbeat that may again land in a committed
+    cache directory.
 
 They are operator-facing artefacts — ``cat`` / ``less`` / the GitHub
 web UI / IDE preview all honour BiDi formatting controls when


### PR DESCRIPTION
## Summary

Aufräumarbeiten nach der VOR-Stammstrecke-only-Konsolidierung vom 2026-05-11. Die drei VOR-Helper-Scripts (`update_vor_cache.py`, `update_vor_stations.py`, `fetch_vor_haltestellen.py`) wurden damals aus `scripts/` entfernt, aber Dokumentation, zwei Workflow-Kommentarblöcke, ein Sicherheitskommentar in `src/utils/cache.py`, ein CLI-Help-String und eine Sentinel-Test-Docstring behaupteten weiterhin, dass es die Skripte gibt. Zusätzlich verblieb ein verwaister `cache/vor_929f1c/`-Ordner mit einer stale `last_run.json` (`status: api_unreachable` vom 2026-05-09), den kein lebender Writer mehr berührt.

### Geänderte Dateien

- **`.github/workflows/manual-full-refresh.yml`** — drei tote Kommentarblöcke entfernt (Helfer-Auflistung im Header, „update-vor-cache.yml escape hatch"-Hinweis, `fetch_vor_haltestellen.py`-Operator-Tipp).
- **`.github/workflows/update-stations.yml`** — VOR-Stop-List-Kommentar korrigiert: zeigte fälschlich auf `build-feed.yml` (richtig: `update-cycle.yml`) und schlug das gelöschte `fetch_vor_haltestellen.py` als Manueller-Refresh-Pfad vor.
- **`docs/development.md`** — `cache/vor_929f1c/` aus dem Hash-Suffix-Hinweis raus; §VOR-Sektion entrümpelt; drei tote Tabelleneinträge entfernt; CLI-Help-Korrekturen.
- **`docs/architecture.md`** — §7-Tabelle verspricht keine Operator-Direktaufrufe von gelöschten Helpers mehr; nur Stammstrecke `/trip` + Auth-Diagnose-Smoke-Tests sind als VOR-Quota-Verbraucher gelistet.
- **`src/cli.py`** — `cache update`-Help-String listet `vor` nicht mehr als gültigen Identifier (der Dispatch hat ihn ohnehin abgewiesen).
- **`src/utils/cache.py`** — `write_status`-Trojan-Source-Kommentar als historisch markiert; die `ensure_ascii=True`-Defence bleibt unverändert.
- **`tests/test_sentinel_quota_status_trojan_source.py`** — Header-Docstring als historisch gekennzeichnet; Test-Assertions unverändert.
- **`cache/vor_929f1c/last_run.json`** — verwaiste Datei + leeres Parent-Verzeichnis gelöscht.
- **`CHANGELOG.md`** — Eintrag unter `[Unreleased]`.

### Was deliberately NICHT geändert wurde

- `src/providers/vor.py` — bleibt aktiv (`scripts/update_stammstrecke_status.py` benutzt `apply_authentication`, `_QUOTA_LOCK`, `save_request_count`, etc.).
- `scripts/verify_vor_access_id.py` / `scripts/check_vor_auth.py` / `scripts/validate_vor_mapping.py` — Diagnose-Helfer bleiben verfügbar.
- `write_status` / `read_status` in `src/utils/cache.py` — aktuell ohne Caller, aber durch Sentinel-Tests gepinnt; bleibt als öffentliche API für zukünftige Provider-Heartbeats.
- `.jules/sentinel.md`, `docs/archive/`, `CHANGELOG.md`-History, `docs/strict-typing-attr-defined-investigation.md` — institutionelles Gedächtnis bzw. historische Snapshots.
- "Attack path"-Narrative in den Sentinel-Tests (`test_sentinel_cache_events_trojan_source.py` & Co.) — beschreiben historische Writer-Surfaces; die Defences bleiben in Kraft.

## Test plan

- [x] `ruff check` auf alle geänderten Python-Dateien — clean
- [x] YAML-Lint auf beide geänderten Workflows — clean
- [x] `pytest -k "vor or cache or cli or stammstrecke or quota or trojan"` — 1505 passed
- [x] `git diff` enthält ausschließlich beabsichtigte Cleanup-Hunks (Test-Side-Effects an `data/stations_last_run.json` / `docs/stations_diff.md` wurden zurückgerollt)
- [ ] CI grün (Tests, mypy-strict, bandit, codeql, complexity-gate)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LD1bgoJuBpkjDtXJsjhZcd)_