### PR TITLE
docs: round-6 follow-up — re-export precision, two-gate VOR quota, ÖBB env vars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Dieses Dokument dient als Leitfaden für KI-Agenten, die an diesem Repository ar
 
 Das Projekt `wien-oepnv` aggregiert Verkehrsmeldungen (Wiener Linien, ÖBB, Stadt-Wien-Baustellen plus den VOR/VAO-basierten S-Bahn-Stammstrecken-Monitor) und stellt sie als RSS-Feed sowie JSON-Daten bereit. Es legt höchsten Wert auf **Reproduzierbarkeit**, **Sicherheit** und **Datenintegrität**.
 
-> **Hinweis zum VOR-Scope:** Seit der Konsolidierung vom 2026-05-11 ist VOR **kein eigenständiger Disruption-Provider** mehr (das frühere `src/providers/vor.py:fetch_events` wurde entfernt). Die VOR/VAO ReST API wird ausschließlich vom Stammstrecken-Verspätungs- und Ausfall-Monitor (`scripts/update_stammstrecke_hbf.py`) konsumiert. Wer einen neuen VOR-Konsumenten plant, muss das Tagesbudget (100 Requests; aktuell sind 48 davon vom Hbf-Monitor belegt) sowie den `_charge_one_request`-Quota-Gate beachten — Details in `docs/architecture.md` §7.
+> **Hinweis zum VOR-Scope:** Seit der Konsolidierung vom 2026-05-11 ist VOR **kein eigenständiger Disruption-Provider** mehr (das frühere `src/providers/vor.py:fetch_events` wurde entfernt). Die VOR/VAO ReST API wird ausschließlich vom Stammstrecken-Verspätungs- und Ausfall-Monitor (`scripts/update_stammstrecke_hbf.py`) konsumiert. Wer einen neuen VOR-Konsumenten plant, muss zwei Quota-Schichten beachten: (a) das Workflow-Pre-Flight-Gate `scripts/preflight_quota_check.py` (verhindert Cron-Ticks, sobald der persistierte Counter das Tagesbudget reißen würde), und (b) die per-Call-Funktion `_charge_one_request` in `scripts/update_stammstrecke_status.py` (importierbar; reserviert einen Quota-Slot **vor** jedem Network Call). Tagesbudget: 100 Requests, aktuell 48 davon vom Hbf-Monitor belegt — Details in `docs/architecture.md` §7.
 
 ### Wichtige Verzeichnisse
 - `src/`: Der gesamte Quellcode des Pakets.
@@ -48,8 +48,8 @@ Wichtige Befehle:
     - Secrets werden über Umgebungsvariablen oder `.env`-Dateien (nicht eingecheckt!) geladen.
 
 2.  **Dateisystem & Pfade**:
-    - Verwende **immer** `validate_path` oder `resolve_env_path` aus `src.feed.config` (bzw. Import via `src.build_feed`), wenn Dateipfade aus Konfigurationen verarbeitet werden.
-    - Schreiben ist nur in `docs/`, `data/` und `log/` erlaubt (Path-Traversal-Schutz).
+    - Verwende **immer** `validate_path` oder `resolve_env_path` aus `src.feed.config`, wenn Dateipfade aus Konfigurationen verarbeitet werden. (`src.build_feed` re-exportiert nur `validate_path` als Test-Hook; `resolve_env_path` ist ausschließlich aus `src.feed.config` importierbar.)
+    - Schreiben ist nur in `docs/`, `data/` und `log/` erlaubt (Path-Traversal-Schutz; siehe `ALLOWED_ROOTS` in `src/feed/config.py`).
     - Verwende `src.utils.files.atomic_write` für alle Dateischreibvorgänge, um Atomizität und korrekte Berechtigungen sicherzustellen.
     - Tests, die temporäre Dateien benötigen, sollten diese in `data/` erstellen, um Path-Traversal-Checks zu bestehen.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -223,14 +223,15 @@ Der Meldungsfeed sammelt offizielle Störungs- und Hinweisinformationen der Wien
   - Eine Meldung wird akzeptiert, wenn sie das Keyword "Wien"/"Vienna" oder einen expliziten Wiener Bahnhof enthält.
   - Meldungen, die *nur* Pendlerbahnhöfe (ohne Wien-Bezug) oder *nur* ferne Bahnhöfe erwähnen, werden verworfen.
   - Dies stellt sicher, dass "Störungen im Bereich Mödling" ohne Wien-Bezug (z. B. Richtung Süden) nicht einfließen, solange keine Auswirkung auf die Wien-Verbindung explizit genannt ist (siehe [data/stations.json](../data/stations.json) für Definitionen von `in_vienna` und `pendler`).
