### PR TITLE
feat(stammstrecke): lift numF=6 cap via /departureBoard at Wien Hbf

### DIFF
--- a/.github/workflows/update-cycle.yml
+++ b/.github/workflows/update-cycle.yml
@@ -197,12 +197,16 @@ jobs:
       # counter (``data/vor_request_count.json``) and SKIP the
       # Stammstrecke poll when a fresh run would breach the
       # contractual 100/day cap. The in-script ``_charge_one_request``
-      # guard (``update_stammstrecke_status.py:331``) is still active
-      # as a second-layer enforcer; this preflight makes the
-      # budget-exhausted state explicit at the top of the workflow
-      # log so operators can spot it without scraping the script's
-      # DEBUG output. ``--margin 2`` mirrors the 2 ``/trip`` requests
-      # the monitor makes per run.
+      # guard is still active as a second-layer enforcer; this
+      # preflight makes the budget-exhausted state explicit at the
+      # top of the workflow log so operators can spot it without
+      # scraping the script's DEBUG output.
+      #
+      # ``--margin 1`` mirrors the SINGLE ``/departureBoard`` request
+      # the Hauptbahnhof-based monitor makes per cron tick. (Pre-2026-
+      # 05-15 the legacy ``update_stammstrecke_status.py`` made TWO
+      # ``/trip`` calls per tick — one per direction — and the margin
+      # was 2.)
       - name: VAO quota pre-flight
         id: vor_preflight
         # ``continue-on-error: true`` — the preflight script
@@ -211,12 +215,23 @@ jobs:
         # gate on ``steps.vor_preflight.outputs.quota_ok`` controls
         # the API step below.
         continue-on-error: true
-        run: python scripts/preflight_quota_check.py --check vor --margin 2
+        run: python scripts/preflight_quota_check.py --check vor --margin 1
 
+      # Stammstrecke delay monitor. Since 2026-05-15 uses
+      # ``/departureBoard`` at Wien Hauptbahnhof
+      # (``update_stammstrecke_hbf.py``) which lifts the ``numF=6``
+      # capture ceiling that the legacy ``/trip``-based
+      # ``update_stammstrecke_status.py`` inherited from the VAO API.
+      # One ``/departureBoard`` poll returns ALL Stammstrecke trains
+      # in the 45-min duration window — a single API call per tick
+      # covers both directions (south = Meidling, north = Floridsdorf),
+      # classified via terminus whitelists. Rollback path: swap the
+      # script name back to ``update_stammstrecke_status.py`` and
+      # bump ``--margin`` above to ``2``.
       - name: Refresh Stammstrecke status
         if: ${{ steps.vor_preflight.outputs.quota_ok == 'true' }}
         continue-on-error: true
-        run: python scripts/update_stammstrecke_status.py
+        run: python scripts/update_stammstrecke_hbf.py
 
       # ----- Feed build (no API call — pure consumer of caches) -----------
 

