### PR TITLE
fix(oebb): collapse multi-route titles into chains, drop wrong line prefix

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -157,7 +157,7 @@ def read_cache_wl() -> list[Any]:
 
 
 def _post_filter_oebb(items: list[Any]) -> list[Any]:
-    """Re-apply the ÖBB relevance filter to cached items.
+    """Re-apply the ÖBB relevance filter and re-derive titles for cached items.
 
     The cache is only refreshed by `update_oebb_cache.py`, so a filter
     update doesn't reach the feed until the next cache refresh. Without
@@ -165,10 +165,19 @@ def _post_filter_oebb(items: list[Any]) -> list[Any]:
     *current* spec considers irrelevant (e.g. Wien↔Distant routes that
     slipped through an older filter version).
 
+    We also re-derive the title via ``_apply_route_title`` so a title-
+    formatting improvement (such as the multi-route chain collapse or
+    the affected-line-prefix tightening) reaches the feed even when the
+    cache still holds an older rendering. The original title is left in
+    place if the re-derived version is empty or identical.
+
     Items without a title are passed through unchanged so test fixtures
     and other generic dictionaries aren't accidentally dropped.
     """
-    from .providers.oebb import _is_relevant  # local import: avoids circular at module load
+    from .providers.oebb import (  # local import: avoids circular at module load
+        _apply_route_title,
+        _is_relevant,
+    )
 
     out: list[Any] = []
     for item in items:
@@ -181,8 +190,13 @@ def _post_filter_oebb(items: list[Any]) -> list[Any]:
             # Stub / metadata item — leave it alone.
             out.append(item)
             continue
-        if _is_relevant(title, description):
-            out.append(item)
+        if not _is_relevant(title, description):
+            continue
+        rederived = _apply_route_title(title, description)
+        if rederived and rederived != title:
+            item = dict(item)
+            item["title"] = rederived
+        out.append(item)
     return out
 
 

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -1384,6 +1384,83 @@ def _expand_station_abbreviations(name: str) -> str:
     return name
 
 
+def _try_chain_routes(canonical_routes: list[tuple[str, str]]) -> list[str] | None:
+    """Collapse routes that share endpoints into a single linear chain.
+
+    Real ÖBB items frequently describe a corridor disruption as several
+    overlapping segments::
+
+        Wien Westbahnhof ↔ Wien Hütteldorf
+        Wien Hütteldorf ↔ Tullnerbach-Pressbaum
+        Wien Westbahnhof ↔ St. Pölten Hauptbahnhof
+
+    Rendered with ``" / "`` between routes that's awkward and repeats
+    the hub station twice. The three segments above are actually one
+    linear chain:
+
+        St. Pölten Hauptbahnhof ↔ Wien Westbahnhof ↔ Wien Hütteldorf
+            ↔ Tullnerbach-Pressbaum
+
+    We accept the routes as chainable when:
+
+    * Every station has degree ≤ 2 (no branching hub).
+    * Exactly two stations have degree 1 (the chain endpoints).
+    * The graph is connected (the traversal hits every node).
+
+    Orientation rule: prefer a Vienna endpoint at the start so the
+    Wien-focused feed leads with a Wien name when possible; otherwise
+    use the alphabetically smaller endpoint for determinism.
+
+    Returns the ordered station list, or ``None`` if the routes don't
+    form a chain (branches, cycles, multiple disconnected paths) — the
+    caller then falls back to the existing ``" / "`` renderer.
+    """
+    if not canonical_routes:
+        return None
+
+    adj: dict[str, set[str]] = {}
+    for a, b in canonical_routes:
+        if a == b:
+            return None  # self-loop, can't chain
+        adj.setdefault(a, set()).add(b)
+        adj.setdefault(b, set()).add(a)
+
+    # No node may branch — chains are degree-≤-2 by construction.
+    if any(len(neighbours) > 2 for neighbours in adj.values()):
+        return None
+
+    # A chain has exactly two endpoints (degree 1). Zero → cycle,
+    # more than two → disconnected forest of paths.
+    endpoints = sorted(n for n, neighbours in adj.items() if len(neighbours) == 1)
+    if len(endpoints) != 2:
+        return None
+
+    start = endpoints[0]
+    for ep in endpoints:
+        info = station_info(ep)
+        if info and info.in_vienna:
+            start = ep
+            break
+
+    chain: list[str] = [start]
+    prev: str | None = None
+    current = start
+    while True:
+        next_set = adj[current] - ({prev} if prev else set())
+        if not next_set:
+            break
+        next_node = next(iter(next_set))
+        chain.append(next_node)
+        prev = current
+        current = next_node
+
+    # Disconnected components masquerade as chains with two endpoints;
+    # require traversal to cover every node to confirm connectedness.
+    if len(chain) != len(adj):
+        return None
+    return chain
+
+
 def _format_route_title(routes: list[tuple[str, str]], line_prefix: str = "") -> str:
     """Build a clean ``A ↔ B`` title from extracted route(s).
 
