### PR TITLE
docs: round-3 follow-up — VOR scope, default-provider env vars, historical marker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,9 @@ Dieses Dokument dient als Leitfaden für KI-Agenten, die an diesem Repository ar
 
 ## Projektüberblick
 
-Das Projekt `wien-oepnv` aggregiert Verkehrsmeldungen (Wiener Linien, ÖBB, VOR, Baustellen) und stellt sie als RSS-Feed sowie JSON-Daten bereit. Es legt höchsten Wert auf **Reproduzierbarkeit**, **Sicherheit** und **Datenintegrität**.
+Das Projekt `wien-oepnv` aggregiert Verkehrsmeldungen (Wiener Linien, ÖBB, Stadt-Wien-Baustellen plus den VOR/VAO-basierten S-Bahn-Stammstrecken-Monitor) und stellt sie als RSS-Feed sowie JSON-Daten bereit. Es legt höchsten Wert auf **Reproduzierbarkeit**, **Sicherheit** und **Datenintegrität**.
+
+> **Hinweis zum VOR-Scope:** Seit der Konsolidierung vom 2026-05-11 ist VOR **kein eigenständiger Disruption-Provider** mehr (das frühere `src/providers/vor.py:fetch_events` wurde entfernt). Die VOR/VAO ReST API wird ausschließlich vom Stammstrecken-Verspätungs- und Ausfall-Monitor (`scripts/update_stammstrecke_hbf.py`) konsumiert. Wer einen neuen VOR-Konsumenten plant, muss das Tagesbudget (100 Requests; aktuell sind 48 davon vom Hbf-Monitor belegt) sowie den `_charge_one_request`-Quota-Gate beachten — Details in `docs/architecture.md` §7.
 
 ### Wichtige Verzeichnisse
 - `src/`: Der gesamte Quellcode des Pakets.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,13 +55,21 @@ python -m src.cli checks --fix
 ### Feed lokal bauen
 Um Änderungen am Feed-Generator zu testen:
 ```bash
-# Beispiel: Nur Wiener Linien und ÖBB aktivieren
+# Beispiel: Nur Wiener Linien und ÖBB aktivieren, Baustellen
+# und Stammstrecke deaktivieren
 export WL_ENABLE=true
 export OEBB_ENABLE=true
-export VOR_ENABLE=false
+export BAUSTELLEN_ENABLE=false
+export STAMMSTRECKE_ENABLE=false
 python -m src.cli feed build
 ```
 Der Output liegt dann unter `docs/feed.xml`.
+
+> ℹ️ Ein `VOR_ENABLE` existiert nicht (mehr): VOR ist seit der
+> 2026-05-11-Konsolidierung kein eigenständiger Disruption-Provider
+> mehr — die VOR/VAO-API treibt ausschließlich den
+> Stammstrecken-Monitor, der über `STAMMSTRECKE_ENABLE` gesteuert
+> wird.
 
 ## Pull Requests (PRs)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **Ein Feed, alle Meldungen: Die zentrale Info-Quelle für den Wiener ÖPNV.**
 
