### PR TITLE
docs: round-4 follow-up — env var coverage, undocumented FEED_GITHUB_*, stale CircuitBreaker claim

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -219,7 +219,7 @@ flowchart LR
 
 - **Process level** — the cron entry point. If `main()` raises, the cron run is the failure unit; this is intentional so a corrupt write doesn't ship a half-built feed.
 - **Provider level** — `_collect_items` wraps each provider's loader in a try/except so one provider's exception cannot drop the others' items. The ThreadPoolExecutor + Apex-Phase-1 deadline-eviction loop bounds wall-clock for unresponsive providers.
-- **Call level** — `request_safe` is the per-call security state machine (§2). `CircuitBreaker` is a Saboteur-pass primitive available for adoption (currently used by Google Places and as a pattern reference for future providers).
+- **Call level** — `request_safe` is the per-call security state machine (§2). `CircuitBreaker` is a Saboteur-pass primitive available for adoption; the shared `src.utils.circuit_breaker.CircuitBreaker` class wraps the OSM client (`src/places/osm_client.py`), the HAFAS client (`src/places/hafas_client.py`) and the Stammstrecke Hbf monitor (`scripts/update_stammstrecke_hbf.py`). Google Places (`src/places/client.py`) carries an ad-hoc inline 5xx-counter breaker rather than the shared primitive — same pattern, separate state.
 - **Transport level** — `JitterRetry` (in `session_with_retries`) handles transient 5xx / connection-reset with jittered exponential backoff. `PinnedHTTPSAdapter` keeps the TLS handshake's SNI on the original hostname while the TCP connect targets the resolved (vetted) IP.
 - **Payload level** — once bytes arrive, every provider validates the top-level type (Zero-Trust shape), handles `RecursionError` from JSON depth-bombs, and operates within the 10 MB body cap.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -139,19 +139,26 @@ schreibt. Die wichtigsten Parameter:
 | Variable                 | Zweck / Standardwert                                                            |
 | ------------------------ | ------------------------------------------------------------------------------- |
 | `OUT_PATH`               | Zielpfad für den RSS-Feed (Standard `docs/feed.xml`).                           |
-| `FEED_TITLE` / `DESC`    | Titel und Beschreibung des Feeds.                                               |
+| `FEED_TITLE` / `FEED_DESC` | Titel und Beschreibung des Feeds (Standards: `"ÖPNV Störungen Wien & Pendler"` / `"Aktive Störungen/Baustellen/Einschränkungen aus offiziellen Quellen"`). |
 | `FEED_LINK`              | Referenz-URL (nur http/https, Standard: GitHub-Repository).                     |
 | `MAX_ITEMS`              | Anzahl der Einträge im Feed (Standard 10).                                      |
 | `FEED_TTL`               | Cache-Hinweis für Clients in Minuten (Standard 15).                             |
 | `MAX_ITEM_AGE_DAYS`      | Maximales Alter von Meldungen aus den Caches (Standard 365).                    |
 | `ABSOLUTE_MAX_AGE_DAYS`  | Harte Altersgrenze für Meldungen (Standard 540).                                |
 | `ENDS_AT_GRACE_MINUTES`  | Kulanzfenster für vergangene Endzeiten (Standard 10 Minuten).                   |