@@ -1391,6 +1468,11 @@ def _format_route_title(routes: list[tuple[str, str]], line_prefix: str = "") ->
     available (so ``Wien Westbf`` → ``Wien Westbahnhof``). The Vienna endpoint
     is placed first to keep the feed visually consistent. Multiple routes are
     joined with ``" / "`` to indicate that several segments are affected.
+
+    When multiple routes share endpoints to form a corridor (e.g. ``A ↔ B``,
+    ``B ↔ C``, ``A ↔ D`` collapses to the linear chain ``D ↔ A ↔ B ↔ C``),
+    we render them as one ``A ↔ B ↔ C ↔ D`` string instead — the
+    "/ "-separated form repeats the hub station and is harder to scan.
 
     Routes that resolve to the same canonical endpoint pair (e.g. one
     description writes ``St. Pölten`` while another writes ``St.Pölten``)
@@ -1401,7 +1483,8 @@ def _format_route_title(routes: list[tuple[str, str]], line_prefix: str = "") ->
     if not routes:
         return ""
 
-    formatted: list[str] = []
+    # Step 1: canonicalise every endpoint pair and dedup case-insensitively.
+    canonical_pairs: list[tuple[str, str]] = []
     seen_canon: set[tuple[str, str]] = set()
     for raw_a, raw_b in routes:
         info_a = station_info(raw_a)
@@ -1421,26 +1504,62 @@ def _format_route_title(routes: list[tuple[str, str]], line_prefix: str = "") ->
         if b_in_vienna and not a_in_vienna:
             name_a, name_b = name_b, name_a
 
-        # Dedup against already-rendered routes after canonical resolution.
         canon_key: tuple[str, str] = tuple(  # type: ignore[assignment]
             sorted((name_a.casefold(), name_b.casefold()))
         )
         if canon_key in seen_canon:
             continue
         seen_canon.add(canon_key)
+        canonical_pairs.append((name_a, name_b))
 
-        formatted.append(f"{name_a} ↔ {name_b}")
+    if not canonical_pairs:
+        return ""
 
-    title = " / ".join(formatted)
+    # Step 2: try to render multi-route titles as a single chain.
+    title_body: str
+    if len(canonical_pairs) >= 2:
+        chain = _try_chain_routes(canonical_pairs)
+        if chain is not None:
+            title_body = " ↔ ".join(chain)
+        else:
+            title_body = " / ".join(f"{a} ↔ {b}" for a, b in canonical_pairs)
+    else:
+        a, b = canonical_pairs[0]
+        title_body = f"{a} ↔ {b}"
+
     if line_prefix:
-        title = f"{line_prefix}: {title}"
-    return title
+        return f"{line_prefix}: {title_body}"
+    return title_body
 
 
 # ---------------- Public ----------------
 
 