-Dieses Projekt bündelt Störungs- und Baustellenmeldungen der Wiener Linien (WL), ÖBB und des VOR in einem deduplizierten RSS-Feed für Wien und das Umland. Ergänzt wird dies durch offizielle OGD-Baustellendaten der Stadt Wien.
+Dieses Projekt bündelt Störungs- und Baustellenmeldungen der Wiener Linien (WL) und ÖBB in einem deduplizierten RSS-Feed für Wien und das Umland, ergänzt um offizielle OGD-Baustellendaten der Stadt Wien sowie einen dedizierten S-Bahn-Stammstrecken-Monitor (Verspätungen & Ausfälle) auf Basis der VOR/VAO ReST API.
 
 ### 🚀 Kernfunktionen auf einen Blick
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,9 +15,18 @@ also expressed prose-first under each diagram.
 
 The headline workflow: a cron job (or the `update-cycle.yml` GitHub
 Action) launches `python -m src.cli feed build` (which calls
-`build_feed.main()`), orchestrating 4–5 transit-data providers in
-parallel, deduplicating the merged events, and writing a single RSS
-feed.
+`build_feed.main()`), invoking the registered transit-data providers,
+deduplicating the merged events, and writing a single RSS feed.
+
+> **Hinweis zum aktuellen Default-Setup:** Das Diagramm illustriert
+> beide Provider-Modi des Builders (sync cache vs. async network).
+> Im aktuellen Cron-Setup (`update-cycle.yml`) werden die HTTP-Fetcher
+> für WL, ÖBB und Baustellen aber **in eigenen Workflow-Steps** vor
+> dem `feed build` ausgeführt und schreiben in `cache/<provider>/`;
+> der Feed-Build selbst sieht alle Default-Provider (WL, ÖBB,
+> Baustellen, Stammstrecke) deshalb als **cache_fetchers** (sync,
+> disk-bound). Der Async-Pfad ist die Plug-in-Aufnahme-Stelle für
+> nicht-cache-basierte Drittprovider — siehe §4.
 
 ```mermaid
 sequenceDiagram

--- a/docs/development.md
+++ b/docs/development.md
@@ -148,8 +148,7 @@ schreibt. Die wichtigsten Parameter:
 | `ENDS_AT_GRACE_MINUTES`  | Kulanzfenster für vergangene Endzeiten (Standard 10 Minuten).                   |
 | `PROVIDER_TIMEOUT`       | Globales Timeout für Netzwerkprovider (Standard 25 Sekunden). Per Provider via `PROVIDER_TIMEOUT_<NAME>` oder `<NAME>_TIMEOUT` anpassbar. |
 | `PROVIDER_MAX_WORKERS`   | Anzahl paralleler Worker (0 = automatisch). Feiner steuerbar über `PROVIDER_MAX_WORKERS_<GRUPPE>` bzw. `<GRUPPE>_MAX_WORKERS`. |
-| `WL_ENABLE` / `OEBB_ENABLE` / `VOR_ENABLE` | Aktiviert bzw. deaktiviert die einzelnen Provider (Standard: aktiv). |
-| `BAUSTELLEN_ENABLE`      | Steuert den neuen Baustellen-Provider (Default: aktiv, nutzt Stadt-Wien-OGD bzw. Fallback-Daten). |
+| `WL_ENABLE` / `OEBB_ENABLE` / `BAUSTELLEN_ENABLE` / `STAMMSTRECKE_ENABLE` | Aktiviert bzw. deaktiviert die einzelnen Default-Provider (alle Standard: aktiv). `STAMMSTRECKE_ENABLE` steuert den VOR/VAO-basierten Verspätungs- und Ausfall-Monitor. Eine separate `VOR_ENABLE`-Variable existiert seit der 2026-05-11-Konsolidierung **nicht mehr**. |
 | `LOG_DIR`, `LOG_MAX_BYTES`, `LOG_BACKUP_COUNT`, `LOG_FORMAT` | Steuerung der Logging-Ausgabe (`log/errors.log`, `log/diagnostics.log`). |
 | `STATE_PATH`, `STATE_RETENTION_DAYS` | Pfad & Aufbewahrung für `data/first_seen.json`.                      |
 | `WIEN_OEPNV_CACHE_PRETTY` | Steuert die Formatierung der Cache-Dateien (`1` = gut lesbar, `0` = kompakt). |
@@ -186,8 +185,11 @@ Das Skript lädt automatisch `.env`, `data/secrets.env` und
 ```bash
 export WL_ENABLE=true
 export OEBB_ENABLE=true
