### PR TITLE
docs: align with 2026-05-15 Stammstrecke /departureBoard migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ python -m src.cli [command]
 Wichtige Befehle:
 - `python -m src.cli feed build`: Erzeugt den Feed lokal.
 - `python -m src.cli checks`: Führt `ruff` (Linter) und `mypy` (Type-Checker) aus.
-- `python -m src.cli tests`: (Falls implementiert, sonst direkt `pytest` nutzen).
+- `python -m pytest`: Führt die Test-Suite aus (kein eigenes `cli tests`-Subkommando).
 
 ### Testing
 - Framework: `pytest`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -506,18 +506,19 @@ consumers tolerate missing or malformed rows gracefully.
 ```mermaid
 flowchart LR
     subgraph "Producers (every cycle tick — IFTTT-triggered update-cycle.yml, ~30 min)"
-        SS[update_stammstrecke_status.py<br/><i>writes one row per direction</i>]
+        SS[update_stammstrecke_hbf.py<br/><i>writes one delay row per direction<br/>+ one row per cancellation</i>]
         BF[build_feed.main<br/><i>_update_item_state strict-new branch</i>]
     end
     subgraph "Append-only ledgers (data/stats/)"
         SCSV[stammstrecke_YYYY.csv<br/><i>timestamp, weekday, hour, direction, delay_minutes</i>]
+        ACSV[ausfaelle_YYYY.csv<br/><i>timestamp, weekday, hour, direction, line</i>]
         DCSV[stoerungen_YYYY.csv<br/><i>timestamp, weekday, hour, provider, location_name</i>]
     end
     subgraph "Daily aggregator (update-cycle.yml, first cycle tick after midnight Vienna)"
         AGG[generate_markdown_stats.py<br/><i>stdlib only, 30-day window</i>]
     end
     subgraph "Feed-build consumer"
-        FRP[src/feed/stammstrecke.py<br/><i>1-hour window, 9-min median trigger</i>]
+        FRP[src/feed/stammstrecke.py<br/><i>1-hour window, ≥2 obs > 9 min trigger</i>]
     end
     subgraph "Outputs"
         MD[docs/statistik.md<br/><i>ASCII / Emoji bars</i>]
@@ -525,8 +526,10 @@ flowchart LR
     end
 
     SS -- append --> SCSV
+    SS -- append --> ACSV
     BF -- append --> DCSV
     SCSV --> AGG
+    ACSV --> AGG
     DCSV --> AGG
     AGG --> MD
     SCSV --> FRP
@@ -611,17 +614,21 @@ die zugehörigen Helper-Scripts (`update_vor_cache.py`,
 `update_vor_stations.py`, `fetch_vor_haltestellen.py`) wurden
 2026-05-11 aus `scripts/` gelöscht. VOR-Stop-IDs kommen jetzt
 ausschließlich aus der gepinnten
-`data/vor-haltestellen.csv`-Snapshot. Siehe
+`data/vor-haltestellen.csv`-Snapshot. Seit 2026-05-15 verbraucht der
+Monitor zudem nur noch **48 Calls/Tag** (vorher 96): das aktive
+`scripts/update_stammstrecke_hbf.py`-Skript ruft pro Cron-Tick
+**eine** `/departureBoard`-Query am Wien Hauptbahnhof auf statt
+zwei `/trip`-Queries (Floridsdorf ↔ Meidling). Siehe
 [`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md)
 für Details des Stammstrecken-Monitors.
 
 | Konsument | Default-Calls/Tag | Konfigurierbar |
 | :--- | ---: | :--- |
-| **Stammstrecke `/trip`** (~alle 30 Min × 2 Richtungen) | 96 | IFTTT-Cadence des `update-cycle.yml`-Triggers, `MAX_TRIPS_PER_QUERY` |
+| **Stammstrecke `/departureBoard`** (~alle 30 Min × 1 Hbf-Call) | 48 | IFTTT-Cadence des `update-cycle.yml`-Triggers |
 | **Station-Enrichment `location.name`** | **0** (Pfad und Script entfernt 2026-05-11) | — |
 | **Disruption-Polling `departureBoard`** | **0** (Pfad und Script entfernt 2026-05-11) | — |
 | **Auth-Diagnose** (`verify_vor_access_id.py`, `check_vor_auth.py`) | **0–2** | nur manueller Operator-Aufruf, einmalige Smoke-Tests |
-| **Tagesbudget gesamt** | **96 / 100** | — |
+| **Tagesbudget gesamt** | **48 / 100** | — |
 
 Zwei zusammenwirkende Mechanismen schützen das Budget:
 
@@ -633,21 +640,26 @@ Zwei zusammenwirkende Mechanismen schützen das Budget:
    (`scripts/verify_vor_access_id.py`, `scripts/check_vor_auth.py`)
    bleiben für gezielte manuelle Smoke-Tests verfügbar.
 
-2. **`_charge_one_request`** (`scripts/update_stammstrecke_status.py`).
-   Vor jedem `/trip`-Call wird ein Quota-Slot via
+2. **`_charge_one_request`** (in
+   `scripts/update_stammstrecke_status.py` definiert, vom aktiven
+   `update_stammstrecke_hbf.py` per Import wiederverwendet). Vor
+   jedem `/departureBoard`-Call wird ein Quota-Slot via
    `vor_provider.save_request_count` reserviert; ein Lauf, der das
    Tagesbudget reißen würde, raised `_QuotaExceeded` *vor* dem
-   Network Call und schreibt einen leeren Cache.
+   Network Call. Defense-in-depth: `update-cycle.yml` schaltet den
+   Step zudem über `scripts/preflight_quota_check.py --check vor
+   --margin 1` vor jedem Tick aus, sobald der persistierte Counter
+   keinen Slot mehr lässt.
 
-Stammstrecke verbraucht damit 96 von 100 Calls/Tag; die restlichen
-4 Calls Puffer bleiben für gelegentliche Operator-Direktaufrufe
-verfügbar. Sollte das Budget in Zukunft enger werden, sind die
-niedrig-hängenden Hebel:
+Mit 48 von 100 Calls/Tag bleibt komfortabel ein Puffer von ~52
+Calls für Operator-Direktaufrufe (`workflow_dispatch` auf
+`update-cycle.yml`, manuelle Smoke-Tests). Sollte das Budget in
+Zukunft enger werden, sind die niedrig-hängenden Hebel:
 
 * IFTTT-Applet von ~30-Min- auf Stunden-Cadence umstellen (halbiert
-  Stammstrecke auf 48 Calls/Tag).
-* `MAX_TRIPS_PER_QUERY = 6` → `3` (kein API-Effekt, da `numF` ein
-  Server-side-Cap ist und VAO mehrere Trips pro Call erlaubt).
+  Stammstrecke auf 24 Calls/Tag).
+* `DEPARTURE_BOARD_DURATION_MIN = 45` → kürzeres Fenster (kein
+  API-Effekt, aber kleinere Antwort-Payloads).
 * Operating-Hours-Cadence im IFTTT-Applet (nur 04-23 Uhr statt
   ganztägig) — die Stammstrecke fährt zwischen 00:30 und 04:00 nur
   ausgedünnt, das Monitoring liefert dort kaum Signal.

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,10 +68,10 @@ Der Feed-Build folgt einem klaren Ablauf:
 | `data/`               | Stationsverzeichnis, GTFS-Testdaten und Hilfslisten (z. B. Pendler-Whitelist).                   |
 | `docs/`               | Audit-Berichte, Referenzen, Beispiel-Feeds und das offizielle VAO/VOR-API-Handbuch.              |
 | `.github/workflows/`  | Automatisierte Jobs für Cache-Updates, Stationspflege, Feed-Erzeugung und Tests.                |