+| `FRESH_PUBDATE_WINDOW_MIN` | Toleranzfenster (Minuten) für „frische" pubDates beim Aging-Check (Standard 5). |
+| `CACHE_MAX_AGE_HOURS`    | Maximalalter der Provider-Cache-Dateien, ab dem eine Warnung im Log erscheint (Standard 24). |
+| `FEED_TITLE_CHAR_LIMIT` / `DESCRIPTION_CHAR_LIMIT` | Maximale Zeichenzahl für Item-Titel/Beschreibungen (Standards 256 / 4000). Nur Verkleinerung wirksam — Sicherheits-Hardening-Ceiling. |
 | `PROVIDER_TIMEOUT`       | Globales Timeout für Netzwerkprovider (Standard 25 Sekunden). Per Provider via `PROVIDER_TIMEOUT_<NAME>` oder `<NAME>_TIMEOUT` anpassbar. |
 | `PROVIDER_MAX_WORKERS`   | Anzahl paralleler Worker (0 = automatisch). Feiner steuerbar über `PROVIDER_MAX_WORKERS_<GRUPPE>` bzw. `<GRUPPE>_MAX_WORKERS`. |
 | `WL_ENABLE` / `OEBB_ENABLE` / `BAUSTELLEN_ENABLE` / `STAMMSTRECKE_ENABLE` | Aktiviert bzw. deaktiviert die einzelnen Default-Provider (alle Standard: aktiv). `STAMMSTRECKE_ENABLE` steuert den VOR/VAO-basierten Verspätungs- und Ausfall-Monitor. Eine separate `VOR_ENABLE`-Variable existiert seit der 2026-05-11-Konsolidierung **nicht mehr**. |
-| `LOG_DIR`, `LOG_MAX_BYTES`, `LOG_BACKUP_COUNT`, `LOG_FORMAT` | Steuerung der Logging-Ausgabe (`log/errors.log`, `log/diagnostics.log`). |
-| `STATE_PATH`, `STATE_RETENTION_DAYS` | Pfad & Aufbewahrung für `data/first_seen.json`.                      |
+| `WL_RSS_URL` / `OEBB_RSS_URL` / `BAUSTELLEN_DATA_URL` / `OVERPASS_URL` | Override der Upstream-URLs. Validiert gegen eine Allow-List bekannter Hosts; abweichende Werte werden ignoriert und der Default verwendet (siehe Modul-Docstrings für Details). |
+| `OEBB_ONLY_VIENNA`       | Strikte ÖBB-Filterung (`1`/`true`/`0`/`false`, Standard `false`): nur Meldungen mit explizitem Wien-Bezug akzeptieren — keine Pendlerbahnhof-Fallbacks (siehe [`docs/reference/oebb_provider_logic.md`](reference/oebb_provider_logic.md)). |
+| `WIEN_OEPNV_OSM_ENRICH`  | Setzt `0` im CI, sobald `scripts/check_overpass_status.py` einen Mirror-Outage detektiert; überspringt dann den OSM-Anreicherungs-Schritt in `scripts/update_station_directory.py`. |
+| `LOG_LEVEL`, `LOG_DIR`, `LOG_MAX_BYTES`, `LOG_BACKUP_COUNT`, `LOG_FORMAT` | Steuerung der Logging-Ausgabe (`log/errors.log`, `log/diagnostics.log`). `LOG_LEVEL` Standard `INFO`; `LOG_FORMAT=json` aktiviert JSON-Logs. |
+| `STATE_PATH`, `STATE_RETENTION_DAYS` | Pfad & Aufbewahrungstage für `data/first_seen.json` (Standard 60 Tage).        |
 | `WIEN_OEPNV_CACHE_PRETTY` | Steuert die Formatierung der Cache-Dateien (`1` = gut lesbar, `0` = kompakt). |
+| `WIEN_OEPNV_DEBUG`       | Auf `1` gesetzt zeigt die CLI (`python -m src.cli`) bei Fehlern den vollständigen Traceback; Standard verhält sich fail-secure (keine Trace-Ausgabe). |
 
 Alle Pfade werden durch `resolve_env_path` (in `src/feed/config.py`) auf `docs/`, `data/` oder `log/` beschränkt, um Path-Traversal zu verhindern.
 
