### PR TITLE
fix(vor): stop atexit flush from inflating daily quota by +1 per run

### DIFF
--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -102,18 +102,23 @@ _QUOTA_CACHE: dict[str, Any] = {"date": None, "count": 0, "unsaved_delta": 0}
 
 
 def _flush_quota_cache() -> None:
-    """Flush any unsaved request counts to disk on exit."""
+    """Flush any unsaved request counts to disk on exit.
+
+    Persists the in-memory ``unsaved_delta`` to disk WITHOUT recording a
+    new request. Pre-fix this function called :func:`save_request_count`,
+    which always increments ``unsaved_delta`` by ``1`` before persisting
+    — every script invocation that made any VOR call therefore booked
+    one phantom request beyond the actual API traffic. With 48 cron
+    ticks/day and 2 real ``/trip`` calls per tick, the bug inflated the
+    persisted counter from ``96`` to ``144`` requests/day, exhausting
+    the contractual ``100``/day VAO Start cap after roughly 33 ticks
+    and leaving the remaining ~15 hours of the day without
+    Stammstrecke observations. The CSV ledger gap that bug produced
+    visibly degraded the README "Letzte 60 Minuten" snapshot when one
+    of the affected hours was the most recent one.
+    """
     with _QUOTA_LOCK:
-        if _QUOTA_CACHE.get("unsaved_delta", 0) > 0:
-            original_batch = os.environ.get("WIEN_OEPNV_TEST_QUOTA_BATCH")
-            try:
-                os.environ["WIEN_OEPNV_TEST_QUOTA_BATCH"] = "1"
-                save_request_count()
-            finally:
-                if original_batch is not None:
-                    os.environ["WIEN_OEPNV_TEST_QUOTA_BATCH"] = original_batch
-                else:
-                    os.environ.pop("WIEN_OEPNV_TEST_QUOTA_BATCH", None)
+        _persist_quota_to_disk()
 
 atexit.register(_flush_quota_cache)
 
@@ -770,6 +775,101 @@ def load_request_count(bypass_cache: bool = False) -> tuple[str | None, int]:
     return (None, 0)
 
 
+def _persist_quota_to_disk() -> int:
+    """Persist any pending ``unsaved_delta`` to disk; **does not increment**.
+
+    Caller MUST hold :data:`_QUOTA_LOCK`. Returns the new on-disk total
+    (or the unchanged in-memory total when there was nothing to flush).
+
+    Split off from :func:`save_request_count` 2026-05-15 to fix a
+    quota-inflation bug: the previous :func:`_flush_quota_cache` invoked
+    :func:`save_request_count`, which incremented ``unsaved_delta`` by
+    one before flushing — every script invocation that made any VOR
+    call therefore booked one phantom request beyond the actual API
+    traffic. The split makes the persist path callable without that
+    side effect while keeping :func:`save_request_count` semantically
+    identical for every existing caller (increment-then-conditionally-
+    flush). All security invariants (TOCTOU-safe capped read, negative-
+    count clamp, atomic write, lock-failure quota-poison sentinel) live
+    in this helper now and are exercised through both entry points.
+    """
+    if _QUOTA_CACHE.get("unsaved_delta", 0) <= 0:
+        return cast(int, _QUOTA_CACHE.get("count", 0))
+
+    vienna_tz = ZoneInfo("Europe/Vienna")
+    now_local = datetime.now(vienna_tz)
+    date_iso = now_local.strftime("%Y-%m-%d")
+
+    # Ensure the parent directory exists before attempting to open the lock file.
+    # This prevents FileNotFoundError if the directory structure is missing.
+    REQUEST_COUNT_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+    lock_path = REQUEST_COUNT_FILE.with_suffix(".lock")
+
+    try:
+        with (
+            lock_path.open("a+", encoding="utf-8") as lock_file,
+            file_lock(lock_file, exclusive=True),
+        ):
+            # Security: TOCTOU-safe size cap via read_capped_json.
+            disk_date = None
+            disk_count = 0
+            data = read_capped_json(
+                REQUEST_COUNT_FILE,
+                MAX_VOR_QUOTA_FILE_BYTES,
+                label="VOR quota",
+                logger=log,
+            )
+            if isinstance(data, dict):
+                disk_date = data.get("date")
+                if "requests" in data:
+                    try:
+                        disk_count = int(data["requests"])
+                    except (ValueError, TypeError):
+                        pass
+
+            # Security: clamp at 0 to defeat negative-count quota-bypass
+            # (mirrors load_request_count's clamp; see its comment block).
+            disk_count = max(0, disk_count)
+
+            if disk_date != date_iso:
+                disk_count = 0
+                _QUOTA_CACHE["count"] = 0
+            else:
+                # Update our memory cache to reflect exactly what's on disk right now
+                _QUOTA_CACHE["count"] = disk_count
+
+            # Add our unsaved delta to what is on disk.
+            new_total = disk_count + _QUOTA_CACHE["unsaved_delta"]
+
+            _QUOTA_CACHE["count"] = new_total
+            _QUOTA_CACHE["date"] = date_iso
+            _QUOTA_CACHE["unsaved_delta"] = 0
+
+            payload = {"date": date_iso, "requests": new_total}
+            try:
+                # Centralised atomic + ASCII-safe write —
+                # see ``_write_request_count_file`` for the
+                # Trojan-Source threat model.
+                _write_request_count_file(REQUEST_COUNT_FILE, payload)
+            except OSError:
+                log.critical("Failed to write to request count file. Quota mechanism poisoned.")
+                _QUOTA_CACHE["count"] = MAX_REQUESTS_PER_DAY + 1
+                _QUOTA_CACHE["unsaved_delta"] = 0
+                return MAX_REQUESTS_PER_DAY + 1
+    except (OSError, TimeoutError) as e:
+        # Sentinel: file/lock errors can carry attacker-controlled
+        # path fragments from a planted lockfile name; sanitise
+        # before logging.
+        log.warning(
+            "Failed to save request count (lock error): %s",
+            sanitize_log_arg(str(e)),
+        )
+        return MAX_REQUESTS_PER_DAY + 1
+
+    return cast(int, new_total)
+
+
 def save_request_count(now_ignored: datetime | None = None) -> int:
     # We ignore the passed 'now' to enforce UTC consistency internally.
     # But keep the signature compatible if callers pass it.