-export VOR_ENABLE=true
-# Provider-spezifische Secrets/Tokens setzen (z. B. VOR_ACCESS_ID, VOR_BASE_URL ...)
+export BAUSTELLEN_ENABLE=true
+export STAMMSTRECKE_ENABLE=true
+# Stammstrecke-Monitor benötigt VOR-Secrets: VOR_ACCESS_ID, VOR_BASE_URL.
+# Eine eigenständige VOR_ENABLE-Variable gibt es seit der 2026-05-11-
+# Konsolidierung nicht mehr (VOR ist Stammstrecke-only).
 python -m src.cli feed build
 ```
 
@@ -258,11 +260,15 @@ Sie sind damit ohne zusätzlichen Build-Schritt sofort für externe Automationen
 Für Python-Anwendungen existieren zwei bequeme Zugriffspfade:
 
 - **Direkter Cache-Zugriff** – `src.utils.cache.read_cache()` liest die zwischengespeicherten Provider-Events als Python-Liste
-  von Dictionaries ein (Wrapper wie `src.build_feed.read_cache_wl()` sind bereits vorkonfiguriert für „wl“, „oebb“, „vor“ und
-  „baustellen“).
-- **Live-Abruf der Provider** – Die Module `src.providers.wl_fetch`, `src.providers.oebb` und `src.providers.vor` stellen
-  jeweils eine Funktion `fetch_events()` bereit, die die Rohdaten der Wiener Linien, ÖBB bzw. der VOR/VAO-API direkt
-  normalisiert. Authentifizierung und Ratenlimits der VOR-API werden dabei automatisch behandelt.
+  von Dictionaries ein (Wrapper wie `src.build_feed.read_cache_wl()` sind bereits vorkonfiguriert für „wl", „oebb" und
+  „baustellen"; zusätzlich erzeugt `src.build_feed.read_cache_stammstrecke()` die Stammstrecke-Events on-the-fly aus dem
+  CSV-Ledger statt aus einer Cache-Datei). VOR hat seit 2026-05-11 keine eigene JSON-Cache-Datei mehr (siehe `cache/`-Hinweis oben).
+- **Live-Abruf der Provider** – Die Module `src.providers.wl_fetch` und `src.providers.oebb` stellen jeweils eine Funktion
+  `fetch_events()` bereit, die die Rohdaten der Wiener Linien bzw. ÖBB direkt normalisiert. `src.providers.vor` ist seit der
+  2026-05-11-Konsolidierung **kein Disruption-Provider** mehr — das Modul exportiert nur noch
+  Authentifizierungs- und Quota-Helfer (`VorAuth`, `apply_authentication`, `load_request_count`, `save_request_count`,
+  `refresh_access_credentials`, `refresh_base_configuration`) für den Stammstrecken-Monitor. Eine eigenständige
+  `fetch_events`-Funktion gibt es nicht mehr.
 
 Minimalbeispiel für den Cache-Zugriff:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,12 +33,12 @@ Weitere Details findest du in der [ausführlichen Projektdokumentation](../READM
 
 ## Datengrundlage und Lizenzierung
 
-| Datenquelle | Inhalt | Aktualisierung |
-|-------------|--------|----------------|
-| Wiener Linien (WL) | Störungs- und Echtzeitmeldungen für U-Bahn, Straßenbahn und Bus | Mehrmals täglich |
-| ÖBB | Informationen zum regionalen und nationalen Bahnverkehr im Großraum Wien | Nach Fahrplanänderungen und Ereignissen |
-| Verkehrsverbund Ost-Region (VOR) | Verbundweite Meldungen und VOR/VAO-API-Dokumentation | Kontinuierlich |
-| Stadt Wien (OGD) | Baustellen- und Ereignisdaten als Fallback | Täglich |
+| Datenquelle | Inhalt | Abruf-Cadence |
+|-------------|--------|---------------|
+| Wiener Linien (WL) | Störungs- und Echtzeitmeldungen für U-Bahn, Straßenbahn und Bus | ~alle 30 Min (IFTTT-getriggert) |
+| ÖBB | Bundesweite Bahnmeldungen mit strikten Wien-Filter | ~alle 30 Min (IFTTT-getriggert) |
+| Verkehrsverbund Ost-Region (VOR) | VOR/VAO ReST API, seit 2026-05-11 **ausschließlich** für den S-Bahn-Stammstrecken-Verspätungs- und Ausfall-Monitor genutzt | ~alle 30 Min (IFTTT-getriggert) |
+| Stadt Wien (OGD) | Offizielle Baustellendaten (Bezirk, Zeitraum, Geo-Infos) | ~alle 30 Min (IFTTT-getriggert) |
 
 Alle Datenquellen werden revisionssicher versioniert, inklusive Lizenzhinweisen. Informiere dich vor der Weiterverwendung über die jeweiligen Nutzungsbedingungen.
 

--- a/docs/strict-typing-attr-defined-investigation.md
+++ b/docs/strict-typing-attr-defined-investigation.md
@@ -1,5 +1,16 @@
 # `[attr-defined]`-Cluster — Investigations-Findings (D.1)
 
+> ⚠️ **Status: Historisches Investigations-Dokument (Snapshot).** Dieser Bericht
+> dokumentiert eine punktuelle mypy-Analyse aus der strict-typing-Migration
+> und wurde gegen die damalige Repository-Struktur erstellt. Mehrere der
+> hier referenzierten Skripte (`scripts/update_vor_cache.py`,
+> `scripts/update_vor_stations.py`, `scripts/fetch_vor_haltestellen.py`)
+> wurden mit der 2026-05-11-VOR-Konsolidierung gelöscht; die zugehörigen
+> Items entfallen in der heutigen Test-Suite. Dieses Dokument wird **nicht**
+> nachgepflegt, weil es eine zeitpunktgenaue Cluster-Analyse beschreibt —
+> aktuelle mypy-Konventionen stehen in
+> [`docs/strict-typing-migration.md`](strict-typing-migration.md).
+
 Dieses Dokument klärt die Strategie für den verbleibenden
 `[attr-defined]`-Cluster (98 Errors) der strict-typing-Migration.
 Ziel: per Sub-Kategorie eine konkrete Fix-Empfehlung formulieren,

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,8 +4,12 @@ Dieses Verzeichnis enthält die automatisierte Test-Suite, basierend auf `pytest
 
 ## Struktur
 
