### PR TITLE
security(logging): pin allow_nan=False on SafeJSONFormatter (sibling-formatter drift of PR #1491)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,35 @@
+## 2026-05-15 - SafeJSONFormatter `allow_nan=False` Drift (Sibling-Formatter Closure of PR #1491 / Round 1488): The `LOG_FORMAT=json` JSON Log Sink — the Ninth-Plus-One Sibling — Renders `extra={"latency_ms": float('nan')}` as the Bare RFC-8259-Forbidden `NaN` / `Infinity` / `-Infinity` Literal That Breaks Every Strict Downstream Log Ingestion Pipeline (Splunk, ElasticSearch, Datadog, Go `encoding/json`, Rust `serde_json` Strict Mode)
+
+**Vulnerability:** PR #1491 (Round 1488) closed the `allow_nan=False` writer-level pin on eight committed-to-main JSON writers. The drift left exactly one structurally identical sibling site uncovered: `src/feed/logging_safe.py:SafeJSONFormatter.format` (line 90 pre-fix), the JSON log sink that fires when `LOG_FORMAT=json` is set (the modern best-practice for log shippers). The formatter walks `record.__dict__` for any non-default field and stuffs it into the serialised payload's `extra` dict — including any `float` value an `extra={...}` caller passes. Pre-fix the call
+
+```python
+log.info("Provider finished", extra={"latency_ms": float('nan')})
+```
+
+renders as
+
+```json
+{"timestamp": "...", "level": "INFO", "logger": "...", "message": "Provider finished", "extra": {"latency_ms": NaN}}
+```
+
+— invalid per RFC 8259 §6, which restricts JSON numeric tokens to finite IEEE-754 floats. Every strict downstream parser refuses the line:
+
+  * **ECMAScript `JSON.parse`** (post-2009 strict mode) — `SyntaxError: Unexpected token N in JSON`.
+  * **Go `encoding/json`** (always strict) — `invalid character 'N' looking for beginning of value`.
+  * **Rust `serde_json`** (strict mode) — `expected value at line 1 column N`.
+  * **Splunk / ElasticSearch / Datadog log ingestion pipelines** that key off RFC-8259 conformance — silently drop the entire batch starting at the malformed line.
+
+The single non-finite float in a single log record breaks the entire ingestion batch for that consumer. The operator-facing alarm pipeline goes blind for the duration of the build cycle, AND every subsequent log line in the batch is silently lost — so the alarm pipeline failure itself is not surfaced. (Python's logging framework does not catch formatter exceptions cleanly: a `ValueError` from `format()` lands in stderr as a noisy traceback that masks the original `log.info(...)` call entirely; the formatter contract is therefore "never raise".)
+
+**Why this site missed PR #1491's writer-inventory walk:** the PR enumerated `json.dump(...)` writer-callsite shapes that produce committed-to-main artefacts. `SafeJSONFormatter.format` uses `json.dumps(...)` (different Python signature) AND its output is operator-facing log lines (not committed artefacts). Both differences hid the structural identity of the threat. The fix path also differed: writers fix the drift via `allow_nan=False` directly, but a `ValueError` from the log formatter would be caught by Python's logging framework and rendered as a raw stderr traceback — invalidating the formatter's never-raise contract. The fix here therefore needs a TWO-LAYER defence:
+
+  1. **Pre-walk the payload** via `_sanitise_non_finite_floats` to convert non-finite floats to safe string repr (`"NaN"` / `"Infinity"` / `"-Infinity"`). Strings round-trip cleanly through every JSON parser.
+  2. **Pin `allow_nan=False`** on the `json.dumps` call as defense-in-depth so a bypass (custom Mapping subclass that `isinstance(d, dict)` does not catch, future container type) surfaces as a loud `ValueError`. The matching `except ValueError` fallback re-encodes via a custom `_FallbackJSONEncoder` that stringifies every float (finite or not) — preserving the never-raise contract while keeping output RFC-8259-conforming.
+
+**Learning:** When closing a writer-shape drift family, walk both the `json.dump(...)` callsite landscape AND the `json.dumps(...)` callsite landscape AND the `logging.Formatter`-subclass landscape — the three sibling shapes share the same RFC-8259 threat model but diverge in fix strategy. JSON log formatters specifically need the two-layer pre-walk + defense-in-depth pattern (because Python's logging contract forbids formatter exceptions). The matching inventory test pins the source-grep invariant `every json.dumps(...) call in src/feed/logging_safe.py must include allow_nan=False` so a future refactor that drops the pin re-fails the gate at PR-review time.
+
+---
+
 ## 2026-05-15 - Committed-Writer `allow_nan=False` Drift: Eight Sibling Writers Outside the Round-1485 / Round-1487 Coordinate-Writer Inventory Land Non-Standard `NaN` / `Infinity` / `-Infinity` Literals (Invalid Per RFC 8259) Into Committed `docs/feed-health.json`, `data/*.json`, `cache/<provider>/last_run.json` — Breaking Every Conforming Downstream JSON Parser (`JSON.parse`, `serde_json`, `encoding/json`)
 
 **Vulnerability:** The 2026-05-14 coordinate finite/range rounds (Round 1485 / Round 1487 — PRs #1485 / #1486 / #1487) pinned `allow_nan=False` on every COORDINATE-emitting writer (the canonical `src/places/merge.py:write_stations`, the five sibling `data/stations.json` writers, the unified `src/utils/cache.py:write_cache`). Those rounds enumerated only the coordinate-writer landscape. Eight sibling COMMITTED-TO-MAIN writers — closed by PR #1434 / PR #1435 ("Trojan-Source / BiDi-Mark Drift Round 11") against the CVE-2021-42574 attack-byte union via `ensure_ascii=True` (or, for `write_feed_health_json`, via the matching `_CONTROL_CHARS_RE.sub("")` scrubs at the payload-build boundary) — never had the `allow_nan=False` pin added:

--- a/src/feed/logging_safe.py
+++ b/src/feed/logging_safe.py
@@ -2,11 +2,144 @@ from __future__ import annotations
 
 import logging
 import json
+import math
 from datetime import datetime
 from typing import Any
 
 from .config import LOG_FORMAT, LOG_TIMEZONE
 from ..utils.logging import sanitize_log_message
+
+
+# Security (Committed-Writer ``allow_nan=False`` Drift, sibling-formatter
+# closure of PR #1491 / Round 1488): ``json.dumps`` defaults to
+# ``allow_nan=True`` which emits the non-standard literals ``NaN`` /
+# ``Infinity`` / ``-Infinity`` for non-finite floats. RFC 8259 forbids
+# those literals, so every strict downstream JSON parser
+# (``JSON.parse`` in ECMAScript-strict mode, Go's ``encoding/json``,
+# Rust's ``serde_json`` strict mode, Splunk / ElasticSearch / Datadog
+# log ingestion pipelines that key on RFC-8259 conformance) refuses
+# the line. PR #1491 closed eight committed-writer sibling sites
+# against this drift; this helper pairs with the
+# :class:`SafeJSONFormatter` JSON log path which is the eighth-plus-one
+# sibling: any ``log.info(..., extra={"latency_ms": float('nan')})``
+# call (or any third-party LoggerAdapter that injects float fields)
+# would otherwise render the entire log batch unparseable for any
+# strict downstream consumer.
+#
+# The helper walks the payload BEFORE ``json.dumps`` and converts each
+# non-finite ``float`` to its safe string representation (``"NaN"``,
+# ``"Infinity"``, ``"-Infinity"``). Strings round-trip cleanly through
+# every JSON parser. The matching ``allow_nan=False`` pin in
+# :meth:`SafeJSONFormatter.format` is defense-in-depth: if the helper
+# misses a future container type (e.g. a custom Mapping subclass), the
+# pin surfaces the bypass as a loud ``ValueError`` rather than a silent
+# RFC-8259 violation. A bounded recursion depth defends against
+# pathological inputs that bypass the upstream depth-bomb guard at the
+# logging-call boundary.
+_MAX_JSON_SANITISE_DEPTH = 50
+
+
+class _FallbackJSONEncoder(json.JSONEncoder):
+    """Last-resort encoder that converts every ``float`` to a string.
+
+    Used only by the formatter's ``except ValueError`` fallback path —
+    fires when the primary :func:`_sanitise_non_finite_floats` walk
+    missed a container type (custom Mapping subclass, non-list
+    iterable). Stringifying every float guarantees the produced JSON
+    stays RFC-8259-conforming even if a non-finite value slipped past
+    the walker. Finite floats lose their numeric typing in the fallback
+    output (``"0.5"`` vs ``0.5``) but the formatter contract is
+    "never raise"; numeric typing is a "nice to have" the primary path
+    preserves.
+    """
+
+    def encode(self, o: Any) -> str:
+        return super().encode(_force_stringify_floats(o, depth=0))
+
+    def iterencode(
+        self, o: Any, _one_shot: bool = False
+    ) -> Any:  # pragma: no cover - thin delegating shim
+        return super().iterencode(_force_stringify_floats(o, depth=0), _one_shot)
+
+
+def _force_stringify_floats(value: object, *, depth: int = 0) -> object:
+    """Recursively convert every ``float`` (finite or not) to its string
+    representation. Used by :class:`_FallbackJSONEncoder` only — the
+    primary walker preserves finite floats as numbers.
+    """
+    if depth > _MAX_JSON_SANITISE_DEPTH:
+        return repr(value)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        if math.isfinite(value):
+            return repr(value)
+        if math.isnan(value):
+            return "NaN"
+        return "Infinity" if value > 0 else "-Infinity"
+    if isinstance(value, dict):
+        return {
+            key: _force_stringify_floats(item, depth=depth + 1)
+            for key, item in value.items()
+        }
+    if isinstance(value, list | tuple):
+        return [_force_stringify_floats(item, depth=depth + 1) for item in value]
+    if isinstance(value, set | frozenset):
+        items = [_force_stringify_floats(item, depth=depth + 1) for item in value]
+        try:
+            return sorted(items, key=str)
+        except TypeError:
+            return items
+    return value
+
+
+def _sanitise_non_finite_floats(value: object, *, depth: int = 0) -> object:
+    """Recursively replace non-finite ``float`` values with safe strings.
+
+    Walks ``dict`` / ``list`` / ``tuple`` / ``set`` containers and
+    converts ``float('nan')`` / ``float('+inf')`` / ``float('-inf')``
+    to ``"NaN"`` / ``"Infinity"`` / ``"-Infinity"`` so the resulting
+    structure round-trips through any RFC-8259-conforming JSON parser.
+    Legitimate finite floats, ints, bools, strings, and ``None`` pass
+    through unchanged. Unknown types pass through to ``json.dumps`` /
+    ``default=`` for normal handling.
+
+    A bounded recursion depth defends against pathological extras that
+    bypass the upstream depth-bomb guard at the logging-call boundary;
+    on overflow the value is rendered via ``repr`` so the formatter
+    still emits a string rather than raising.
+    """
+    if depth > _MAX_JSON_SANITISE_DEPTH:
+        return repr(value)
+    if isinstance(value, bool):
+        # Must precede the float branch because ``bool`` is a subclass of
+        # ``int`` (and ``int`` is JSON-safe by default).
+        return value
+    if isinstance(value, float) and not math.isfinite(value):
+        if math.isnan(value):
+            return "NaN"
+        return "Infinity" if value > 0 else "-Infinity"
+    if isinstance(value, dict):
+        return {
+            key: _sanitise_non_finite_floats(item, depth=depth + 1)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_sanitise_non_finite_floats(item, depth=depth + 1) for item in value]
+    if isinstance(value, tuple):
+        return tuple(
+            _sanitise_non_finite_floats(item, depth=depth + 1) for item in value
+        )
+    if isinstance(value, set | frozenset):
+        # ``set`` is not JSON-serialisable, but a third-party caller
+        # may pass one as an extra; convert to a sorted list so the
+        # downstream serialiser can render it deterministically.
+        items = [_sanitise_non_finite_floats(item, depth=depth + 1) for item in value]
+        try:
+            return sorted(items, key=str)
+        except TypeError:
+            return items
+    return value
 
 class SafeFormatter(logging.Formatter):
     """
@@ -85,9 +218,49 @@ class SafeJSONFormatter(logging.Formatter):
         if extras:
             payload["extra"] = extras
 
+        # Security (Committed-Writer ``allow_nan=False`` Drift, sibling-
+        # formatter closure of PR #1491): pre-walk the payload to convert
+        # non-finite ``float`` values in extras (``float('nan')`` /
+        # ``float('+inf')`` / ``float('-inf')``) to safe string literals
+        # BEFORE ``json.dumps``. RFC 8259 forbids the ``NaN`` / ``Infinity``
+        # / ``-Infinity`` JSON literals that Python's default
+        # ``allow_nan=True`` emits, breaking every strict downstream
+        # parser (Splunk / ElasticSearch / Datadog log ingestion,
+        # ``serde_json`` strict mode, Go ``encoding/json``). Operator-
+        # facing call sites that pass float metrics via ``extra={...}``
+        # (latency, response-size ratio, error rate) would otherwise
+        # render the entire log batch unparseable for any conforming
+        # consumer the moment the upstream peer responds with a bogus
+        # rate. See ``_sanitise_non_finite_floats`` for the canonical
+        # walk shape and threat model.
+        safe_payload = _sanitise_non_finite_floats(payload)
         # We sanitize the full JSON string to catch secrets nested in dictionaries or lists
         # (e.g. extra={"context": {"api_key": "..."}}) which the previous per-field logic missed.
-        dumped = json.dumps(payload, ensure_ascii=False)
+        # Defense-in-depth: ``allow_nan=False`` raises ``ValueError`` if
+        # the helper missed a non-finite float (e.g. a custom Mapping
+        # subclass that ``isinstance(d, dict)`` did not cover), so a
+        # bypass surfaces loudly. The ``except ValueError`` fallback
+        # preserves the formatter's never-raise contract — Python's
+        # logging framework wraps formatter exceptions in noisy stderr
+        # output that would mask the original log call entirely.
+        try:
+            dumped = json.dumps(safe_payload, ensure_ascii=False, allow_nan=False)
+        except ValueError:
+            # Final fallback for the pathological-bypass case (custom
+            # Mapping subclass / non-list iterable that the walker did
+            # not recurse into). ``json.dumps``' ``default=`` callback
+            # is invoked for unsupported types AND, via the custom
+            # encoder below, for any ``float`` that survived the
+            # primary walk — so a leaked ``NaN`` is rendered as the
+            # safe string repr rather than an RFC-8259-violating
+            # bare literal. ``allow_nan=False`` stays pinned so any
+            # second-level bypass surfaces loudly at the test layer.
+            dumped = json.dumps(
+                safe_payload,
+                ensure_ascii=False,
+                allow_nan=False,
+                cls=_FallbackJSONEncoder,
+            )
         sanitized = sanitize_log_message(dumped, strip_control_chars=False)
         return sanitized.replace("\n", "\\n").replace("\r", "\\r")
 

--- a/tests/test_sentinel_safe_json_formatter_allow_nan_drift.py
+++ b/tests/test_sentinel_safe_json_formatter_allow_nan_drift.py
@@ -1,0 +1,413 @@
+"""Sentinel — ``SafeJSONFormatter`` ``allow_nan=False`` drift (sibling of PR #1491).
+
+PR #1491 (Round 1488) closed the ``allow_nan=False`` writer-level pin on eight
+committed-to-main JSON writers (``docs/feed-health.json`` + six ``data/*.json``
+sidecars + ``cache/<provider>/last_run.json``). The drift left one structurally
+identical sibling site uncovered:
+
+* :class:`src.feed.logging_safe.SafeJSONFormatter.format` (line 90 pre-fix).
+
+Threat model
+============
+
+When ``LOG_FORMAT=json`` is set (the modern best-practice for log shippers),
+every log record is rendered through :class:`SafeJSONFormatter`. The formatter
+walks ``record.__dict__`` for any non-default fields and stuffs them into the
+serialised payload's ``extra`` dict. Any ``log.info("...", extra={...})`` call
+that includes a non-finite ``float`` (``float('nan')`` / ``float('+inf')`` /
+``float('-inf')``) — a benign caller pattern for latency / response-size /
+error-rate metrics — would have rendered as the non-standard literals ``NaN``
+/ ``Infinity`` / ``-Infinity`` because Python's ``json.dumps`` defaults to
+``allow_nan=True``.
+
+RFC 8259 §6 forbids those literals. Every strict downstream consumer rejects
+them:
+
+* ECMAScript ``JSON.parse`` (post-2009 strict mode);
+* Go's ``encoding/json`` (always strict);
+* Rust's ``serde_json`` (strict mode);
+* Splunk / ElasticSearch / Datadog log ingestion pipelines that key off
+  RFC-8259 conformance.
+
+A single non-finite float in a single log record breaks the entire ingestion
+batch for that consumer, silently dropping every subsequent log line. The
+operator-facing alarm pipeline goes blind for the duration of the build cycle.
+
+Threat shape mirrors PR #1491 byte-for-byte:
+
+* Same ``json.dumps(..., ensure_ascii=False)`` writer signature.
+* Same Python lenient-parse round-trip recovery (``json.loads`` accepts the
+  literals — masking the issue from the writer's own validators).
+* Same RFC-8259 strict-parse rejection at the boundary.
+
+The fix:
+
+1. Pre-walk the payload via :func:`_sanitise_non_finite_floats` to convert
+   non-finite floats to safe string repr (``"NaN"`` / ``"Infinity"`` /
+   ``"-Infinity"``).
+2. Pin ``allow_nan=False`` on the ``json.dumps`` call as defense-in-depth so a
+   bypass (custom Mapping subclass, future container type) surfaces as a loud
+   ``ValueError`` rather than a silent RFC-8259 violation.
+3. Wrap the dump in a ``try / except ValueError`` fallback that re-renders
+   with ``default=str`` so the formatter's never-raise contract holds.
+
+This file pins the inventory invariant + the behavioural PoCs.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from src.feed.logging_safe import (
+    SafeJSONFormatter,
+    _sanitise_non_finite_floats,
+)
+
+
+# A strict parse_constant hook re-raises the ``ValueError`` that the
+# JSON spec mandates for the non-standard literals. ``json.loads`` calls
+# ``parse_constant`` with the literal text (``"NaN"`` / ``"Infinity"`` /
+# ``"-Infinity"``) when the corresponding source bytes appear in the
+# input — so injecting this hook turns Python's lenient parser into a
+# spec-conforming one for the duration of the test.
+def _strict_parse_constant(literal: str) -> object:
+    raise ValueError(
+        f"Non-standard JSON literal {literal!r} (RFC 8259 forbids NaN / Infinity)"
+    )
+
+
+def _make_record(name: str = "sentinel") -> logging.LogRecord:
+    """Build a minimal ``LogRecord`` wired up so the formatter doesn't
+    blow up on missing attributes. Tests then add ``extra``-shape
+    attributes by direct assignment, mirroring the runtime path
+    Python's logging library uses when ``extra={...}`` is passed.
+    """
+    return logging.LogRecord(
+        name=name,
+        level=logging.INFO,
+        pathname="test.py",
+        lineno=1,
+        msg="Sentinel canary",
+        args=(),
+        exc_info=None,
+    )
+
+
+# ----------------------------------------------------------------------
+# Inventory invariant
+# ----------------------------------------------------------------------
+
+
+def test_safe_json_formatter_pins_allow_nan_false() -> None:
+    """Pin the ``allow_nan=False`` writer-side defence at the canonical
+    ``json.dumps`` site in :class:`SafeJSONFormatter.format`.
+
+    Source-grep invariant: a future refactor that drops the pin (or
+    rewrites the dump call) re-opens the RFC-8259 drift documented in
+    the module docstring above. The structural assertion mirrors the
+    inventory pattern in ``test_sentinel_committed_writer_allow_nan_drift.py``
+    so the gap-closure remains discoverable.
+    """
+    source = Path("src/feed/logging_safe.py").read_text(encoding="utf-8")
+    # The formatter must pin ``allow_nan=False`` on every ``json.dumps``
+    # call — there are exactly two callsites post-fix (the primary dump
+    # and the ``except ValueError`` fallback). Both must carry the pin.
+    json_dumps_calls = source.count("json.dumps(")
+    pinned_calls = source.count("allow_nan=False")
+    assert json_dumps_calls >= 1, (
+        "SafeJSONFormatter source no longer contains a json.dumps call "
+        "(canonical writer reorganised — re-pin this inventory invariant)."
+    )
+    assert pinned_calls >= json_dumps_calls, (
+        f"SafeJSONFormatter source has {json_dumps_calls} json.dumps call(s) "
+        f"but only {pinned_calls} ``allow_nan=False`` pin(s). Every json.dumps "
+        f"call must pin the RFC-8259 conformance defence; otherwise a future "
+        f"refactor re-opens the Round-1488 sibling-formatter drift."
+    )
+
+
+def test_sanitiser_helper_is_module_exported() -> None:
+    """Pin the existence of the canonical sanitiser helper so a future
+    refactor that inlines the walk into the formatter (or splits it
+    across multiple helpers) does not silently lose the recursive
+    contract this drift round established."""
+    from src.feed import logging_safe
+
+    assert hasattr(logging_safe, "_sanitise_non_finite_floats"), (
+        "Canonical non-finite-float sanitiser helper is missing — a refactor "
+        "removed the Round-1488 drift-closure boundary."
+    )
+    assert callable(logging_safe._sanitise_non_finite_floats)
+
+
+# ----------------------------------------------------------------------
+# Behavioural PoCs (strict parse_constant boundary)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "field_name,bad_value",
+    [
+        ("nan_metric", float("nan")),
+        ("plus_inf", float("inf")),
+        ("minus_inf", float("-inf")),
+    ],
+)
+def test_format_does_not_emit_nan_or_infinity_in_top_level_extra(
+    field_name: str, bad_value: float
+) -> None:
+    """PoC: pre-fix a single non-finite float in ``extra`` rendered as the
+    literal ``NaN`` / ``Infinity`` / ``-Infinity`` token in the output —
+    invalid per RFC 8259, rejected by every strict downstream parser.
+
+    Post-fix: the output must parse cleanly through a strict parser
+    (``json.loads`` with a ``parse_constant`` hook that re-raises on the
+    forbidden literals).
+    """
+    formatter = SafeJSONFormatter()
+    record = _make_record()
+    setattr(record, field_name, bad_value)
+
+    output = formatter.format(record)
+
+    # Lenient parser must accept the output (sanity).
+    parsed = json.loads(output)
+
+    # Strict parser must accept the output (the load-bearing assertion).
+    json.loads(output, parse_constant=_strict_parse_constant)
+
+    # The non-finite float must have been replaced by its safe string
+    # representation, not silently dropped.
+    extras = parsed.get("extra", {})
+    actual = extras.get(field_name)
+    assert isinstance(actual, str), (
+        f"Non-finite float in extras['{field_name}'] should round-trip as "
+        f"a string, got {type(actual).__name__}: {actual!r}"
+    )
+    if math.isnan(bad_value):
+        assert actual == "NaN"
+    elif bad_value > 0:
+        assert actual == "Infinity"
+    else:
+        assert actual == "-Infinity"
+
+
+def test_format_handles_nested_non_finite_floats() -> None:
+    """The walker must recurse into nested ``dict`` / ``list`` / ``tuple``
+    containers — the canonical operator-facing extras shape carries
+    metric dicts (``{"latency": {"p50": ..., "p99": ...}}``) where a
+    transient upstream blip can land ``inf`` in a single quantile.
+    """
+    formatter = SafeJSONFormatter()
+    record = _make_record()
+    record.metrics = {
+        "latency_ms": {"p50": 12.5, "p99": float("inf")},
+        "samples": [1.0, float("nan"), 3.0],
+        "as_tuple": (float("-inf"), 0.5),
+    }
+
+    output = formatter.format(record)
+    json.loads(output, parse_constant=_strict_parse_constant)
+
+    parsed = json.loads(output)
+    metrics = parsed["extra"]["metrics"]
+    assert metrics["latency_ms"]["p50"] == 12.5
+    assert metrics["latency_ms"]["p99"] == "Infinity"
+    assert metrics["samples"] == [1.0, "NaN", 3.0]
+    assert metrics["as_tuple"] == ["-Infinity", 0.5]
+
+
+def test_format_preserves_finite_floats_and_other_primitives() -> None:
+    """Sanitiser must not over-eagerly mangle valid JSON-serialisable
+    primitives — finite floats, ints, bools, strings, ``None`` all
+    round-trip unchanged.
+    """
+    formatter = SafeJSONFormatter()
+    record = _make_record()
+    record.finite_float = 0.5
+    record.an_int = 42
+    record.a_bool = True
+    record.a_string = "ok"
+    record.a_none = None
+    record.zero_float = 0.0
+    record.negative_zero = -0.0
+
+    output = formatter.format(record)
+    parsed = json.loads(output, parse_constant=_strict_parse_constant)
+
+    extras = parsed["extra"]
+    assert extras["finite_float"] == 0.5
+    assert extras["an_int"] == 42
+    assert extras["a_bool"] is True
+    assert extras["a_string"] == "ok"
+    assert extras["a_none"] is None
+    assert extras["zero_float"] == 0.0
+    # JSON does not distinguish negative zero from positive zero, but
+    # Python's ``json.dumps`` emits ``-0.0`` literally and the strict
+    # parser accepts it.
+    assert extras["negative_zero"] == 0.0
+
+
+def test_format_via_logger_extra_passes_strict_parse_constant() -> None:
+    """End-to-end PoC through Python's logging framework — mirrors the
+    real-world call shape ``log.info("...", extra={...})`` that an
+    operator-facing caller would use to attach a metric.
+    """
+    logger = logging.getLogger(__name__ + ".strict_parse")
+    # Avoid handler accumulation across pytest runs.
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(SafeJSONFormatter())
+    logger.addHandler(handler)
+
+    try:
+        logger.info(
+            "Provider %s finished in %s",
+            "vor",
+            "12.5s",
+            extra={
+                "duration_s": float("nan"),
+                "throughput_qps": float("inf"),
+                "items": 7,
+            },
+        )
+    finally:
+        logger.removeHandler(handler)
+
+    output = stream.getvalue().strip()
+    # Strict parse must succeed (no NaN / Infinity literals).
+    parsed = json.loads(output, parse_constant=_strict_parse_constant)
+    extras = parsed["extra"]
+    assert extras["duration_s"] == "NaN"
+    assert extras["throughput_qps"] == "Infinity"
+    assert extras["items"] == 7
+
+
+def test_format_handles_set_extras_deterministically() -> None:
+    """A ``set`` extra is not natively JSON-serialisable. The walker
+    converts it to a sorted list so the formatter does not raise, and
+    the strict parser still accepts the output.
+    """
+    formatter = SafeJSONFormatter()
+    record = _make_record()
+    record.tags = {"err", "abc", "def"}
+
+    output = formatter.format(record)
+    parsed = json.loads(output, parse_constant=_strict_parse_constant)
+
+    tags = parsed["extra"]["tags"]
+    assert isinstance(tags, list)
+    assert sorted(tags) == ["abc", "def", "err"]
+
+
+# ----------------------------------------------------------------------
+# Helper unit tests (pin the recursive contract directly)
+# ----------------------------------------------------------------------
+
+
+def test_helper_replaces_nan_at_top_level() -> None:
+    assert _sanitise_non_finite_floats(float("nan")) == "NaN"
+    assert _sanitise_non_finite_floats(float("inf")) == "Infinity"
+    assert _sanitise_non_finite_floats(float("-inf")) == "-Infinity"
+
+
+def test_helper_preserves_finite_floats_and_other_primitives() -> None:
+    assert _sanitise_non_finite_floats(0.5) == 0.5
+    assert _sanitise_non_finite_floats(0.0) == 0.0
+    assert _sanitise_non_finite_floats(42) == 42
+    assert _sanitise_non_finite_floats(True) is True
+    assert _sanitise_non_finite_floats(False) is False
+    assert _sanitise_non_finite_floats("ok") == "ok"
+    assert _sanitise_non_finite_floats(None) is None
+
+
+def test_helper_preserves_bool_distinct_from_int() -> None:
+    """``isinstance(True, int)`` is ``True`` in Python — the helper
+    must check ``bool`` BEFORE ``int`` / ``float`` so booleans round-trip
+    as JSON ``true`` / ``false`` rather than being swallowed by a
+    numeric branch."""
+    out_true = _sanitise_non_finite_floats(True)
+    out_false = _sanitise_non_finite_floats(False)
+    assert out_true is True
+    assert out_false is False
+    assert json.dumps(out_true) == "true"
+    assert json.dumps(out_false) == "false"
+
+
+def test_helper_recurses_into_nested_containers() -> None:
+    payload = {
+        "outer": {
+            "inner_list": [float("nan"), 1.0, [float("inf")]],
+            "inner_tuple": (float("-inf"), 2.0),
+        },
+    }
+    sanitised = _sanitise_non_finite_floats(payload)
+    assert sanitised == {
+        "outer": {
+            "inner_list": ["NaN", 1.0, ["Infinity"]],
+            "inner_tuple": ("-Infinity", 2.0),
+        },
+    }
+
+
+def test_helper_bounded_recursion_depth() -> None:
+    """A pathological deeply-nested structure must NOT blow the Python
+    recursion stack — the helper falls back to ``repr`` past the cap so
+    the formatter still produces output.
+    """
+    # Build a 60-level deep nested dict ({k: {k: ...}}). The helper's
+    # cap is 50, so the deeper levels collapse to ``repr``.
+    payload: object = "leaf"
+    for _ in range(60):
+        payload = {"k": payload}
+    out = _sanitise_non_finite_floats(payload)
+    # The structure is finite and the helper returns without raising.
+    assert out is not None
+
+
+# ----------------------------------------------------------------------
+# Defense-in-depth: ``allow_nan=False`` traps any future bypass
+# ----------------------------------------------------------------------
+
+
+def test_allow_nan_false_traps_a_walker_bypass() -> None:
+    """If a future container type slipped past the walker, the
+    ``allow_nan=False`` pin on ``json.dumps`` would raise ``ValueError``.
+    The fallback ``except`` branch then renders via ``default=str`` so
+    the formatter still emits valid JSON. This test simulates the
+    bypass by feeding the formatter a custom dict subclass — the
+    walker covers it (``isinstance(d, dict)`` is True), so the test
+    additionally verifies that the fallback path itself produces
+    RFC-conforming output.
+    """
+    # The simulated bypass: monkey-patch the helper to be a no-op so
+    # the raw NaN reaches json.dumps. The ``allow_nan=False`` pin then
+    # fires and the ``except ValueError`` fallback re-renders via
+    # ``default=str``. End-state: still RFC-8259-conforming, no leaked
+    # bare ``NaN`` literal.
+    from src.feed import logging_safe
+
+    original = logging_safe._sanitise_non_finite_floats
+    logging_safe._sanitise_non_finite_floats = lambda value, **_: value
+    try:
+        formatter = SafeJSONFormatter()
+        record = _make_record()
+        record.canary = float("nan")
+        output = formatter.format(record)
+        # Strict parse: the fallback must still produce conforming JSON.
+        json.loads(output, parse_constant=_strict_parse_constant)
+        # Verify the canary was rendered (via ``default=str``) rather
+        # than dropped silently.
+        parsed = json.loads(output)
+        assert "nan" in parsed["extra"]["canary"].lower()
+    finally:
+        logging_safe._sanitise_non_finite_floats = original


### PR DESCRIPTION
## Summary

Closes the **sibling-formatter** drift left by PR #1491 (Round 1488). PR #1491 pinned `allow_nan=False` on **eight** committed-to-main JSON writers; the structurally identical JSON-log-formatter site at `src/feed/logging_safe.py:SafeJSONFormatter.format` was outside that walk and would have rendered `extra={"latency_ms": float('nan')}` as the bare RFC-8259-forbidden literal `NaN`, breaking every strict downstream log ingestion pipeline (Splunk, ElasticSearch, Datadog, Go `encoding/json`, Rust `serde_json` strict mode).

- **+pre-walk** via `_sanitise_non_finite_floats`: recursively converts non-finite floats in `dict` / `list` / `tuple` / `set` extras to safe string repr (`"NaN"` / `"Infinity"` / `"-Infinity"`).
- **+`allow_nan=False`** on `json.dumps` as defense-in-depth — bypasses (custom Mapping subclass that `isinstance(d, dict)` does not catch) surface as a loud `ValueError`.
- **+`except ValueError` fallback** via custom `_FallbackJSONEncoder` (stringifies every float) preserves the formatter's never-raise contract while keeping output RFC-8259-conforming.

## Threat model

When `LOG_FORMAT=json` is set (the modern best-practice for log shippers), every log record is rendered through `SafeJSONFormatter`. Any `log.info("...", extra={"latency_ms": float('nan')})` call (operator-facing metric pattern) would have rendered as:

```json
{"timestamp": "...", "level": "INFO", ..., "extra": {"latency_ms": NaN}}
```

— invalid per RFC 8259 §6, rejected by every strict downstream parser. A single non-finite float in a single log record breaks the entire ingestion batch for that consumer; the operator-facing alarm pipeline goes blind for the duration of the build cycle, AND every subsequent log line in the batch is silently lost — so the alarm pipeline failure itself is not surfaced.

## Why this site missed PR #1491's writer-inventory walk

- `SafeJSONFormatter.format` uses `json.dumps(...)` (different Python signature from the `json.dump(...)` writers PR #1491 enumerated).
- Output is operator-facing log lines (not committed-to-main artefacts).
- The fix path differs: a writer can raise `ValueError` cleanly, but Python's logging framework wraps formatter exceptions in noisy stderr tracebacks that mask the original log call entirely. The formatter contract is "never raise" — hence the two-layer pre-walk + defense-in-depth pattern.

## Test plan

Companion test suite: `tests/test_sentinel_safe_json_formatter_allow_nan_drift.py` (15 tests, all pass)

- [x] **Inventory pin** (`test_safe_json_formatter_pins_allow_nan_false`): source-grep for `json.dumps(...)` calls in `src/feed/logging_safe.py` and assert every one carries `allow_nan=False`.
- [x] **Behavioural PoCs (3, parametrised)**: `nan` / `+inf` / `-inf` in top-level extra → strict `parse_constant` hook accepts the output (would have failed pre-fix with `Non-standard JSON literal 'NaN'`).
- [x] **Recursion PoC**: nested `dict` / `list` / `tuple` with mixed finite + non-finite floats round-trip through strict-parse cleanly.
- [x] **Set-extra PoC**: `record.tags = {"a", "b"}` (not natively JSON-serialisable) gets converted to a deterministically-sorted list.
- [x] **End-to-end via logger**: `log.info(..., extra={"throughput_qps": float('inf')})` produces RFC-8259-conforming JSON on stderr.
- [x] **Helper unit tests**: pin the bool-before-float ordering (`isinstance(True, int)` trap), finite-float preservation, recursion-depth cap, and set→sorted-list conversion.
- [x] **Defense-in-depth test**: simulates a walker bypass (monkeypatches the helper to no-op) and verifies the fallback `_FallbackJSONEncoder` still emits strict-parse-conforming JSON.
- [x] Local static checks pass: ruff ✓, mypy strict (`PYTHONPATH=src python3 -m mypy --no-pretty src tests`) → 0 errors ✓, bandit ✓, secret scanner ✓, C901 complexity gate (0 new violations) ✓, pip-audit ✓.
- [x] Full pytest suite: **5675 passed, 2 skipped** in 152s (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018cyvcNefihuwq3UPBzB3zQ)_