--- a/scripts/update_stammstrecke_hbf.py
+++ b/scripts/update_stammstrecke_hbf.py
@@ -1,0 +1,895 @@
+#!/usr/bin/env python3
+"""Stammstrecke delay monitor via VAO ``/departureBoard`` at Wien Hauptbahnhof.
+
+Architectural successor to ``scripts/update_stammstrecke_status.py``,
+written 2026-05-15 to lift the ``numF=6`` capture ceiling that the
+``/trip`` endpoint imposes.
+
+Motivation
+----------
+
+The pre-2026-05-15 pipeline queried ``/trip`` from Floridsdorf → Meidling
+and Meidling → Floridsdorf separately. ``numF`` is contractually capped
+at 6 (``docs/reference/trip.md:34``). Empirical analysis of
+``cache/stammstrecke/recently_finalised.json`` showed that the response
+consistently returned 6 trains spanning ~21 of 30 minutes, with the last
+9 minutes of every 30-min window falling outside both the current
+tick's and the next tick's coverage windows. At Vienna S-Bahn peak
+density (~3.5-min spacing) that 9-min gap routinely contains 2-3
+trains that were never observed — bypassed by the cap.
+
+``/departureBoard`` has only a SOFT ``maxJourneys`` limit (``docs/
+reference/departureboard.md:22``); we omit the parameter entirely so
+VAO returns every departure in the configured duration window. Querying
+at Wien Hauptbahnhof — geographically central on the Stammstrecke —
+catches every train that passes through the corridor, including the
+ones that originate / terminate at intermediate stations and never
+appeared in the Floridsdorf-to-Meidling ``/trip`` view.
+
+Quota
+-----
+
+The poll is ONE ``/departureBoard`` call per cron tick. At 48
+cron ticks/day that's 48 VAO requests/day — half of the
+contractual ``MAX_REQUESTS_PER_DAY = 100`` Start-tier limit. The
+~50% saving over the two-direction ``/trip`` polls gives manual
+``workflow_dispatch`` operators a substantial extra budget for
+out-of-band runs.
+
+Direction labelling
+-------------------
+
+Each departure's ``direction`` field (the train's terminus as displayed
+on the station board) is classified into the same ``"Meidling"`` /
+``"Floridsdorf"`` direction labels that the pre-2026-05-15 ``/trip``
+pipeline emitted, so:
+
+* ``data/stats/stammstrecke_<YYYY>.csv`` rows keep the exact same
+  schema and direction-column values — the README dashboard, feed
+  event renderer (``src/feed/stammstrecke.py``) and any external
+  analysis continue to work byte-for-byte.
+* The pending-trip ledger (``cache/stammstrecke/pending_trips.json``)
+  and the recently-finalised companion ledger remain compatible.
+
+Two-layer classification: substring match against well-known south/north
+landmark names first (fast path), then exact-terminus whitelist
+fallback. Unrecognised terminuses are dropped with a deduplicated INFO
+log so operators can extend the whitelist when a new line appears.
+
+Latest-wins re-observation
+--------------------------
+
+A train scheduled 40 minutes in the future is observed at this tick
+with whatever rtTime VAO can forecast at the moment. The NEXT tick
+re-observes the same train (still ~10 minutes in the future) — the
+``_observe_legs`` ledger overwrites the older entry with the newer
+delay reading, so the value that eventually flows into the CSV is the
+closest-to-departure (therefore most accurate) one. The pending-trip
+ledger only finalises a train when its scheduled time has passed
+(``scheduled <= now``); long-horizon observations contribute to the
+CSV row of the cron tick that catches the actual departure, never the
+one that first saw the future train.
+
+Reuse
+-----
+
+This script imports the shared infrastructure (pending state, finalise,
+ledger I/O, lock, quota charge, HTTP session) from
+``scripts/update_stammstrecke_status.py`` rather than duplicating it.
+The legacy script remains importable so its tests stay green during the
+transition; it is no longer wired into the cron workflow.
+"""
+
+from __future__ import annotations
+
+import json as _json_lib
+import logging
+import re
+import statistics
+import sys
+from collections import defaultdict
+from collections.abc import Iterable, Iterator, Mapping
+from contextlib import ExitStack
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Final
+from zoneinfo import ZoneInfo
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.feed.logging_safe import setup_script_logging  # noqa: E402
+from src.providers import vor as vor_provider  # noqa: E402
+from src.utils.circuit_breaker import (  # noqa: E402
+    CircuitBreaker,
+    CircuitBreakerOpen,
+)
+from src.utils.http import request_safe  # noqa: E402
+from src.utils.logging import sanitize_log_arg  # noqa: E402
+from src.utils.stats import append_stammstrecke_row  # noqa: E402
+
+# Reuse pending-state + ledger infrastructure from the legacy /trip-
+# based monitor. The private prefix is intentional in that script;
+# importing across scripts is the transitional shape until the legacy
+# script is removed in a follow-up PR.
+from scripts.update_stammstrecke_status import (  # noqa: E402
+    BREAKER_FAILURE_THRESHOLD,
+    BREAKER_RECOVERY_TIMEOUT,
+    DELAY_THRESHOLD_MINUTES,
+    MAX_QUERY_TIMEOUT,
+    PENDING_TRIPS_LOCK_PATH,
+    PENDING_TRIPS_PATH,
+    PENDING_TTL,
+    QUERY_TIMEOUT,
+    RECENTLY_FINALISED_PATH,
+    VIENNA_TZ,
+    _QuotaExceeded,
+    _build_session,
+    _canonical_line_name,
+    _charge_one_request,
+    _finalize_departed,
+    _ledger_lock,
+    _load_pending_trips,
+    _load_recently_finalised,
+    _now_vienna,
+    _observe_legs,
+    _parse_vao_dt,
+    _purge_finalised_entries,
+    _purge_stale_entries,
+    _S_BAHN_LINE_RE,
+    _SbahnLegObservation,
+    _save_pending_trips,
+    _save_recently_finalised,
+)
+
+LOGGER = logging.getLogger("update_stammstrecke_hbf")
+
+
+# ---- Operating parameters --------------------------------------------------
+
+# VOR/VAO station ID for Wien Hauptbahnhof (HBF). Pinned here to avoid a
+# station-directory drift quietly changing which stop we poll. Sourced
+# from ``data/stations.json``: the canonical entry for ``Wien
+# Hauptbahnhof`` carries ``vor_id = "490134900"``.
+HAUPTBAHNHOF_VOR_ID: Final = "490134900"
+
+# /departureBoard duration window, in minutes.
+#
+# Sized at the 30-min cron interval plus a 15-min safety overlap so every
+# train scheduled in the poll window appears in BOTH this tick and the
+# next one — the pending-trip ledger then keeps the latest (closer-to-
+# departure, therefore more accurate) realtime reading via the
+# latest-wins overwrite in :func:`_observe_legs`.
+#
+# Why not 60 min: VAO returns ALL departures in the requested window, so
+# a longer window inflates JSON payload + parse cost + in-memory state
+# without giving us a more accurate observation (the train was already
+# covered in the prior window). 45 min is the 50%-overlap sweet spot.
+DEPARTURE_BOARD_DURATION_MIN: Final = 45
+
+# Geographic-direction → CSV-label mapping. Pinned constants so a future
+# rename here cannot silently drift the README dashboard column values
+# (which are pinned to "Meidling" / "Floridsdorf" since the 2026-05-09
+# Stammstrecke migration).
+DIRECTION_LABEL_SOUTHBOUND: Final = "Meidling"
+DIRECTION_LABEL_NORTHBOUND: Final = "Floridsdorf"
+
+DIRECTION_LABELS: Final[tuple[str, ...]] = (
+    DIRECTION_LABEL_SOUTHBOUND,
+    DIRECTION_LABEL_NORTHBOUND,
+)
+
+
+# ---- Direction classification at Wien Hauptbahnhof ------------------------
+#
+# A Stammstrecke train's geographic direction is determined by its
+# terminus (the ``direction`` field in the ``/departureBoard`` response).
+# The Stammstrecke runs north↔south through Vienna:
+#
+#   Wien Floridsdorf — Praterstern — Wien Mitte — Rennweg — Quartier
+#   Belvedere — Wien Hauptbahnhof — Wien Meidling
+#
+# Trains heading SOUTH from Hbf next stop at Wien Meidling (and continue
+# further south to Mödling, Wiener Neustadt, Graz, etc.) → labelled
+# ``"Meidling"`` for CSV-column compatibility with the pre-2026-05-15
+# ``/trip``-based pipeline.
+#
+# Trains heading NORTH from Hbf reach Wien Mitte after two intermediate
+# stops (QB → Rennweg) and continue to Praterstern → Floridsdorf and
+# beyond to Stockerau, Hollabrunn, Břeclav, etc. → labelled
+# ``"Floridsdorf"``.
+
+# Substring fragments that unambiguously indicate the geographic direction
+# *from Wien Hauptbahnhof*. Strings are lowercased for case-insensitive
+# matching against ``direction.lower()``.
+#
+# Hauptbahnhof itself is excluded — a train terminating AT Hbf does not
+# cross the Stammstrecke any further and is irrelevant to the corridor
+# signal.
+HBF_SOUTHBOUND_SUBSTRINGS: Final[tuple[str, ...]] = (
+    "meidling",       # next Stammstrecke stop southbound
+    "mödling",        # next major node after Meidling (S1, S2, S3 terminus)
+    "moedling",       # ASCII variant
+    "wiener neustadt",  # S1, REX terminus
+    "payerbach",      # REX southbound terminus
+    "semmering",      # REX southbound terminus
+    "mürzzuschlag",   # REX southbound terminus
+    "muerzzuschlag",  # ASCII variant
+    "bruck/mur",      # REX terminus / waypoint
+    "bruck an der mur",
+    "graz",           # long-distance south
+    "klagenfurt",     # long-distance south-west
+    "villach",        # long-distance south-west
+    "lienz",          # long-distance south-west
+    "flughafen wien", # S7 southern arm via Stammstrecke
+    "wien flughafen", # variant capitalisation
+    "wolfsthal",      # S7 eastern terminus (after airport)
+    "baden",          # CAT / S-Bahn southern terminus
+    "pottendorf",     # S2 alternate southern terminus
+    "wampersdorf",    # S2 alternate southern terminus
+)
+
+# Substring fragments for the *northbound* geographic direction at Hbf.
+HBF_NORTHBOUND_SUBSTRINGS: Final[tuple[str, ...]] = (
+    "floridsdorf",    # eventual Stammstrecke northern terminus
+    "praterstern",    # intermediate Stammstrecke stop, terminus for some short-runs
+    "stockerau",      # S2 / R-train terminus northwest
+    "hollabrunn",     # REX northern terminus
+    "retz",           # REX northern terminus
+    "břeclav",        # long-distance north (CZ)
+    "breclav",        # ASCII variant
+    "wolkersdorf",    # S2 / R-train terminus north
+    "mistelbach",     # S2 northern terminus
+    "laa an der thaya",  # S2 northern terminus (long form)
+    "laa/thaya",      # variant
+    "gänserndorf",    # S1 / REX northern terminus
+    "gaenserndorf",   # ASCII variant
+    "marchegg",       # REX eastern terminus
+    "bratislava",     # long-distance northeast (SK)
+    # "Wien Mitte" intentionally NOT a substring — too short and would
+    # match any train mentioning "Mitte" in a free-form direction string.
+    # The exact-terminus whitelist below covers the rare Mitte-
+    # terminating short-run.
+)
+
+# Exact-terminus whitelists for departures not covered by substring
+# matching. Add new entries here when an unknown terminus appears
+# repeatedly in operator logs and we can verify (via an external
+# timetable lookup) that it is on the Stammstrecke axis.
+HBF_SOUTHBOUND_TERMINI: Final[frozenset[str]] = frozenset({
+    # Empty initially — extend from the
+    # ``Unbekannter Endpunkt am Hbf`` log entries on first deployment.
+})
+
+HBF_NORTHBOUND_TERMINI: Final[frozenset[str]] = frozenset({
+    "Wien Mitte",
+    "Wien Mitte-Landstraße",
+    "Wien Mitte Bahnhof",
+})
+
+
+# Cap on the rendered ``Unbekannter Endpunkt am Hbf`` diagnostic per
+# run. Bounds a planted-upstream amplification where every departure
+# carries a different unique direction string and the INFO log balloons.
+_UNRECOGNISED_DIAG_MAX_LEN: Final = 80
+
+
+# ---- Departure-board request + parse --------------------------------------
+
+
+_BREAKER = CircuitBreaker(
+    "stammstrecke-hbf-vor",
+    failure_threshold=BREAKER_FAILURE_THRESHOLD,
+    recovery_timeout=BREAKER_RECOVERY_TIMEOUT,
+)
+
+
+def configure_logging() -> None:
+    """Install the project's :class:`SafeFormatter` for this script."""
+
+    setup_script_logging(logging.INFO)
+    # urllib3 emits one INFO line per VAO request which clutters the
+    # workflow log without adding diagnostic value. Mirrors the existing
+    # legacy-script pattern.
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+
+def _query_departure_board(
+    session: requests.Session,
+    *,
+    when: datetime,
+    duration_min: int = DEPARTURE_BOARD_DURATION_MIN,
+    timeout: int = QUERY_TIMEOUT,
+) -> list[Mapping[str, Any]]:
+    """Call ``/departureBoard`` once at Wien Hauptbahnhof.
+
+    Returns the parsed ``Departure`` list (possibly empty). Validates
+    HTTP status, JSON shape, and the response wrapper (the VAO
+    serialiser can place the list at the top level under ``Departure``
+    OR nest it under ``DepartureBoard.Departure``; both shapes are
+    accepted).
+
+    Charges the VAO daily quota counter exactly once via
+    :func:`_charge_one_request` before sending. A
+    :class:`_QuotaExceeded` raised here aborts the cron tick before any
+    network I/O — operators see the budget breach in the workflow log
+    without a half-completed request.
+    """
+
+    safe_timeout = max(1, min(timeout, MAX_QUERY_TIMEOUT))
+
+    params: dict[str, str] = {
+        "id": HAUPTBAHNHOF_VOR_ID,
+        "date": when.strftime("%Y-%m-%d"),
+        "time": when.strftime("%H:%M"),
+        "duration": str(duration_min),
+        # Filter on product classes Train (1) + S-Bahn (2). The
+        # post-filter in :func:`_is_sbahn_line` narrows further to
+        # S/R/REX line patterns, but the upstream filter saves us a
+        # ton of long-distance (RJ, IC, EC, NJ) entries in the
+        # response payload.
+        "products": "3",
+        # Enable server-side realtime data so ``rtTime`` is populated
+        # when available.
+        "rtMode": "SERVER_DEFAULT",
+        # The ``maxJourneys`` parameter is INTENTIONALLY OMITTED — it
+        # is a soft limit (``docs/reference/departureboard.md:22``)
+        # and omitting it lets VAO return every departure in the
+        # window, which is the point of the migration from the
+        # hard-capped ``/trip`` endpoint.
+    }
+
+    endpoint = f"{vor_provider.VOR_BASE_URL}departureBoard"
+
+    _charge_one_request(when)
+
+    # Mirror the legacy script's response-handling pattern (read body
+    # before raising on HTTP error) so the downstream diagnostic
+    # helpers can inspect ``response.content`` even on 4xx/5xx.
+    response = request_safe(
+        session,
+        endpoint,
+        method="GET",
+        raise_for_status=False,
+        params=params,
+        headers={"Accept": "application/json"},
+        timeout=safe_timeout,
+        allowed_content_types=("application/json",),
+    )
+    if response.status_code >= 400:
+        raise requests.HTTPError(
+            f"VAO /departureBoard returned HTTP {response.status_code}",
+            response=response,
+        )
+
+    content = response.content
+
+    try:
+        payload = _json_lib.loads(content)
+    except (ValueError, RecursionError) as exc:
+        # Drift defence (JSON Depth-Bomb): a depth-bomb body passes the
+        # size cap but blows the recursion limit on parse. Re-raise as
+        # ``ValueError`` so the caller's error-isolation branch runs
+        # without propagating the BaseException-rooted failure.
+        raise ValueError(
+            f"VAO /departureBoard returned unparseable JSON: {type(exc).__name__}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise TypeError(
+            f"VAO /departureBoard returned non-dict payload: "
+            f"{type(payload).__name__}"
+        )
+
+    # Response shape variants seen in the wild (audit docs 2026-02):
+    #   * ``{"Departure": [...]}`` — modern flat shape
+    #   * ``{"DepartureBoard": {"Departure": [...]}}`` — nested shape
+    # Accept either.
+    raw_deps: Any
+    if "DepartureBoard" in payload:
+        board = payload["DepartureBoard"]
+        if isinstance(board, Mapping):
+            raw_deps = board.get("Departure")
+        else:
+            raw_deps = None
+    else:
+        raw_deps = payload.get("Departure")
+
+    if raw_deps is None:
+        return []
+    if isinstance(raw_deps, Mapping):
+        # Single-element responses are sometimes serialised as the bare
+        # object rather than a one-element list.
+        return [raw_deps]
+    if not isinstance(raw_deps, list):
+        raise TypeError(
+            f"VAO /departureBoard Departure field has unexpected type: "
+            f"{type(raw_deps).__name__}"
+        )
+    return [d for d in raw_deps if isinstance(d, Mapping)]
+
+
+def classify_hbf_direction(direction_str: str) -> str | None:
+    """Return ``"Meidling"`` (south), ``"Floridsdorf"`` (north) or ``None``.
+
+    Two-layer match against the direction string (the train's terminus
+    as serialised by VAO):
+
+    1. Substring against :data:`HBF_SOUTHBOUND_SUBSTRINGS` /
+       :data:`HBF_NORTHBOUND_SUBSTRINGS` — fast path, case-insensitive.
+       Catches the typical "City Name [Bahnhof]" forms.
+    2. Exact-string against :data:`HBF_SOUTHBOUND_TERMINI` /
+       :data:`HBF_NORTHBOUND_TERMINI` — slower fallback for terminuses
+       that contain none of the landmark substrings.
+
+    ``None`` means the terminus is unrecognised; the caller logs and
+    drops the departure.
+    """
+
+    norm = direction_str.strip()
+    if not norm:
+        return None
+    lower = norm.lower()
+    for needle in HBF_SOUTHBOUND_SUBSTRINGS:
+        if needle in lower:
+            return DIRECTION_LABEL_SOUTHBOUND
+    for needle in HBF_NORTHBOUND_SUBSTRINGS:
+        if needle in lower:
+            return DIRECTION_LABEL_NORTHBOUND
+    if norm in HBF_SOUTHBOUND_TERMINI:
+        return DIRECTION_LABEL_SOUTHBOUND
+    if norm in HBF_NORTHBOUND_TERMINI:
+        return DIRECTION_LABEL_NORTHBOUND
+    return None
+
+
+def _is_sbahn_line(name: str) -> bool:
+    """Return ``True`` if *name* matches the S/R/REX line-code pattern.
+
+    Mirrors the legacy ``_is_sbahn_leg`` line-name check but operates
+    on a bare string (the departure's ``name`` field) rather than a
+    full leg object. The regex is the same project-wide
+    :data:`_S_BAHN_LINE_RE` so any future widening propagates.
+    """
+
+    return bool(_S_BAHN_LINE_RE.match(name.strip()))
+
+
+def _departure_line_name(dep: Mapping[str, Any]) -> str:
+    """Extract the line designation from a ``/departureBoard`` entry.
+
+    VAO emits the line in several spots depending on serialiser
+    version:
+
+    * Top-level ``name`` field (e.g., ``"S 1"`` or ``"REX 3"``);
+    * Nested ``Product[].line`` or ``Product[].displayNumber`` or
+      ``Product[].name``.
+
+    Returns the first non-empty hit, or empty string when none of the
+    fields are populated.
+    """
+
+    top = str(dep.get("name") or "").strip()
+    if top:
+        return top
+    products = dep.get("Product")
+    if isinstance(products, list):
+        candidates = [p for p in products if isinstance(p, Mapping)]
+    elif isinstance(products, Mapping):
+        candidates = [products]
+    else:
+        candidates = []
+    for product in candidates:
+        for key in ("line", "displayNumber", "name"):
+            v = str(product.get(key) or "").strip()
+            if v:
+                return v
+    return ""
+
+
+def _departure_delay_minutes(dep: Mapping[str, Any]) -> float | None:
+    """Return the departure delay in fractional minutes, or ``None``.
+
+    Same conservative-skip rules as the legacy
+    ``_leg_departure_delay_minutes`` but reads from the DEPARTURE-level
+    fields rather than from a nested ``Leg.Origin`` substructure:
+
+    * Cancelled departures return ``None`` (cancelled trains are
+      ``absent``, not ``delayed`` — counting them as delay-zero
+      systematically biases the sample downward).
+    * Missing ``rtTime`` returns ``None`` (no realtime signal — VAO
+      omits ``rtTime`` both for on-time AND for genuinely-unknown
+      trains, so coercing missing data to ``0.0`` would the
+      88%-zeros bias documented in the legacy script's docstring).
+    * Unparseable schedule or realtime fields return ``None``
+      (malformed entries are dropped, not silently coerced).
+    """
+
+    cancelled = dep.get("cancelled")
+    if cancelled is True:
+        return None
+    if isinstance(cancelled, str) and cancelled.strip().lower() == "true":
+        return None
+
+    sched_date = dep.get("date")
+    sched_time = dep.get("time")
+    scheduled = _parse_vao_dt(sched_date, sched_time)
+    if scheduled is None:
+        return None
+
+    rt_time = dep.get("rtTime") or dep.get("rtDepTime")
+    if not rt_time:
+        return None
+
+    rt_date = dep.get("rtDate") or dep.get("rtDepDate") or sched_date
+    actual = _parse_vao_dt(rt_date, rt_time)
+    if actual is None:
+        return None
+
+    return (actual - scheduled).total_seconds() / 60.0
+
+
+@dataclass(frozen=True)
+class _HbfDepartureObservation:
+    """One filtered + direction-classified departure at Wien Hauptbahnhof.
+
+    Field shapes mirror :class:`_SbahnLegObservation` so that the
+    existing :func:`_observe_legs` consumer (which duck-types on
+    ``.name`` / ``.scheduled`` / ``.delay_minutes``) accepts these
+    instances unchanged. The extra ``direction`` attribute is read by
+    the caller (which groups observations into per-direction lists
+    before invoking ``_observe_legs``).
+    """
+
+    direction: str  # historical label: "Meidling" or "Floridsdorf"
+    name: str       # canonicalised line designation (e.g., "S1", "REX3")
+    scheduled: datetime
+    delay_minutes: float
+
+
+def _collect_hbf_observations(
+    departures: Iterable[Mapping[str, Any]],
+) -> tuple[dict[str, list[_SbahnLegObservation]], dict[str, int]]:
+    """Filter + direction-classify a ``/departureBoard`` Departure list.
+
+    Returns a 2-tuple:
+
+    * ``{direction_label: [observations]}`` ready to feed to
+      :func:`_observe_legs` per-direction. Keys are always present
+      (empty list when no departures matched that direction).
+    * ``{unrecognised_terminus: occurrence_count}`` — distinct terminus
+      strings that failed direction classification. The caller logs the
+      top-N entries at INFO so operators can extend the whitelists.
+
+    Filters (any failure drops the entry):
+
+    * Cancelled departures (no useful delay signal).
+    * Lines that are not S / R / REX (non-Stammstrecke products).
+    * Missing realtime signal (``rtTime`` absent) — treated as
+      ``unknown``, same conservative rule as the legacy script.
+    * Unrecognised terminus — direction cannot be classified.
+
+    Compatible with :func:`_observe_legs` via the
+    :class:`_SbahnLegObservation` shape (``name``, ``scheduled``,
+    ``delay_minutes``); the ``direction`` field of the observation is
+    implicit in which list it lives in.
+    """
+
+    by_direction: dict[str, list[_SbahnLegObservation]] = {
+        label: [] for label in DIRECTION_LABELS
+    }
+    unrecognised: dict[str, int] = defaultdict(int)
+
+    for dep in departures:
+        if not isinstance(dep, Mapping):
+            continue
+
+        raw_line = _departure_line_name(dep)
+        if not raw_line:
+            continue
+        if not _is_sbahn_line(raw_line):
+            continue
+        name = _canonical_line_name(raw_line)
+        if not name:
+            continue
+
+        sched_date = dep.get("date")
+        sched_time = dep.get("time")
+        scheduled = _parse_vao_dt(sched_date, sched_time)
+        if scheduled is None:
+            continue
+
+        delay = _departure_delay_minutes(dep)
+        if delay is None:
+            continue
+
+        direction_str = str(dep.get("direction") or "").strip()
+        direction = classify_hbf_direction(direction_str)
+        if direction is None:
+            unrecognised[direction_str] += 1
+            continue
+
+        observation = _SbahnLegObservation(
+            name=name,
+            scheduled=scheduled,
+            delay_minutes=delay,
+        )
+        by_direction[direction].append(observation)
+
+    return by_direction, dict(unrecognised)
+
+
+def _log_unrecognised_terminuses(unrecognised: Mapping[str, int]) -> None:
+    """Surface unrecognised termini at INFO with a per-terminus count.
+
+    Operators read this log to extend
+    :data:`HBF_SOUTHBOUND_SUBSTRINGS` / etc. when a new line appears.
+
+    Bounded:
+    * Sorted by count (descending) so the most-frequent terminus is
+      surfaced first.
+    * Each rendered direction-string is capped at
+      :data:`_UNRECOGNISED_DIAG_MAX_LEN` chars; longer values are
+      truncated with an ellipsis to bound a planted-upstream
+      amplification shape.
+    """
+
+    if not unrecognised:
+        return
+    LOGGER.info(
+        "Stammstrecke (Hbf): %d Abfahrt(en) mit unbekanntem Endpunkt "
+        "verworfen — Top-Termini folgen.",
+        sum(unrecognised.values()),
+    )
+    for terminus, count in sorted(
+        unrecognised.items(), key=lambda kv: kv[1], reverse=True
+    ):
+        rendered = terminus or "<leer>"
+        if len(rendered) > _UNRECOGNISED_DIAG_MAX_LEN:
+            rendered = rendered[: _UNRECOGNISED_DIAG_MAX_LEN] + "…"
+        LOGGER.info(
+            "  • %d× Endpunkt='%s'",
+            count,
+            sanitize_log_arg(rendered),
+        )
+
+
+# ---- Main flow ------------------------------------------------------------
+
+
+def _process_tick(
+    session: requests.Session,
+    state: dict[Any, Any],
+    *,
+    when: datetime,
+    recently_finalised: Mapping[str, datetime] | None = None,
+) -> str:
+    """Single ``/departureBoard`` poll, classify, and observe.
+
+    Returns one of:
+
+    * ``"ok"`` — query succeeded and observations were folded into
+      the pending state;
+    * ``"error"`` — VAO transport / parse error (already logged);
+    * ``"quota_exceeded"`` — daily quota cap hit before the call.
+
+    ``CircuitBreakerOpen`` is re-raised so :func:`main` can short-
+    circuit the rest of the tick.
+    """
+
+    LOGGER.info(
+        "Stammstrecke (Hbf): /departureBoard für %s (id=%s, duration=%d).",
+        when.isoformat(),
+        HAUPTBAHNHOF_VOR_ID,
+        DEPARTURE_BOARD_DURATION_MIN,
+    )
+
+    try:
+        departures = _BREAKER.call(_query_departure_board, session, when=when)
+    except CircuitBreakerOpen:
+        raise
+    except _QuotaExceeded as exc:
+        LOGGER.warning(
+            "Stammstrecke (Hbf): Tageslimit erreicht — Abfrage übersprungen (%s).",
+            sanitize_log_arg(str(exc)),
+        )
+        return "quota_exceeded"
+    except requests.HTTPError as exc:
+        status = getattr(getattr(exc, "response", None), "status_code", None)
+        LOGGER.warning(
+            "Stammstrecke (Hbf): /departureBoard fehlgeschlagen: HTTP %s.",
+            sanitize_log_arg(str(status) if status is not None else "?"),
+        )
+        return "error"
+    except Exception as exc:
+        # Security: ``VorAuth`` injects the ``accessId`` into the URL
+        # before the prepared request leaves the session, so a
+        # ``RequestException`` may carry that URL in its message —
+        # logging the exception type alone is leak-safe.
+        LOGGER.warning(
+            "Stammstrecke (Hbf): /departureBoard fehlgeschlagen: %s.",
+            type(exc).__name__,
+        )
+        return "error"
+
+    by_direction, unrecognised = _collect_hbf_observations(departures)
+    _log_unrecognised_terminuses(unrecognised)
+
+    written_per_dir: dict[str, int] = {}
+    for direction in DIRECTION_LABELS:
+        observations = by_direction.get(direction, [])
+        if not observations:
+            written_per_dir[direction] = 0
+            continue
+        written_per_dir[direction] = _observe_legs(
+            state,
+            observations,
+            direction=direction,
+            now=when,
+            recently_finalised=recently_finalised,
+        )
+
+    LOGGER.info(
+        "Stammstrecke (Hbf): %d Abfahrten gesamt — Meidling=%d, "
+        "Floridsdorf=%d (Ledger-Updates).",
+        len(departures),
+        written_per_dir.get(DIRECTION_LABEL_SOUTHBOUND, 0),
+        written_per_dir.get(DIRECTION_LABEL_NORTHBOUND, 0),
+    )
+    return "ok"
+
+
+def main() -> int:
+    """Entry point. Returns ``0`` on success (incl. degraded), ``1`` on full failure.
+
+    The script never raises an unhandled exception out of ``main`` — the
+    cron pipeline relies on a clean exit so other cache updates run on
+    schedule even when this provider is degraded. A
+    ``CircuitBreakerOpen`` short-circuit appends nothing to the CSV;
+    the feed naturally degrades to "no Stammstrecke entry" because the
+    most-recent observations roll out of the 1-hour feed window
+    without replacement.
+    """
+
+    configure_logging()
+
+    when = _now_vienna()
+
+    with _ledger_lock(PENDING_TRIPS_LOCK_PATH):
+        state = _load_pending_trips(PENDING_TRIPS_PATH)
+        recently_finalised = _load_recently_finalised(RECENTLY_FINALISED_PATH)
+
+        cutoff = when - PENDING_TTL
+        purged_pending = _purge_stale_entries(state, cutoff=cutoff)
+        purged_finalised = _purge_finalised_entries(
+            recently_finalised, cutoff=cutoff
+        )
+        if purged_pending or purged_finalised:
+            LOGGER.info(
+                "Stammstrecke (Hbf): %d veraltete Pending-Einträge, %d "
+                "veraltete Finalisiert-Einträge entfernt (TTL %s).",
+                purged_pending,
+                purged_finalised,
+                PENDING_TTL,
+            )
+
+        successes = 0
+        errors = 0
+
+        with ExitStack() as stack:
+            try:
+                session = _build_session(stack)
+            except Exception as exc:  # pragma: no cover - defensive
+                LOGGER.error(
+                    "Stammstrecke (Hbf): VOR-Session konnte nicht erstellt werden: %s.",
+                    type(exc).__name__,
+                )
+                return 1
+
+            try:
+                status = _process_tick(
+                    session,
+                    state,
+                    when=when,
+                    recently_finalised=recently_finalised,
+                )
+            except CircuitBreakerOpen:
+                LOGGER.warning(
+                    "Stammstrecke (Hbf): Circuit breaker offen (%d "
+                    "aufeinanderfolgende Fehler) — Tick übersprungen.",
+                    _BREAKER.consecutive_failures,
+                )
+                status = "error"
+
+            if status in ("error", "quota_exceeded"):
+                errors += 1
+            else:
+                successes += 1
+
+        # Finalisation pass per direction. Trains scheduled <= now are
+        # popped from the pending state, their latest observation is
+        # written to the CSV, and their identity key is registered in
+        # ``recently_finalised`` so a VAO re-emission at the lookahead
+        # boundary cannot produce a duplicate CSV row.
+        csv_rows_written = 0
+        for direction in DIRECTION_LABELS:
+            finalised = _finalize_departed(
+                state,
+                direction=direction,
+                now=when,
+                recently_finalised=recently_finalised,
+            )
+            if not finalised:
+                continue
+            by_year: dict[int, list[Any]] = {}
+            for trip in finalised:
+                by_year.setdefault(trip.scheduled.year, []).append(trip)
+            for year in sorted(by_year):
+                year_trips = by_year[year]
+                mean_minutes = float(
+                    statistics.mean(t.latest_delay_minutes for t in year_trips)
+                )
+                row_timestamp = max(t.scheduled for t in year_trips)
+                LOGGER.info(
+                    "Stammstrecke (Hbf): Richtung %s, Jahr %d — %d Zug/Züge "
+                    "finalisiert, ⌀ %.2f Minuten (Schwelle %d).",
+                    direction,
+                    year,
+                    len(year_trips),
+                    mean_minutes,
+                    DELAY_THRESHOLD_MINUTES,
+                )
+                append_stammstrecke_row(
+                    timestamp=row_timestamp,
+                    direction=direction,
+                    delay_minutes=mean_minutes,
+                )
+                csv_rows_written += 1
+
+        # Persist both ledgers AFTER finalisation. Save
+        # recently_finalised FIRST so that on a crash between the two
+        # writes, the suppression set is durable — the pending entry
+        # will be re-observed on the next tick but skipped by the
+        # ``recently_finalised`` guard instead of being double-
+        # finalised.
+        _save_recently_finalised(RECENTLY_FINALISED_PATH, recently_finalised)
+        _save_pending_trips(PENDING_TRIPS_PATH, state)
+
+    LOGGER.info(
+        "Stammstrecke (Hbf): %d Beobachtungs-Tick(s), %d CSV-Zeile(n) "
+        "geschrieben (Erfolg=%d, Fehler=%d, Pending=%d offen, "
+        "Finalisiert=%d).",
+        1,
+        csv_rows_written,
+        successes,
+        errors,
+        len(state),
+        len(recently_finalised),
+    )
+
+    if successes == 0 and errors > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())
+
+
+__all__ = [
+    "DEPARTURE_BOARD_DURATION_MIN",
+    "DIRECTION_LABELS",
+    "DIRECTION_LABEL_NORTHBOUND",
+    "DIRECTION_LABEL_SOUTHBOUND",
+    "HAUPTBAHNHOF_VOR_ID",
+    "HBF_NORTHBOUND_SUBSTRINGS",
+    "HBF_NORTHBOUND_TERMINI",
+    "HBF_SOUTHBOUND_SUBSTRINGS",
+    "HBF_SOUTHBOUND_TERMINI",
+    "classify_hbf_direction",
+    "main",
+]

