### PR TITLE
docs: round-9 follow-up — sequence diagram cache-fetchers list

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ sequenceDiagram
     participant Cron as cron / GH Action
     participant Build as build_feed.main
     participant Collect as _collect_items
-    participant Cache as Cache fetchers<br/>(WL+ÖBB cache)
+    participant Cache as Cache fetchers<br/>(WL + ÖBB + Baustellen + Stammstrecke)
     participant Pool as ThreadPoolExecutor
     participant WL as WL.fetch_events
     participant OEBB as ÖBB.fetch_events


### PR DESCRIPTION
## Summary

Single targeted fix in the §1 sequence diagram in `docs/architecture.md`. After eight previous review rounds, this is the only meaningful drift I found this pass.

## What changed

- **`docs/architecture.md` §1 sequence diagram, Cache participant label** — was `Cache fetchers (WL+ÖBB cache)`, a snapshot from before Baustellen (2026-04) and Stammstrecke (2026-05-09 CSV-ledger migration) entered the `cache_fetchers` bucket. Per the current `src/feed/providers.py:register_default_providers`, all four default providers — WL, ÖBB, Baustellen, Stammstrecke — run as sync `cache_fetchers` (each loader carries `_provider_cache_name`, which is what `_categorize_providers` uses to route the loader into the sync bucket). Updated the label to enumerate all four so the reader sees the actual on-disk cache-fetcher set, not a two-year-old subset.

The par block below the cache fetchers still shows WL/ÖBB/VOR as network-mode examples for plug-in providers. That section is explicitly contextualised by the "Hinweis zum aktuellen Default-Setup" callout above the diagram (added in PR #1507) — those names are illustrative of the design pattern, not the current production path, so I left them as-is.

## Verification

- `grep -n "register_provider" src/feed/providers.py` confirms the four registered default providers (`WL_ENABLE`, `OEBB_ENABLE`, `BAUSTELLEN_ENABLE`, `STAMMSTRECKE_ENABLE`).
- `grep -n "_provider_cache_name" src/feed/providers.py` confirms every registered loader carries this attribute via the `register_provider` helper at line 54, so all four route into `cache_fetchers`.

## Test plan

- [ ] Skim the §1 diagram in GitHub's Mermaid renderer to confirm the participant label change is rendered correctly.

https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP)_