-| `tests/`              | Umfangreiche Pytest-Suite (über 2000 Tests in ca. 390 Modulen) für Feed-Logik, Provider-Adapter und Utility-Funktionen. |
+| `tests/`              | Umfangreiche Pytest-Suite (über 2600 Tests in rund 400 Modulen) für Feed-Logik, Provider-Adapter und Utility-Funktionen. |
 
 
-> **Hinweis zu Cache-Pfaden:** Die tatsächlichen Verzeichnisse unter `cache/` tragen einen Hash-Suffix zur Cache-Versionierung (Stand Mai 2026: `cache/wl_9d709a/`, `cache/oebb_c40d21/`, `cache/baustellen_d438c3/`). In dieser Dokumentation werden aus Lesbarkeitsgründen verkürzte Schreibweisen wie `cache/wl/events.json` verwendet — sie verweisen jeweils auf das aktuelle Provider-Verzeichnis. Ein eigenes VOR-Cache-Verzeichnis existiert seit der 2026-05-11-Migration nicht mehr (VOR ist auf den Stammstrecken-Monitor beschränkt). Der **Stammstrecke-Monitor** persistiert nicht in einer JSON-Cache-Datei; seit der 2026-05-09-Migration liest der Feed-Builder die Beobachtungen direkt aus dem CSV-Ledger `data/stats/stammstrecke_<YYYY>.csv` (siehe [`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md)).
+> **Hinweis zu Cache-Pfaden:** Die tatsächlichen Verzeichnisse unter `cache/` tragen einen Hash-Suffix zur Cache-Versionierung (Stand Mai 2026: `cache/wl_9d709a/`, `cache/oebb_c40d21/`, `cache/baustellen_d438c3/`). In dieser Dokumentation werden aus Lesbarkeitsgründen verkürzte Schreibweisen wie `cache/wl/events.json` verwendet — sie verweisen jeweils auf das aktuelle Provider-Verzeichnis. Ein eigenes VOR-Cache-Verzeichnis existiert seit der 2026-05-11-Migration nicht mehr (VOR ist auf den Stammstrecken-Monitor beschränkt). Der **Stammstrecke-Monitor** schreibt seit der 2026-05-09-Migration **kein** `events.json` mehr — der Feed-Builder liest die Beobachtungen direkt aus dem CSV-Ledger `data/stats/stammstrecke_<YYYY>.csv`. Unter `cache/stammstrecke/` liegen weiterhin die internen Sidecar-Dateien `pending_trips.json` und `recently_finalised.json`, mit denen der Hbf-Producer (siehe [`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md)) Trip-IDs zur Doppel-Vermeidung über mehrere Cron-Ticks hinweg trackt.
 
 ## Installation & Setup
 
@@ -154,7 +154,7 @@ schreibt. Die wichtigsten Parameter:
 | `STATE_PATH`, `STATE_RETENTION_DAYS` | Pfad & Aufbewahrung für `data/first_seen.json`.                      |
 | `WIEN_OEPNV_CACHE_PRETTY` | Steuert die Formatierung der Cache-Dateien (`1` = gut lesbar, `0` = kompakt). |
 
-Alle Pfade werden durch `_resolve_env_path` auf `docs/`, `data/` oder `log/` beschränkt, um Path-Traversal zu verhindern.
+Alle Pfade werden durch `resolve_env_path` (in `src/feed/config.py`) auf `docs/`, `data/` oder `log/` beschränkt, um Path-Traversal zu verhindern.
 
 ### Logging-Initialisierung als Bibliothek verwenden
 
@@ -167,7 +167,7 @@ verwendest.
 
 - Läuft der Feed-Build über `python -m src.cli feed build`, landen Fehler- und Traceback-Ausgaben automatisch in `log/errors.log` (rotierende Log-Datei, konfigurierbar über `LOG_DIR`, `LOG_MAX_BYTES`, `LOG_BACKUP_COUNT`). Ohne Fehler bleibt die Datei unberührt.
 - Ausführliche Statusmeldungen (z. B. zum VOR-Abruf) werden zusätzlich in `log/diagnostics.log` gesammelt.
-- Beim manuellen Aufruf der Hilfsskripte (bzw. `python -m src.cli cache update vor`) erscheinen Warnungen und Fehler direkt auf `stdout`. Für nachträgliche Analysen kannst du den jeweiligen Lauf zusätzlich mit `LOG_DIR` auf ein separates Verzeichnis umleiten.
+- Beim manuellen Aufruf der Hilfsskripte (bzw. `python -m src.cli cache update wl`) erscheinen Warnungen und Fehler direkt auf `stdout`. Für nachträgliche Analysen kannst du den jeweiligen Lauf zusätzlich mit `LOG_DIR` auf ein separates Verzeichnis umleiten.
 - Setzt du `LOG_FORMAT=json`, schreibt das Projekt strukturierte JSON-Logs mit Zeitstempeln im Format `Europe/Vienna`. Ohne Angabe bleibt das klassische Textformat aktiv.
 
 ## Feed-Ausführung lokal
@@ -219,8 +219,8 @@ Der Meldungsfeed sammelt offizielle Störungs- und Hinweisinformationen der Wien
 
 ### Verkehrsverbund Ost-Region (VOR)
 
