### PR TITLE
fix(feed-stammstrecke): resolve legacy direction label in trigger compute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+* **Stammstrecke-Feed-Trigger — Legacy-Label-Auflösung im
+  Compute-Pfad (2026-05-15)**:
+  * Der Trigger-Compute in `src.feed.stammstrecke.compute_
+    stammstrecke_events` bucket'te Observations bisher nach
+    `obs.direction` (raw CSV value); der Backwards-Compat-Alias in
+    `DIRECTIONS_BY_LABEL` (Floridsdorf → Praterstern-`_Direction`)
+    war auf dem heißen Pfad nicht aktiv. Folge: CSV-Zeilen mit dem
+    Legacy-Label `"Floridsdorf"` (z.B. nach Backup-Restore, Partial-
+    Deploy oder Hand-Edit) wären silently im Loop ignoriert worden,
+    weil das Loop-Lookup `direction.target_label = "Praterstern"`
+    den `by_direction["Floridsdorf"]`-Bucket nicht aufsucht. Fix:
+    Observations werden via `DIRECTIONS_BY_LABEL` zur kanonischen
+    Direction aufgelöst, bevor sie in den Bucket landen.
+  * Neue Test-Suite `tests/test_feed_stammstrecke_trigger.py`
+    (9 Tests) pinnt die Trigger-Semantik: Happy-Path (2 Praterstern-
+    Zeilen > 9 min), Legacy-Compat (2 Floridsdorf-Zeilen fold-in),
+    Mixed (1+1), Threshold-Gate (Single-row + boundary-9.0),
+    Window-Cutoff (Beobachtung knapp außerhalb 1h), Empty-Input,
+    Direction-Isolation (beide Richtungen feuern parallel),
+    Constants-Pinning (`DELAY_THRESHOLD_MINUTES`, `FEED_WINDOW`).
 * **Stammstrecke-Monitor — Nord-Richtungs-Label umbenannt:
   "Floridsdorf" → "Praterstern" (2026-05-15)**:
   * Die CSV-Spalte `direction` und das `DIRECTION_LABEL_NORTHBOUND`

--- a/src/feed/stammstrecke.py
+++ b/src/feed/stammstrecke.py
@@ -236,9 +236,25 @@ def compute_stammstrecke_events(
     )
     if not observations:
         return []
+    # Bucket observations by their *canonical* direction label so a CSV
+    # row that still carries the legacy ``"Floridsdorf"`` value (from a
+    # backup restore, a partial deploy that skipped the migration
+    # commit, or a hand-edited row) folds into the same trigger
+    # evaluation as the post-rename ``"Praterstern"`` rows. Without
+    # this canonicalisation the loop below — which iterates over
+    # :data:`DIRECTIONS` and looks up ``direction.target_label`` —
+    # would silently ignore the legacy-label observations because
+    # the ``by_direction`` key would be ``"Floridsdorf"`` while the
+    # registered direction's ``target_label`` is ``"Praterstern"``.
     by_direction: defaultdict[str, list[StammstreckeObservation]] = defaultdict(list)
     for obs in observations:
-        by_direction[obs.direction].append(obs)
+        canonical = DIRECTIONS_BY_LABEL.get(obs.direction)
+        if canonical is None:
+            # Unknown / unrecognised direction value — silently dropped.
+            # Protects against a future writer that emits a direction
+            # outside the registry without updating this consumer.
+            continue
+        by_direction[canonical.target_label].append(obs)
     feed_window_start = current - feed_window
     events: list[dict[str, Any]] = []
     # Process directions in registry order so two simultaneous events

--- a/tests/test_feed_stammstrecke_trigger.py
+++ b/tests/test_feed_stammstrecke_trigger.py
@@ -25,6 +25,7 @@ This module pins:
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Any
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
@@ -52,7 +53,7 @@ def _obs(
     )
 
 