-- **Quelle**: Offizielle ÖBB-Störungsinformationen.
+  - Mit `OEBB_ONLY_VIENNA=1` lässt sich der Fallback auf reine Pendler-Bahnhof-Routen abschalten — siehe [`docs/reference/oebb_provider_logic.md`](reference/oebb_provider_logic.md).
+- **Quelle**: Offizielle ÖBB-Störungsinformationen (RSS-Feed; Default-URL via `OEBB_RSS_URL` überschreibbar, validiert gegen die `fahrplan.oebb.at`-Allow-List).
 - **Cache**: `cache/oebb/events.json`.
 
 ### Verkehrsverbund Ost-Region (VOR)
 
 - **Anforderung**: VAO-Tagesbudget (100 Requests/Tag) wird seit 2026-05-11 ausschließlich vom S-Bahn-Stammstrecken-Monitor verbraucht. Seit der 2026-05-15-Migration auf `/departureBoard` am Wien Hauptbahnhof sind das **48 Calls/Tag** (1 Hbf-Call × ~48 Cycles statt vorher 2 `/trip`-Calls × 48 Cycles). Ein automatisiertes Disruption-Polling existiert nicht mehr (Operator-Policy "VOR nur für die Stammstrecke").
 - **Quelle**: VOR/VAO-ReST-API (`/departureBoard`-Endpunkt am Wien Hauptbahnhof), authentifiziert über Access Token.
-- **Persistenz**: keine eigene JSON-Cache-Datei mehr; der Stammstrecken-Monitor schreibt Beobachtungen direkt in den CSV-Ledger `data/stats/stammstrecke_<YYYY>.csv` (siehe [`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md)).
+- **Persistenz**: keine eigene JSON-Cache-Datei mehr; der Stammstrecken-Monitor schreibt Beobachtungen direkt in zwei CSV-Ledgers: `data/stats/stammstrecke_<YYYY>.csv` (aggregierte Verspätungen pro Richtung und Tick) und `data/stats/ausfaelle_<YYYY>.csv` (eine Zeile pro entdecktem Ausfall, dedupliziert via Pending-Trip-Ledger unter `cache/stammstrecke/`). Siehe [`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md).
 
 ### Stadt Wien – Baustellen
 


### PR DESCRIPTION
## Summary

Sixth pass focused on previously-too-loose claims in `AGENTS.md` and `docs/development.md` that were technically true at the surface but imprecise enough to mislead a careful reader.

## What changed

- **`AGENTS.md` path-validation paragraph** — claimed both `validate_path` AND `resolve_env_path` are importable "via `src.build_feed`". Only the former is: `src/build_feed.py:82` explicitly aliases `validate_path = feed_config.validate_path` as a test hook, but `resolve_env_path` has no such re-export (`grep "resolve_env_path" src/build_feed.py` returns no matches). Also pinned the `ALLOWED_ROOTS` constant as the canonical reference for the `docs/`/`data/`/`log/` allowlist.
- **`AGENTS.md` VOR-scope callout** — referenced only `_charge_one_request` for new VOR consumers. Actual defense-in-depth has TWO gates: workflow-level pre-flight (`scripts/preflight_quota_check.py`) AND per-call `_charge_one_request`. Documented both layers so a future agent doesn't bypass the pre-flight by accident.
- **`docs/development.md` ÖBB provider section**:
  - "Quelle: Offizielle ÖBB-Störungsinformationen." dropped the `OEBB_RSS_URL` env var that the WL section (line 204) correctly names for its own counterpart. Aligned both — the env exists in `src/providers/oebb.py:92` and is allow-list-validated against `fahrplan.oebb.at`.
  - Added a one-line `OEBB_ONLY_VIENNA` mention pointing at the reference doc so operators discover the strict-Wien filter from the dev-doc index, not only from the deep-link.
- **`docs/development.md` VOR persistence bullet** — only named the `stammstrecke_<YYYY>.csv` ledger; the Hbf monitor also writes to `ausfaelle_<YYYY>.csv` (added 2026-05-15) and maintains the pending-trip JSON sidecars under `cache/stammstrecke/`. Spelled out both outputs and the sidecar path so the Persistenz row matches the actual on-disk surface.

## Verification

- Verified `validate_path` re-export: `src/build_feed.py:82` (`validate_path = feed_config.validate_path`). `__all__ = ["RunReport", "ThreadPoolExecutor", "feed_config"]` at line 69 doesn't include either name; the re-export is informal but works.
- Verified `resolve_env_path` is NOT in `src/build_feed.py` (no matches via grep).
- Verified `_charge_one_request` exists in `scripts/update_stammstrecke_status.py:888`.
- Verified `OEBB_RSS_URL` is allow-list-validated in `src/providers/oebb.py:92`.
- Verified `OEBB_ONLY_VIENNA` is consumed in `src/providers/oebb.py:103`.
- Verified the Hbf script writes both `stammstrecke_*.csv` and `ausfaelle_*.csv` via `append_stammstrecke_row` / `append_ausfall_row` from `src.utils.stats`.

## Test plan

- [ ] Skim each updated section for German prose flow.
- [ ] Confirm no further drift surfaces (`grep -rn "resolve_env_path" src/build_feed.py` should be empty; `grep -n "validate_path =" src/build_feed.py` should show the alias).

https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP)_