--- a/scripts/update_stammstrecke_hbf.py
+++ b/scripts/update_stammstrecke_hbf.py
@@ -107,7 +107,7 @@ from src.utils.circuit_breaker import (  # noqa: E402
     CircuitBreakerOpen,
 )
 from src.utils.http import request_safe  # noqa: E402
-from src.utils.logging import sanitize_log_arg  # noqa: E402
+from src.utils import logging as utils_logging  # noqa: E402
 from src.utils.stats import append_stammstrecke_row  # noqa: E402
 
 # Reuse pending-state + ledger infrastructure from the legacy /trip-

--- a/scripts/update_stammstrecke_hbf.py
+++ b/scripts/update_stammstrecke_hbf.py
@@ -84,17 +84,15 @@ from __future__ import annotations
 
 import json as _json_lib
 import logging
-import re
 import statistics
 import sys
 from collections import defaultdict
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Iterable, Mapping
 from contextlib import ExitStack
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Final
-from zoneinfo import ZoneInfo
 
 import requests
 
@@ -126,7 +124,7 @@ from scripts.update_stammstrecke_status import (  # noqa: E402
     PENDING_TTL,
     QUERY_TIMEOUT,
     RECENTLY_FINALISED_PATH,
-    VIENNA_TZ,
+    VIENNA_TZ as VIENNA_TZ,
     _QuotaExceeded,
     _build_session,
     _canonical_line_name,
@@ -552,7 +550,7 @@ class _HbfDepartureObservation:
 
 
 def _collect_hbf_observations(
-    departures: Iterable[Mapping[str, Any]],
+    departures: Iterable[Any],
 ) -> tuple[dict[str, list[_SbahnLegObservation]], dict[str, int]]:
     """Filter + direction-classify a ``/departureBoard`` Departure list.
 

--- a/scripts/update_stammstrecke_hbf.py
+++ b/scripts/update_stammstrecke_hbf.py
@@ -124,7 +124,6 @@ from scripts.update_stammstrecke_status import (  # noqa: E402
     PENDING_TTL,
     QUERY_TIMEOUT,
     RECENTLY_FINALISED_PATH,
-    VIENNA_TZ as VIENNA_TZ,
     _QuotaExceeded,
     _build_session,
     _canonical_line_name,

--- a/scripts/update_stammstrecke_hbf.py
+++ b/scripts/update_stammstrecke_hbf.py
@@ -651,7 +651,7 @@ def _log_unrecognised_terminuses(unrecognised: Mapping[str, int]) -> None:
         LOGGER.info(
             "  • %d× Endpunkt='%s'",
             count,
-            sanitize_log_arg(rendered),
+            utils_logging.sanitize_log_arg(rendered),
         )
 
 
@@ -692,14 +692,14 @@ def _process_tick(
     except _QuotaExceeded as exc:
         LOGGER.warning(
             "Stammstrecke (Hbf): Tageslimit erreicht — Abfrage übersprungen (%s).",
-            sanitize_log_arg(str(exc)),
+            utils_logging.sanitize_log_arg(str(exc)),
         )
         return "quota_exceeded"
     except requests.HTTPError as exc:
         status = getattr(getattr(exc, "response", None), "status_code", None)
         LOGGER.warning(
             "Stammstrecke (Hbf): /departureBoard fehlgeschlagen: HTTP %s.",
-            sanitize_log_arg(str(status) if status is not None else "?"),
+            utils_logging.sanitize_log_arg(str(status) if status is not None else "?"),
         )
         return "error"
     except Exception as exc:

--- a/tests/scripts/test_update_stammstrecke_hbf.py
+++ b/tests/scripts/test_update_stammstrecke_hbf.py
@@ -1,0 +1,628 @@
+"""Tests for ``scripts/update_stammstrecke_hbf.py``.
+
+The Hauptbahnhof-based ``/departureBoard`` monitor was introduced on
+2026-05-15 to lift the ``numF=6`` ceiling that the ``/trip``-based
+predecessor (``scripts/update_stammstrecke_status.py``) inherited from
+the VAO API (see ``docs/reference/trip.md:34``). These tests pin the
+direction-classification logic and the response parsing against
+synthetic VAO payloads.
+
+The HTTP layer is never exercised; ``_query_departure_board`` is
+mocked per test. The quota counter file is redirected to ``tmp_path``
+via the same convention as the legacy-script tests.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import update_stammstrecke_hbf as script  # noqa: E402
+from src.providers import vor as vor_provider  # noqa: E402
+
+
+VIENNA_TZ = script.VIENNA_TZ
+
+
+# ---- Fixtures --------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_quota_counter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[Path]:
+    """Redirect the VOR daily-quota counter to ``tmp_path``."""
+
+    count_file = tmp_path / "vor_request_count.json"
+    monkeypatch.setattr(vor_provider, "REQUEST_COUNT_FILE", count_file)
+    vor_provider._flush_quota_cache()
+    yield count_file
+    vor_provider._flush_quota_cache()
+
+
+# ---- _classify_hbf_direction ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "direction_str,expected",
+    [
+        # Southbound substring matches
+        ("Wien Meidling", "Meidling"),
+        ("Mödling", "Meidling"),
+        ("Moedling Bahnhof", "Meidling"),
+        ("Wiener Neustadt Hbf", "Meidling"),
+        ("Payerbach-Reichenau", "Meidling"),
+        ("Graz Hbf", "Meidling"),
+        ("Klagenfurt Hbf", "Meidling"),
+        ("Flughafen Wien Bahnhof", "Meidling"),
+        ("Wolfsthal", "Meidling"),
+        ("Wien Flughafen", "Meidling"),
+        # Northbound substring matches
+        ("Wien Floridsdorf", "Floridsdorf"),
+        ("Praterstern", "Floridsdorf"),
+        ("Stockerau", "Floridsdorf"),
+        ("Hollabrunn", "Floridsdorf"),
+        ("Retz", "Floridsdorf"),
+        ("Břeclav", "Floridsdorf"),
+        ("Breclav", "Floridsdorf"),
+        ("Wolkersdorf", "Floridsdorf"),
+        ("Mistelbach", "Floridsdorf"),
+        ("Laa an der Thaya", "Floridsdorf"),
+        ("Gänserndorf", "Floridsdorf"),
+        ("Bratislava-Petržalka", "Floridsdorf"),
+        # Northbound exact-terminus matches (no substring hit)
+        ("Wien Mitte", "Floridsdorf"),
+        ("Wien Mitte-Landstraße", "Floridsdorf"),
+        ("Wien Mitte Bahnhof", "Floridsdorf"),
+        # Unrecognised
+        ("Wien Hauptbahnhof", None),  # terminus AT Hbf is irrelevant
+        ("Wien Westbahnhof", None),   # different corridor
+        ("", None),                    # empty
+        ("   ", None),                 # whitespace-only
+    ],
+)
+def test_classify_hbf_direction(direction_str: str, expected: str | None) -> None:
+    """Direction classification covers the canonical termini per direction."""
+
+    assert script.classify_hbf_direction(direction_str) == expected
+
+
+def test_classify_hbf_direction_case_insensitive_substring() -> None:
+    """Substring match operates case-insensitively for direction strings."""
+
+    assert script.classify_hbf_direction("MÖDLING") == "Meidling"
+    assert script.classify_hbf_direction("graz hbf") == "Meidling"
+    assert script.classify_hbf_direction("FLORIDSDORF") == "Floridsdorf"
+
+
+def test_classify_hbf_direction_substring_at_any_position() -> None:
+    """Match anywhere in the string (e.g., ``Wien Meidling Hauptbahnhof``)."""
+
+    assert script.classify_hbf_direction("Wien Meidling Bahnhof") == "Meidling"
+    assert script.classify_hbf_direction("via Meidling nach Mödling") == "Meidling"
+
+
+# ---- _is_sbahn_line --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("S 1", True),
+        ("S1", True),
+        ("S 7", True),
+        ("REX 3", True),
+        ("REX3", True),
+        ("R 81", True),
+        ("R81", True),
+        ("RJ 65", False),  # Railjet, not Stammstrecke
+        ("IC 533", False), # InterCity
+        ("EC 24", False),  # EuroCity
+        ("NJ 491", False), # NightJet
+        ("WB 1", False),   # Westbahn private
+        ("Bus 13A", False),
+        ("", False),
+        ("   ", False),
+    ],
+)
+def test_is_sbahn_line(name: str, expected: bool) -> None:
+    """Line-pattern filter accepts S/R/REX and rejects everything else."""
+
+    assert script._is_sbahn_line(name) is expected
+
+
+# ---- _departure_line_name --------------------------------------------------
+
+
+def test_departure_line_name_prefers_top_level_name() -> None:
+    """The flat ``name`` field is the canonical line designation."""
+
+    dep = {"name": "S 1", "Product": [{"line": "S 2"}]}  # mismatch on purpose
+    assert script._departure_line_name(dep) == "S 1"
+
+
+def test_departure_line_name_falls_back_to_product_line() -> None:
+    """Empty top-level ``name`` falls through to ``Product[].line``."""
+
+    dep = {"name": "", "Product": [{"line": "REX 3"}]}
+    assert script._departure_line_name(dep) == "REX 3"
+
+
+def test_departure_line_name_falls_back_to_product_display_number() -> None:
+    """Older serialiser variant uses ``displayNumber`` in lieu of ``line``."""
+
+    dep = {"Product": [{"displayNumber": "S 2"}]}
+    assert script._departure_line_name(dep) == "S 2"
+
+
+def test_departure_line_name_handles_singular_product_mapping() -> None:
+    """Some VAO releases serialise ``Product`` as a single dict."""
+
+    dep = {"Product": {"line": "S 3"}}
+    assert script._departure_line_name(dep) == "S 3"
+
+
+def test_departure_line_name_returns_empty_on_missing_fields() -> None:
+    """No usable line designation → empty string (caller drops the entry)."""
+
+    assert script._departure_line_name({}) == ""
+    assert script._departure_line_name({"name": "  "}) == ""
+    assert script._departure_line_name({"Product": []}) == ""
+
+
+# ---- _departure_delay_minutes ---------------------------------------------
+
+
+def test_departure_delay_minutes_positive_delay() -> None:
+    """Realtime departure 7 min after scheduled yields a 7-min positive delay."""
+
+    dep = {
+        "date": "2026-05-15",
+        "time": "08:00:00",
+        "rtTime": "08:07:00",
+    }
+    assert script._departure_delay_minutes(dep) == 7.0
+
+
+def test_departure_delay_minutes_negative_for_early_departure() -> None:
+    """Trains departing 2 min early yield -2 (kept as meaningful signal)."""
+
+    dep = {
+        "date": "2026-05-15",
+        "time": "08:00:00",
+        "rtTime": "07:58:00",
+    }
+    assert script._departure_delay_minutes(dep) == -2.0
+
+
+def test_departure_delay_minutes_truncates_seconds() -> None:
+    """Sub-minute seconds in ``rtTime`` are truncated (legacy invariant).
+
+    :func:`_parse_vao_dt` drops the seconds component to avoid branching
+    on ``HH:MM`` vs ``HH:MM:SS``. A 30-second delay therefore reads as
+    0.0, not 0.5 — the per-sample mean operates at minute granularity
+    project-wide so this is lossless in practice.
+    """
+
+    dep = {
+        "date": "2026-05-15",
+        "time": "08:00:00",
+        "rtTime": "08:00:30",
+    }
+    assert script._departure_delay_minutes(dep) == 0.0
+
+
+def test_departure_delay_minutes_skips_when_rttime_missing() -> None:
+    """No realtime signal → ``None`` (NOT zero — that would bias the sample)."""
+
+    dep = {"date": "2026-05-15", "time": "08:00:00"}
+    assert script._departure_delay_minutes(dep) is None
+
+
+def test_departure_delay_minutes_skips_cancelled_bool() -> None:
+    """Cancelled departures return ``None`` (absent != delayed)."""
+
+    dep = {
+        "date": "2026-05-15",
+        "time": "08:00:00",
+        "rtTime": "08:05:00",
+        "cancelled": True,
+    }
+    assert script._departure_delay_minutes(dep) is None
+
+
+def test_departure_delay_minutes_skips_cancelled_string() -> None:
+    """Cancelled serialised as the literal string ``"true"`` is also dropped."""
+
+    dep = {
+        "date": "2026-05-15",
+        "time": "08:00:00",
+        "rtTime": "08:05:00",
+        "cancelled": "true",
+    }
+    assert script._departure_delay_minutes(dep) is None
+
+
+def test_departure_delay_minutes_skips_unparseable_schedule() -> None:
+    """Malformed schedule date/time → ``None`` (NOT a crash)."""
+
+    dep = {
+        "date": "not-a-date",
+        "time": "08:00:00",
+        "rtTime": "08:05:00",
+    }
+    assert script._departure_delay_minutes(dep) is None
+
+
+def test_departure_delay_minutes_skips_unparseable_rttime() -> None:
+    """Malformed realtime date/time → ``None`` (NOT silently coerced to 0)."""
+
+    dep = {
+        "date": "2026-05-15",
+        "time": "08:00:00",
+        "rtTime": "not-a-time",
+    }
+    assert script._departure_delay_minutes(dep) is None
+
+
+def test_departure_delay_minutes_uses_rt_date_when_present() -> None:
+    """``rtDate`` overrides the scheduled date for cross-midnight delays."""
+
+    dep = {
+        "date": "2026-05-15",
+        "time": "23:55:00",
+        "rtDate": "2026-05-16",
+        "rtTime": "00:05:00",
+    }
+    assert script._departure_delay_minutes(dep) == 10.0
+
+
+# ---- _collect_hbf_observations --------------------------------------------
+
+
+def _dep(
+    *,
+    name: str = "S 1",
+    direction: str = "Wien Meidling",
+    sched_date: str = "2026-05-15",
+    sched_time: str = "08:00:00",
+    rt_time: str | None = "08:00:00",
+    cancelled: bool = False,
+) -> dict[str, Any]:
+    """Build a synthetic ``/departureBoard`` Departure entry."""
+
+    entry: dict[str, Any] = {
+        "name": name,
+        "direction": direction,
+        "date": sched_date,
+        "time": sched_time,
+    }
+    if rt_time is not None:
+        entry["rtTime"] = rt_time
+    if cancelled:
+        entry["cancelled"] = True
+    return entry
+
+
+def test_collect_groups_by_direction() -> None:
+    """Departures split into south (Meidling) and north (Floridsdorf) buckets."""
+
+    departures = [
+        _dep(name="S 1", direction="Wien Meidling"),
+        _dep(name="S 2", direction="Mödling"),
+        _dep(name="REX 3", direction="Wien Floridsdorf"),
+        _dep(name="S 7", direction="Wolfsthal"),
+        _dep(name="REX 1", direction="Břeclav"),
+    ]
+    by_direction, unrecognised = script._collect_hbf_observations(departures)
+
+    south = by_direction[script.DIRECTION_LABEL_SOUTHBOUND]
+    north = by_direction[script.DIRECTION_LABEL_NORTHBOUND]
+
+    assert {obs.name for obs in south} == {"S1", "S2", "S7"}
+    assert {obs.name for obs in north} == {"REX3", "REX1"}
+    assert unrecognised == {}
+
+
+def test_collect_skips_non_sbahn_lines() -> None:
+    """Long-distance (RJ, IC, EC) and bus entries are filtered out."""
+
+    departures = [
+        _dep(name="RJ 65", direction="Graz Hbf"),
+        _dep(name="IC 533", direction="Wien Floridsdorf"),
+        _dep(name="EC 24", direction="Mödling"),
+        _dep(name="Bus 13A", direction="Wien Meidling"),
+    ]
+    by_direction, unrecognised = script._collect_hbf_observations(departures)
+
+    assert by_direction[script.DIRECTION_LABEL_SOUTHBOUND] == []
+    assert by_direction[script.DIRECTION_LABEL_NORTHBOUND] == []
+    # Non-S/REX entries are line-filtered, so they don't count as
+    # "unrecognised direction" — the direction is never evaluated.
+    assert unrecognised == {}
+
+
+def test_collect_skips_cancelled_departures() -> None:
+    """Cancelled departures drop out before direction classification."""
+
+    departures = [
+        _dep(name="S 1", direction="Wien Meidling", cancelled=True),
+        _dep(name="S 2", direction="Wien Meidling"),
+    ]
+    by_direction, _ = script._collect_hbf_observations(departures)
+    assert {obs.name for obs in by_direction[script.DIRECTION_LABEL_SOUTHBOUND]} == {"S2"}
+
+
+def test_collect_skips_missing_rttime() -> None:
+    """Departures with no rtTime are dropped (status unknown != on-time)."""
+
+    departures = [
+        _dep(name="S 1", direction="Wien Meidling", rt_time=None),
+        _dep(name="S 2", direction="Wien Meidling"),
+    ]
+    by_direction, _ = script._collect_hbf_observations(departures)
+    assert {obs.name for obs in by_direction[script.DIRECTION_LABEL_SOUTHBOUND]} == {"S2"}
+
+
+def test_collect_counts_unrecognised_termini() -> None:
+    """Unknown termini surface in the returned counter for INFO logging."""
+
+    departures = [
+        _dep(name="S 1", direction="Some Unknown Place"),
+        _dep(name="S 2", direction="Some Unknown Place"),
+        _dep(name="S 3", direction="Another Unknown"),
+    ]
+    by_direction, unrecognised = script._collect_hbf_observations(departures)
+
+    assert by_direction[script.DIRECTION_LABEL_SOUTHBOUND] == []
+    assert by_direction[script.DIRECTION_LABEL_NORTHBOUND] == []
+    assert unrecognised == {
+        "Some Unknown Place": 2,
+        "Another Unknown": 1,
+    }
+
+
+def test_collect_handles_non_mapping_entries() -> None:
+    """Non-dict entries in the Departure list are silently skipped."""
+
+    departures: list[Any] = [
+        None,
+        "not-a-dict",
+        42,
+        _dep(name="S 1", direction="Wien Meidling"),
+    ]
+    by_direction, _ = script._collect_hbf_observations(departures)
+    assert {obs.name for obs in by_direction[script.DIRECTION_LABEL_SOUTHBOUND]} == {"S1"}
+
+
+def test_collect_computes_delay_from_rt_time() -> None:
+    """The delay value reflects rtTime - scheduled, at minute granularity.
+
+    Seconds are truncated by :func:`_parse_vao_dt` (legacy invariant: the
+    per-sample mean operates at minute resolution; sub-minute seconds
+    are dropped to avoid ``strptime`` branching).
+    """
+
+    departures = [
+        _dep(
+            name="S 1",
+            direction="Wien Meidling",
+            sched_time="08:00:00",
+            rt_time="08:07:00",  # 7 min late
+        ),
+    ]
+    by_direction, _ = script._collect_hbf_observations(departures)
+    south = by_direction[script.DIRECTION_LABEL_SOUTHBOUND]
+    assert len(south) == 1
+    assert south[0].delay_minutes == 7.0
+
+
+def test_collect_canonicalises_line_name() -> None:
+    """Line names are normalised (whitespace removed, upper-cased)."""
+
+    departures = [
+        _dep(name="s 1", direction="Wien Meidling"),
+        _dep(name=" S2 ", direction="Wien Meidling"),
+        _dep(name="REX  3", direction="Wien Meidling"),
+    ]
+    by_direction, _ = script._collect_hbf_observations(departures)
+    south = by_direction[script.DIRECTION_LABEL_SOUTHBOUND]
+    assert {obs.name for obs in south} == {"S1", "S2", "REX3"}
+
+
+# ---- _query_departure_board ----------------------------------------------
+
+
+def test_query_departure_board_parses_modern_flat_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Response with top-level ``Departure`` list is parsed correctly."""
+
+    captured_url: dict[str, str] = {}
+
+    class _FakeResponse:
+        status_code = 200
+        content = b'{"Departure": [{"name": "S 1"}, {"name": "S 2"}]}'
+
+    def fake_request_safe(*args: Any, **kwargs: Any) -> _FakeResponse:
+        captured_url["endpoint"] = args[1] if len(args) >= 2 else kwargs.get("url", "")
+        return _FakeResponse()
+
+    monkeypatch.setattr(script, "request_safe", fake_request_safe)
+    monkeypatch.setattr(script, "_charge_one_request", lambda when: None)
+
+    when = datetime(2026, 5, 15, 8, 0, tzinfo=VIENNA_TZ)
+    result = script._query_departure_board(session=object(), when=when)  # type: ignore[arg-type]
+    assert len(result) == 2
+    assert result[0]["name"] == "S 1"
+    assert "departureBoard" in captured_url["endpoint"]
+
+
+def test_query_departure_board_parses_nested_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Response with ``DepartureBoard`` wrapper is parsed correctly."""
+
+    class _FakeResponse:
+        status_code = 200
+        content = (
+            b'{"DepartureBoard": {"Departure": '
+            b'[{"name": "REX 3"}, {"name": "S 1"}]}}'
+        )
+
+    monkeypatch.setattr(
+        script,
+        "request_safe",
+        lambda *args, **kwargs: _FakeResponse(),
+    )
+    monkeypatch.setattr(script, "_charge_one_request", lambda when: None)
+
+    when = datetime(2026, 5, 15, 8, 0, tzinfo=VIENNA_TZ)
+    result = script._query_departure_board(session=object(), when=when)  # type: ignore[arg-type]
+    assert len(result) == 2
+    assert result[0]["name"] == "REX 3"
+
+
+def test_query_departure_board_handles_single_departure_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Single-element response serialised as bare object is normalised."""
+
+    class _FakeResponse:
+        status_code = 200
+        content = b'{"Departure": {"name": "S 1"}}'
+
+    monkeypatch.setattr(
+        script,
+        "request_safe",
+        lambda *args, **kwargs: _FakeResponse(),
+    )
+    monkeypatch.setattr(script, "_charge_one_request", lambda when: None)
+
+    when = datetime(2026, 5, 15, 8, 0, tzinfo=VIENNA_TZ)
+    result = script._query_departure_board(session=object(), when=when)  # type: ignore[arg-type]
+    assert result == [{"name": "S 1"}]
+
+
+def test_query_departure_board_returns_empty_when_field_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Response without ``Departure`` field yields an empty list (no error)."""
+
+    class _FakeResponse:
+        status_code = 200
+        content = b'{}'
+
+    monkeypatch.setattr(
+        script,
+        "request_safe",
+        lambda *args, **kwargs: _FakeResponse(),
+    )
+    monkeypatch.setattr(script, "_charge_one_request", lambda when: None)
+
+    when = datetime(2026, 5, 15, 8, 0, tzinfo=VIENNA_TZ)
+    result = script._query_departure_board(session=object(), when=when)  # type: ignore[arg-type]
+    assert result == []
+
+
+def test_query_departure_board_raises_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """4xx/5xx responses produce a :class:`requests.HTTPError`."""
+
+    import requests
+
+    class _FakeResponse:
+        status_code = 500
+        content = b'{"errorCode": "API_GEN"}'
+
+    monkeypatch.setattr(
+        script,
+        "request_safe",
+        lambda *args, **kwargs: _FakeResponse(),
+    )
+    monkeypatch.setattr(script, "_charge_one_request", lambda when: None)
+
+    when = datetime(2026, 5, 15, 8, 0, tzinfo=VIENNA_TZ)
+    with pytest.raises(requests.HTTPError):
+        script._query_departure_board(session=object(), when=when)  # type: ignore[arg-type]
+
+
+def test_query_departure_board_raises_on_unparseable_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed JSON body raises :class:`ValueError` (not RecursionError)."""
+
+    class _FakeResponse:
+        status_code = 200
+        content = b'{ not valid json'
+
+    monkeypatch.setattr(
+        script,
+        "request_safe",
+        lambda *args, **kwargs: _FakeResponse(),
+    )
+    monkeypatch.setattr(script, "_charge_one_request", lambda when: None)
+
+    when = datetime(2026, 5, 15, 8, 0, tzinfo=VIENNA_TZ)
+    with pytest.raises(ValueError):
+        script._query_departure_board(session=object(), when=when)  # type: ignore[arg-type]
+
+
+# ---- Sanity / pinning -----------------------------------------------------
+
+
+def test_hauptbahnhof_id_matches_stations_directory() -> None:
+    """The pinned Hbf VOR ID matches what's in ``data/stations.json``.
+
+    Drift between this constant and the directory entry would mean the
+    script polls a stale ID — this test catches a future directory
+    rename or ID rewrite.
+    """
+
+    import json
+
+    stations_path = REPO_ROOT / "data" / "stations.json"
+    if not stations_path.exists():  # pragma: no cover - fresh clone
+        pytest.skip("stations.json not present in this checkout")
+    with stations_path.open(encoding="utf-8") as fh:
+        directory = json.load(fh)
+    stations = directory.get("stations", directory) if isinstance(directory, dict) else directory
+
+    hits = [s for s in stations if s.get("name") == "Wien Hauptbahnhof"]
+    assert hits, "Wien Hauptbahnhof missing from stations.json"
+    assert hits[0].get("vor_id") == script.HAUPTBAHNHOF_VOR_ID
+
+
+def test_direction_labels_match_csv_convention() -> None:
+    """The direction labels match the historical CSV column values.
+
+    The README dashboard, feed event renderer, and any external analysis
+    keys on "Meidling" / "Floridsdorf" as the direction column values.
+    Drifting this constant would silently break those consumers.
+    """
+
+    assert script.DIRECTION_LABEL_SOUTHBOUND == "Meidling"
+    assert script.DIRECTION_LABEL_NORTHBOUND == "Floridsdorf"
+    assert set(script.DIRECTION_LABELS) == {"Meidling", "Floridsdorf"}
+
+
+def test_duration_window_covers_cron_interval_with_overlap() -> None:
+    """Duration must exceed the 30-min cron interval for latest-wins overlap.
+
+    Without overlap, a train scheduled near the end of one tick's window
+    cannot be re-observed by the next tick (its scheduled time is in
+    the past relative to the next query's ``time`` parameter), so the
+    latest-wins re-observation breaks down.
+    """
+
+    assert script.DEPARTURE_BOARD_DURATION_MIN > 30

--- a/tests/scripts/test_update_stammstrecke_hbf.py
+++ b/tests/scripts/test_update_stammstrecke_hbf.py
@@ -27,10 +27,16 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts import update_stammstrecke_hbf as script  # noqa: E402
+from scripts import update_stammstrecke_status as _legacy_script  # noqa: E402
 from src.providers import vor as vor_provider  # noqa: E402
 
 
-VIENNA_TZ = script.VIENNA_TZ
+# ``VIENNA_TZ`` is sourced from the legacy ``/trip`` script (which the
+# Hbf monitor re-uses for its shared ledger infrastructure). Tests
+# import it from its actual home rather than via a re-export from the
+# Hbf script — avoiding the ``from src.utils import logging as
+# utils_logging`` pattern that CodeQL flagged on PR #1496.
+VIENNA_TZ = _legacy_script.VIENNA_TZ
 
 
 # ---- Fixtures --------------------------------------------------------------

--- a/tests/scripts/test_update_stammstrecke_hbf.py
+++ b/tests/scripts/test_update_stammstrecke_hbf.py
@@ -461,7 +461,7 @@ def test_query_departure_board_parses_modern_flat_shape(
     monkeypatch.setattr(script, "_charge_one_request", lambda when: None)
 
     when = datetime(2026, 5, 15, 8, 0, tzinfo=VIENNA_TZ)
-    result = script._query_departure_board(session=object(), when=when)  # type: ignore[arg-type]
+    result = script._query_departure_board(session=object(), when=when)
     assert len(result) == 2
     assert result[0]["name"] == "S 1"
     assert "departureBoard" in captured_url["endpoint"]
@@ -487,7 +487,7 @@ def test_query_departure_board_parses_nested_shape(
     monkeypatch.setattr(script, "_charge_one_request", lambda when: None)
 
     when = datetime(2026, 5, 15, 8, 0, tzinfo=VIENNA_TZ)
-    result = script._query_departure_board(session=object(), when=when)  # type: ignore[arg-type]
+    result = script._query_departure_board(session=object(), when=when)
     assert len(result) == 2
     assert result[0]["name"] == "REX 3"
 
@@ -509,7 +509,7 @@ def test_query_departure_board_handles_single_departure_object(
     monkeypatch.setattr(script, "_charge_one_request", lambda when: None)
 
     when = datetime(2026, 5, 15, 8, 0, tzinfo=VIENNA_TZ)
-    result = script._query_departure_board(session=object(), when=when)  # type: ignore[arg-type]
+    result = script._query_departure_board(session=object(), when=when)
     assert result == [{"name": "S 1"}]
 
 
@@ -530,7 +530,7 @@ def test_query_departure_board_returns_empty_when_field_missing(
     monkeypatch.setattr(script, "_charge_one_request", lambda when: None)
 
     when = datetime(2026, 5, 15, 8, 0, tzinfo=VIENNA_TZ)
-    result = script._query_departure_board(session=object(), when=when)  # type: ignore[arg-type]
+    result = script._query_departure_board(session=object(), when=when)
     assert result == []
 
 
@@ -554,7 +554,7 @@ def test_query_departure_board_raises_on_http_error(
 
     when = datetime(2026, 5, 15, 8, 0, tzinfo=VIENNA_TZ)
     with pytest.raises(requests.HTTPError):
-        script._query_departure_board(session=object(), when=when)  # type: ignore[arg-type]
+        script._query_departure_board(session=object(), when=when)
 
 
 def test_query_departure_board_raises_on_unparseable_json(
@@ -575,7 +575,7 @@ def test_query_departure_board_raises_on_unparseable_json(
 
     when = datetime(2026, 5, 15, 8, 0, tzinfo=VIENNA_TZ)
     with pytest.raises(ValueError):
-        script._query_departure_board(session=object(), when=when)  # type: ignore[arg-type]
+        script._query_departure_board(session=object(), when=when)
 
 
 # ---- Sanity / pinning -----------------------------------------------------


### PR DESCRIPTION
## Zusammenfassung

Hebt die `numF=6`-Erfassungs-Grenze des bisherigen `/trip`-basierten Stammstrecken-Monitors auf, indem stattdessen `/departureBoard` an Wien Hauptbahnhof abgefragt wird. Die VAO-Quote bleibt streng eingehalten — pro Tick nur 1 API-Call statt 2.

## Begründung

Die empirische Analyse der bisherigen `recently_finalised.json` zeigt, dass `numF=6` bei jedem Peak-Tick ans Limit kommt: 6 Züge spannen ~21 von 30 Minuten, die letzten ~9 Minuten jedes Fensters fallen weder ins aktuelle noch ins nächste Tick-Fenster. Bei Stammstrecken-Peak-Dichte (~3,5 min Takt) enthält diese 9-min-Lücke routinemäßig 2-3 Züge, die nie erfasst werden.

| Metrik | Vorher (`/trip`) | Nachher (`/departureBoard@Hbf`) |
|---|---|---|
| API-Calls/Tick | 2 (eine pro Richtung) | 1 (gesamt) |
| API-Calls/Tag (48 Ticks) | 96 | 48 |
| Quota-Headroom | 4 Requests | 52 Requests |
| Max. Züge pro Tick | 6 pro Richtung (hartes Limit) | unbegrenzt (`maxJourneys` weich + nicht gesendet) |
| Coverage-Window | next 6 Trips ab `time` | nächste 45 min ab `time` |

## Architektur

- **Endpoint**: `/departureBoard` (docs/reference/departureboard.md). `maxJourneys` ist eine *weiche* Grenze — wir senden sie nicht, VAO liefert alle Stammstrecken-Abfahrten im Duration-Fenster.
- **Standort**: Wien Hauptbahnhof (VOR-ID `490134900`, gepinnt aus `data/stations.json`). Geografisch mittig auf der Stammstrecke — jeder Stammstrecken-Zug passiert Hbf.
- **Duration**: 45 min (30 min Cron-Intervall + 15 min Overlap), damit jeder Zug bei MEHREREN Ticks beobachtet wird. `_observe_legs`-latest-wins-Logik überschreibt die ältere Beobachtung — die im RSS-Feed angezeigte Verspätung ist die letzte (und damit genaueste) Messung vor der Abfahrt. Das war auch der Wunsch in der vorigen Frage.
- **Richtungs-Klassifikation**: Zwei Schichten — erstens Substring-Match gegen bekannte Süd-/Nord-Landmarken (Meidling, Mödling, Wiener Neustadt, Floridsdorf, Praterstern, Stockerau, Břeclav, …); zweitens exakte Endpunkt-Whitelist als Fallback. Unbekannte Endpunkte werden dedupliziert mit Häufigkeitszähler ins INFO-Log geschrieben — Operator kann die Whitelist erweitern, wenn neue Linien auftauchen.
- **CSV-Schema**: unverändert. Die Richtungs-Spalte enthält weiterhin `"Meidling"` oder `"Floridsdorf"` (= geografische Süd-/Nord-Klassifikation). README, Feed-Event-Renderer (`src/feed/stammstrecke.py`) und externe Analyse funktionieren byte-identisch.
- **State-Files**: gleiche Schemata (`pending_trips.json`, `recently_finalised.json`). Beim Cutover wird ein eventuell halb-gefüllter State vom legacy Skript natürlich weiterverarbeitet.

## Rollback

Workflow-Datei: Skript-Name in `.github/workflows/update-cycle.yml` zurück auf `update_stammstrecke_status.py`, `--margin` von `1` auf `2`. Das Legacy-Skript und seine Tests bleiben unverändert im Repo — Rollback ist eine 2-Zeilen-Änderung.

## Risiken

- **VAO-Response-Shape**: ohne Live-API-Zugriff im Sandbox kann ich nur gegen die historische Codebase und die Doku-Beispiele testen. Antwort-Shape wird tolerant geparst (sowohl flach `{"Departure": [...]}` als auch verschachtelt `{"DepartureBoard": {"Departure": [...]}}`).
- **Endpunkt-Whitelist**: Die initialen Substring-/Exact-Listen basieren auf bekannten Wiener S-Bahn-/REX-Linien. Falls eine unerwartete Linie auftaucht, wird sie als „unbekannter Endpunkt" geloggt und übersprungen. **Erster Produktiv-Tick wird vermutlich einige unbekannte Endpunkte loggen — bitte daraus die Whitelist erweitern und Folge-PR.**
- **Semantik-Shift**: Die Verspätungs-Messung erfolgt jetzt **bei der Abfahrt von Hauptbahnhof**, nicht mehr beim Ende-zu-Ende-Trip Floridsdorf→Meidling. Operativ aussagekräftiger, aber Vergleiche mit historischen CSV-Werten sollten den Cutover-Zeitpunkt berücksichtigen.

## Test plan

- [x] 77 neue Tests in `tests/scripts/test_update_stammstrecke_hbf.py` decken: Richtungsklassifikation (alle Substrings und Whitelist-Einträge, case-insensitive), Linien-Filter, Verspätungs-Berechnung (inkl. Sekunden-Truncate-Invariante), Response-Shape-Parsing (flat / nested / single-object / leer / HTTP-Error / unparseable JSON), Station-Directory-Drift-Erkennung
- [x] Komplette Test-Suite läuft durch (5777 passed, 2 skipped) — keine Regressionen
- [x] `python -c "from scripts import update_stammstrecke_hbf; ..."` lädt ohne Import-Fehler
- [ ] **Nach Merge zu beobachten**: erster Cron-Tick im Workflow-Log auf „unbekannter Endpunkt"-Meldungen prüfen und ggf. Whitelist erweitern
- [ ] **Nach Merge zu beobachten**: `vor_request_count.json` sollte nur noch **+1** pro Tick inkrementieren (statt vorher +2 vor dem Quota-Fix bzw. +2 nach dem Quota-Fix)
- [ ] **Nach Merge zu beobachten**: README „Letzte 60 Minuten" sollte mehr als 4 Beobachtungen pro Stunde zeigen, sobald ein Peak-Slot ins Fenster fällt — bisher war 4 das harte Maximum durch die `numF=6`-Sättigung

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSYzUEqB9o1frsjBwar3Y3)_