### PR TITLE
test(feed-stammstrecke-trigger): add dedicated Meidling-only pinning test

### DIFF
--- a/tests/test_feed_stammstrecke_trigger.py
+++ b/tests/test_feed_stammstrecke_trigger.py
@@ -79,6 +79,34 @@ def test_two_praterstern_rows_above_threshold_fire_event() -> None:
     assert event["_identity"].startswith("stammstrecke_delay_praterstern|")
 
 
+def test_two_meidling_rows_above_threshold_fire_event() -> None:
+    """Two ``"Meidling"``-direction rows > 9 min within the window → 1 event.
+
+    Symmetry pin for the southbound direction. The trigger pipeline
+    is direction-agnostic (the same ``_episode_start``,
+    ``_build_event``, ``_observe_legs`` codepath serves both buckets),
+    but a dedicated test guards against an asymmetric regression
+    landing on only one direction — e.g., a future ``DIRECTIONS``
+    tuple reorder that inadvertently shadowed Meidling, or a typo
+    in the ``DIRECTIONS_BY_LABEL`` lookup that handled Praterstern
+    but mis-routed Meidling.
+    """
+
+    obs = [
+        _obs(when=NOW - timedelta(minutes=30), direction="Meidling", delay=10.5),
+        _obs(when=NOW - timedelta(minutes=5), direction="Meidling", delay=12.0),
+    ]
+    events = _run(obs)
+    assert len(events) == 1
+    event = events[0]
+    assert "in Richtung Meidling" in event["description"]
+    assert event["_identity"].startswith("stammstrecke_delay_meidling|")
+    # Meidling has no legacy alias (only the northbound label was
+    # renamed in 2026-05-15), so the identity_prefix is the original
+    # 2026-05-09 value.
+    assert "stammstrecke_delay_praterstern" not in event["_identity"]
+
+
 # ---- Backwards compat: legacy "Floridsdorf" rows fold into Praterstern --
 
 


### PR DESCRIPTION
## Antwort auf die Frage „Funktioniert der Trigger in BEIDEN Richtungen?"

**Ja — und ich habe es in 5 Szenarien verifiziert:**

| Szenario | Erwartung | Ergebnis |
| --- | --- | --- |
| A: Nur **Meidling** 2× > 9 min | 1 Event, Süd-GUID | ✅ `stammstrecke_delay_meidling`, „Richtung Meidling" |
| B: Nur **Praterstern** 2× > 9 min | 1 Event, Nord-GUID | ✅ `stammstrecke_delay_praterstern`, „Richtung Praterstern" |
| C: **Beide simultan** | 2 Events parallel | ✅ Registry-Order, getrennte GUIDs/first_seen |
| D: **Asymmetrisch** (Meidling Outlier, Praterstern 2×) | 0+1 Events | ✅ Outlier-Protektion direction-isoliert |
| E: **Boundary** (delay==9.0 in beiden) | 0 Events (strikt >) | ✅ Kein False-Trigger |

Bei der Verifikation habe ich allerdings eine **kleine Asymmetrie in der Test-Suite** gefunden, die ich mit diesem PR schließe.

## Was war die Lücke?

`tests/test_feed_stammstrecke_trigger.py` (eingeführt mit PR #1501) hatte:
- ✅ `test_two_praterstern_rows_above_threshold_fire_event` — Nord-only explizit
- ✅ `test_two_directions_with_concurrent_disruption_emit_two_events` — beide simultan
- ✅ Legacy/Mixed/Outlier/Boundary/Window/Empty/Constants pinned
- ❌ **Kein dedizierter Test für „Meidling-only"** — die Süd-Richtung wurde nur indirekt durch den Both-firing-Test geprüft

Asymmetrische Test-Coverage ist eine Klasse von Bugs, die latent bleibt: Ein zukünftiger Refactor könnte eine Richtung unbemerkt brechen, wenn nur die andere isoliert getestet wird.

## Was dieser PR hinzufügt

Ein neuer Test `test_two_meidling_rows_above_threshold_fire_event` — Spiegelbild des bestehenden Praterstern-Tests:

- **Positive Assertion**: 2 Meidling-Zeilen > 9 min → 1 Event mit Süd-GUID
- **Negative Assertion**: Das Praterstern-Identity-Präfix erscheint NICHT im Meidling-Event (Cross-Talk-Schutz zwischen Buckets)

## Test plan

- [x] `mypy --strict src tests` — sauber
- [x] `ruff check` — sauber  
- [x] `pytest tests/test_feed_stammstrecke_trigger.py` — 10 passed (war 9)
- [x] Live-Simulation der 5 Szenarien — alle pass
- [ ] Nach Merge produktiv: Test wird in CI gepinnt, schützt gegen asymmetrische Regressionen

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSYzUEqB9o1frsjBwar3Y3)_