### PR TITLE
docs: round-7 follow-up — FEED_GITHUB_* HTTPS pin, ÖBB row source fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Das Projekt unterscheidet konsequent zwischen *Live-Verkehrsmeldungen* (treiben 
 | Quelle | Zweck |
 | --- | --- |
 | **Wiener Linien (WL)** | Störungs- und Baustellenmeldungen für U-Bahn, Straßenbahn und Bus innerhalb des WL-Netzes. |
-| **ÖBB** | Bundesweite Bahnmeldungen mit Wien-Filter; Stammstrecken-Verspätungs-Snapshots fließen in die Statistik. |
+| **ÖBB** | Bundesweite Bahnmeldungen mit Wien-Filter (RSS-Feed, `OEBB_RSS_URL`-konfigurierbar). |
 | **VOR/VAO** | Regionalverkehr Wien/Niederösterreich/Burgenland. Wird seit 2026-05-11 ausschließlich für den Stammstrecken-Monitor genutzt (siehe `docs/architecture.md` §7). |
 | **OGD Stadt Wien** | Offizielle Baustellendaten der Stadt Wien (Bezirk, Zeitraum, Geo-Infos). |
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -547,7 +547,7 @@ Operator:innen können den Feed-Builder so konfigurieren, dass er bei Fehlern au
 | `FEED_GITHUB_ISSUE_LABELS` / `_ASSIGNEES` | Komma-separierte Listen für Issue-Labels/Assignees. |
 | `FEED_GITHUB_ISSUE_TITLE_PREFIX` | Titel-Präfix (Standard `"Fehlerbericht"`). |
 
-Sicherheits-Gates: Der Reporter validiert das Repo-Slug gegen GitHubs Naming-Grammatik (`owner` 1-39 Zeichen alphanumerisch/Bindestrich, `name` 1-100 Zeichen `[A-Za-z0-9._-]`) und akzeptiert als API-Host **nur** `api.github.com` (öffentliches GitHub) oder Hosts, die explizit über `FEED_GITHUB_ENTERPRISE_HOSTS` gewhitelistet wurden. Eine fehlkonfigurierte `FEED_GITHUB_API_URL` führt deshalb nicht zur Token-Exfiltration.
+Sicherheits-Gates: Der Reporter validiert das Repo-Slug gegen GitHubs Naming-Grammatik (`owner` 1-39 Zeichen alphanumerisch/Bindestrich, `name` 1-100 Zeichen `[A-Za-z0-9._-]`) und akzeptiert als API-Host **nur** `api.github.com` (öffentliches GitHub) oder Hosts, die explizit über `FEED_GITHUB_ENTERPRISE_HOSTS` gewhitelistet wurden. Seit [PR #1512](https://github.com/Origamihase/wien-oepnv/pull/1512) ist der Scheme zusätzlich auf **`https://` gepinnt** — `http://`-URLs werden auch bei korrektem Host abgelehnt, damit der Bearer-Token niemals im Klartext über die Leitung geht. Eine fehlkonfigurierte `FEED_GITHUB_API_URL` führt deshalb nicht zur Token-Exfiltration.
 
 ## Authentifizierung & Sicherheit
 


### PR DESCRIPTION
## Summary

Seventh pass surfaced two precision drifts: one freshly introduced by yesterday's #1512 (HTTPS-pin merged after my round-4 docs landed), and one stale source attribution in the README table.

## What changed

- **`docs/development.md` FEED_GITHUB_* security-gates paragraph** — predated the [PR #1512](https://github.com/Origamihase/wien-oepnv/pull/1512) HTTPS-pin. The scheme check in `src/feed/reporting.py:_is_trusted_github_api` was tightened from `in {"http", "https"}` to exact `"https"` (line 967), so `http://api.github.com` is now rejected. Added a one-line callout to the gates paragraph so operators know `http://` URLs won't carry the bearer token even on a trusted host.
- **`README.md` "Verkehrsmeldungen (Live-Feed)" table** — the ÖBB row attributed "Stammstrecken-Verspätungs-Snapshots" to ÖBB. Those snapshots actually come from the VOR/VAO API (next row, which already documents the Stammstrecke-only scope correctly). Rewrote the ÖBB row to mention the actual env-var (`OEBB_RSS_URL`) and dropped the misleading Stammstrecke claim so each source's row is now consistent with its actual contribution.

## Verification

- Verified the HTTPS-pin in `src/feed/reporting.py:967` (`if parsed.scheme.lower() != "https": return False`). Lines 947–952 carry an explicit "Security (HTTPS-only Validator Drift)" comment block.
- Verified the VOR row in the README still correctly attributes Stammstrecke to the VOR/VAO API.
- Cross-referenced the actual Stammstrecke producer (`scripts/update_stammstrecke_hbf.py`) which polls VAO `/departureBoard`, not the ÖBB RSS feed.

## Test plan

- [ ] Skim the FEED_GITHUB_* gates paragraph and the README data-source table.
- [ ] Confirm no further URL-scheme drift surfaces: `grep -n "http:" docs/development.md` should not show the FEED_GITHUB-related rows accepting `http://`.

https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP)_