### PR TITLE
fix(filter): drop compound facility nouns (Personenlift etc.)

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -162,8 +162,16 @@ _MULTI_COMMA_RE = re.compile(r"\s*,{2,}\s*")
 # A message is treated as such when its title carries one of these
 # keywords AND none of the "real" transit-disruption keywords below.
 _FACILITY_KEYWORD_RE = re.compile(
-    r"\b(aufzug|aufzüge|aufzuege|aufzugsinfo|lift|fahrstuhl|fahrtreppe|"
-    r"fahrtreppen|fahrtreppeninfo|rolltreppe|rolltreppen)\b",
+    # Match the facility root anywhere inside a German compound word —
+    # the ÖBB feed uses ``Personenlift``, ``Aufzugsstörung``,
+    # ``Liftanlage`` etc. as compound nouns. Word boundaries on both
+    # sides would only catch the bare-root form (``Aufzug``, ``Lift``)
+    # and miss real cache items like
+    # ``Technische Störung des Personenlift in Stockerau: Bahnsteig 1/2``.
+    # The optional surrounding ``\w*`` lets the regex match any
+    # German prefix/suffix without enumerating every variant.
+    r"\b\w*(?:aufzug|aufz(?:ü|ue)ge|aufzugsinfo|lift|fahrstuhl|"
+    r"fahrtreppen?(?:info)?|rolltreppen?)\w*\b",
     re.IGNORECASE,
 )
 _WEATHER_KEYWORD_RE = re.compile(

--- a/src/providers/wl_text.py
+++ b/src/providers/wl_text.py
@@ -40,7 +40,12 @@ KW_EXCLUDE = re.compile(
 )
 
 FACILITY_ONLY = re.compile(
-    r"\b(aufzug|aufzüge|aufzuege|lift|fahrstuhl|fahrtreppe|fahrtreppen|rolltreppe|rolltreppen|aufzugsinfo|fahrtreppeninfo)\b",
+    # Match the facility root anywhere inside a German compound noun
+    # (``Personenlift``, ``Aufzugsanlage``, ``Liftbetrieb`` etc.) —
+    # the bare-root pattern with ``\b`` on both sides misses real
+    # ÖBB titles like ``Technische Störung des Personenlift``.
+    r"\b\w*(?:aufzug|aufz(?:ü|ue)ge|lift|fahrstuhl|"
+    r"fahrtreppen?(?:info)?|rolltreppen?|aufzugsinfo)\w*\b",
     re.IGNORECASE,
 )
 

--- a/tests/test_compound_facility_drop.py
+++ b/tests/test_compound_facility_drop.py
@@ -1,0 +1,110 @@
+"""Regression test for Bug 31A (compound facility nouns escape the drop filter).
+
+User feedback: three real ÖBB lift-failure meldungen reached the feed::
+
+    Technische Störung des Personenlift in Gramatneusiedl: Bahnsteig 3/4
+    Technische Störung des Personenlift in Bad Vöslau: Bahnsteig 1
+    Technische Störung des Personenlift in Stockerau: Bahnsteig 1/2
+
+These describe broken passenger lifts (Personenlift) — pure facility
+notices that the project spec explicitly excludes ("Defekte Aufzüge
+oder die Wetterlage hat im Feed nichts zu suchen").
+
+The previous ``_FACILITY_KEYWORD_RE`` pattern ``\\b(...|lift|...)\\b``
+used word boundaries on both sides, so it caught the bare ``Lift`` /
+``Aufzug`` forms but missed compound German nouns like:
+
+* ``Personenlift`` — passenger lift
+* ``Aufzugsstörung`` — lift fault
+* ``Liftanlage`` — lift installation
+
+Real German transit text uses these compound forms constantly. The
+fix wraps each root with ``\\w*`` so the regex catches both standalone
+and compound variants.
+"""
+
+from __future__ import annotations
+
+from src.providers.oebb import _is_facility_or_weather_only, _is_relevant
+from src.providers.wl_text import _is_facility_only
+
+
+class TestOebbCompoundFacilityDropped:
+    def test_personenlift_gramatneusiedl(self) -> None:
+        title = (
+            "Technische Störung des Personenlift in Gramatneusiedl: "
+            "Bahnsteig 3/4"
+        )
+        desc = (
+            "Wegen einer technischen Störung ist derzeit der "
+            "Personenlift zu Bahnsteig 3/4 in Gramatneusiedl Bahnhof "
+            "außer Betrieb und kann daher nicht benutzt werden."
+        )
+        assert _is_facility_or_weather_only(title, desc) is True
+        assert _is_relevant(title, desc) is False
+
+    def test_personenlift_bad_voeslau(self) -> None:
+        title = "Technische Störung des Personenlift in Bad Vöslau: Bahnsteig 1"
+        desc = (
+            "Wegen einer technischen Störung ist derzeit der "
+            "Personenlift zu Bahnsteig 1 in Bad Vöslau Bahnhof außer "
+            "Betrieb und kann daher nicht benutzt werden."
+        )
+        assert _is_relevant(title, desc) is False
+
+    def test_personenlift_stockerau(self) -> None:
+        title = "Technische Störung des Personenlift in Stockerau: Bahnsteig 1/2"
+        desc = (
+            "Wegen einer technischen Störung ist derzeit der "
+            "Personenlift zu Bahnsteig 1/2 in Stockerau Bahnhof außer "
+            "Betrieb und kann daher nicht benutzt werden."
+        )
+        assert _is_relevant(title, desc) is False
+
+    def test_compound_aufzugsstoerung(self) -> None:
+        # Other compound forms must also drop.
+        title = "Aufzugsstörung am Wien Hauptbahnhof"
+        assert _is_facility_or_weather_only(title, "") is True
+
+    def test_compound_liftanlage(self) -> None:
+        title = "Liftanlage außer Betrieb in Wien"
+        assert _is_facility_or_weather_only(title, "") is True
+
+
+class TestOebbBareFacilityStillDropped:
+    """The existing standalone-form behaviour must continue to hold."""
+
+    def test_bare_aufzug(self) -> None:
+        assert _is_facility_or_weather_only("Aufzug defekt: Wien Hbf", "") is True
+
+    def test_bare_lift(self) -> None:
+        assert _is_facility_or_weather_only("Lift außer Betrieb", "") is True
+
+    def test_rolltreppe(self) -> None:
+        assert _is_facility_or_weather_only("Rolltreppe defekt", "") is True
+
+
+class TestOebbRealDisruptionsNotDropped:
+    """Compound-noun matching must not over-strip legitimate disruption titles."""
+
+    def test_bauarbeiten_route_kept(self) -> None:
+        title = "Bauarbeiten Wien Hbf ↔ Mödling"
+        assert _is_facility_or_weather_only(title, "") is False
+
+    def test_s_bahn_route_kept(self) -> None:
+        title = "S 50: Wien Westbahnhof ↔ Wien Hütteldorf"
+        assert _is_facility_or_weather_only(title, "") is False
+
+
+class TestWlCompoundFacilityDropped:
+    def test_personenlift_wl(self) -> None:
+        assert _is_facility_only("Personenlift defekt am Stephansplatz") is True
+
+    def test_aufzugsstoerung_wl(self) -> None:
+        assert _is_facility_only("Aufzugsstörung U1 Stephansplatz") is True
+
+    def test_real_wl_disruption_kept(self) -> None:
+        assert (
+            _is_facility_only("U6: Verspätung wegen Schadhaftem Fahrzeug")
+            is False
+        )


### PR DESCRIPTION
## Summary

User feedback: three real ÖBB lift-failure meldungen reached the feed without being filtered:

```
Technische Störung des Personenlift in Gramatneusiedl: Bahnsteig 3/4
Technische Störung des Personenlift in Bad Vöslau: Bahnsteig 1
Technische Störung des Personenlift in Stockerau: Bahnsteig 1/2
```

These describe broken passenger lifts (Personenlift) — pure facility notices that the project spec explicitly excludes ("Defekte Aufzüge oder die Wetterlage hat im Feed nichts zu suchen").

### Bug 31A — compound facility nouns escape the drop filter

The previous `_FACILITY_KEYWORD_RE` pattern used word boundaries on both sides of each root:

```
\b(aufzug|...|lift|fahrstuhl|fahrtreppe|rolltreppe)\b
```

That catches the bare `Lift` / `Aufzug` forms but misses real German compound nouns:

- **`Personenlift`** — `n` (in *Personen*) directly precedes `l` in *lift*, so `\b` doesn't match.
- `Aufzugsstörung` — same issue at the suffix end.
- `Liftanlage` / `Liftbetrieb` — likewise.

### Fix

Wrap each facility root with `\w*` so the regex matches both standalone and compound forms (`\b\w*(?:aufzug|lift|...)\w*\b`).

The change applies to:
- ÖBB `_FACILITY_KEYWORD_RE` (the canonical facility-drop check in `_is_facility_or_weather_only`).
- WL parallel `FACILITY_ONLY` regex in `wl_text.py`.

A defence-against-false-positive test set verifies the change does not over-strip legitimate disruption titles like `Bauarbeiten Wien Hbf ↔ Mödling` or `S 50: Wien Westbahnhof ↔ Wien Hütteldorf`.

## Test plan

- [x] 13 new regression tests in `tests/test_compound_facility_drop.py`
- [x] User's three reproductions covered 1:1
- [x] Compound forms: `Personenlift`, `Aufzugsstörung`, `Liftanlage`
- [x] Bare forms still match: `Aufzug`, `Lift`, `Rolltreppe`
- [x] Real disruptions still kept: `Bauarbeiten Wien Hbf ↔ Mödling`, `S 50: Wien Westbahnhof ↔ Wien Hütteldorf`
- [x] WL parallel filter validated
- [x] `pytest tests/` — 5549 passed, 2 skipped (no regression)
- [x] `mypy --strict` — clean
- [x] `ruff check` — clean

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_