-- **`conftest.py`**: Enthält globale Fixtures, z.B. Mocks für `requests.Session` oder temporäre Verzeichnisse.
-- **`test_*.py`**: Die eigentlichen Testdateien. Sie sind meist nach dem Modul benannt, das sie testen (z.B. `test_build_feed.py` testet `src/build_feed.py`).
+- **`conftest.py`**: Enthält globale Fixtures (z. B. Mocks für `requests.Session`, das `isolate_stats_writes`-Autouse-Fixture und das `reset_circuit_breakers`-Autouse-Fixture für deterministische Test-Reihenfolge).
+- **`test_*.py`**: Die eigentlichen Testdateien. Sie sind meist nach dem Modul benannt, das sie testen (`test_build_feed_atom.py`, `test_build_feed_cache.py`, … decken jeweils einen Aspekt von `src/build_feed.py` ab; das Pendant zu `src/build_feed.py` ist also kein einzelnes Modul, sondern eine Familie themenspezifischer Dateien).
+- **Unterverzeichnisse** für strukturierte Test-Suites:
+  - `tests/places/` — Tier-1/2/3-Stationsverzeichnis-Pipeline (OSM, HAFAS, Google Places).
+  - `tests/providers/` — WL- und ÖBB-Provider-Adapter.
+  - `tests/scripts/` — Wartungsskripte (`update_stammstrecke_*`, `update_station_directory`, `generate_markdown_stats`, …).
 
 ## Tests ausführen
 