@@ -439,7 +446,7 @@ Die wichtigsten GitHub Actions:
 - `test.yml` & `test-vor-api.yml` – führen die vollständige Test-Suite bzw. VOR-spezifische Integrationstests aus; `test.yml` läuft bei jedem Push sowie Pull Request und stellt die kontinuierliche Testabdeckung sicher.
 - `mypy-strict.yml`, `bandit.yml`, `codeql.yml`, `complexity-gate.yml`, `seo-guard.yml` – ergänzende Qualitäts-Gates (strikte Typprüfung, Security-Lint, CodeQL-Scan, Komplexitäts-Baseline, SEO/Sitemap-Pflege).
 
-Der `update-cycle.yml`-Job committet alle Cache-, Feed- und Statistik-Outputs in einem einzigen Commit; ein direkter `needs:`-Trigger zwischen Workflows ist damit unnötig. Andere Cache-Update-Workflows (`update-*-cache.yml`) committen ihre Ergebnisse einzeln und werden vom nächsten Cycle-Lauf eingelesen.
+Der `update-cycle.yml`-Job committet alle Cache-, Feed- und Statistik-Outputs in einem einzigen Commit; ein direkter `needs:`-Trigger zwischen Workflows ist damit unnötig. Eigenständige `update-<provider>-cache.yml`-Workflows gibt es seit der DAG-zu-Single-Job-Migration (2026-05-09) nicht mehr — alle Cache-Fetcher (`update_wl_cache.py`, `update_oebb_cache.py`, `update_baustellen_cache.py`) sind Schritte innerhalb von `update-cycle.yml`. Wer einzelne Cache-Fetcher außerhalb des Cycles manuell auslösen will, ruft das jeweilige Skript per `python -m src.cli cache update <provider>` direkt auf oder triggert den vollständigen `manual-full-refresh.yml`-Job.
 
 ## Skripte im Überblick
 
@@ -501,7 +508,7 @@ benötigt werden (z. B. `--no-download` für die WL-OGD-CSVs).
 - **Tests**: `python -m pytest` führt über 2600 Unit- und Integrationstests in rund 400 Modulen unter `tests/` aus.
 - **Kontinuierliche Tests**: Die GitHub Action `test.yml` automatisiert die im Audit empfohlene regelmäßige Testausführung und bricht Builds bei fehlschlagender Test-Suite ab.
 - **Statische Analyse & Typprüfung**: `ruff check` (Stil/Konsistenz, Regelgruppen `E`, `F`, `S`, `B`, `UP` — siehe `pyproject.toml`) und `mypy --strict` (vollständige Typabdeckung über `src/` und `tests/`, derzeit 0 Errors) laufen identisch zur CI via `python -m src.cli checks`. Optional lassen sich über `--fix` Ruff-Autofixes aktivieren oder zusätzliche Argumente an Ruff durchreichen. Ein zusätzlicher `mypy-strict.yml`-Workflow setzt das Allowlist-Gate auf Pull Requests durch.
-- **Pre-Commit-Hooks**: `.pre-commit-config.yaml` aktiviert lokale Checks (Ruff, mypy, Secret-Scan, Whitespace-Hygiene) bei jedem `git commit`. Einmalig nach dem Klonen `pre-commit install` ausführen — Details in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+- **Pre-Commit-Hooks**: `.pre-commit-config.yaml` aktiviert lokale Checks bei jedem `git commit`: Ruff, `mypy --strict`, Bandit, der eigene Secret-Scanner (`scripts/scan_secrets.py`), das C901-Komplexitäts-Gate (`scripts/check_complexity.py`) sowie Whitespace-/Merge-Conflict-/YAML-/TOML-/JSON-/Large-File-Hygiene. Einmalig nach dem Klonen `pre-commit install` ausführen — Details in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 - **Logging**: Zur Laufzeit entsteht `log/errors.log` mit rotierenden Dateien; Größe und Anzahl sind konfigurierbar.
 
 ## Developer Experience & Observability
