### PR TITLE
docs: round-10 follow-up — replace VOR.fetch_events with generic Plugin in §1 diagram

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ sequenceDiagram
     participant Pool as ThreadPoolExecutor
     participant WL as WL.fetch_events
     participant OEBB as ÖBB.fetch_events
-    participant VOR as VOR.fetch_events
+    participant Plug as Plugin.fetch_events<br/>(custom provider)
     participant Safe as request_safe
     participant Up as Upstream API
     participant Merge as _merge_result
@@ -69,13 +69,13 @@ sequenceDiagram
         Up-->>Safe: response
         Safe-->>OEBB: validated body
         OEBB-->>Merge: list[FeedItem]
-    and VOR
-        Pool->>VOR: submit fetch
-        VOR->>Safe: request_safe (per station)
+    and Plugin
+        Pool->>Plug: submit fetch
+        Plug->>Safe: request_safe(session, url, ...)
         Safe->>Up: HTTPS GET (pinned IP)
         Up-->>Safe: response
-        Safe-->>VOR: validated body
-        VOR-->>Merge: list[FeedItem]
+        Safe-->>Plug: validated body
+        Plug-->>Merge: list[FeedItem]
     end
 
     Note over Pool: Apex-Phase-1 deadline-eviction loop:<br/>per-future timeout vs perf_counter()<br/>cancels stragglers


### PR DESCRIPTION
## Summary

Single targeted fix: replace `VOR.fetch_events` with a generic `Plugin.fetch_events` in the §1 sequence diagram. After 9 previous rounds, this is the last substantive drift item I could identify.

## What changed

- **`docs/architecture.md` §1 sequence diagram, third async-branch participant** — was `VOR.fetch_events` with a `request_safe (per station)` annotation. VOR has had no `fetch_events` since the 2026-05-11 consolidation:
  - `src/providers/vor.py` exposes only auth/quota helpers (verified via `__all__` at line 922).
  - `src/config/defaults.py:56-57` explicitly notes `# VOR_ENABLE intentionally absent`.
  - The `per station` annotation referred to the original station-disruption-polling loop that was deleted along with `update_vor_cache.py`.

Replaced with a generic `Plugin.fetch_events (custom provider)` participant. The diagram now illustrates the network-fetcher design pattern via two historical examples (WL, ÖBB — both still have `fetch_events`, even though they no longer go through this path in production) plus a generic plug-in slot, which lines up with the "Hinweis zum aktuellen Default-Setup" callout above the diagram (from PR #1507) describing the async path as "die Plug-in-Aufnahme-Stelle für nicht-cache-basierte Drittprovider".

## Verification

- `grep -n "fetch_events" src/providers/vor.py` returns no matches.
- `grep -n "_BREAKER\|fetch_events" scripts/update_stammstrecke_hbf.py` confirms the only VOR consumer goes through `request_safe` directly from a workflow step, not through `_collect_items`.

## Test plan

- [ ] Visually confirm the Mermaid sequence diagram still renders in GitHub.
- [ ] Confirm no remaining "VOR.fetch_events" references in docs: `grep -rn "VOR\.fetch_events" docs/` should be empty.

https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BwFoEjsLkyLmbWBSB7PukP)_