-def _run(observations: list[StammstreckeObservation]) -> list[dict[str, object]]:
+def _run(observations: list[StammstreckeObservation]) -> list[dict[str, Any]]:
     with patch.object(
         feed_module,
         "read_recent_stammstrecke_observations",

--- a/tests/test_feed_stammstrecke_trigger.py
+++ b/tests/test_feed_stammstrecke_trigger.py
@@ -1,0 +1,194 @@
+"""Trigger semantics for :mod:`src.feed.stammstrecke`.
+
+The Stammstrecke feed event is fired when at least **two** CSV rows in
+a direction's last-hour window carry a sample-mean delay strictly
+greater than :data:`DELAY_THRESHOLD_MINUTES` (9 minutes). Each CSV row
+is itself the mean of multiple trains finalised by the same cron tick
+(typically 10-15 since the 2026-05-15 ``/departureBoard`` + track-filter
+migration), so the trigger requires sustained widespread delay, not a
+single outlier train.
+
+This module pins:
+
+1. The canonical happy-path: 2 ``Praterstern`` rows above threshold →
+   one event with the new ``stammstrecke_delay_praterstern`` GUID
+   prefix.
+2. The mixed-source legacy compatibility: a legacy ``"Floridsdorf"``
+   row from before the 2026-05-15 rename participates in the same
+   direction's trigger via the ``DIRECTIONS_BY_LABEL`` alias resolver.
+3. The threshold gate: a single row above 9 min must NOT fire (avoid
+   single-tick outliers from triggering the feed entry).
+4. The empty / sub-threshold cases: no rows or all rows ≤ 9 min must
+   produce zero events.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+from src.feed import stammstrecke as feed_module
+from src.feed.stammstrecke import (
+    DELAY_THRESHOLD_MINUTES,
+    FEED_WINDOW,
+    compute_stammstrecke_events,
+)
+from src.utils.stats import StammstreckeObservation
+
+
+VIENNA_TZ = ZoneInfo("Europe/Vienna")
+NOW = datetime(2026, 5, 15, 16, 30, 0, tzinfo=VIENNA_TZ)
+
+
+def _obs(
+    *,
+    when: datetime,
+    direction: str,
+    delay: float,
+) -> StammstreckeObservation:
+    return StammstreckeObservation(
+        timestamp=when, direction=direction, delay_minutes=delay
+    )
+
+
+def _run(observations: list[StammstreckeObservation]) -> list[dict[str, object]]:
+    with patch.object(
+        feed_module,
+        "read_recent_stammstrecke_observations",
+        return_value=observations,
+    ):
+        return compute_stammstrecke_events(now=NOW)
+
+
+# ---- Happy path: canonical Praterstern label fires the trigger ----------
+
+
+def test_two_praterstern_rows_above_threshold_fire_event() -> None:
+    """Two ``"Praterstern"``-direction rows > 9 min within the window → 1 event."""
+
+    obs = [
+        _obs(when=NOW - timedelta(minutes=30), direction="Praterstern", delay=10.0),
+        _obs(when=NOW - timedelta(minutes=5), direction="Praterstern", delay=11.5),
+    ]
+    events = _run(obs)
+    assert len(events) == 1
+    event = events[0]
+    assert "in Richtung Praterstern" in event["description"]
+    assert event["_identity"].startswith("stammstrecke_delay_praterstern|")
+
+
+# ---- Backwards compat: legacy "Floridsdorf" rows fold into Praterstern --
+
+
+def test_legacy_floridsdorf_rows_fold_into_praterstern_trigger() -> None:
+    """Two legacy ``"Floridsdorf"`` rows still trigger via DIRECTIONS_BY_LABEL alias.
+
+    Regression test for the 2026-05-15 rename: backup-restored or hand-
+    edited CSV rows that carry the pre-rename direction value must
+    still participate in the trigger evaluation. The canonical
+    direction label resolver in :func:`compute_stammstrecke_events`
+    canonicalises ``"Floridsdorf"`` → ``"Praterstern"`` via
+    :data:`DIRECTIONS_BY_LABEL` so the loop's ``direction.target_label``
+    lookup finds the observations.
+    """
+
+    obs = [
+        _obs(when=NOW - timedelta(minutes=30), direction="Floridsdorf", delay=12.0),
+        _obs(when=NOW - timedelta(minutes=5), direction="Floridsdorf", delay=15.0),
+    ]
+    events = _run(obs)
+    assert len(events) == 1
+    event = events[0]
+    # Description renders the *canonical* label even when input rows
+    # used the legacy value — the rename is operator-visible.
+    assert "in Richtung Praterstern" in event["description"]
+    assert event["_identity"].startswith("stammstrecke_delay_praterstern|")
+
+
+def test_mixed_legacy_and_canonical_rows_count_together() -> None:
+    """One legacy + one canonical row jointly satisfy the 2-row threshold."""
+
+    obs = [
+        _obs(when=NOW - timedelta(minutes=30), direction="Floridsdorf", delay=10.0),
+        _obs(when=NOW - timedelta(minutes=5), direction="Praterstern", delay=10.0),
+    ]
+    events = _run(obs)
+    assert len(events) == 1
+    assert "in Richtung Praterstern" in events[0]["description"]
+
+
+# ---- Threshold gate: single high row must NOT fire ----------------------
+
+
+def test_single_row_above_threshold_does_not_fire() -> None:
+    """A single sample-mean above 9 min is treated as outlier — no event.
+
+    Per the module docstring's "defensive: a single high outlier cannot
+    push the direction past the threshold on its own" invariant.
+    """
+
+    obs = [
+        _obs(when=NOW - timedelta(minutes=5), direction="Praterstern", delay=20.0),
+    ]
+    events = _run(obs)
+    assert events == []
+
+
+def test_all_rows_at_or_below_threshold_do_not_fire() -> None:
+    """Strictly-greater-than gate: rows with delay == 9.0 do NOT fire."""
+
+    obs = [
+        _obs(when=NOW - timedelta(minutes=30), direction="Praterstern", delay=9.0),
+        _obs(when=NOW - timedelta(minutes=5), direction="Praterstern", delay=9.0),
+    ]
+    events = _run(obs)
+    assert events == []
+
+
+def test_rows_outside_feed_window_are_ignored() -> None:
+    """Observations older than the 1-hour feed window don't contribute."""
+
+    just_outside = NOW - FEED_WINDOW - timedelta(seconds=1)
+    obs = [
+        _obs(when=just_outside, direction="Praterstern", delay=20.0),
+        _obs(when=NOW - timedelta(minutes=5), direction="Praterstern", delay=20.0),
+    ]
+    events = _run(obs)
+    # Only 1 row is inside the feed window → trigger requires 2 →
+    # no event.
+    assert events == []
+
+
+def test_empty_observations_yield_no_events() -> None:
+    """No CSV rows → no events (defensive fast-exit)."""
+
+    events = _run([])
+    assert events == []
+
+
+# ---- Direction isolation: north and south fire independently -----------
+
+
+def test_two_directions_with_concurrent_disruption_emit_two_events() -> None:
+    """Both Meidling and Praterstern over threshold → two events, one per
+    direction, in registry order (Meidling first, Praterstern second)."""
+
+    obs = [
+        _obs(when=NOW - timedelta(minutes=30), direction="Meidling", delay=10.0),
+        _obs(when=NOW - timedelta(minutes=5), direction="Meidling", delay=10.0),
+        _obs(when=NOW - timedelta(minutes=30), direction="Praterstern", delay=11.0),
+        _obs(when=NOW - timedelta(minutes=5), direction="Praterstern", delay=11.0),
+    ]
+    events = _run(obs)
+    assert len(events) == 2
+    # Registry order: Meidling first, Praterstern second.
+    assert "in Richtung Meidling" in events[0]["description"]
+    assert "in Richtung Praterstern" in events[1]["description"]
+
+
+def test_threshold_constant_is_9_minutes() -> None:
+    """Pin the threshold constant so a typo / drift trips the test."""
+
+    assert DELAY_THRESHOLD_MINUTES == 9.0
+    assert FEED_WINDOW == timedelta(hours=1)


### PR DESCRIPTION
## Antwort auf die Frage „Funktioniert der Trigger noch korrekt?"

**JA, der Trigger feuert korrekt** — verifiziert end-to-end gegen die echten Produktivdaten und gegen synthetische Edge-Cases. Beispiel: 2 simulierte Praterstern-Zeilen à 10/11.5 min Verspätung → korrektes Event mit `description = "Durchschnittliche Verspätung von 10.8 Minuten in Richtung Praterstern [Seit 15.05.2026]"`, GUID-Präfix `stammstrecke_delay_praterstern`.

**ABER**: Bei der Verifikation habe ich eine latente Lücke entdeckt — der von mir in PR #1499 eingeführte `DIRECTIONS_BY_LABEL["Floridsdorf"]`-Backwards-Compat-Alias war auf dem heißen Pfad inaktiv. Eine externe Backup-Restore-Wiederherstellung mit Legacy-`Floridsdorf`-CSV-Zeilen wäre silently durch den Trigger gefallen.

## Wurzelursache

```python
# Vorher: by_direction-Bucket nach raw obs.direction:
for obs in observations:
    by_direction[obs.direction].append(obs)
# ↓
# Loop: direction.target_label = "Praterstern"
direction_obs = by_direction.get(direction.target_label)  # findet "Praterstern" — aber nicht "Floridsdorf"!
```

Der Alias in `DIRECTIONS_BY_LABEL` wurde im Compute-Pfad nicht abgerufen, sondern stand nur für andere Lookups bereit.

## Fix

Pre-Bucket-Resolve via `DIRECTIONS_BY_LABEL`:

```python
for obs in observations:
    canonical = DIRECTIONS_BY_LABEL.get(obs.direction)
    if canonical is None:
        continue  # unbekannte Direction — silently drop (defensive)
    by_direction[canonical.target_label].append(obs)
```

So landen beide Labels („Floridsdorf" und „Praterstern") im selben kanonischen Bucket.

## Trigger-Semantik (für die parenthetische Frage)

> 2 Züge in die selbe Richtung sind über 9 Minuten innerhalb einer Stunde verspätet

Eine wichtige Präzisierung zur tatsächlichen Implementation: Der Code prüft **2 CSV-Zeilen** (= 2 Cron-Tick-Sample-Means), nicht 2 individuelle Züge. Jede CSV-Zeile ist seit PR #1498 der **Mittelwert über alle Stammstrecken-Züge eines Ticks** (typisch 10-15 Züge nach Track-Filter). Damit muss der Mean strikt > 9 min sein — was wesentlich strenger als „2 Einzelzüge > 9 min" ist und Einzelausreißer abfedert.

Trigger feuert wenn:
- mindestens **2 CSV-Zeilen** im 1h-Fenster
- mit `delay_minutes > 9.0` (strikt größer)
- in derselben Richtung
- → 1 Event pro Richtung (Meidling und Praterstern unabhängig)

## Neue Tests (9 Cases)

| Case | Was getestet wird |
| --- | --- |
| `test_two_praterstern_rows_above_threshold_fire_event` | Happy path: kanonisches Label feuert |
| `test_legacy_floridsdorf_rows_fold_into_praterstern_trigger` | **Regressionstest** für den Fix |
| `test_mixed_legacy_and_canonical_rows_count_together` | 1 Legacy + 1 Canonical = 2 Rows → Trigger |
| `test_single_row_above_threshold_does_not_fire` | Outlier-Protektion: 1 Zeile reicht nicht |
| `test_all_rows_at_or_below_threshold_do_not_fire` | Strikt-größer-als-9.0 (Grenzwert nicht-feuernd) |
| `test_rows_outside_feed_window_are_ignored` | 1h-Window-Cutoff (s+1 Sekunden zu alt) |
| `test_empty_observations_yield_no_events` | Defensive Fast-Exit |
| `test_two_directions_with_concurrent_disruption_emit_two_events` | Richtungs-Isolation + Registry-Order |
| `test_threshold_constant_is_9_minutes` | Constants-Pinning |

## Test plan

- [x] `mypy --strict src tests` — sauber
- [x] `ruff check` — sauber
- [x] C901 — 0 neue Verstöße
- [x] `pytest` — 5821 passed (+9 neue Trigger-Tests), 2 skipped
- [x] End-to-end gegen echte CSV verifiziert (2026-05-15 15:30 Hbf-Tick: Verspätung 6.80 min → kein Trigger, korrekt sub-threshold)
- [ ] Nach Merge produktiv: nächste Verspätungs-Episode > 9 min in beiden Ticks einer Stunde sollte das RSS-Event mit dem neuen GUID-Präfix emittieren

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSYzUEqB9o1frsjBwar3Y3)_