@@ -524,6 +531,22 @@ Die neue Kommandozeile (`python -m src.cli`) bündelt bisher verstreute Skripte.
 ### Logging & Beobachtbarkeit
 
 Die CLI respektiert die vorhandene Logging-Konfiguration (`log/errors.log`, `log/diagnostics.log`). Für Ad-hoc-Audits lassen sich Berichte und Skriptausgaben über `--output`-Parameter in nachvollziehbaren Pfaden versionieren. Jeder Feed-Build erzeugt zusätzlich einen aktuellen Gesundheitsbericht unter `docs/feed-health.md` (lokal nach jedem Build, nicht im Repository versioniert).
+
+### Optionale GitHub-Issue-Auto-Erstellung bei Feed-Build-Fehlern
+
+Operator:innen können den Feed-Builder so konfigurieren, dass er bei Fehlern automatisch ein GitHub Issue im konfigurierten Repository öffnet (`src/feed/reporting.py:_GithubIssueConfig`). Die Funktion ist standardmäßig **deaktiviert**; sie wird erst aktiv, wenn `FEED_GITHUB_CREATE_ISSUES=true` gesetzt ist und sowohl ein Repository als auch ein Token vorliegen:
+
+| Variable | Zweck |
+| --- | --- |
+| `FEED_GITHUB_CREATE_ISSUES` | Master-Switch (`true`/`false`, Standard `false`). |
+| `FEED_GITHUB_REPOSITORY` | Ziel-Repository im Format `owner/name`. Fallback `GITHUB_REPOSITORY` (von GitHub Actions automatisch gesetzt). Wird gegen die GitHub-Slug-Grammatik validiert. |
+| `FEED_GITHUB_TOKEN` | API-Token mit `issues:write`. Fallback `GITHUB_TOKEN`. Wird ausschließlich an vertrauenswürdige GitHub-API-Hosts gesendet. |
+| `FEED_GITHUB_API_URL` | Optionaler API-Base-Override (z. B. GitHub Enterprise `https://<host>/api/v3`). Fallback `GITHUB_API_URL`, Default `https://api.github.com`. |
+| `FEED_GITHUB_ENTERPRISE_HOSTS` | CSV-Allowlist erlaubter GHE-Hosts; muss bei nicht-public-GitHub-API gesetzt sein, sonst lehnt der Reporter den Call ab und der Token verlässt den Prozess nicht. |
+| `FEED_GITHUB_ISSUE_LABELS` / `_ASSIGNEES` | Komma-separierte Listen für Issue-Labels/Assignees. |
+| `FEED_GITHUB_ISSUE_TITLE_PREFIX` | Titel-Präfix (Standard `"Fehlerbericht"`). |
+
+Sicherheits-Gates: Der Reporter validiert das Repo-Slug gegen GitHubs Naming-Grammatik (`owner` 1-39 Zeichen alphanumerisch/Bindestrich, `name` 1-100 Zeichen `[A-Za-z0-9._-]`) und akzeptiert als API-Host **nur** `api.github.com` (öffentliches GitHub) oder Hosts, die explizit über `FEED_GITHUB_ENTERPRISE_HOSTS` gewhitelistet wurden. Eine fehlkonfigurierte `FEED_GITHUB_API_URL` führt deshalb nicht zur Token-Exfiltration.
 
 ## Authentifizierung & Sicherheit
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,8 @@ dnspython>=2.0.0,<3
 # XXE Mitigation applied
 # pyhafas removed 2026-05-09: the released wheel on PyPI does not export
 # ``pyhafas.profile.OEBBProfile`` so the Stammstrecke monitor was migrated
-# to the VOR/VAO ReST ``/trip`` endpoint (see scripts/update_stammstrecke_status.py).
+# to the VOR/VAO ReST API. The active producer since 2026-05-15 is
+# ``scripts/update_stammstrecke_hbf.py`` (``/departureBoard`` at Wien Hbf);
+# it reuses the shared infrastructure (pending-trip ledger, quota charger,
+# circuit breaker tuning) from the legacy ``scripts/update_stammstrecke_status.py``
+# via import.


### PR DESCRIPTION
## Summary