@@ -17,7 +21,11 @@ python -m pytest
 
 ### Spezifische Tests
 ```bash
-python -m pytest tests/test_build_feed.py
+# Einzelne Datei
+python -m pytest tests/test_build_feed_atom.py
+
+# Alle Build-Feed-Tests via Glob
+python -m pytest tests/test_build_feed_*.py
 ```
 Oder filtere nach Testnamen:
 ```bash


### PR DESCRIPTION
## Summary

Third pass through the documentation. The 2026-05-11 VOR consolidation (which removed `src/providers/vor.py:fetch_events`) had left several docs still treating VOR as a peer disruption provider — this PR aligns them with the current Stammstrecke-only scope. Also closes two smaller drifts and flags a historical document.

## What changed

### VOR scope corrections

- **`docs/development.md` "Programmgesteuerter Zugriff"** — claimed `src.providers.vor` exports `fetch_events`; it does not. The current public API is auth/quota helpers only (`VorAuth`, `apply_authentication`, `load_request_count`, …). Also corrected the `read_cache_<provider>` wrapper list ("vor" removed, "stammstrecke" added).
- **`docs/development.md` env var table** — `VOR_ENABLE` listed alongside `WL_ENABLE`/`OEBB_ENABLE`; the env var has **no effect** since VOR is not in the default provider registry (see `src/feed/providers.py:96-104`). Replaced with the actual defaults `WL_ENABLE` / `OEBB_ENABLE` / `BAUSTELLEN_ENABLE` / `STAMMSTRECKE_ENABLE`.
- **`docs/development.md` feed-build example** — exported `VOR_ENABLE=true`, which is a no-op. Replaced with the right toggle set for the current default registry.
- **`CONTRIBUTING.md` feed-build example** — same `VOR_ENABLE=false` no-op, fixed plus an explicit callout that `VOR_ENABLE` doesn't exist.
- **`AGENTS.md` project overview** — clarified that VOR is the Stammstrecke monitor only, with a callout for future agents who might want to add a new VOR consumer (must respect the 100/day quota gate).
- **`README.md` tagline** — "Wiener Linien (WL), ÖBB und des VOR" was misleading. Reworded to call out the Stammstrecke monitor as the VOR consumer.
- **`docs/index.md` data-source table** — VOR row described "Verbundweite Meldungen" (the pre-2026-05-11 scope). Replaced with the Stammstrecke-only description; the "Aktualisierung" column now states the actual ~30-min cron cadence for every row instead of the previous mix ("Mehrmals täglich" / "Kontinuierlich" / "Täglich") that obscured the real cadence.

### Other corrections

- **`docs/architecture.md` §1** — added a callout below the sequence diagram clarifying that all four default providers run as `cache_fetchers` (sync) under the production cron workflow. The diagram's network-fetcher branch only fires for third-party plugins that don't set `_provider_cache_name`.
- **`tests/README.md`** — referenced a non-existent `test_build_feed.py` (the project has `test_build_feed_atom.py` / `_cache.py` / etc., not a monolithic file). Expanded the structure section with the three test sub-directories (`places/`, `providers/`, `scripts/`) and named the two key autouse fixtures.
- **`docs/strict-typing-attr-defined-investigation.md`** — added a prominent banner marking it as a historical snapshot. References scripts that no longer exist (deleted with the 2026-05-11 consolidation); rather than nachpflegen, the banner points readers at the still-current `strict-typing-migration.md`.

## Verification

- Cross-checked `src/providers/vor.py:__all__` (line 922) — no `fetch_events`, only auth/quota helpers.
- Cross-checked `register_default_providers()` (`src/feed/providers.py:96-104`) — the four registered env vars are `WL_ENABLE`, `OEBB_ENABLE`, `BAUSTELLEN_ENABLE`, `STAMMSTRECKE_ENABLE`. No `VOR_ENABLE`.
- Cross-checked `register_provider()` (`src/feed/providers.py:44-56`) — sets `_provider_cache_name` on every registered loader, so `_categorize_providers` puts all of them in `cache_fetchers`.
- Cross-checked `tests/conftest.py` — `isolate_stats_writes` at line 241, `reset_circuit_breakers` at line 297.
- Verified all the historical document refs (`scripts/update_vor_*.py`) are indeed gone via `ls scripts/`.

## Test plan

- [ ] Skim each updated doc for German prose flow.
- [ ] Verify no further VOR-scope drift surfaces (`grep -rn "VOR_ENABLE" docs/ AGENTS.md README.md CONTRIBUTING.md` should only return the new callouts explaining the variable's absence).
- [ ] Verify the `tests/test_build_feed_atom.py` reference works (`ls tests/test_build_feed_atom.py`).

https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP)_