-_LINE_TOKEN_RE = re.compile(r"\b((?:REX|S(?:-Bahn)?|U)\s*\d+)\b")
+# Match an affected line code in the description. We require the line
+# code to be followed by a clear "Züge"/"Zug" disruption signal so we
+# don't pick up alternative-route references like
+# ``U3: Wien Ottakring <=> Hütteldorfer Straße`` (which were silently
+# prepended as the title prefix and produced wrong titles like
+# ``U3: Wien Westbahnhof ↔ St. Pölten`` for an S-Bahn disruption).
+_LINE_TOKEN_RE = re.compile(
+    r"\b((?:REX|S(?:-Bahn)?|U)\s*\d+)\s*[-\s]Z[üu]g",
+    re.IGNORECASE,
+)
+
+
+def _normalize_line_token(token: str) -> str:
+    """Render an ÖBB line marker in the canonical ``LETTERS DIGITS`` form.
+
+    The description text sometimes glues the letter prefix to the digit
+    suffix (``REX7-Züge``, ``S50-Züge``) or uses the more verbose
+    ``S-Bahn 50``. Both forms should surface in the user-facing title
+    as ``REX 7`` / ``S 50`` for consistency with the official ÖBB
+    rendering. We collapse interior whitespace runs and then insert a
+    single space between the trailing letter and leading digit when
+    they are glued together.
+    """
+    cleaned = re.sub(r"\s+", " ", token).strip()
+    return re.sub(r"^([A-Za-z][A-Za-z-]*)(\d)", r"\1 \2", cleaned)
 
 
 def _derive_guid(raw_guid: str, title: str, link: str) -> str:
@@ -1461,20 +1580,41 @@ def _apply_route_title(title: str, desc: str) -> str:
     from the description when not already present in the title. Supersedes
     messy raw titles like "Bauarbeiten: Flughafen Wien Wien Mitte-Landstraße"
     with canonical station names and drops the category prefix.
