### PR TITLE
docs: round-2 follow-up — three CSV ledgers, ruff UP, code comment drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Begleitende Stamm-/Identifier-Quellen: das **ÖBB-Excel** „Verzeichnis der Ver
 - **RSS-Feed abonnieren:** [`https://origamihase.github.io/wien-oepnv/feed.xml`](https://origamihase.github.io/wien-oepnv/feed.xml)
 - **Projekt-Website:** <https://origamihase.github.io/wien-oepnv/>
 - **JSON-Schema der Events:** [`docs/schema/events.schema.json`](docs/schema/events.schema.json)
-- **Feed-Health-Report:** `docs/feed-health.md` _(wird lokal nach jedem Feed-Build erzeugt; nicht im Repository versioniert)_
+- **Feed-Health-Report:** `docs/feed-health.md` (+ `docs/feed-health.json` für maschinelle Konsumenten) _(beide werden lokal nach jedem Feed-Build erzeugt; nicht im Repository versioniert)_
 
 ### 💻 Für Entwickler & Mitwirkende
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -494,10 +494,12 @@ path since the original `_download_ogd_csv` shape.
 
 ## 6. Statistics & Dashboard Pipeline
 
-Two append-only CSV ledgers under `data/stats/` capture every relevant
+Three append-only CSV ledgers under `data/stats/` capture every relevant
 observation as it happens. They serve **two consumers** with
 different windows: the daily Markdown dashboard
-(`docs/statistik.md`, 30-day window) and the RSS feed itself
+(`docs/statistik.md`, 30-day window) plus the four README STATS
+markers (`STATS:STAMMSTRECKE[_LIVE]` and `STATS:AUSFAELLE[_LIVE]`,
+60-min + 30-day snapshots), and the RSS feed itself
 (Stammstrecke section, 1-hour window — see
 [`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md)).
 The hot-path build never blocks on observability I/O — both
@@ -566,9 +568,9 @@ it:
    `src/` or `scripts/`" invariant is enforced by
    `tests/test_sentinel_csv_size_bomb.py`.
 2. **Malformed-row tolerance** — `_parse_stammstrecke_rows` /
-   `_parse_stoerung_rows` skip individual rows that fail
-   `fromisoformat` or `float()`. A single fat-fingered manual edit
-   never corrupts the entire dashboard.
+   `_parse_stoerung_rows` / `_parse_ausfall_rows` skip individual
+   rows that fail `fromisoformat` or `float()`. A single fat-fingered
+   manual edit never corrupts the entire dashboard.
 3. **Atomic dashboard write** — the rendered Markdown lands on disk
    through `src.utils.files.atomic_write`. A kill-signal mid-render
    cannot replace the previous dashboard with a half-written file.
@@ -591,6 +593,7 @@ keyword always wins inside `stats_path`.
 | Question | Section in `docs/statistik.md` |
 |---|---|
 | **When** do Stammstrecke delays occur? | "Stammstrecke" — weekday + hour distributions of both observation count and average delay |
+| **How often** is the Stammstrecke cancelling trains? | "Ausfälle" — per-direction and per-line tables plus weekday + hour distributions |
 | **Where** (and **when**) are disruption hotspots? | "Störungen" — per-provider table, weekday + hour distributions, top-5 hotspots with per-location hourly profile |
 
 The location heuristic in `extract_location_name` tries — in order —

--- a/docs/development.md
+++ b/docs/development.md
@@ -494,7 +494,7 @@ benötigt werden (z. B. `--no-download` für die WL-OGD-CSVs).
 
 - **Tests**: `python -m pytest` führt über 2600 Unit- und Integrationstests in rund 400 Modulen unter `tests/` aus.
 - **Kontinuierliche Tests**: Die GitHub Action `test.yml` automatisiert die im Audit empfohlene regelmäßige Testausführung und bricht Builds bei fehlschlagender Test-Suite ab.
-- **Statische Analyse & Typprüfung**: `ruff check` (Stil/Konsistenz, Regelgruppen `E`, `F`, `S`, `B`) und `mypy --strict` (vollständige Typabdeckung über `src/` und `tests/`, derzeit 0 Errors) laufen identisch zur CI via `python -m src.cli checks`. Optional lassen sich über `--fix` Ruff-Autofixes aktivieren oder zusätzliche Argumente an Ruff durchreichen. Ein zusätzlicher `mypy-strict.yml`-Workflow setzt das Allowlist-Gate auf Pull Requests durch.
+- **Statische Analyse & Typprüfung**: `ruff check` (Stil/Konsistenz, Regelgruppen `E`, `F`, `S`, `B`, `UP` — siehe `pyproject.toml`) und `mypy --strict` (vollständige Typabdeckung über `src/` und `tests/`, derzeit 0 Errors) laufen identisch zur CI via `python -m src.cli checks`. Optional lassen sich über `--fix` Ruff-Autofixes aktivieren oder zusätzliche Argumente an Ruff durchreichen. Ein zusätzlicher `mypy-strict.yml`-Workflow setzt das Allowlist-Gate auf Pull Requests durch.
 - **Pre-Commit-Hooks**: `.pre-commit-config.yaml` aktiviert lokale Checks (Ruff, mypy, Secret-Scan, Whitespace-Hygiene) bei jedem `git commit`. Einmalig nach dem Klonen `pre-commit install` ausführen — Details in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 - **Logging**: Zur Laufzeit entsteht `log/errors.log` mit rotierenden Dateien; Größe und Anzahl sind konfigurierbar.
 

--- a/src/feed/providers.py
+++ b/src/feed/providers.py
@@ -236,12 +236,15 @@ def read_cache_baustellen() -> list[Any]:
 # Stammstrecke is the only provider whose feed entries are derived
 # *directly* from the statistics ledger (``data/stats/stammstrecke_<YYYY>.csv``)
 # rather than from a separate provider-fetched JSON cache. The cron
-# script ``scripts/update_stammstrecke_status.py`` appends one
-# observation row per direction per run; this provider folds the rows
-# from the most recent hour into 0..N feed events when the per-
-# direction average delay exceeds the threshold. Single source of
-# truth = the CSV ledger; the README dashboard reads the same file
-# (just with a 30-day window instead of the feed's 1-hour window).
+# script ``scripts/update_stammstrecke_hbf.py`` (active since
+# 2026-05-15; reuses shared infrastructure from
+# ``scripts/update_stammstrecke_status.py`` via import) appends one
+# aggregate observation row per direction per cron tick; this provider
+# folds the rows from the most recent hour into 0..N feed events when
+# the per-direction trigger gate (≥2 observations strictly above 9 min
+# in that hour) fires. Single source of truth = the CSV ledger; the
+# README dashboard reads the same file (just with a 30-day window
+# instead of the feed's 1-hour window).
 #
 # Replaced the ``cache/stammstrecke/events.json`` JSON cache 2026-05-09
 # (PR follow-up to #1397). Operational rationale in


### PR DESCRIPTION
## Summary

Round-2 follow-up to the merged docs review ([PR #1506](https://github.com/Origamihase/wien-oepnv/pull/1506)). A deeper second pass through the documentation surfaced three additional drift items that the first PR missed, all anchored on the 2026-05-15 introduction of the `ausfaelle_<YYYY>.csv` ledger + the `update_stammstrecke_hbf.py` migration. All changes are documentation-only except a single accompanying code-comment update in `src/feed/providers.py` that referenced the legacy producer name.

## What changed

- **`docs/architecture.md` §6** — "Two append-only CSV ledgers" → three; the `ausfaelle_<YYYY>.csv` ledger (added 2026-05-15) was missing from the intro paragraph, the malformed-row-tolerance parser list (`_parse_ausfall_rows`), and the "What the dashboard answers" table now lists the dedicated Ausfälle section. Intro paragraph also names the four README STATS markers for completeness.
- **`docs/development.md`** — ruff config description: rule group list was missing `UP` (it has been in `pyproject.toml` since the pyupgrade roll-out).
- **`README.md`** — Feed-Health-Report bullet now also names the JSON sidecar (`docs/feed-health.json`), matching the `provider_plugins.md` how-to and the actual writer in `src/feed/reporting.py`.
- **`src/feed/providers.py`** — module-level comment on `read_cache_stammstrecke()` referenced `update_stammstrecke_status.py` as the writer; the active producer since 2026-05-15 is `update_stammstrecke_hbf.py` (the legacy module survives only as an import target for shared infrastructure). Updated the trigger-gate semantics in the comment to match the actual ≥2-above-threshold check in `src/feed/stammstrecke.py`.

## Verification

- Cross-checked `scripts/generate_markdown_stats.py` for the three parsers (`_parse_stammstrecke_rows`, `_parse_stoerung_rows`, `_parse_ausfall_rows`) and the four README rendering helpers (`render_readme_*_block`, `render_readme_ausfaelle_*_block`).
- Verified `pyproject.toml` `[tool.ruff.lint] select` contains `UP`.
- Verified `DEFAULT_FEED_HEALTH_JSON_PATH` exists in `src/config/defaults.py:33`.
- Verified that the dashboard sections in `docs/statistik.md` are: Kennzahlen, Stammstrecke, Ausfälle, Störungen.
- No code-behaviour changes — `src/feed/providers.py` change is a code-comment only.

## Test plan

- [ ] Skim the updated architecture.md §6 / development.md ruff bullet / README.md feed-health line for German prose flow.
- [ ] Confirm the §6 Mermaid diagram in `docs/architecture.md` still renders correctly (untouched — it already showed all three ledgers).
- [ ] Verify no other stale refs surface (`grep -rn "Two append-only\|update_stammstrecke_status" docs/ src/feed/providers.py` should be empty for current-state usage).

https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP)_