@@ -797,73 +897,7 @@ def save_request_count(now_ignored: datetime | None = None) -> int:
 
         # Only perform expensive file I/O periodically (every X requests) or on the first request
         if current_total == 1 or _QUOTA_CACHE["unsaved_delta"] >= batch_limit or current_total >= MAX_REQUESTS_PER_DAY:
-            # Ensure the parent directory exists before attempting to open the lock file.
-            # This prevents FileNotFoundError if the directory structure is missing.
-            REQUEST_COUNT_FILE.parent.mkdir(parents=True, exist_ok=True)
-
-            lock_path = REQUEST_COUNT_FILE.with_suffix(".lock")
-
-            try:
-                with (
-                    lock_path.open("a+", encoding="utf-8") as lock_file,
-                    file_lock(lock_file, exclusive=True),
-                ):
-                        # Security: TOCTOU-safe size cap via read_capped_json.
-                        disk_date = None
-                        disk_count = 0
-                        data = read_capped_json(
-                            REQUEST_COUNT_FILE,
-                            MAX_VOR_QUOTA_FILE_BYTES,
-                            label="VOR quota",
-                            logger=log,
-                        )
-                        if isinstance(data, dict):
-                            disk_date = data.get("date")
-                            if "requests" in data:
-                                try:
-                                    disk_count = int(data["requests"])
-                                except (ValueError, TypeError):
-                                    pass
-
-                        # Security: clamp at 0 to defeat negative-count quota-bypass
-                        # (mirrors load_request_count's clamp; see its comment block).
-                        disk_count = max(0, disk_count)
-
-                        if disk_date != date_iso:
-                            disk_count = 0
-                            _QUOTA_CACHE["count"] = 0
-                        else:
-                            # Update our memory cache to reflect exactly what's on disk right now
-                            _QUOTA_CACHE["count"] = disk_count
-
-                        # Add our unsaved delta to what is on disk.
-                        new_total = disk_count + _QUOTA_CACHE["unsaved_delta"]
-
-                        _QUOTA_CACHE["count"] = new_total
-                        _QUOTA_CACHE["unsaved_delta"] = 0
-
-                        payload = {"date": date_iso, "requests": new_total}
-                        try:
-                            # Centralised atomic + ASCII-safe write —
-                            # see ``_write_request_count_file`` for the
-                            # Trojan-Source threat model.
-                            _write_request_count_file(REQUEST_COUNT_FILE, payload)
-                        except OSError:
-                            log.critical("Failed to write to request count file. Quota mechanism poisoned.")
-                            _QUOTA_CACHE["count"] = MAX_REQUESTS_PER_DAY + 1
-                            _QUOTA_CACHE["unsaved_delta"] = 0
-                            return MAX_REQUESTS_PER_DAY + 1
-            except (OSError, TimeoutError) as e:
-                # Sentinel: file/lock errors can carry attacker-controlled
-                # path fragments from a planted lockfile name; sanitise
-                # before logging.
-                log.warning(
-                    "Failed to save request count (lock error): %s",
-                    sanitize_log_arg(str(e)),
-                )
-                return MAX_REQUESTS_PER_DAY + 1
-
-            return cast(int, new_total)
+            return _persist_quota_to_disk()
 
         return cast(int, current_total)
 

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -826,6 +826,13 @@ def _persist_quota_to_disk() -> int:
                     try:
                         disk_count = int(data["requests"])
                     except (ValueError, TypeError):