Fourth pass on the documentation. Did an exhaustive env-var-by-env-var cross-check between `src/` + `scripts/` and the documented configuration table, surfaced an entirely undocumented operator feature (`FEED_GITHUB_*` issue auto-creation), and corrected two stale architectural claims.

## What changed

### Env var table fixes (`docs/development.md`)

- **Typo**: `FEED_TITLE / DESC` row referenced `DESC` but the actual env var is `FEED_DESC`. Corrected, and added the default strings for both fields.
- **Missing user-facing entries added**:
  - `FRESH_PUBDATE_WINDOW_MIN` (default 5)
  - `CACHE_MAX_AGE_HOURS` (default 24)
  - `FEED_TITLE_CHAR_LIMIT` / `DESCRIPTION_CHAR_LIMIT` (256/4000)
  - `WL_RSS_URL` / `OEBB_RSS_URL` / `BAUSTELLEN_DATA_URL` / `OVERPASS_URL` — upstream host overrides (allow-list validated)
  - `OEBB_ONLY_VIENNA` — strict Wien-only filter for ÖBB
  - `WIEN_OEPNV_OSM_ENRICH` — OSM enrichment toggle
  - `LOG_LEVEL` (default INFO) — was missing from the LOG_* group
  - `WIEN_OEPNV_DEBUG` — CLI traceback-on-error flag
- Also surfaced the `STATE_RETENTION_DAYS` default (60 days), which had no number in the previous row.

### Newly documented feature

- **`FEED_GITHUB_*` issue auto-creation** (`docs/development.md` "Developer Experience & Observability" section). The feed builder can create GitHub Issues on errors when configured; entirely undocumented before. Lists all seven env vars, the GHE-host allowlist requirement, and the security gates that prevent token exfiltration.

### Stale claim corrections

- **`docs/architecture.md` §3** — Call-level bullet claimed `CircuitBreaker` is "currently used by Google Places". Actually, `src/places/client.py` uses an ad-hoc inline 5xx-counter, NOT the shared `src.utils.circuit_breaker.CircuitBreaker` class. The shared class actually wraps OSM, HAFAS and the Stammstrecke Hbf monitor.
- **`docs/development.md` automatisierte Workflows** — Line claimed "Andere Cache-Update-Workflows (`update-*-cache.yml`) committen ihre Ergebnisse einzeln" — but those per-provider workflows were retired with the 2026-05-09 DAG-to-single-job migration. Updated to describe the actual setup.
- **Pre-commit hook list** — was incomplete (missed Bandit, C901, JSON/TOML/YAML/large-file checks). Expanded to match `.pre-commit-config.yaml`.
- **`requirements.txt`** — pyhafas-removal comment pointed at `update_stammstrecke_status.py` as the active producer; with the 2026-05-15 `/departureBoard` migration that's now the legacy module. Updated.

## Verification

- Verified env var defaults against `src/config/defaults.py:31-58`.
- Verified `_GithubIssueConfig` env var names against `src/feed/reporting.py:870-905`.
- Verified the shared CircuitBreaker users via `grep -rn "CircuitBreaker(" src/ scripts/`: OSM (`osm_client.py:147`), HAFAS (`hafas_client.py:127`), Stammstrecke (`update_stammstrecke_hbf.py:442`, `_status.py:387`). Google Places (`places/client.py:401-403`) uses an inline counter.
- Verified `.github/workflows/` actually has no `update-*-cache.yml` files anymore — just the consolidated `update-cycle.yml`.
- Confirmed `.pre-commit-config.yaml` hook list matches the new prose.

## Test plan

- [ ] Skim each updated section for German prose flow.
- [ ] Confirm the new `FEED_GITHUB_*` subsection renders cleanly.
- [ ] `grep -rn "DESC" docs/development.md` should no longer find the standalone `DESC` env var name (only legitimate uses like `DESCRIPTION_CHAR_LIMIT`).

https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP)_