-- **Anforderung**: VAO-Tagesbudget (100 Requests/Tag) wird seit 2026-05-11 ausschließlich vom S-Bahn-Stammstrecken-Monitor verbraucht (96 Calls/Tag = 48 Cycles × 2 Richtungen). Ein automatisiertes Disruption-Polling existiert nicht mehr (Operator-Policy "VOR nur für die Stammstrecke").
-- **Quelle**: VOR/VAO-ReST-API (`/trip`-Endpunkt), authentifiziert über Access Token.
+- **Anforderung**: VAO-Tagesbudget (100 Requests/Tag) wird seit 2026-05-11 ausschließlich vom S-Bahn-Stammstrecken-Monitor verbraucht. Seit der 2026-05-15-Migration auf `/departureBoard` am Wien Hauptbahnhof sind das **48 Calls/Tag** (1 Hbf-Call × ~48 Cycles statt vorher 2 `/trip`-Calls × 48 Cycles). Ein automatisiertes Disruption-Polling existiert nicht mehr (Operator-Policy "VOR nur für die Stammstrecke").
+- **Quelle**: VOR/VAO-ReST-API (`/departureBoard`-Endpunkt am Wien Hauptbahnhof), authentifiziert über Access Token.
 - **Persistenz**: keine eigene JSON-Cache-Datei mehr; der Stammstrecken-Monitor schreibt Beobachtungen direkt in den CSV-Ledger `data/stats/stammstrecke_<YYYY>.csv` (siehe [`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md)).
 
 ### Stadt Wien – Baustellen
@@ -426,7 +426,7 @@ Nachnutzung zu gewährleisten.
 Die wichtigsten GitHub Actions:
 
 - `update-cycle.yml` – die zentrale Refresh-Pipeline. Trigger: `repository_dispatch: ifttt_feed_trigger` (ein externes IFTTT-Applet feuert ~alle 30 Minuten auf :00/:30 — zuverlässiger als der frühere GitHub-Cron `0,30 * * * *`, der am 2026-05-10 in Commit `55ca72f` entfernt wurde) sowie `workflow_dispatch` für manuelle Operator-Läufe. Einziger Job, der in einem Runner sequenziell die Provider-Cache-Fetcher (WL, ÖBB, Baustellen), den VAO-Pre-flight + die Stammstrecke-Abfrage, den Feed-Build (`docs/feed.xml`, `data/first_seen.json`, `data/stats/stoerungen_<YYYY>.csv`) sowie das README-/`docs/statistik.md`-Render ausführt und alles in einem Auto-Commit zusammenfasst. Hält die `external-api-fetch`-Concurrency-Lane, damit nie zwei API-Cycles parallel laufen.
-- VOR ist **ausschließlich** für den S-Bahn-Stammstrecke-Verspätungs-Monitor in `update-cycle.yml` eingesetzt (`/trip`-Endpunkt, ~96 Calls/Tag von 100 VAO-Start-Tier-Quota). Eine VOR-Disruption-Polling- bzw. Stations-Anreicherungs-Automatisierung gibt es nicht mehr (Entscheidung 2026-05-11); die zugehörigen Helper-Scripts (`update_vor_cache.py`, `update_vor_stations.py`, `fetch_vor_haltestellen.py`) wurden ebenfalls entfernt. Diagnose-Aufrufe gegen den VOR-Auth-Pfad bleiben via `scripts/verify_vor_access_id.py` und `scripts/check_vor_auth.py` möglich.
+- VOR ist **ausschließlich** für den S-Bahn-Stammstrecke-Verspätungs-Monitor in `update-cycle.yml` eingesetzt (seit 2026-05-15: `/departureBoard`-Endpunkt am Wien Hauptbahnhof, ~48 Calls/Tag von 100 VAO-Start-Tier-Quota; davor zwei `/trip`-Calls pro Tick = 96/Tag). Eine VOR-Disruption-Polling- bzw. Stations-Anreicherungs-Automatisierung gibt es nicht mehr (Entscheidung 2026-05-11); die zugehörigen Helper-Scripts (`update_vor_cache.py`, `update_vor_stations.py`, `fetch_vor_haltestellen.py`) wurden ebenfalls entfernt. Diagnose-Aufrufe gegen den VOR-Auth-Pfad bleiben via `scripts/verify_vor_access_id.py` und `scripts/check_vor_auth.py` möglich.
 - `build-feed.yml` – Code-Change-Verifikationspfad. Der reguläre Cron wurde 2026-05-09 in `update-cycle.yml` migriert; dieser Workflow läuft nur noch auf `push` (für `src/**`, `requirements.txt`, `pyproject.toml`, `.github/workflows/build-feed.yml`) sowie auf `workflow_dispatch` und baut den Feed aus den vorhandenen Caches neu — ohne neue API-Abfrage.
 - `update-stations.yml` – pflegt wöchentlich (Sonntag 01:00 UTC, Cron `0 1 * * 0`) `data/stations.json`. Die Anreicherung ist als **drei-stufige Kaskade** modelliert: OpenStreetMap (Overpass API) liefert die primären Koordinaten; der vorgeschaltete Smoke-Test (`scripts/check_overpass_status.py`) bricht den OSM-Schritt aber kontrolliert ab, falls der Mirror down ist. HAFAS (ÖBB Scotty) übernimmt seit 2026-05-14 als **Tier-2-Fallback** alle Stationen ohne OSM-Koordinaten — eingebettet in `request_safe` und durch einen eigenen `CircuitBreaker` abgesichert (siehe `docs/architecture.md` §5). Direkt davor läuft `scripts/sync_hafas_profile.py` als eigener Workflow-Step und aktualisiert das Mgate-Profil-Sidecar aus dem Open-Source-Projekt `public-transport/hafas-client`. Google Places bleibt der **Tier-3-Notausgang** für die strikte Restmenge, die weder OSM noch HAFAS auflösen konnten. VOR ist seit 2026-05-11 **nicht mehr** Teil des Stations-Refreshs (VOR-Stop-IDs aus gepinnter `data/vor-haltestellen.csv`). Die Stammstrecke-Abfrage und die tägliche `docs/statistik.md`-Regeneration laufen jeweils als Schritt in `update-cycle.yml`.
 - `manual-full-refresh.yml` – `workflow_dispatch`-only-Komplettlauf für Disaster-Recovery (führt alle Cache-Fetcher + Feed-Build hintereinander aus).
@@ -449,7 +449,8 @@ benötigt werden (z. B. `--no-download` für die WL-OGD-CSVs).
 | `update_wl_cache.py` | Liest die Realtime-Störungen der Wiener Linien und schreibt `cache/wl/events.json`. CLI: `python -m src.cli cache update wl`. |
 | `update_oebb_cache.py` | Holt die ÖBB-Störungs-RSS-Feeds, filtert sie strikt auf Wien-Bezug (`_is_relevant`) und persistiert sie. CLI: `python -m src.cli cache update oebb`. |
 | `update_baustellen_cache.py` | Lädt den Baustellen-Layer der Stadt Wien (oder den `data/samples/baustellen_sample.geojson`-Fallback) und legt Events ab. CLI: `python -m src.cli cache update baustellen`. |
-| `update_stammstrecke_status.py` | Refresh-Producer für den S-Bahn-Stammstrecke-Monitor (wird vom IFTTT-getriggerten `update-cycle.yml` ~alle 30 Min aufgerufen). Schreibt eine Beobachtungs-Zeile pro Lauf und Richtung in `data/stats/stammstrecke_<YYYY>.csv` (siehe [Reference](reference/stammstrecke_provider_logic.md)). |
+| `update_stammstrecke_hbf.py` | Aktiver Refresh-Producer für den S-Bahn-Stammstrecke-Monitor (seit 2026-05-15; wird vom IFTTT-getriggerten `update-cycle.yml` ~alle 30 Min aufgerufen). Fragt einmal pro Tick `/departureBoard` am Wien Hauptbahnhof ab, klassifiziert die Abfahrten per Bahnsteig-1/2-Filter + Endhaltestellen-Whitelist und schreibt aggregierte Verspätungs-Zeilen pro Richtung nach `data/stats/stammstrecke_<YYYY>.csv` sowie eine Zeile pro Ausfall nach `data/stats/ausfaelle_<YYYY>.csv` (siehe [Reference](reference/stammstrecke_provider_logic.md)). |
+| `update_stammstrecke_status.py` | Legacy-Producer (`/trip` × 2 Richtungen, vor 2026-05-15). Wird vom Cron-Workflow nicht mehr direkt aufgerufen, bleibt aber als Modul importierbar — `update_stammstrecke_hbf.py` re-used die geteilte Pending-Trip- / Recently-Finalised-Infrastruktur, den Quota-Charger sowie das CircuitBreaker-Tuning daraus. |
 | `generate_markdown_stats.py` | Aggregiert die CSV-Ledger zu `docs/statistik.md` (30-Tage-Fenster) und patcht die `<!-- STATS:* -->`-Marker im README. |
 
 ### Stationsverzeichnis
@@ -491,7 +492,7 @@ benötigt werden (z. B. `--no-download` für die WL-OGD-CSVs).
 
 ## Entwicklung & Qualitätssicherung
 
-- **Tests**: `python -m pytest` führt über 2000 Unit- und Integrationstests in rund 390 Modulen unter `tests/` aus.
+- **Tests**: `python -m pytest` führt über 2600 Unit- und Integrationstests in rund 400 Modulen unter `tests/` aus.
 - **Kontinuierliche Tests**: Die GitHub Action `test.yml` automatisiert die im Audit empfohlene regelmäßige Testausführung und bricht Builds bei fehlschlagender Test-Suite ab.
 - **Statische Analyse & Typprüfung**: `ruff check` (Stil/Konsistenz, Regelgruppen `E`, `F`, `S`, `B`) und `mypy --strict` (vollständige Typabdeckung über `src/` und `tests/`, derzeit 0 Errors) laufen identisch zur CI via `python -m src.cli checks`. Optional lassen sich über `--fix` Ruff-Autofixes aktivieren oder zusätzliche Argumente an Ruff durchreichen. Ein zusätzlicher `mypy-strict.yml`-Workflow setzt das Allowlist-Gate auf Pull Requests durch.
 - **Pre-Commit-Hooks**: `.pre-commit-config.yaml` aktiviert lokale Checks (Ruff, mypy, Secret-Scan, Whitespace-Hygiene) bei jedem `git commit`. Einmalig nach dem Klonen `pre-commit install` ausführen — Details in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
@@ -503,8 +504,8 @@ benötigt werden (z. B. `--no-download` für die WL-OGD-CSVs).
 
 Die neue Kommandozeile (`python -m src.cli`) bündelt bisher verstreute Skripte. Wichtige Unterbefehle:
 
-- `python -m src.cli cache update <wl|oebb|vor|baustellen>` – aktualisiert den jeweiligen Provider-Cache.
-- `python -m src.cli stations update <all|directory|vor|wl>` – führt die bestehenden Stations-Skripte mit optionalem `--verbose` aus.
+- `python -m src.cli cache update <wl|oebb|baustellen>` – aktualisiert den jeweiligen Provider-Cache. (VOR ist seit 2026-05-11 nicht mehr cache-fähig — der Stammstrecke-Monitor läuft als eigener Workflow-Step und schreibt direkt in den CSV-Ledger.)
+- `python -m src.cli stations update <all|directory|wl>` – führt die bestehenden Stations-Skripte mit optionalem `--verbose` aus. (VOR-Stations-Refresh wurde 2026-05-11 entfernt — `data/vor-haltestellen.csv` wird redaktionell gepflegt.)
 - `python -m src.cli feed build` – startet den Feed-Build mit der aktuellen Umgebung.
 - `python -m src.cli feed lint` – prüft die aggregierten Items auf fehlende GUIDs oder unerwartete Duplikate.
 - `python -m src.cli tokens verify <vor|google-places|vor-auth>` – validiert Secrets und API-Zugänge.
@@ -523,7 +524,7 @@ Die CLI respektiert die vorhandene Logging-Konfiguration (`log/errors.log`, `log
 - **Secrets**: (z. B. `VOR_ACCESS_ID`, `VOR_BASE_URL`) werden ausschließlich über Umgebungsvariablen bereitgestellt und niemals im
   Repository abgelegt. Das Skript `src/utils/secret_scanner.py` schützt proaktiv vor versehentlich eingecheckten Geheimnissen.
 - **SSRF-Schutz**: Externe Netzwerkanfragen laufen über `fetch_content_safe` (in `src/utils/http.py`). Diese Funktion verhindert Server-Side Request Forgery, indem sie DNS-Rebinding blockiert, private IP-Adressen (Localhost, internes Netzwerk) ablehnt und DNS-Timeouts erzwingt.
-- **Dateisystem**: Schreibvorgänge nutzen `atomic_write`, um Datenkorruption bei Abstürzen zu vermeiden. Pfadeingaben werden strikt validiert (`_resolve_env_path`), um Path-Traversal-Angriffe zu verhindern. Schreibzugriffe sind auf `docs/`, `data/` und `log/` beschränkt.
+- **Dateisystem**: Schreibvorgänge nutzen `atomic_write`, um Datenkorruption bei Abstürzen zu vermeiden. Pfadeingaben werden strikt validiert (`resolve_env_path` / `validate_path` aus `src/feed/config.py`), um Path-Traversal-Angriffe zu verhindern. Schreibzugriffe sind auf `docs/`, `data/` und `log/` beschränkt.
 - **Logging-Sicherheit**: Kontrollzeichen in Logs werden maskiert, um Log-Injection-Attacken zu unterbinden.
 - **Input-Validierung**: HTML-Ausgaben werden escaped und kritische XML-Felder in CDATA gekapselt, um XSS in Feed-Readern vorzubeugen.
 

--- a/docs/reference/oebb_provider_logic.md
+++ b/docs/reference/oebb_provider_logic.md
@@ -42,7 +42,9 @@ Aktuell gibt es im Projekt zwei separate Stellen, an denen Schlüsselwörter fü
   [`stammstrecke_provider_logic.md`](stammstrecke_provider_logic.md).
   Das Stammstrecken-Verspätungs-Monitoring lief ursprünglich über
   `pyhafas` mit dem ÖBB-HAFAS-Endpunkt; seit der 2026-05-09 Migration
-  läuft es über die VOR/VAO ReST API und ist deshalb in einer eigenen
-  Referenzdatei dokumentiert. Die emittierten Events tragen weiterhin
-  `source: "ÖBB"` (für Konsumenten unsichtbarer Fork), die Datenquelle
-  hat sich aber geändert.
+  läuft es über die VOR/VAO ReST API und seit der 2026-05-15 Migration
+  über `/departureBoard` am Wien Hauptbahnhof. Es ist in einer eigenen
+  Referenzdatei dokumentiert. Mit der 2026-05-09 Migration wurde auch
+  das `source`-Feld der emittierten Events von `"ÖBB"` auf `"VOR/VAO"`
+  umgestellt, weil die Datenquelle inzwischen technisch die VOR/VAO-API
+  ist (`EVENT_SOURCE` in `src/feed/stammstrecke.py`).

--- a/docs/reference/stammstrecke_provider_logic.md
+++ b/docs/reference/stammstrecke_provider_logic.md
@@ -1,145 +1,192 @@
 # S-Bahn Stammstrecke Provider Logic
 
-Das Stammstrecken-Verspätungs-Monitoring überwacht die zentrale
-Pendlerachse Wien Floridsdorf ↔ Wien Meidling auf signifikante
-Verspätungen und emittiert daraus dynamisch Feed-Events. Die Logik
-verteilt sich auf zwei Module:
+Das Stammstrecken-Verspätungs-Monitoring überwacht die Stammstrecke
+am Wien Hauptbahnhof auf signifikante Verspätungen und Ausfälle und
+emittiert daraus dynamisch Feed-Events. Die Logik verteilt sich auf
+zwei Module:
 
 | Komponente | Verantwortlichkeit |
 | :--- | :--- |
-| `scripts/update_stammstrecke_status.py` | Refresh-Producer: wird vom IFTTT-getriggerten `update-cycle.yml` (~alle 30 Min auf :00/:30) als Pipeline-Schritt aufgerufen, fragt die VOR/VAO `/trip`-API ab und hängt eine Beobachtungs-Zeile an `data/stats/stammstrecke_<YYYY>.csv` (CSV-Ledger). |
-| `src/feed/stammstrecke.py` | Feed-Renderer: liest die zuletzt geschriebenen Zeilen, bestimmt für jede Richtung über ein 1-Stunden-Fenster den Median der Verspätung und erzeugt — ggf. — einen schema-konformen FeedItem. |
+| `scripts/update_stammstrecke_hbf.py` | Refresh-Producer (aktiv seit 2026-05-15): wird vom IFTTT-getriggerten `update-cycle.yml` (~alle 30 Min auf :00/:30) als Pipeline-Schritt aufgerufen, fragt einmal pro Tick die VOR/VAO `/departureBoard`-API am Wien Hauptbahnhof ab und hängt eine aggregierte Beobachtungs-Zeile pro Richtung an `data/stats/stammstrecke_<YYYY>.csv` sowie eine Zeile pro Ausfall an `data/stats/ausfaelle_<YYYY>.csv` (CSV-Ledger). Die geteilte Pending-Trip- und Recently-Finalised-Infrastruktur wird per Import aus dem Legacy-Modul `scripts/update_stammstrecke_status.py` wiederverwendet — letzteres wird vom Cron-Workflow nicht mehr direkt aufgerufen. |
+| `src/feed/stammstrecke.py` | Feed-Renderer: liest die zuletzt geschriebenen Zeilen, prüft für jede Richtung über ein 1-Stunden-Fenster, ob mindestens zwei Beobachtungen die 9-Minuten-Schwelle überschreiten, und erzeugt — ggf. — einen schema-konformen FeedItem. |
 
-Diese Trennung wurde am 2026-05-09 eingeführt (zuvor schrieb der
-Cron-Job direkt in `cache/stammstrecke/events.json`). Sie hat zwei
-Vorteile: (a) das CSV-Ledger ist die einzige Quelle der Wahrheit
-sowohl für den RSS-Feed (1-Stunden-Fenster) als auch für das
-30-Tage-Dashboard in `docs/statistik.md`; (b) die Schwellen-Logik
-lebt jetzt im Feed-Builder und wird für jeden Build neu ausgewertet —
-ein nachträglich angepasster Threshold wirkt sofort, ohne dass der
-Cron-Job neu laufen muss.
+Diese Architektur entstand in zwei Schritten:
 
-## Migration: pyhafas → VOR/VAO ReST API (2026-05-09)
+* **2026-05-09** — Trennung von Producer (Cron-Skript) und Renderer
+  (Feed-Builder). Zuvor schrieb der Cron-Job direkt in
+  `cache/stammstrecke/events.json`. Seither ist das CSV-Ledger die
+  einzige Quelle der Wahrheit sowohl für den RSS-Feed (1-Stunden-Fenster)
+  als auch für das 30-Tage-Dashboard in `docs/statistik.md`; die
+  Schwellen-Logik lebt im Feed-Builder und wird für jeden Build neu
+  ausgewertet, sodass ein nachträglich angepasster Threshold sofort
+  wirkt, ohne dass der Cron-Job neu laufen muss.
+* **2026-05-15** — Migration von `/trip` (zwei Richtungs-Abfragen
+  Floridsdorf ↔ Meidling) auf `/departureBoard` am Wien Hauptbahnhof.
+  Halbiert das API-Budget (1 statt 2 Calls/Tick) und hebt die
+  `numF=6`-Sampling-Lücke des Vorgängers. Eine begleitende Persistenz-
+  Schicht (`cache/stammstrecke/pending_trips.json` + `recently_finalised.
+  json`) trackt Trip-IDs über mehrere Cron-Ticks hinweg, damit jede
+  Verspätung/jeder Ausfall genau einmal in den CSV-Ledger fließt.
 
-Der Monitor wurde ursprünglich gegen den öffentlichen ÖBB-`mgate.exe`-
-Endpunkt via [`pyhafas`](https://pypi.org/project/pyhafas/)
-(`OEBBProfile`) implementiert. Das 2026-05-09 Audit zeigte, dass
-`OEBBProfile` in keiner auf PyPI veröffentlichten `pyhafas`-Version
-exportiert wird (der Import schlug seit Wochen still fehl, das Skript
-hat in der Folge nie eine CSV-Zeile geschrieben). Der Monitor wurde
-auf die im Projekt bereits etablierte VOR/VAO-Infrastruktur portiert
-— gleicher authentifizierter Session-Stack, gleicher Quota-Counter,
-gleicher `fetch_content_safe`-HTTP-Layer wie die Disruption-Provider.
+## Migrations-Historie
 
-Im selben Schritt wurde das alte JSON-Cache-Layout entsorgt: der Cron-
-Job schreibt nur noch eine **Beobachtungs-Zeile** pro Lauf und
-Richtung in das CSV-Ledger; die Threshold- und First-Seen-Logik
-wurde nach `src/feed/stammstrecke.py` verschoben und arbeitet zur
-Build-Zeit auf den Ledger-Zeilen.
+* **Pre-2026-05-09 — `pyhafas` (`OEBBProfile`)**: Der Monitor war
+  ursprünglich gegen den öffentlichen ÖBB-`mgate.exe`-Endpunkt via
+  [`pyhafas`](https://pypi.org/project/pyhafas/) implementiert. Das
+  2026-05-09 Audit zeigte, dass `OEBBProfile` in keiner auf PyPI
+  veröffentlichten `pyhafas`-Version exportiert wird (der Import
+  schlug seit Wochen still fehl, das Skript hat in der Folge nie eine
+  CSV-Zeile geschrieben).
+* **2026-05-09 — VOR/VAO `/trip`**: Portierung auf die im Projekt
+  bereits etablierte VOR/VAO-Infrastruktur — gleicher
+  authentifizierter Session-Stack, gleicher Quota-Counter, gleicher
+  `request_safe`-HTTP-Layer wie die anderen VOR-Konsumenten. Im
+  selben Schritt wurde das alte JSON-Cache-Layout entsorgt: der Cron-
+  Job schreibt nur noch Beobachtungs-Zeilen ins CSV-Ledger; die
+  Threshold- und First-Seen-Logik wanderte nach `src/feed/stammstrecke.py`.
+* **2026-05-15 — VOR/VAO `/departureBoard` am Wien Hauptbahnhof**:
+  Wechsel auf einen Stammstrecken-Mittelpunkt mit
+  Bahnsteig-1/2-Filter und Trip-ID-Tracking über mehrere Cron-Ticks
+  hinweg. Halbiert das API-Budget (1 Call/Tick statt 2), hebt die
+  `numF=6`-Sampling-Lücke des Vorgängers und führt eine separate
+  Ausfall-Statistik (`data/stats/ausfaelle_<YYYY>.csv`) ein. **Semantischer
+  Bruch**: Die Verspätung wird ab 2026-05-15 am Hbf gemessen, davor
+  am Origin (Floridsdorf bzw. Meidling) — Werte sind über den
+  Stichtag hinweg nicht direkt vergleichbar.
 
-## Cron-Producer (`scripts/update_stammstrecke_status.py`)
+## Cron-Producer (`scripts/update_stammstrecke_hbf.py`)
 
 ### Datenquelle und Abfrage
 
 | Aspekt | Wert |
 | :--- | :--- |
-| Endpoint | `${VOR_BASE_URL}trip` (offizielle VOR/VAO ReST API) |
-| HTTP-Layer | `src.utils.http.fetch_content_safe` (SSRF-Guard, Slowloris-Cap, MAX_PAYLOAD_SIZE) |
+| Endpoint | `${VOR_BASE_URL}departureBoard` (offizielle VOR/VAO ReST API) |
+| HTTP-Layer | `src.utils.http.request_safe` (SSRF-Guard, Slowloris-Cap, MAX_PAYLOAD_SIZE, Content-Type-Validierung) |
 | Auth | `accessId` als Query-Parameter via `vor_provider.VorAuth` |
-| Richtung 1 | Wien Floridsdorf (`490033400`) → Wien Meidling (`490101500`) |
-| Richtung 2 | Wien Meidling (`490101500`) → Wien Floridsdorf (`490033400`) |
-| `maxChange` | `0` (nur direkte S-Bahn-Verbindungen) |
-| `numF` | `6` (`MAX_TRIPS_PER_QUERY`, VAO-Cap; eine möglichst große Median-Stichprobe pro Richtung) |
+| Stop-ID | Wien Hauptbahnhof (`490134900`, gepinnt in `HAUPTBAHNHOF_VOR_ID`) |
+| `duration` | `45` Minuten (`DEPARTURE_BOARD_DURATION_MIN`); 50%-Overlap zur ~30-Min-Cron-Cadence, sodass jeder Zug in zwei Ticks erscheint und die jüngere Beobachtung gewinnt |
+| `products` | `3` (Bitmaske Train + S-Bahn) — schmälert die Server-Antwort vor dem clientseitigen S-Bahn-Filter |
+| `maxJourneys` | bewusst weggelassen — VAO-soft-Limit (`docs/reference/departureboard.md:22`); ohne Cap liefert der Server alle Abfahrten im Fenster |
 | `rtMode` | `SERVER_DEFAULT` (Echtzeitdaten aktivieren) |
 | Refresh-Trigger | ~alle 30 Min auf :00/:30 — läuft als Schritt im IFTTT-getriggerten `update-cycle.yml` (`repository_dispatch: ifttt_feed_trigger`). Für Operator-Reruns siehe `manual-full-refresh.yml` oder ein `workflow_dispatch` auf `update-cycle.yml` selbst. |
 
-**Beide Richtungen werden strikt getrennt ausgewertet.** Eine
-Zusammenlegung würde die Daten verfälschen — eine Störung in eine
-Richtung läuft häufig in der Gegenrichtung normal weiter.
+**Eine Abfrage liefert beide Richtungen.** Die Klassifikation in
+„nordwärts" (Praterstern) und „südwärts" (Meidling) erfolgt
+clientseitig über die Endhaltestellen-Strings (siehe unten).
 
-### Filter und Aggregation pro Richtung
+### Filter und Aggregation
 
-Aus den zurückgegebenen `Trip`-Objekten werden alle Trips ausgewählt,
-die genau **einen Ride-Leg** enthalten (Walk-Vor-/Nachläufe sind
-toleriert, Mehrteil-Verbindungen mit Umstieg werden verworfen) und
-deren Ride-Leg ein S-Bahn-Produkt ist.
+Aus den zurückgegebenen `Departure`-Objekten überlebt nur, wer
+**alle drei Filter** passiert:
 
-**S-Bahn-Erkennung** (`_is_sbahn_leg`) — drei orthogonale Signale, jedes
-einzelne reicht:
+1. **Bahnsteig-Filter** (`STAMMSTRECKE_HBF_TRACK_TRUNKS = {"1", "2"}`):
+   Wien Hbf hat zwei Stammstrecken-Bahnsteige — Bahnsteig 1 nordwärts
+   (Praterstern), Bahnsteig 2 südwärts (Meidling). Alle anderen
+   Bahnsteige (3–12 inkl. Halb-Bahnsteige „1A"/„10A-B") tragen
+   Fernverkehr (RJ/IC/EC/NJ), Hbf-endende REX-Züge, die Marchegger
+   Ostbahn, die Pottendorfer Linie, die Westbahn — sie werden
+   deterministisch ausgeschlossen. `rtTrack` überschreibt das
+   geplante `track`, sodass eine kurzfristige Bahnsteig-Verlegung
+   weg von Bahnsteig 1/2 das Sample korrekt verlässt.
+2. **Richtungs-Klassifikation** (`HBF_SOUTHBOUND_SUBSTRINGS` /
+   `HBF_NORTHBOUND_SUBSTRINGS` + `HBF_SOUTHBOUND_TERMINI` /
+   `HBF_NORTHBOUND_TERMINI`): Substring-Match gegen
+   `direction.lower()` zuerst, dann exakter Whitelist-Match.
+   Unbekannte Termini werden mit deduplizierter INFO-Log-Zeile
+   verworfen, damit Operator:innen die Whitelist erweitern können.
+3. **S-Bahn-Linien-Filter** (`_is_sbahn_line`, Regex
+   `_S_BAHN_LINE_RE`): Nur Linien, die das `S\d+`-Muster matchen.
+   `REX`/`R`/`IC`/`Railjet` werden trotz Bahnsteig 1/2 verworfen.
 
-1. `leg.category in {"S", "SB"}` — VAOs bevorzugtes Feld.
-2. `leg.name` matched `^\s*S\s*\d+\s*$` (z. B. `S 1`, `S 7`, `S 80`)
-   — Fallback für ältere VAO-Peers, die nur das Anzeige-Label setzen.
-3. `leg.Product[].catOut` / `Product[].line` — JSON-RPC-verschachtelte
-   Form, die manche VAO-Releases verwenden.
+**Cancellation-Branch (Ausfälle)**: Der Cancellation-Check läuft VOR
+dem `rtTime`-Filter, weil VAO bei ausgefallenen Zügen oft keine
+`rtTime` mehr ausliefert. Ausfälle landen mit eigener Identity-Key-
+Dedup (`(direction, name, scheduled)`) im `_PendingTrip`-Ledger
+(Feld `cancelled: bool`); beim Finalisieren generiert jeder
+Cancellation-Eintrag eine eigene Zeile in `data/stats/ausfaelle_
+<YYYY>.csv` (Spalten: `timestamp, weekday, hour, direction, line`).
 
-Andere Verkehrsmittel auf den gleichen Gleisen (`REX`, `R`, `IC`,
-`Railjet`) werden verworfen — sie sind kein Stammstrecken-Produkt.
+**Verspätungs-Berechnung** (`_departure_delay_minutes`) —
+Differenz `rtTime − time` in Minuten. Pro Pending-Trip wird beim
+Finalisieren der Mittelwert über die zuletzt beobachtete
+Verspätung gebildet (latest-wins-Overwrite über die Tick-Beobachtungen
+des selben physischen Zugs); das Aggregat pro Richtung+Tick wird
+als eine Zeile an `data/stats/stammstrecke_<YYYY>.csv` angehängt
+(Spalten: `timestamp, weekday, hour, direction, delay_minutes`,
+ISO 8601 `Europe/Vienna`).
 
-**Verspätungs-Berechnung** (`_leg_departure_delay_minutes`) —
-Differenz `Origin.rtTime − Origin.time` in Minuten. Aus den
-verbleibenden Legs wird der **Median** der Delay-Werte gebildet,
-separat für jede Richtung:
-
-* Stornierte Legs (`leg.cancelled` oder `Origin.cancelled`) werden
-  vom Median ausgeschlossen (kein Signal).
-* Legs ohne `Origin.rtTime` werden ebenfalls ausgeschlossen — `0`
-  einzusetzen würde den Median nach unten ziehen.
+* Stornierte Departures werden vom Verspätungs-Aggregat
+  ausgeschlossen (sie zählen ausschließlich in `ausfaelle_<YYYY>.csv`).
+* Departures ohne `rtTime` werden vom Aggregat ausgeschlossen — `0`
+  einzusetzen würde den Mittelwert systematisch nach unten ziehen.
 * Pures `0`-Delay aus tatsächlich verspätungsfreien Fahrten zählt
   vollwertig.
 
-Der berechnete Median pro Richtung wird als eine Zeile an
-`data/stats/stammstrecke_<YYYY>.csv` angehängt (Spalten:
-`timestamp, weekday, hour, direction, delay_minutes`, ISO 8601
-`Europe/Vienna`). **Es werden keine Schwellenwerte oder Events mehr
-direkt vom Cron-Skript erzeugt** — die Render-Phase arbeitet
-ausschließlich auf den Ledger-Zeilen.
+**Es werden keine Schwellenwerte oder Events mehr direkt vom Cron-
+Skript erzeugt** — die Render-Phase arbeitet ausschließlich auf den
+Ledger-Zeilen.
+
+**Pending-/Finalised-Ledger** (`cache/stammstrecke/pending_trips.json`
+und `cache/stammstrecke/recently_finalised.json`): Identity-Key
+`(direction, name, scheduled)`. Beobachtungen ferner Züge (z. B. 40
+Min in der Zukunft) werden bei späteren Ticks mit jüngerer rtTime
+überschrieben (latest-wins). Erst wenn `scheduled <= now`, finalisiert
+der Pass die jeweils beste Beobachtung und schreibt eine CSV-Zeile;
+der Recently-Finalised-Schutz verhindert eine Doppelzählung, falls
+VAO denselben Zug in einem späteren Lookahead-Fenster nochmal listet.
+Legacy-Einträge ohne `cancelled`-Feld laden als `cancelled=False`.
 
 ### Resilience und API Rate-Limit
 
 Die VOR/VAO API erlaubt **100 Requests pro Tag** (das `VAO Start`-
-Kontingent). Der Monitor ist mit Abstand der dominante VOR-Konsument:
+Kontingent). Der Monitor ist mit Abstand der dominante VOR-Konsument;
+seit der 2026-05-15-Migration auf `/departureBoard` halbiert sich
+das Hbf-Budget gegenüber dem `/trip`-Vorgänger:
 
 | Komponente | Calls/Tag |
 | :--- | ---: |
-| Stammstrecke (~alle 30 Min × 2 Richtungen, IFTTT-getriggert) | 96 |
-| Station-Enrichment (wöchentlich, Stammstrecke-Whitelist) | ~10 (1× pro Woche) |
-| Disruption-Polling (`DEFAULT_MONITOR_WHITELIST=""`) | 0 |
-| **Tagesbudget gesamt** | **96 / 100** |
+| Stammstrecke (~alle 30 Min × 1 Hbf-Call, IFTTT-getriggert) | 48 |
+| Station-Enrichment (entfernt 2026-05-11) | 0 |
+| Disruption-Polling (entfernt 2026-05-11) | 0 |
+| **Tagesbudget gesamt** | **48 / 100** |
+
+Die freiwerdenden ~52 Calls/Tag bleiben als Puffer für gelegentliche
+Operator-Direktaufrufe (`workflow_dispatch`, manuelle Smoke-Tests
+gegen `verify_vor_access_id.py` / `check_vor_auth.py`).
 
 Der Producer charged ein Quota-Slot **vor** jedem Network Call via
 `_charge_one_request`; eine quota-erschöpfte Stunde produziert
-sauber `_QuotaExceeded`, ohne den Endpoint zu treffen.
+sauber `_QuotaExceeded`, ohne den Endpoint zu treffen. Zusätzlich
+gated `update-cycle.yml` den Schritt mit
+`scripts/preflight_quota_check.py --check vor --margin 1` — die
+neue Margin von `1` reflektiert die EINE `/departureBoard`-Anfrage
+pro Tick (vor 2026-05-15 war es `--margin 2`).
 
 Die Circuit-Breaker-Konfiguration deckelt zusätzlich:
 
 * `failure_threshold = 10` — nach 10 aufeinanderfolgenden Fehlern
-  wechselt der Breaker in den OPEN-Zustand.
+  wechselt der Breaker `stammstrecke-hbf-vor` in den OPEN-Zustand.
 * `recovery_timeout = 3600.0` (1 Stunde) — der Breaker bleibt eine
   Stunde lang OPEN, bevor ein Probe-Call zugelassen wird.
 
-Im Normalbetrieb produziert die Pipeline durch die IFTTT-getriggerte
-~30-Min-Cadence (2 Ausführungen pro Stunde) und 2 Richtungen pro
-Ausführung **4 Calls pro Stunde** — komfortabel unter dem Limit.
-
 Weitere Schutzmechanismen:
 
-* **HTTP-Timeout via `fetch_content_safe`**: Per-Call `timeout=20`
+* **HTTP-Timeout via `request_safe`**: Per-Call `timeout=20`
   (clamped auf `MAX_QUERY_TIMEOUT=30`) wird vom HTTP-Layer direkt
-  an `requests.Session.get` durchgereicht — kein Patching der Session
-  mehr notwendig wie noch in der pyhafas-Ära.
-* **CircuitBreakerOpen** kurzschließt nach erstem Auftreten innerhalb
-  einer Iteration: wenn der Breaker während der Abarbeitung der ersten
-  Richtung öffnet, wird die zweite Richtung *nicht* mehr versucht.
-  Bereits gesammelte CSV-Zeilen der ersten Richtung sind über den
-  best-effort-`append_stammstrecke_row`-Pfad bereits geschrieben.
-* **Per-Direction-Fehlerisolation**: ein transienter Fehler bei
-  Richtung 1 (RequestException, Connection Reset etc.) wirft Richtung
-  2 *nicht* weg.
+  an `requests.Session.get` durchgereicht.
+* **CircuitBreakerOpen** kurzschließt sauber: wenn der Breaker
+  öffnet, schreibt der Tick keine neue Zeile und kommt im nächsten
+  Tick wieder durch, sobald `recovery_timeout` abgelaufen ist.
 * **Atomares Schreiben** für CSV-Zeilen ist nicht nötig: einzelne
   Append-Schreibvorgänge unterhalb des `PIPE_BUF`-Limits (4 KiB) sind
   unter POSIX atomar; der Renderer toleriert zudem fehlerhafte
   Einzelzeilen über `csv.reader` + `fromisoformat`-Try/Except.
+* **Atomares Persistieren des Pending-Ledgers**: Der Finalize-Pass
+  schreibt zuerst `recently_finalised.json` und dann
+  `pending_trips.json`; ein Crash zwischen beiden Schreibvorgängen
+  führt im nächsten Tick im Schlimmsten Fall dazu, dass ein bereits
+  finalisierter Trip nochmals beobachtet wird — der
+  `recently_finalised`-Guard verhindert das Doppel-Recording.
 * **Logging** (`src.feed.logging_safe.setup_script_logging` →
   `SafeFormatter`): Jede Diagnose-Nachricht wird durch das projekt-
   weite Sanitisierungsverfahren (Secret-Redaktion, ANSI-/BiDi-Stripping,
@@ -152,10 +199,10 @@ Weitere Schutzmechanismen:
   läuft in UTC. Sowohl die Anfrage-Zeit (`date=` / `time=` Parameter)
   als auch der CSV-`timestamp` werden konsequent auf Europe/Vienna
   ausgerichtet.
-* **JSON-Depth-Bomb-Schutz**: `_query_trips` umschließt
-  `json.loads` mit `except (ValueError, RecursionError)` und
-  re-raised als `ValueError` — eine deeply-nested-aber-wohlgeformte
-  Antwort vom Upstream landet damit im pro-Richtungs-Error-Branch
+* **Non-Finite-Literal-Schutz** (`loads_finite`): Der Parser
+  rejected `NaN` / `Infinity` / `1e1000`-Literale aus einer
+  kompromittierten / MITM-getarnten VAO-Antwort. Eine
+  Depth-Bomb-Antwort landet als `ValueError` im pro-Tick-Error-Branch
   statt eine `BaseException`-getriebene Recursion-Failure aus dem
   Skript zu propagieren.
 
@@ -171,11 +218,11 @@ Cache zu lesen oder zu schreiben.
 
 | Name | Wert | Bedeutung |
 | :--- | :--- | :--- |
-| `DELAY_THRESHOLD_MINUTES` | `9.0` | Median > 9 Minuten innerhalb des Feed-Fensters → Event wird emittiert. |
-| `FEED_WINDOW` | `1 h` | Zeitfenster (rückwirkend von `now`), in dem der Trigger-Median berechnet wird. |
+| `DELAY_THRESHOLD_MINUTES` | `9.0` | Schwellenwert pro Beobachtung; wird vom Trigger-Gate konsumiert. |
+| `FEED_WINDOW` | `1 h` | Zeitfenster (rückwirkend von `now`), in dem das Trigger-Gate ausgewertet wird. |
 | `EPISODE_LOOKBACK` | `6 h` | Max. Rückblick zur Bestimmung des `first_seen`-Zeitpunkts der laufenden Episode. |
 | `EPISODE_GAP_TOLERANCE` | `70 min` | Maximale Lücke zwischen zwei Beobachtungen, ehe eine Episode als beendet gilt (deckt einen ausgefallenen Cron-Tick ab). |
-| `EVENT_SOURCE` | `"VOR/VAO"` | `source`-Feld der emittierten Events (vorher `"ÖBB"`; geändert mit der Migration, weil die Datenquelle inzwischen technisch die VOR/VAO-API ist). |
+| `EVENT_SOURCE` | `"VOR/VAO"` | `source`-Feld der emittierten Events (vorher `"ÖBB"`; geändert mit der 2026-05-09-Migration, weil die Datenquelle inzwischen technisch die VOR/VAO-API ist). |
 | `EVENT_CATEGORY` | `"Störung"` | RSS-`category`-Feld. |
 | `EVENT_TITLE` | `"S-Bahn Stammstrecke Verspätungen"` | konstantes Item-Title. |
 | `EVENT_LINK` | `https://www.wienerlinien.at/web/wienerlinien/oeffis-stoerungen-strecke` | weiterführender Link für Feed-Reader. |
@@ -184,16 +231,20 @@ Cache zu lesen oder zu schreiben.
 
 Pro Richtung und pro Build:
 
-1. Lade alle CSV-Zeilen aus dem `EPISODE_LOOKBACK`-Fenster (6 Stunden).
+1. Lade alle CSV-Zeilen aus dem `EPISODE_LOOKBACK`-Fenster (6 Stunden)
+   und kanonisiere die Richtung (Legacy-Label `"Floridsdorf"` → kanonische
+   Direction `Praterstern`).
 2. Filtere auf das jüngste `FEED_WINDOW` (1 Stunde) — typischerweise
-   2 Beobachtungen.
-3. **Trigger**: liegt der **Median** der Verspätungswerte in dieser
-   Untermenge **strikt** über `DELAY_THRESHOLD_MINUTES`, wird ein
-   Event emittiert. Median statt Mean: ein einzelner Ausreißer kann
-   die Richtung nicht alleine ins Event drücken.
+   2 Beobachtungen pro Richtung.
+3. **Trigger**: emittiere ein Event genau dann, wenn **mindestens zwei**
+   Beobachtungen in dieser Untermenge **strikt** über
+   `DELAY_THRESHOLD_MINUTES` liegen. Die 2-aus-N-Regel verhindert,
+   dass ein einzelner Ausreißer eine Richtung allein ins Event drückt;
+   bei der typischen Stichprobengröße (2 Beobachtungen pro Stunde)
+   müssen also beide jüngsten Ticks die Schwelle reißen.
 4. **Anzeigewert**: das Event-`description`-Feld zeigt den **Mittelwert**
-   (`mean`) derselben Untermenge — für End-Nutzer:innen leichter
-   interpretierbar als der Median.
+   (`mean`) der Beobachtungen im Feed-Fenster — für End-Nutzer:innen
+   leichter interpretierbar als der Median.
 5. **`first_seen`**: gehe vom jüngsten Above-Threshold-Sample im
    6-Stunden-Lookback rückwärts und nimm den frühesten Zeitpunkt einer
    zusammenhängenden Folge mit `> DELAY_THRESHOLD_MINUTES` und
@@ -232,11 +283,11 @@ Meldungen als **separate** Notifications anzeigen.
 | `guid` | abgeleitet von `(prefix, first_seen)` → stabil pro Episode |
 | `description` | "[Seit DD.MM.YYYY]" zeigt `first_seen`-Datum |
 
-Erst wenn das Trigger-Gate auflöst (Median ≤ 9 oder das Episode-
-Lookback findet nichts) und später erneut zuschlägt, bekommt das
-nächste Event eine **frische** `first_seen`-Marke und damit eine neue
-`guid`. Dies modelliert "erneute Verspätungsphase" als eigene
-Notification.
+Erst wenn das Trigger-Gate auflöst (weniger als 2 Beobachtungen
+> 9 min oder das Episode-Lookback findet nichts) und später erneut
+zuschlägt, bekommt das nächste Event eine **frische** `first_seen`-
+Marke und damit eine neue `guid`. Dies modelliert "erneute
+Verspätungsphase" als eigene Notification.
 
 ### Self-Healing & Resilienz
 
@@ -258,51 +309,52 @@ werden, übernimmt das CSV-Ledger das Self-Healing implizit:
   oder `float()` nicht parsen, werden übersprungen (sentinel-test
   in `tests/test_sentinel_csv_size_bomb.py`).
 
-### Stationsnamen-Auflösung
+### Stationsnamen / Richtungs-Labels
 
-Die in `description` angezeigten Richtungs-Labels ("Meidling" für Süd,
-seit 2026-05-15 "Praterstern" für Nord; bis dahin war Nord "Floridsdorf")
-werden für die Süd-Richtung über das kanonische Stationsverzeichnis
-(`src.utils.stations`) aufgelöst, für die Nord-Richtung hartcodiert
-(siehe `DIRECTIONS` in `src/feed/stammstrecke.py`). Der
-Producer legt für jede Richtung ein Tupel `(_Direction)` an, das
-`target_label` aus `display_name(canonical_name(seed))` ableitet und
-mit dem `Wien `-Präfix-Strip eine kompakte Form für die `description`
-erzeugt:
+Die in `description` angezeigten Richtungs-Labels lauten seit der
+2026-05-15-Migration `"Meidling"` (südwärts, nächster Stammstrecken-
+Halt nach Hbf) und `"Praterstern"` (nordwärts, nächster
+Stammstrecken-Halt nach Hbf). Beide Labels sind als Konstanten
+(`DIRECTION_LABEL_SOUTHBOUND` / `DIRECTION_LABEL_NORTHBOUND` im
+Hbf-Producer und `DIRECTIONS` im Renderer) gepinnt, sodass die
+CSV-`direction`-Spalte byte-stabil bleibt.
 
-```
-canonical_name("Wien Meidling")  →  "Wien Meidling"  (Verzeichnis-Hit)
-display_name("Wien Meidling")    →  "Wien Meidling"  (kein Override)
-strip "Wien "                    →  "Meidling"       (Kompakt-Form)
-```
+Vor 2026-05-15 hieß das Nord-Label `"Floridsdorf"`. Die
+Umbenennungs-Begründung: Bei kurzen Wendezügen, die bereits am
+Praterstern oder Wien Mitte terminieren (und nicht bis Floridsdorf
+weiterfahren), bezeichnete die alte Beschriftung fälschlich einen
+Endpunkt, den die meisten Züge gar nicht erreichen. Die Süd-
+Beschriftung benennt seit jeher die nächste Stammstrecken-
+Haltestelle nach dem Hbf — die Umbenennung gibt der Nord-
+Beschriftung dieselbe Semantik.
 
-Wenn das Verzeichnis später eine kanonische Umbenennung (z. B.
-`Wien Meidling` → `Wien Meidling/Philadelphiabrücke`) oder einen
-`display_name`-Override registriert, propagiert das beim nächsten
-Cron-Lauf automatisch in die CSV-`direction`-Spalte und damit in den
-Suffix nach `in Richtung `.
-
-Die Fallback-Kette in `_short_target_label` deckt drei Failure-Modi
-ab:
-1. `canonical_name` liefert `None` (Verzeichnis-Miss): der Seed-Name
-   wird mit Strip verwendet.
-2. `canonical_name` wirft (kaputtes/fehlendes
-   `data/stations.json`): exception swallowing + Strip.
-3. `display_name` liefert leer: ebenfalls Seed mit Strip.
+**Backwards-Compat-Shim**: `DIRECTIONS_BY_LABEL` im Renderer mappt
+das Legacy-Label `"Floridsdorf"` weiterhin auf die Praterstern-
+Direction; Hbf-Cron-Skript ruft `_finalize_departed` zusätzlich für
+`LEGACY_DIRECTION_LABEL_NORTHBOUND` auf. So fließen extern
+wiederhergestellte alte Pending-State-Einträge oder hand-editierte
+CSV-Zeilen mit `"Floridsdorf"` transparent in den Praterstern-Bucket;
+neu geschrieben wird stets das kanonische `"Praterstern"`.
 
 ## Statistik-Logging und Dashboard
 
-Das CSV-Ledger ist gleichzeitig die Datenquelle für das tägliche
+Die CSV-Ledger sind gleichzeitig die Datenquellen für das tägliche
 Statistik-Dashboard:
 
-* **Producer** — `scripts/update_stammstrecke_status.py` schreibt
-  pro Cron-Tick und Richtung eine Zeile, **unabhängig** davon, ob
-  die 9-Minuten-Schwelle überschritten wird oder nicht. Damit
-  reflektiert das Dashboard die *gesamte* Verteilung (auch
-  on-time-Fahrten).
+* **Producer** — `scripts/update_stammstrecke_hbf.py` schreibt pro
+  Cron-Tick und Richtung eine aggregierte Zeile in
+  `data/stats/stammstrecke_<YYYY>.csv` (Verspätungs-Mittelwert über
+  alle finalisierten Pending-Trips dieses Ticks), **unabhängig**
+  davon, ob die 9-Minuten-Schwelle überschritten wird oder nicht.
+  Damit reflektiert das Dashboard die *gesamte* Verteilung (auch
+  on-time-Fahrten). Ausfälle landen separat in
+  `data/stats/ausfaelle_<YYYY>.csv` (eine Zeile pro Cancellation).
 * **Renderer** — `scripts/generate_markdown_stats.py` regeneriert
-  `docs/statistik.md` täglich aus den CSV-Ledgers (30-Tage-Fenster).
-* **Feed-Builder** — liest dasselbe Ledger mit einem 1-Stunden-Fenster.
+  `docs/statistik.md` täglich aus den CSV-Ledgers (30-Tage-Fenster)
+  und patcht zusätzlich die `<!-- STATS:* -->`-Marker im README
+  (60-Min- und 30-Tage-Snapshots für Verspätungen + Ausfälle).
+* **Feed-Builder** — liest `stammstrecke_<YYYY>.csv` mit einem
+  1-Stunden-Fenster über das Trigger-Gate (siehe oben).
 
 Beide Konsumenten benutzen denselben Reader-Pfad
 (`src.utils.stats.read_recent_stammstrecke_observations`) und
@@ -315,31 +367,37 @@ Architektur-Kontext und Diagramm: siehe Section 6 in
 * **Schwelle anpassen**: Konstante `DELAY_THRESHOLD_MINUTES` in
   `src/feed/stammstrecke.py`. Aktuell `9.0` (dokumentierter Standard
   "deutliche Stammstrecken-Beeinträchtigung").
-* **VOR-Stations-IDs**: `FLORIDSDORF_VOR_ID` / `MEIDLING_VOR_ID` —
-  Stop-IDs aus dem VOR/VAO-Stations­verzeichnis (`data/stations.json`).
-  Pinned an die jeweils gültigen IDs, sodass eine Verzeichnis-Drift
-  nicht stillschweigend den Monitor umlenken kann.
-* **Stationsnamen-Seeds**: `FLORIDSDORF_CANONICAL_SEED` /
-  `MEIDLING_CANONICAL_SEED` sind die Lookup-Keys, die durch das
-  Stationsverzeichnis kanonisch aufgelöst werden.
-* **Richtungs-Tabelle**: `DIRECTIONS` in `src/feed/stammstrecke.py`
-  spiegelt die Producer-Tupel wider; `target_label` muss byteweise
-  zur CSV-`direction`-Spalte passen.
+* **VOR-Stop-ID**: `HAUPTBAHNHOF_VOR_ID` in
+  `scripts/update_stammstrecke_hbf.py`. Pinned an `490134900`
+  (Wien Hauptbahnhof), sodass eine Verzeichnis-Drift nicht
+  stillschweigend den Monitor umlenken kann.
+* **Bahnsteig-Whitelist**: `STAMMSTRECKE_HBF_TRACK_TRUNKS` (aktuell
+  `{"1", "2"}`) im Hbf-Producer. Erweiterung nur sinnvoll, wenn ÖBB
+  einen weiteren Hbf-Bahnsteig auf die Stammstrecke umlenkt.
+* **Richtungs-Klassifikation**: `HBF_SOUTHBOUND_SUBSTRINGS` /
+  `HBF_NORTHBOUND_SUBSTRINGS` für den schnellen Substring-Match,
+  `HBF_SOUTHBOUND_TERMINI` / `HBF_NORTHBOUND_TERMINI` für die
+  exakte Whitelist seltener Termini. Erweiterung über die
+  `Unbekannter Endpunkt am Hbf`-INFO-Logs des Hbf-Producers.
+* **Direction-Labels**: `DIRECTION_LABEL_SOUTHBOUND` /
+  `DIRECTION_LABEL_NORTHBOUND` (Producer) und `DIRECTIONS` (Renderer)
+  müssen byteweise übereinstimmen — die CSV-`direction`-Spalte
+  trägt das `target_label` verbatim.
 * **HTTP-Timeout**: `QUERY_TIMEOUT` (Default-Sekunden) und
   `MAX_QUERY_TIMEOUT` (oberer Clamp) im Producer. Wird direkt an
-  `fetch_content_safe(timeout=…)` durchgereicht.
-* **Sample-Größe**: `MAX_TRIPS_PER_QUERY` (aktuell `6`, VAO-Cap).
-  Liefert den Median über bis zu 6 unmittelbar anstehende S-Bahnen
-  pro Richtung — die VAO-Antwortgröße ist zwischen `numF=5` und
-  `numF=6` identisch, der Cap maximiert die Stichprobe ohne extra
-  Quota-Kosten.
+  `request_safe(timeout=…)` durchgereicht.
+* **Duration-Window**: `DEPARTURE_BOARD_DURATION_MIN` (aktuell `45`).
+  Sized als 30-Min-Cron-Cadence + 15-Min-Overlap, damit jeder Zug
+  zweimal beobachtet wird (latest-wins-Overwrite). Eine Verlängerung
+  bläht die Antwort ohne Genauigkeits-Gewinn auf.
 * **Regex für S-Bahn-Linien**: `_S_BAHN_LINE_RE`. Erfasst alle ÖBB-
   S-Bahn-Linien (`S\d+`), inklusive zukünftiger Erweiterungen
   (`S 90`, `S 100`).
 * **Rate-Limit**: `BREAKER_FAILURE_THRESHOLD` /
   `BREAKER_RECOVERY_TIMEOUT`. Aktuell auf `10` / `3600 s` gesetzt. Das
   100/Tag-VAO-Budget wird durch den `_charge_one_request`-Pfad
-  zusätzlich am Skript-Eingang geschützt.
+  zusätzlich am Skript-Eingang geschützt; davor läuft im Workflow
+  `scripts/preflight_quota_check.py --check vor --margin 1`.
 * **Window-Längen** im Renderer: `FEED_WINDOW` (1 h) und
   `EPISODE_LOOKBACK` (6 h) in `src/feed/stammstrecke.py`. Eine
   Verkürzung des Feed-Window erhöht die Reaktionszeit, vergrößert


### PR DESCRIPTION
## Summary

Documentation review identified several factual drifts between user-facing docs and the current code/workflow state — most importantly the 2026-05-15 cutover of the Stammstrecke monitor from `/trip × 2 directions` to a single `/departureBoard` poll at Wien Hauptbahnhof. This PR aligns the docs with that reality and corrects a handful of related stale references.

## What changed

- **`docs/reference/stammstrecke_provider_logic.md`** — substantially rewritten. Producer is now `update_stammstrecke_hbf.py`, endpoint is `/departureBoard` at HBF (`vor_id 490134900`), quota is 48/100 not 96/100, trigger gate is "≥2 obs > 9 min" (count-based, not median), platform-level Bahnsteig 1/2 filter is documented, latest-wins re-observation + pending/recently-finalised ledger explained, Erweiterungs-Punkte updated to current constants.
- **`docs/architecture.md`** — §6 diagram now shows `ausfaelle_<YYYY>.csv` ledger + new producer name + ≥2 trigger; §7 quota table reflects 48/100 with `/departureBoard` (and the migration's halved budget).
- **`docs/development.md`**:
  - VOR section updated to 48 calls/day on `/departureBoard`.
  - Scripts table lists `update_stammstrecke_hbf.py` as active producer + `update_stammstrecke_status.py` as legacy import target.
  - Removed non-existent `cli cache update vor` / `cli stations update vor` (the CLI rejected those since 2026-05-11).
  - Fixed `_resolve_env_path` → `resolve_env_path` (the helper is public, not private).
  - Refreshed the `cache/`-paths note: `cache/stammstrecke/{pending_trips,recently_finalised}.json` sidecars exist (Hbf-Producer trip-ID tracking), but no `events.json`.
  - Test count refreshed to ~2600 tests / 400 modules.
- **`docs/reference/oebb_provider_logic.md`** — Stammstrecke `source` field is now `"VOR/VAO"`, not `"ÖBB"` (matches `EVENT_SOURCE` in `src/feed/stammstrecke.py` since the 2026-05-09 migration).
- **`AGENTS.md`** — removed the speculative "`python -m src.cli tests` (Falls implementiert, sonst direkt `pytest` nutzen)" reference; the subcommand never existed.

## Verification

- All numbers and helper / script names cross-checked against `src/`, `scripts/`, and `.github/workflows/update-cycle.yml`.
- Trigger gate semantics verified against `src/feed/stammstrecke.py:274–276` (`delayed_count = sum(...); if delayed_count < 2: continue`) — the previous "median > threshold" claim was code-inaccurate.
- Quota math cross-checked against `update-cycle.yml`'s `--margin 1` preflight call (matches the single-call-per-tick model).
- No code changes — docs only.

## Test plan

- [ ] Skim each updated doc for German prose flow / formatting.
- [ ] Verify the architecture diagram still renders in GitHub's Mermaid viewer.
- [ ] Confirm no further stale refs surface (`grep -rn "update_stammstrecke_status\|cli cache update.*vor\|_resolve_env_path" docs/` returns only the legacy-marker entries that this PR intentionally keeps).

https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP)_