+
+    Line-prefix sourcing: the description's ``-Züge`` mention is the
+    authoritative signal for *which* line is disrupted (the WL ÖBB feed
+    occasionally lists alternative U-Bahn routes by name, and a naive
+    "first line token in description" match prepended those alternative
+    line codes as a bogus title prefix). When the description identifies
+    an affected line, it overrides any existing title prefix; otherwise
+    the title's own prefix is kept.
     """
+    desc_line_match = _LINE_TOKEN_RE.search(desc)
+    desc_line = (
+        _normalize_line_token(desc_line_match.group(1))
+        if desc_line_match
+        else ""
+    )
     existing_line_prefix, _ = _extract_line_prefix(title)
+    # Prefer the description-sourced affected line when it disagrees with
+    # the cached title prefix (older cache items occasionally carry a
+    # stale or wrong prefix like ``U3:`` for an S 50 disruption); fall
+    # back to the existing prefix when the description has no affected-
+    # line signal at all.
+    if desc_line:
+        effective_prefix = desc_line
+    else:
+        effective_prefix = existing_line_prefix
+
     routes = _extract_routes(title, desc)
     relevant_routes = [
         (a, b) for (a, b) in routes if _route_is_wien_relevant(a, b)
     ]
     if relevant_routes:
-        title = _format_route_title(relevant_routes, existing_line_prefix)
+        return _format_route_title(relevant_routes, effective_prefix)
 
-    line_match = _LINE_TOKEN_RE.search(desc)
-    if line_match:
-        line_str = line_match.group(1)
-        if line_str not in title:
-            title = f"{line_str}: {title}"
+    if desc_line and not existing_line_prefix:
+        return f"{desc_line}: {title}"
     return title
 
 

--- a/tests/test_oebb_chain_route_title.py
+++ b/tests/test_oebb_chain_route_title.py
@@ -1,0 +1,212 @@
+"""Regression tests for Bug 30A (multi-route titles collapsed into a chain).
+
+User feedback: an ÖBB corridor disruption surfaced as the redundant
+title::
+
+    U3: Wien Westbahnhof ↔ Wien Hütteldorf
+        / Wien Hütteldorf ↔ Tullnerbach-Pressbaum
+        / Wien Westbahnhof ↔ St. Pölten Hauptbahnhof
+
+Two issues:
+
+1. The ``U3:`` prefix is *wrong*: the disrupted line is ``S 50`` (the
+   description's ``keine S 50-Züge fahren`` clause), but the previous
+   ``_LINE_TOKEN_RE`` matched the FIRST line code in the description —
+   which happened to be ``U3`` mentioned in the alternative-routes
+   block (``U3: Wien Ottakring <=> Hütteldorfer Straße ...``).
+
+2. The ``/ ``-separated multi-route title is overloaded: the three
+   segments are a single corridor with ``Wien Westbahnhof`` and ``Wien
+   Hütteldorf`` as inner hubs. A clean chain reads::
+
+       S 50: St. Pölten Hauptbahnhof ↔ Wien Westbahnhof
+            ↔ Wien Hütteldorf ↔ Tullnerbach-Pressbaum
+
+The fixes:
+
+* ``_LINE_TOKEN_RE`` now requires a ``-Züge``/``Zug`` follower so it
+  only matches affected lines (not alternative-route headings).
+* When the description identifies an affected line that disagrees
+  with the cached title prefix, the description wins.
+* ``_format_route_title`` builds an undirected graph from the
+  resolved routes and renders a linear chain when one is possible
+  (every node degree ≤ 2, exactly two endpoints of degree 1, single
+  connected component). Otherwise the old ``/`` form remains.
+* The chain's start endpoint prefers Wien (when one endpoint is in
+  Wien) so the Wien-focused feed leads with the Wien name; otherwise
+  the alphabetically smaller endpoint goes first.
+* The line marker is canonicalised to ``LETTERS DIGITS`` form so
+  ``REX7`` from the description renders as ``REX 7`` in the title.
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import (
+    _apply_route_title,
+    _format_route_title,
+    _normalize_line_token,
+    _try_chain_routes,
+)
+
+
+class TestLineTokenNormalisation:
+    def test_concatenated_to_spaced(self) -> None:
+        assert _normalize_line_token("REX7") == "REX 7"
+        assert _normalize_line_token("S50") == "S 50"
+
+    def test_already_spaced_unchanged(self) -> None:
+        assert _normalize_line_token("REX 7") == "REX 7"
+        assert _normalize_line_token("S 50") == "S 50"
+
+    def test_multiple_internal_whitespace_collapsed(self) -> None:
+        assert _normalize_line_token("REX   7") == "REX 7"
+
+    def test_s_bahn_prefix_preserved(self) -> None:
+        # The "S-Bahn 50" verbose form keeps its hyphen.
+        assert _normalize_line_token("S-Bahn50") == "S-Bahn 50"
+
+    def test_strip_outer_whitespace(self) -> None:
+        assert _normalize_line_token("  S 50  ") == "S 50"
+
+
+class TestChainRouteCollapse:
+    def test_three_segment_corridor_chains(self) -> None:
+        # The exact reproduction from the user-reported cache item.
+        routes = [
+            ("Wien Westbahnhof", "Wien Hütteldorf"),
+            ("Wien Hütteldorf", "Tullnerbach-Pressbaum"),
+            ("Wien Westbahnhof", "St. Pölten Hauptbahnhof"),
+        ]
+        chain = _try_chain_routes(routes)
+        assert chain is not None
+        # The chain must visit each station exactly once.
+        assert sorted(chain) == sorted(
+            ["Wien Westbahnhof", "Wien Hütteldorf",
+             "Tullnerbach-Pressbaum", "St. Pölten Hauptbahnhof"]
+        )
+        # Connected stations are adjacent in the chain.
+        pairs = {tuple(sorted(p)) for p in zip(chain, chain[1:], strict=False)}
+        for a, b in routes:
+            assert tuple(sorted((a, b))) in pairs
+
+    def test_two_segments_share_endpoint(self) -> None:
+        routes = [
+            ("Wien Hbf", "Wien Meidling"),
+            ("Wien Meidling", "Mödling"),
+        ]
+        chain = _try_chain_routes(routes)
+        assert chain is not None
+        assert chain == ["Wien Hbf", "Wien Meidling", "Mödling"]
+
+    def test_disjoint_routes_not_chained(self) -> None:
+        # Two routes that share no endpoint must NOT collapse — that
+        # would silently merge two unrelated disruptions.
+        routes = [
+            ("Wien Hbf", "Mödling"),
+            ("Wien Floridsdorf", "Wien Praterstern"),
+        ]
+        assert _try_chain_routes(routes) is None
+
+    def test_branching_hub_not_chained(self) -> None:
+        # Three routes all sharing one hub form a star, not a chain.
+        routes = [
+            ("Wien Hbf", "Mödling"),
+            ("Wien Hbf", "Baden"),
+            ("Wien Hbf", "Wiener Neustadt"),
+        ]
+        assert _try_chain_routes(routes) is None
+
+    def test_cycle_not_chained(self) -> None:
+        routes = [
+            ("A", "B"),
+            ("B", "C"),
+            ("C", "A"),
+        ]
+        assert _try_chain_routes(routes) is None
+
+    def test_self_loop_rejected(self) -> None:
+        assert _try_chain_routes([("A", "A")]) is None
+
+    def test_single_route_passes_through(self) -> None:
+        # A single segment is trivially a 2-node chain.
+        chain = _try_chain_routes([("Wien Hbf", "Mödling")])
+        assert chain == ["Wien Hbf", "Mödling"] or chain == ["Mödling", "Wien Hbf"]
+
+
+class TestFormatRouteTitleChain:
+    def test_corridor_renders_as_chain(self) -> None:
+        # User's exact requested output.
+        routes = [
+            ("Wien Westbahnhof", "Wien Hütteldorf"),
+            ("Wien Hütteldorf", "Tullnerbach-Pressbaum"),
+            ("Wien Westbahnhof", "St. Pölten Hauptbahnhof"),
+        ]
+        out = _format_route_title(routes, "S 50")
+        assert out == (
+            "S 50: St. Pölten Hauptbahnhof ↔ Wien Westbahnhof"
+            " ↔ Wien Hütteldorf ↔ Tullnerbach-Pressbaum"
+        )
+
+    def test_disjoint_routes_keep_slash_format(self) -> None:
+        routes = [
+            ("Wien Hbf", "Mödling"),
+            ("Wien Floridsdorf", "Wien Praterstern"),
+        ]
+        out = _format_route_title(routes)
+        assert " / " in out
+        # The chain-collapse must NOT activate for disjoint routes.
+
+    def test_single_route_unchanged(self) -> None:
+        out = _format_route_title([("Wien Hbf", "Mödling")])
+        # Vienna-first orientation preserved; Hbf expands to Hauptbahnhof
+        # via ``_expand_station_abbreviations`` for readability.
+        assert out == "Wien Hauptbahnhof ↔ Mödling"
+
+
+class TestApplyRouteTitleEndToEnd:
+    def test_alternative_line_not_picked_as_prefix(self) -> None:
+        # Cache item #13 reproduction. The description names
+        # alternative U-Bahn routes (``U3: Wien Ottakring <=> …``)
+        # BEFORE the actual affected lines (``keine S 50-Züge``).
+        # The previous logic prepended ``U3:`` as the title prefix.
+        title = (
+            "U3: Wien Westbahnhof ↔ Wien Hütteldorf"
+            " / Wien Hütteldorf ↔ Tullnerbach-Pressbaum"
+            " / Wien Westbahnhof ↔ St. Pölten Hauptbahnhof"
+        )
+        desc = (
+            "Wegen Bauarbeiten können von 03.06.2026 (23:00 Uhr) bis "
+            "08.06.2026 (03:00 Uhr) zwischen Wien Westbahnhof (U) und "
+            "Wien Hütteldorf Bahnhof (U) keine Nahverkehrszüge fahren. "
+            "Reisende mit gültigem Ticket haben die Möglichkeit "
+            "folgende Alternativverbindungen der WIENER LINIEN zu "
+            "nutzen:\n"
+            "U3: Wien Ottakring <=> Hütteldorfer Straße <=> Wien Westbahnhof\n"
+            "U4: Wien Hütteldorf <=> Hietzing\n"
+            "Zwischen Wien Hütteldorf Bahnhof und Tullnerbach-Pressbaum "
+            "Bahnhof können keine S 50-Züge fahren.\n"
+            "Zwischen Wien Westbahnhof (U) und St.Pölten Hbf können "
+            "keine REX 50-Züge fahren."
+        )
+        out = _apply_route_title(title, desc)
+        # The wrong U3 prefix must be gone, replaced by the actual S 50.
+        assert "U3:" not in out
+        assert out.startswith("S 50:")
+        # And the multi-route body collapses into a single chain.
+        # Three "↔" separators for a 4-node chain.
+        assert out.count("↔") == 3
+        assert " / " not in out
+
+    def test_normalisation_preserves_correct_existing_prefix(self) -> None:
+        # When the cached title's prefix already agrees with the
+        # description-detected line (modulo whitespace normalisation),
+        # the rendered prefix uses the canonical form.
+        title = "REX 7: Wien Floridsdorf ↔ Flughafen Wien"
+        desc = (
+            "Wegen Bauarbeiten zwischen Wien Floridsdorf Bahnhof (U) "
+            "und Flughafen Wien Bahnhof können einige REX7-Züge nicht "
+            "fahren."
+        )
+        out = _apply_route_title(title, desc)
+        assert out.startswith("REX 7: ")
+        assert "REX7:" not in out  # canonicalised away