+                        # Unparseable ``requests`` field (string,
+                        # ``null``, malformed) → fall through to the
+                        # default ``disk_count = 0``. The next write
+                        # rewrites the file with the canonical schema
+                        # so the corruption self-heals on the next
+                        # cron tick. Mirrors the silent-bail shape of
+                        # ``load_request_count`` for the same field.
                         pass
 
             # Security: clamp at 0 to defeat negative-count quota-bypass

--- a/tests/test_vor_request_limit.py
+++ b/tests/test_vor_request_limit.py
@@ -220,6 +220,91 @@ def reset_vor_quota_cache(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 
+def test_flush_quota_cache_does_not_inflate_persisted_count(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Regression: ``_flush_quota_cache`` MUST persist without recording.
+
+    Pre-fix, the atexit-registered flush invoked ``save_request_count``,
+    which always increments ``unsaved_delta`` by ``1`` before flushing.
+    Every script invocation that made any VOR call therefore booked one
+    *phantom* request beyond the actual API traffic. With the
+    Stammstrecke cron (2 ``/trip`` calls per tick × 48 ticks/day = 96
+    real requests) the bug inflated the persisted counter to ``144``
+    requests/day, breaching the contractual ``100``/day VAO Start cap
+    after roughly 33 ticks and leaving the remaining ~15 hours of the
+    day without Stammstrecke observations. The visible symptom on the
+    README dashboard was a "Letzte 60 Minuten" snapshot that bottomed
+    out at 1-3 observations whenever an affected hour was the most
+    recent one.
+
+    This test pins the invariant: after N real ``save_request_count``
+    calls plus a final ``_flush_quota_cache``, the persisted count is
+    exactly ``N`` — never ``N + 1``.
+    """
+    target_file = tmp_path / "vor_request_count.json"
+    monkeypatch.setattr(vor, "REQUEST_COUNT_FILE", target_file)
+
+    # Simulate a single Stammstrecke cron tick: 2 ``/trip`` requests
+    # (one per direction). The first call triggers an immediate flush
+    # via the ``current_total == 1`` branch; the second call only
+    # increments ``unsaved_delta`` because the batch limit is 10.
+    real_calls = 2
+    moment = datetime.now(ZoneInfo("Europe/Vienna"))
+    for _ in range(real_calls):
+        vor.save_request_count(moment)
+
+    # End-of-process flush — must NOT add another phantom request.
+    vor._flush_quota_cache()
+
+    stored = json.loads(target_file.read_text(encoding="utf-8"))
+    assert stored["requests"] == real_calls, (
+        f"Expected exactly {real_calls} persisted requests after "
+        f"{real_calls} actual API calls + flush, but found "
+        f"{stored['requests']}. The flush helper is double-counting."
+    )
+
+    # A second flush must be a strict no-op — the in-memory delta is
+    # zero so neither the cache nor the disk should change.
+    vor._flush_quota_cache()
+    stored_again = json.loads(target_file.read_text(encoding="utf-8"))
+    assert stored_again["requests"] == real_calls
+
+
+def test_flush_quota_cache_with_no_unsaved_delta_is_noop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Idempotent ``_flush_quota_cache`` — never writes when delta=0.
+
+    Belt-and-braces alongside the regression test above: if a future
+    refactor reintroduces an unconditional ``save_request_count`` call
+    inside the flush helper, this test catches it on the *no-call* code
+    path (where the prior test would still have recorded a real call to
+    mask the regression).
+    """
+    target_file = tmp_path / "vor_request_count.json"
+    monkeypatch.setattr(vor, "REQUEST_COUNT_FILE", target_file)
+
+    # Cache primed with date but zero unsaved delta — the canonical
+    # "nothing to flush" state.
+    today = datetime.now(ZoneInfo("Europe/Vienna")).strftime("%Y-%m-%d")
+    monkeypatch.setitem(vor._QUOTA_CACHE, "date", today)
+    monkeypatch.setitem(vor._QUOTA_CACHE, "count", 0)
+    monkeypatch.setitem(vor._QUOTA_CACHE, "unsaved_delta", 0)
+
+    vor._flush_quota_cache()
+
+    # No write should have happened: the file must not exist (or, if
+    # it does, must reflect zero requests rather than the phantom +1
+    # the pre-fix code would have produced).
+    assert not target_file.exists(), (
+        "Expected no on-disk write when there is nothing to flush, but "
+        f"found {target_file.read_text(encoding='utf-8')!r}."
+    )
+
+
 def test_load_request_count_resets_on_legacy_integer(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Behebt einen Bug in der VAO-Quota-Buchhaltung, der die README-Statistik "Letzte 60 Minuten" auf der S-Bahn-Stammstrecke teilweise auf 1-3 Beobachtungen heruntergedrückt hat.

## Diagnose (vom Nutzer berichtet)

> Im Readme sind nur 3 Beobachtungen in den letzten 60 Minuten zu sehen. Das kommt mir auf der Stammstrecke in beiden Richtungen recht wenig vor.

Die normale Kadenz ist 4 Beobachtungen/Stunde (2 pro Richtung × 2 Cron-Ticks à 30 min). 3 Einträge im 60-min-Fenster sind also bereits 25 % unter dem Soll. Tatsächlich ist die Lage schlimmer: `data/stats/stammstrecke_2026.csv` hatte am 14.05. nur **64 Einträge statt erwarteter 96** — Lücke von 16:00 bis 00:00 CEST ohne *eine einzige* Beobachtung.

## Wurzelursache

`_flush_quota_cache()` (atexit-Handler in `src/providers/vor.py`) hat `save_request_count()` aufgerufen — eine Funktion, die `unsaved_delta += 1` macht, *bevor* sie auf Disk schreibt. Jeder Skriptlauf, der irgendeinen VOR-Call macht, hat damit **einen Phantom-Request** mehr gebucht als tatsächlich gesendet wurde.

Bei der Stammstrecken-Cron (2 `/trip`-Calls × 48 Ticks/Tag = 96 echte Requests) wurde der persistierte Counter so auf **144 Requests/Tag** aufgeblasen — das vertragliche `MAX_REQUESTS_PER_DAY = 100` (VAO Start) wird nach ~33 Ticks (≈16 h) gerissen, und der `preflight_quota_check.py`-Gate im Workflow überspringt die restlichen Ticks komplett (`continue-on-error: true`, kein CSV-Update).

Verifiziert per Mini-Repro:
```
After 2 real save_request_count() calls + flush:
  pre-fix:  {"date": "2026-05-15", "requests": 3}   ← phantom +1
  post-fix: {"date": "2026-05-15", "requests": 2}   ← korrekt
```

## Fix

- **Extraktion**: Persist-to-Disk-Logik aus `save_request_count` in einen neuen privaten Helper `_persist_quota_to_disk()` ausgegliedert. Der Helper rührt `unsaved_delta` *nicht* an, hält alle Security-Invarianten (TOCTOU-sicher gekappter Read, Negative-Count-Clamp, atomarer Write, Lock-Failure-Quota-Poison-Sentinel).
- **`save_request_count`**: inkrementiert wie bisher, ruft dann konditional den Helper. Vertrag für alle bestehenden Aufrufer ist byte-identisch.
- **`_flush_quota_cache`**: ruft jetzt direkt den Helper, ohne den `WIEN_OEPNV_TEST_QUOTA_BATCH`-Env-Var-Hack.

## Test plan

- [x] Bestehende Tests laufen alle durch: `5677 passed, 2 skipped` in der vollen Suite.
- [x] Neuer Regressionstest `test_flush_quota_cache_does_not_inflate_persisted_count`: pinnt das No-Inflation-Invariant (2 echte Calls + Flush ⇒ Disk zeigt exakt 2).
- [x] Neuer Idempotenz-Test `test_flush_quota_cache_with_no_unsaved_delta_is_noop`: stellt sicher, dass ein Flush ohne pending Delta auch keine Datei schreibt.
- [x] Mini-Repro-Skript bestätigt: Disk-Counter ist nach Fix korrekt bei `requests: N` für `N` echte Calls.
- [ ] Nach Merge produktiv beobachten: ab dem nächsten Cron-Tick sollte der `vor_request_count.json` nur noch +2 statt +3 pro Lauf inkrementieren; der Tagescounter sollte unter 100 bleiben (96 = 2 × 48 Ticks); die README "Letzte 60 Minuten" sollte konstant 4 Beobachtungen zeigen (statt 1-3 in den vom Quota-Block betroffenen Stunden).

## Hinweis zur Entstehungsgeschichte

Branch wurde vor Beginn der Untersuchung als `claude/fix-observation-stats-mYO6d` provisioniert; die hier behobene Ursache liegt aber in der Quota-Buchhaltung, nicht im Stammstrecke-Skript selbst. Das CSV-Beobachtungsskript (`scripts/update_stammstrecke_status.py`) und der Statistik-Renderer (`scripts/generate_markdown_stats.py`) verhalten sich korrekt — sie können nur nicht zählen, was nicht erfasst wird, weil der Quota-Bug die Erfassung blockiert.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSYzUEqB9o1frsjBwar3Y3)_