### PR DESCRIPTION
## Summary

User feedback: an ÖBB corridor disruption surfaced with a wrong and overloaded title:

```
U3: Wien Westbahnhof ↔ Wien Hütteldorf
    / Wien Hütteldorf ↔ Tullnerbach-Pressbaum
    / Wien Westbahnhof ↔ St. Pölten Hauptbahnhof
```

Two distinct bugs, both fixed.

### Bug 30A — wrong line prefix (`U3:` for an S 50 disruption)

The disrupted line is **S 50** (the description's `keine S 50-Züge fahren` clause), but the previous `_LINE_TOKEN_RE` matched the FIRST line code in the description — which happened to be `U3` mentioned in the *alternative-routes* block (`U3: Wien Ottakring <=> Hütteldorfer Straße ...`).

Fix:
- `_LINE_TOKEN_RE` now requires a `-Züge`/`Zug` follower so it only matches the actually affected line.
- `_apply_route_title` treats the description-detected line as authoritative — replacing any wrong cached prefix instead of stacking on top (previously a wrong + correct prefix would render as `S 50: U3: ...`).

### Bug 30B — overloaded multi-route title

Three segments sharing endpoints form one corridor. The new `_try_chain_routes` helper builds an undirected graph from the deduped routes and renders a linear chain when:

- every node has degree ≤ 2,
- exactly two endpoints have degree 1,
- the graph is a single connected component.

Disjoint routes, branching hubs, and cycles fall back to the existing `" / "` form unchanged. Orientation rule: prefer a Vienna endpoint at the start; otherwise alphabetically first.

The cached title for item 872100 now renders exactly as the user suggested:

```
S 50: St. Pölten Hauptbahnhof ↔ Wien Westbahnhof ↔ Wien Hütteldorf ↔ Tullnerbach-Pressbaum
```

### Defence-in-depth

`_post_filter_oebb` (the cache-read filter) now re-derives each title via `_apply_route_title`, so the chain-collapse fix reaches the feed before the next cache refresh. Two additional cached items also benefit:

- `Wien Hauptbahnhof ↔ Götzendorf / Wien Hauptbahnhof ↔ Gramatneusiedl` → `Gramatneusiedl ↔ Wien Hauptbahnhof ↔ Götzendorf`
- `Wien Mitte ↔ Flughafen Wien / Wien Mitte ↔ Wien Floridsdorf` → `Wien Floridsdorf ↔ Wien Mitte ↔ Flughafen Wien`

### Polish

A line-marker normaliser (`REX7` → `REX 7`, `S50` → `S 50`) keeps the rendered prefix in the canonical spaced form regardless of how the description gluespells the line code.

## Test plan

- [x] 17 new regression tests in `tests/test_oebb_chain_route_title.py`
- [x] User's reproduction reproduced 1:1 in `test_alternative_line_not_picked_as_prefix`
- [x] Chain edge cases: disjoint routes, branching hubs, cycles, self-loops, 2-node and 3-node chains
- [x] `pytest tests/` — 5549 passed, 2 skipped
- [x] `mypy --strict` — clean on all modified files
- [x] `ruff check` — clean
- [x] Reproduction directly verified against cached ÖBB items #4, #7, #13

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_