### PR TITLE
security(logging): add samlart/csrf/xsrf to log redaction regex

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,62 @@
+## 2026-05-16 - `sanitize_log_message` Sibling-Drift Closure (`_keys` + `_header_keys` Regex Alternations Missing `samlart`/`csrf`/`xsrf`): The Parallel-Codepath Sibling Of The 2026-05-16 PR #1531 `_SENSITIVE_QUERY_KEYS` SAML/CSRF/WordPress Round — Same Threat Model (SAML 2.0 Artifact / Bare CSRF/XSRF Credential Leaks Through Operator-Facing Log Streams), Different Consuming Function (The Canonical `sanitize_log_message` Log Sanitizer Called By `sanitize_log_arg` / `clean_message` / `_sanitize_log_detail` Across The Codebase)
+
+**Vulnerability:** PR #1531 closed the SAML/CSRF/WordPress drift in `src/utils/http.py:_SENSITIVE_QUERY_KEYS` — the canonical exact-match set used by `_sanitize_url_for_error` (for URL error-log redaction) AND `_strip_sensitive_params` (for cross-origin redirect protection). That round closed the URL-parsing codepath. BUT the **parallel codepath** in `src/utils/logging.py:sanitize_log_message` (the canonical log sanitizer, called by `sanitize_log_arg` / `clean_message` / `_sanitize_log_detail` across the codebase) has its OWN regex alternation sets (`_keys` for query-form and JSON-form redaction, `_header_keys` for HTTP-Header-form redaction) — and those sets SHARE the drift with `_SENSITIVE_QUERY_KEYS`. Pre-fix every leaked URL / header / JSON document containing `SAMLArt=...`, `_csrf=...`, `xsrf=...`, `X-CSRF: ...`, `XSRF: ...`, or `"samlart": "..."` that passed through `sanitize_log_message` (the dominant log-sanitization entry point) landed the credential VERBATIM in operator log streams. The two consuming functions cover COMPLEMENTARY surface area: `_sanitize_url_for_error` requires a valid URL parsable by `urlparse`, while `sanitize_log_message` handles RAW LOG TEXT (multi-line tracebacks, JSON snippets embedded in error strings, `Header: Value` pairs, `key=value&...` fragments embedded in prose, partial URL fragments — anything that `urlparse` would reject). PR #1531 closed only Path 1; this round closes Path 2.
+
+**Pre-fix inventory (PoC verified):**
+- `samlart` (SAML 2.0 Artifact) — NOT in `_keys` regex, NOT in `_header_keys` regex. **LEAKS in query/header/JSON forms**.
+- Bare `csrf` (Spring `_csrf` normalised; bare `csrf` token name) — NOT in either regex. **LEAKS**. (The `csrf_token` / `XSRF-TOKEN` suffixed variants are ALREADY covered via the existing `[a-z0-9_.\-]*token` alternation; only the bare forms slipped through.)
+- Bare `xsrf` (Angular bare form, distinct from `XSRF-TOKEN` covered via `token`) — NOT in either regex. **LEAKS**.
+- `relaystate` (SAML 2.0 RelayState) — ALREADY covered via the bare `state` alternation (regex substring match). ✓ no action needed.
+- `_wpnonce` (WordPress nonce) — ALREADY covered via the bare `nonce` alternation (regex substring match). ✓ no action needed.
+
+The sibling-drift gap is therefore THREE new alternations (`samlart` / `csrf` / `xsrf`) added to BOTH `_keys` AND `_header_keys`.
+
+**Threat model:** Same per-credential severity ladder as PR #1531 (SAMLArt HIGH = 5-min ARS-resolvable bearer credential; bare CSRF/XSRF MEDIUM-HIGH = session-lifetime replay) but applied to a DIFFERENT leak surface: the canonical log-sanitization chain (`sanitize_log_arg` → `sanitize_log_message`, and the secondary chain `clean_message` → `sanitize_log_message` and `_sanitize_log_detail` → `clean_message` → `sanitize_log_message`). Every `log.warning("... %s ...", sanitize_log_arg(value))` callsite across `src/` and `scripts/` (the canonical entry point — dozens of sites per the existing journal entries) propagates this drift. Real-world emission patterns reaching this codepath: exception messages embedding URLs with sensitive query params (`log.exception("Request to %s failed: %s", sanitize_log_arg(url), sanitize_log_arg(exc))`), cache-key collision logs, GitHub Issue body sanitization (`feed/reporting.py:clean_message`) for operator-facing issue bodies carrying request URLs / tracebacks, traceback sanitization (`sanitize_log_message(text, strip_control_chars=False)`) for Python tracebacks that include HTTP request URL repr() in their frames, and pre-commit hook diagnostic output when secret-scanner finding context (URL fragments) is sanitized before display.
+
+**Sites closed (2 regex alternation extensions):**
+
+* `src/utils/logging.py:_keys` regex — added `samlart|csrf|xsrf` as bare alternations alongside the existing `nonce|state` style. The regex requires the alternation match to be followed by `=` (query form), `:` (header form via the broader pattern), or `"` (JSON form), so natural-language prose containing "csrf" / "xsrf" / "samlart" WITHOUT a key=value structure is NOT over-redacted. Verified via 9 negative test cases (natural-language sentences, separator-free mentions, English idioms).
+
+* `src/utils/logging.py:_header_keys` regex — added `samlart|csrf|xsrf` alongside the existing `nonce|state` style. Used by the HTTP-Header-form pattern at the consuming-function site `(?i)((?:[-a-zA-Z0-9_]*(?:{_header_keys})[-a-zA-Z0-9_]*):\s*)`. Covers `SAMLArt: ...`, `X-CSRF: ...`, `XSRF: ...` and X-prefixed variants.
+
+Zero changes to the consuming `sanitize_log_message` function body, zero changes to `sanitize_log_arg` / `clean_message` / `_sanitize_log_detail`, zero changes to any callsite, zero C901 complexity impact, zero per-call performance overhead (the regex is compiled once at module-import time per the existing pattern; the alternation grows by 3 entries which is negligible at the regex engine level).
+
+**Severity:** **MEDIUM-HIGH** — the SAMLArt case (HIGH per PR #1531's threat model) is the worst path; bare CSRF/XSRF (MEDIUM-HIGH) are bounded by session lifetime. The propagation is across DOZENS of `sanitize_log_arg(value)` callsites and every `clean_message(text)` invocation in the reporting pipeline (which feeds GitHub Issue bodies, operator-facing `docs/feed-health.md`, and `docs/stations_validation_report.md`). CodeQL / Semgrep do not flag this drift because their default rules cover the well-known token/secret/api_key alternations but not the SAML/CSRF/XSRF specific identifiers.
+
+**Fix:** Two-keyword extension of both regex alternations:
+```python
+_keys = (
+    # ... existing alternations ...
+    r"nonce|state|"
+    r"samlart|csrf|xsrf|"  # NEW
+    # ... rest ...
+)
+_header_keys = (
+    # ... existing alternations ...
+    r"saml[-_.\s]*request|saml[-_.\s]*response|nonce|state|"
+    r"samlart|csrf|xsrf|"  # NEW
+    # ... rest ...
+)
+```
+The bare alternations mirror the existing `nonce|state` style — case-insensitive substring match within the surrounding key=value / Header: Value / JSON pattern. The regex's structural requirements (followed by `=`, `:`, or JSON-quoted form) prevent over-redaction of natural-language prose.
+
+Zero FP risk for the three new keywords: "csrf" / "xsrf" / "samlart" do not appear as substrings of common English words. The bare alternations match only at key-name positions in structured input (query/header/JSON), not in free-form text.
+
+**Tests added:** `tests/test_sentinel_sanitize_log_message_drift.py` — 37 tests across 7 categories:
+  1. Query-form PoCs (8 cases × SAMLArt / _csrf / csrf / CSRF / xsrf / standalone forms): proves the credentials are redacted in `?key=value` / `key=value` log fragments.
+  2. Header-form PoCs (6 cases × `SAMLArt:` / `X-SAMLArt:` / `X-CSRF:` / `CSRF:` / `X-XSRF:` / `XSRF:`): proves the `_header_keys` extension covers bare and X-prefixed header forms.
+  3. JSON-form PoCs (4 cases × `{"key": "value"}` / `{'key': 'value'}`): proves the `_keys` extension covers JSON-style document fragments.
+  4. Regression guards (6 cases): existing alternations (`token` / `password` / `RelayState` via state / `_wpnonce` via nonce / `csrf_token` via token / `XSRF-TOKEN` via token) continue to redact — proves additive change is non-destructive.
+  5. Negative cases (9 cases): natural-language prose containing "csrf" / "xsrf" / "samlart" / "saml" without key=value structure must NOT be redacted — proves regex structural requirements prevent over-redaction.
+  6. `sanitize_log_arg` wrapper PoCs (3 cases): the dominant canonical entry point (`log.warning(..., sanitize_log_arg(value))` callsites) propagates the alternation extension.
+  7. Combined SP-initiated SSO PoC: real-world ACS-POST-failed log line carrying SAMLArt + RelayState side by side — both must be redacted (SAMLArt via new alternation, RelayState via existing `state`).
+
+**Learning:** The codebase has TWO independent redaction codepaths for sensitive credentials in URLs / headers / JSON: (1) the **structured-URL path** (`_SENSITIVE_QUERY_KEYS` + `_SENSITIVE_KEY_SUBSTRINGS` in `src/utils/http.py`) used by `_sanitize_url_for_error` and `_strip_sensitive_params`, and (2) the **raw-text log path** (`_keys` + `_header_keys` regex alternations in `src/utils/logging.py`) used by `sanitize_log_message` / `sanitize_log_arg` / `clean_message` / `_sanitize_log_detail`. The two paths cover complementary input surfaces — structured URLs go through Path 1, raw log text goes through Path 2 — but they share the same KEYWORD LIST contract. **When extending the keyword list, BOTH paths must be updated.** PR #1531 closed Path 1's drift for the SAML/CSRF/WP family; this round closes Path 2. The canonical drift detection: any keyword added to `_SENSITIVE_QUERY_KEYS` should also be checked against `sanitize_log_message`'s `_keys` and `_header_keys`. Future drift rounds should explicitly enumerate both paths in their "Sites closed" section. **The substring-match property of bare regex alternations** (`nonce`, `state`, and now `samlart`/`csrf`/`xsrf`) means that prefix/suffix variants are AUTOMATICALLY covered (`_wpnonce` via `nonce`, `RelayState` via `state`, `_csrf` / `_samlart` via the new entries) — this is more lenient than `_SENSITIVE_QUERY_KEYS`'s exact-match-on-normalised-key contract, which provides a higher SIGNAL-to-noise ratio because the URL-parsing path can be precise about key boundaries while the log-text path must work without structural boundaries.
+
+**Next-round candidates (named-but-deferred):** **OAuth 1.0 `oauth_verifier`** — bare `oauth_verifier` and similar OAuth 1.0 specific parameters not currently covered. **WordPress action-specific nonces (`_ajax_nonce`)** — already partially covered via `nonce` substring, but precise attribution missing. **AWS Sig V4 multi-field `AWS4-HMAC-SHA256`** — still deferred pending body-structure-aware framework. **The five remaining auth-scheme deferred candidates** (Mutual / vapid / SCRAM / Digest / AWS4-HMAC-SHA256 — all multi-field bodies) remain pending body-structure-aware framework architecture.
+
+**Marker:** SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT.
+
 ## 2026-05-16 - `_SENSITIVE_QUERY_KEYS` SAML/CSRF/WordPress Drift: Five High-Impact Query Parameter Names (`SAMLArt`/`RelayState`/`_csrf`/`xsrf`/`_wpnonce`) Leaked Verbatim Across BOTH `_sanitize_url_for_error` (Operator Error-Log Streams) AND `_strip_sensitive_params` (URLs Carried Through Cross-Origin Redirect Chains To Potentially-Malicious Target Hosts) — The Bare-Form Drift Sibling Of The Multi-Round HTTP-Header / Query-Param Redaction Family
 
 **Vulnerability:** `src/utils/http.py:_SENSITIVE_QUERY_KEYS` (the canonical exact-match set used by both `_sanitize_url_for_error` for error-log redaction AND `_strip_sensitive_params` for cross-origin redirect protection) was missing five high-impact query parameter names whose normalised forms (`samlart` / `relaystate` / `csrf` / `xsrf` / `wpnonce`) are NOT substrings of any entry in `_SENSITIVE_KEY_SUBSTRINGS` (the `token` substring catches `csrf_token`, `csrfmiddlewaretoken`, `XSRF-TOKEN` and similar prefixed/suffixed variants — but NOT bare `csrf` / `xsrf` from Spring Security's `_csrf` GET-based protection or Angular's bootstrap `xsrf` cookie). Pre-fix every leaked `?SAMLArt=<60-char-base64>` / `?RelayState=<URL>` / `?_csrf=<UUID>` / `?xsrf=<24-char-token>` / `?_wpnonce=<10-char-hash>` query parameter:

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -281,6 +281,27 @@ def sanitize_log_message(
         r"saml[-_.\s]*request|saml[-_.\s]*response|"
         r"[a-z0-9_.\-]*accessid[a-z0-9_.\-]*|id[-_.\s]*token|[a-z0-9_.\-]*session[-_.\s]*id[a-z0-9_.\-]*|session|cookie|[a-z0-9_.\-]*apikey[a-z0-9_.\-]*|[a-z0-9_.\-]*secret[a-z0-9_.\-]*|ticket|[a-z0-9_.\-]*token|code|key|sig|sid|"
         r"nonce|state|"
+        # Security (sibling-drift closure of PR #1531's
+        # ``_SENSITIVE_QUERY_KEYS`` SAML/CSRF/WordPress round):
+        #   * ``samlart`` — SAML 2.0 Artifact per OASIS SAML 2.0
+        #     §3.6.4. 5-min ARS-resolvable bearer credential. The
+        #     bare ``saml`` substring is NOT in the existing
+        #     alternation (only ``saml-request|saml-response`` are
+        #     present), so a leaked ``SAMLArt=...`` query param /
+        #     ``SAMLArt: ...`` header / ``"samlart": "..."`` JSON
+        #     fragment passing through ``sanitize_log_message`` lands
+        #     verbatim in operator log streams.
+        #   * ``csrf`` / ``xsrf`` — bare CSRF/XSRF token names
+        #     (Spring Security's ``_csrf`` GET-based protection,
+        #     Angular's bare ``xsrf`` cookie). The token-suffixed
+        #     forms (``csrf_token``, ``XSRF-TOKEN``) are ALREADY
+        #     covered via the existing ``[a-z0-9_.\-]*token``
+        #     alternation. Only the bare forms need explicit
+        #     coverage here. The ``RelayState`` and ``_wpnonce``
+        #     siblings from PR #1531 are ALREADY covered via the
+        #     existing ``state`` / ``nonce`` alternations (substring
+        #     match within the longer key name).
+        r"samlart|csrf|xsrf|"
         r"jsessionid|phpsessid|asp\.net_sessionid|__cfduid|"
         r"authorization|auth|bearer[-_.\s]*token|bearer|[a-z0-9_.\-]*api[-_.\s]*key[a-z0-9_.\-]*|[a-z0-9_.\-]*private[-_.\s]*key|auth[-_.\s]*token|"
         r"tenant[-_.\s]*id|tenant|subscription[-_.\s]*id|subscription|object[-_.\s]*id|oid|"
@@ -301,6 +322,12 @@ def sanitize_log_message(
         r"api[-_.\s]*key|token|secret|signature|password|auth|session|cookie|private|"
         r"client[-_.\s]*assertion|[a-z0-9_.\-]*assertion[a-z0-9_.\-]*|"
         r"saml[-_.\s]*request|saml[-_.\s]*response|nonce|state|"
+        # Sibling-drift closure (see ``_keys`` above): ``samlart`` /
+        # ``csrf`` / ``xsrf`` bare header forms (``SAMLArt: ...``,
+        # ``X-CSRF: ...``, ``XSRF: ...``) bypass the existing
+        # alternations. Suffixed variants (``X-CSRF-Token``,
+        # ``X-XSRF-TOKEN``) are already covered via ``token``.
+        r"samlart|csrf|xsrf|"
         r"credential|client[-_.\s]*id|passphrase|access[-_.\s]*key|e[-_.\s]*mail"
     )
 

--- a/tests/test_sentinel_sanitize_log_message_drift.py
+++ b/tests/test_sentinel_sanitize_log_message_drift.py
@@ -1,0 +1,498 @@
+"""Sentinel PoC: ``sanitize_log_message`` sibling-drift closure for the
+2026-05-16 ``_SENSITIVE_QUERY_KEYS`` SAML/CSRF/WordPress round.
+
+The 2026-05-16 PR #1531 closed the SAML 2.0 Artifact / RelayState +
+bare CSRF/XSRF + WordPress ``_wpnonce`` drift in
+``src/utils/http.py:_SENSITIVE_QUERY_KEYS`` (the canonical exact-match
+set used by both ``_sanitize_url_for_error`` and
+``_strip_sensitive_params``). That round closed the URL-path
+redaction surface. BUT — the **parallel codepath** in
+``src/utils/logging.py:sanitize_log_message`` (the canonical log
+sanitizer, called by ``sanitize_log_arg`` and ``clean_message`` and
+``_sanitize_log_detail`` across the codebase) has its OWN regex
+alternation sets (``_keys`` for query/JSON param redaction,
+``_header_keys`` for ``Header: Value`` redaction) — and those sets
+SHARE the drift with ``_SENSITIVE_QUERY_KEYS``.
+
+Pre-fix state inventory (PoC verified):
+
+  * ``samlart`` (SAML 2.0 Artifact) — NOT in ``_keys`` regex, NOT in
+    ``_header_keys`` regex. Leaks verbatim through every
+    ``sanitize_log_message`` invocation.
+  * Bare ``csrf`` (Spring ``_csrf`` normalised) — NOT in ``_keys``,
+    NOT in ``_header_keys``. Leaks verbatim. Note that the existing
+    ``[a-z0-9_.\-]*token`` alternation catches the SUFFIXED form
+    (``csrf_token``, ``XSRF-TOKEN``) but NOT the bare form.
+  * Bare ``xsrf`` (Angular bare form) — NOT in ``_keys``, NOT in
+    ``_header_keys``. Leaks verbatim. Same suffix asymmetry as csrf.
+  * ``relaystate`` (SAML 2.0 RelayState) — ALREADY covered via the
+    bare ``state`` alternation (which matches the ``state``
+    substring inside ``RelayState``). ✓ no action needed.
+  * ``_wpnonce`` (WordPress nonce) — ALREADY covered via the bare
+    ``nonce`` alternation (which matches the ``nonce`` substring
+    inside ``_wpnonce``). ✓ no action needed.
+
+So the sibling-drift gap is THREE additional alternations
+(``samlart``, ``csrf``, ``xsrf``) that need to be added to BOTH
+``_keys`` AND ``_header_keys``.
+
+Threat model
+------------
+
+A leaked URL / header / JSON document containing ``SAMLArt=...``,
+``_csrf=...``, ``xsrf=...``, ``X-CSRF: ...``, or ``"samlart": ...``
+that passes through ``sanitize_log_message`` (the canonical log
+sanitizer) lands the credential verbatim in operator log streams.
+This is the same threat model as the 2026-05-16 PR #1531 round, but
+via a DIFFERENT consuming function.
+
+Why two distinct redaction paths exist in the codebase:
+
+  * ``_sanitize_url_for_error`` / ``_strip_sensitive_params`` (PR
+    #1531's targets) parse the URL via ``urlparse`` + ``parse_qsl``
+    and redact query params by KEY NAME LOOKUP against
+    ``_SENSITIVE_QUERY_KEYS``. This is the structured path: it
+    requires a valid URL parsable by ``urlparse``.
+
+  * ``sanitize_log_message`` (this round's target) handles RAW
+    LOG TEXT — multi-line tracebacks, JSON snippets embedded in
+    error strings, ``Header: Value`` pairs, ``key=value&...``
+    fragments embedded in prose, partial URL fragments — anything
+    that ``urlparse`` would reject. It uses regex pattern matching
+    against the ``_keys`` and ``_header_keys`` alternation sets
+    to find ``<key>=<value>`` / ``<key>: <value>`` / ``"<key>":
+    "<value>"`` patterns anywhere in the input string.
+
+The two paths cover complementary surface area. Closing only the
+URL path (PR #1531) left every log message that didn't pass through
+``urlparse`` exposed. This round closes the log-sanitization sibling.
+
+Severity per credential class (same as PR #1531):
+
+  * ``SAMLArt``: HIGH — 5-min ARS-resolvable bearer credential.
+  * Bare ``csrf`` / ``xsrf``: MEDIUM-HIGH — session-lifetime replay.
+
+Real-world emission patterns that reach ``sanitize_log_message``:
+
+  * ``log.exception("Request to %s failed: %s", sanitize_log_arg(url),
+    sanitize_log_arg(exc))`` — when the exception message embeds a
+    URL with sensitive query params.
+  * ``log.warning("Cache key collision: %s", sanitize_log_arg(key))``
+    — when cache keys include sensitive parameters.
+  * GitHub Issue body sanitization (``feed/reporting.py:clean_message``)
+    — operator-facing issue bodies carrying request URLs / tracebacks
+    with embedded sensitive params.
+  * Traceback sanitization (``sanitize_log_message(text,
+    strip_control_chars=False)``) — Python tracebacks that include
+    HTTP request URL repr() in their frames.
+  * Pre-commit hook diagnostic output — when the secret scanner
+    finding context (which may include URL fragments) is sanitized
+    before display.
+
+Fix
+---
+
+Extend BOTH ``_keys`` and ``_header_keys`` regex alternations with
+three new entries (``samlart``, ``csrf``, ``xsrf``) — bare
+alternations mirroring the existing ``nonce|state`` style. The
+regex requires the alternation match to be followed by ``=`` (query
+form), ``:`` (header form), or ``": "`` (JSON form), so natural-
+language prose containing "csrf" / "xsrf" / "samlart" without a
+key=value structure is NOT over-redacted.
+
+Marker: SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.utils.logging import sanitize_log_arg, sanitize_log_message
+
+
+SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT = (
+    "sanitize_log_message _keys/_header_keys regex sibling drift: "
+    "samlart/csrf/xsrf alternations missing — leaks in log message "
+    "and header redaction paths"
+)
+
+
+# Realistic credential bodies (28+ chars to ensure they're entropy-like
+# and would trigger the secret scanner's _HIGH_ENTROPY_RE in committed
+# source — testing the sanitization path that would prevent the leaks
+# from reaching log output).
+_SAMLART_BODY = "AAQAACK4Gj1uFBjQqwbeQk5jeSrXgQAOEYRwsZA1J3GibE5oWyA89uVbiNI"
+assert len(_SAMLART_BODY) >= 40
+_CSRF_BODY = "abc123def456ghi789jkl012mno345pqr678"
+assert len(_CSRF_BODY) >= 28
+_XSRF_BODY = "AbCdEfGhIjKlMnOpQrStUvWx1234"
+assert len(_XSRF_BODY) >= 24
+
+
+# ---------------------------------------------------------------------------
+# (1) Query-parameter form (``?key=value``) — primary leak surface for
+#     URL-bearing log messages that don't pass through urlparse.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url_fragment,credential_body,label",
+    [
+        (
+            "https://sp.example.com/saml/acs?SAMLArt=" + _SAMLART_BODY,
+            _SAMLART_BODY,
+            "SAML 2.0 Artifact",
+        ),
+        (
+            "https://app.example.com/login?_csrf=" + _CSRF_BODY,
+            _CSRF_BODY,
+            "Spring Security _csrf",
+        ),
+        (
+            "https://app.example.com/login?csrf=" + _CSRF_BODY,
+            _CSRF_BODY,
+            "bare csrf",
+        ),
+        (
+            "https://app.example.com/login?CSRF=" + _CSRF_BODY,
+            _CSRF_BODY,
+            "uppercase CSRF",
+        ),
+        (
+            "https://app.example.com/login?xsrf=" + _XSRF_BODY,
+            _XSRF_BODY,
+            "bare xsrf",
+        ),
+        # Standalone key=value (not in URL context — common in
+        # traceback frames, exception messages, log prose).
+        (
+            "Auth failed with samlart=" + _SAMLART_BODY,
+            _SAMLART_BODY,
+            "standalone samlart=",
+        ),
+        (
+            "Submitted form: csrf=" + _CSRF_BODY,
+            _CSRF_BODY,
+            "standalone csrf=",
+        ),
+        (
+            "Cookie xsrf=" + _XSRF_BODY,
+            _XSRF_BODY,
+            "standalone xsrf=",
+        ),
+    ],
+)
+def test_sanitize_log_message_redacts_query_form(
+    url_fragment: str, credential_body: str, label: str
+) -> None:
+    """``sanitize_log_message`` must redact ``SAMLArt=...``, ``csrf=...``,
+    ``xsrf=...`` (and their underscored / case-shifted variants) when
+    they appear in query-parameter / key=value form in raw log text.
+    Pre-fix the credentials surface verbatim.
+    """
+    sanitized = sanitize_log_message(url_fragment)
+
+    assert credential_body not in sanitized, (
+        f"{label}: credential leaked verbatim through "
+        f"sanitize_log_message. INPUT={url_fragment!r} "
+        f"OUTPUT={sanitized!r}. "
+        f"({SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT})"
+    )
+    # The redacted form must contain ``***``.
+    assert "***" in sanitized, (
+        f"{label}: no ``***`` redaction marker present in output "
+        f"{sanitized!r}. ({SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (2) Header form (``Header: Value``) — the second leak surface,
+#     handled by the ``_header_keys`` regex alternation.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "header_line,credential_body,label",
+    [
+        (
+            f"SAMLArt: {_SAMLART_BODY}",
+            _SAMLART_BODY,
+            "SAML 2.0 Artifact header",
+        ),
+        (
+            f"X-SAMLArt: {_SAMLART_BODY}",
+            _SAMLART_BODY,
+            "X-prefixed SAMLArt header",
+        ),
+        (
+            f"X-CSRF: {_CSRF_BODY}",
+            _CSRF_BODY,
+            "X-CSRF (bare; X-CSRF-Token covered via 'token')",
+        ),
+        (
+            f"CSRF: {_CSRF_BODY}",
+            _CSRF_BODY,
+            "bare CSRF header",
+        ),
+        (
+            f"X-XSRF: {_XSRF_BODY}",
+            _XSRF_BODY,
+            "X-XSRF (bare; X-XSRF-TOKEN covered via 'token')",
+        ),
+        (
+            f"XSRF: {_XSRF_BODY}",
+            _XSRF_BODY,
+            "bare XSRF header",
+        ),
+    ],
+)
+def test_sanitize_log_message_redacts_header_form(
+    header_line: str, credential_body: str, label: str
+) -> None:
+    """``sanitize_log_message`` must redact ``SAMLArt: ...``,
+    ``X-CSRF: ...``, ``XSRF: ...`` (and their bare / X-prefixed
+    variants) when they appear in HTTP-Header form in raw log text.
+    The ``_header_keys`` regex alternation must include the new
+    entries.
+    """
+    sanitized = sanitize_log_message(header_line)
+
+    assert credential_body not in sanitized, (
+        f"{label}: header value leaked verbatim through "
+        f"sanitize_log_message. INPUT={header_line!r} "
+        f"OUTPUT={sanitized!r}. "
+        f"({SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT})"
+    )
+    assert "***" in sanitized, (
+        f"{label}: no ``***`` redaction marker in header output "
+        f"{sanitized!r}. ({SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (3) JSON form (``"key": "value"``) — third leak surface, also gated
+#     by ``_keys`` regex (with double-quote and single-quote variants).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "json_fragment,credential_body,label",
+    [
+        (
+            f'{{"SAMLArt": "{_SAMLART_BODY}"}}',
+            _SAMLART_BODY,
+            "JSON-double-quote samlart",
+        ),
+        (
+            f"{{'samlart': '{_SAMLART_BODY}'}}",
+            _SAMLART_BODY,
+            "JSON-single-quote samlart",
+        ),
+        (
+            f'{{"csrf": "{_CSRF_BODY}"}}',
+            _CSRF_BODY,
+            "JSON-double-quote csrf",
+        ),
+        (
+            f'{{"xsrf": "{_XSRF_BODY}"}}',
+            _XSRF_BODY,
+            "JSON-double-quote xsrf",
+        ),
+    ],
+)
+def test_sanitize_log_message_redacts_json_form(
+    json_fragment: str, credential_body: str, label: str
+) -> None:
+    """``sanitize_log_message`` must redact JSON-style ``"key":
+    "value"`` and ``'key': 'value'`` patterns when the key matches
+    the ``_keys`` regex. This is the third sink alongside query and
+    header forms.
+    """
+    sanitized = sanitize_log_message(json_fragment)
+
+    assert credential_body not in sanitized, (
+        f"{label}: JSON value leaked verbatim through "
+        f"sanitize_log_message. INPUT={json_fragment!r} "
+        f"OUTPUT={sanitized!r}. "
+        f"({SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (4) Regression: already-covered cases must continue to redact.
+#     ``relaystate`` (via ``state`` substring) and ``wpnonce`` (via
+#     ``nonce`` substring) were already covered pre-this-round. Plus
+#     the broader ``token`` / ``secret`` / ``password`` family.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fragment,credential_body,label",
+    [
+        # Already covered by existing alternations:
+        (
+            "?RelayState=" + "AbCdEfGhIjKlMnOpQrStUvWx0123",
+            "AbCdEfGhIjKlMnOpQrStUvWx0123",
+            "RelayState via state substring",
+        ),
+        (
+            "?_wpnonce=" + "a1b2c3d4e5",
+            "a1b2c3d4e5",
+            "_wpnonce via nonce substring",
+        ),
+        (
+            "?token=" + "AbCdEfGhIjKlMnOpQrStUvWx",
+            "AbCdEfGhIjKlMnOpQrStUvWx",
+            "token (canonical entry)",
+        ),
+        (
+            "?csrf_token=" + _CSRF_BODY,
+            _CSRF_BODY,
+            "csrf_token via token substring",
+        ),
+        (
+            "?XSRF-TOKEN=" + _XSRF_BODY,
+            _XSRF_BODY,
+            "XSRF-TOKEN via [a-z0-9_.\\-]*token",
+        ),
+        (
+            "?password=" + "MyP@ssw0rd1234",
+            "MyP@ssw0rd1234",
+            "password (canonical entry)",
+        ),
+    ],
+)
+def test_existing_redactions_still_work(
+    fragment: str, credential_body: str, label: str
+) -> None:
+    """Adding new alternations must NOT break existing redactions.
+    Every entry that was redacted pre-this-round must continue to
+    redact. Regression guard against accidental removal during the
+    alternation-extension diff.
+    """
+    sanitized = sanitize_log_message(fragment)
+
+    assert credential_body not in sanitized, (
+        f"REGRESSION: previously-redacted {label} no longer redacted. "
+        f"INPUT={fragment!r} OUTPUT={sanitized!r}. "
+        f"({SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (5) Negative cases: ensure the new alternations do NOT over-redact
+#     natural-language prose containing the trigger keywords without
+#     a key=value / Header: Value / JSON structure.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Natural-language mention without key=value structure.
+        "We need to add CSRF protection to the form.",
+        "XSRF vulnerability discovered in module X.",
+        "Audit the SAMLArt resolver for replay vulnerabilities.",
+        "The csrf token expires after 30 minutes.",
+        # Mention with a different separator (no = or :).
+        "csrf -> verified ok",
+        "xsrf rotation policy: daily",
+        # Inside an English sentence.
+        "The previous round closed the csrf attack surface.",
+        # Words containing the substrings but NOT followed by =/:.
+        "Don't get caught up in the cross-site issue.",  # benign
+        "saturday morning standups",  # contains 'art' — but NOT 'samlart'
+    ],
+)
+def test_natural_language_not_over_redacted(text: str) -> None:
+    """The regex alternations require the trigger keyword to be
+    followed by ``=`` (query form), ``:`` (header form), or ``": "``
+    (JSON form). Natural-language prose without these structural
+    markers must NOT be redacted.
+    """
+    sanitized = sanitize_log_message(text)
+
+    # The output should match the input modulo whitespace / control-
+    # char stripping. Specifically the original word content must be
+    # preserved (no ``***`` substitution for non-key=value mentions).
+    # We don't require byte-for-byte equality because
+    # ``sanitize_log_message`` also strips control chars / BiDi marks,
+    # but ``***`` must NOT be present (no over-redaction triggered).
+    assert "***" not in sanitized, (
+        f"OVER-REDACTION: natural-language text was unnecessarily "
+        f"redacted. INPUT={text!r} OUTPUT={sanitized!r}. "
+        f"({SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (6) sanitize_log_arg wrapper PoC: the canonical entry point used by
+#     every ``log.warning("...: %s", sanitize_log_arg(value))`` callsite
+#     across the codebase must benefit from the alternation extension.
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_log_arg_redacts_samlart() -> None:
+    """``sanitize_log_arg`` delegates to ``sanitize_log_message`` so
+    the alternation extension propagates to every callsite using the
+    wrapper. The wrapper is the dominant canonical entry point —
+    every ``log.warning(...)`` call in the codebase uses it for
+    user/upstream/env-controlled args."""
+    url = "https://sp.example.com/saml/acs?SAMLArt=" + _SAMLART_BODY
+    sanitized = sanitize_log_arg(url)
+    assert _SAMLART_BODY not in sanitized, (
+        f"sanitize_log_arg leaked SAML Artifact: INPUT={url!r} "
+        f"OUTPUT={sanitized!r}. ({SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT})"
+    )
+
+
+def test_sanitize_log_arg_redacts_csrf() -> None:
+    """The same propagation invariant for bare csrf."""
+    url = "Failed: form payload included _csrf=" + _CSRF_BODY
+    sanitized = sanitize_log_arg(url)
+    assert _CSRF_BODY not in sanitized, (
+        f"sanitize_log_arg leaked CSRF token: INPUT={url!r} "
+        f"OUTPUT={sanitized!r}. ({SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT})"
+    )
+
+
+def test_sanitize_log_arg_redacts_xsrf() -> None:
+    """The same propagation invariant for bare xsrf."""
+    url = "Cookie: xsrf=" + _XSRF_BODY
+    sanitized = sanitize_log_arg(url)
+    assert _XSRF_BODY not in sanitized, (
+        f"sanitize_log_arg leaked XSRF token: INPUT={url!r} "
+        f"OUTPUT={sanitized!r}. ({SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (7) Combined SAML 2.0 SSO PoC: real-world SP-initiated SSO error log
+#     line carrying SAMLArt + RelayState side by side. Both must be
+#     redacted (SAMLArt via the new alternation, RelayState via the
+#     existing ``state`` substring).
+# ---------------------------------------------------------------------------
+
+
+def test_combined_samlart_relaystate_redacted_in_log() -> None:
+    """A real-world SP-initiated SSO error log line carries both
+    ``SAMLArt`` and ``RelayState`` query parameters. Both must be
+    redacted simultaneously by ``sanitize_log_message`` — SAMLArt via
+    this round's new alternation, RelayState via the existing
+    ``state`` substring."""
+    body = "https%3A%2F%2Fapp.example.com%2Fdashboard"
+    line = (
+        f"ACS POST failed for "
+        f"https://sp.example.com/saml/acs?SAMLArt={_SAMLART_BODY}"
+        f"&RelayState={body}"
+    )
+    sanitized = sanitize_log_message(line)
+
+    assert _SAMLART_BODY not in sanitized, (
+        f"SAMLArt leaked verbatim: OUTPUT={sanitized!r}. "
+        f"({SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT})"
+    )
+    assert body not in sanitized, (
+        f"RelayState leaked verbatim: OUTPUT={sanitized!r}. "
+        f"({SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT})"
+    )


### PR DESCRIPTION
## Summary

Sibling-drift closure of PR #1531's `_SENSITIVE_QUERY_KEYS` SAML/CSRF/WordPress round. PR #1531 closed the **structured-URL** redaction path (`_sanitize_url_for_error` + `_strip_sensitive_params`) but left the **parallel raw-text log path** in `src/utils/logging.py:sanitize_log_message` (called by `sanitize_log_arg` / `clean_message` / `_sanitize_log_detail` across the codebase) with the same drift.

## Pre-fix verified gap

```
SAMLArt=AAQAACK4...                : LEAK
_csrf=abc123def456ghi789jkl012...  : LEAK
xsrf=AbCdEfGhIjKlMnOpQrStUvWx      : LEAK
X-CSRF: abc123def456...            : LEAK
```

Already covered by existing alternations (verified):
```
RelayState=httpsAppDashboard       : OK (via state substring)
_wpnonce=a1b2c3d4e5                : OK (via nonce substring)
csrf_token=...                     : OK (via [a-z0-9_.\-]*token)
XSRF-TOKEN=...                     : OK (via [a-z0-9_.\-]*token)
```

## Change

```python
# src/utils/logging.py
_keys = (
    # ... existing alternations ...
    r"nonce|state|"
    r"samlart|csrf|xsrf|"  # NEW
    # ... rest ...
)

_header_keys = (
    # ... existing alternations ...
    r"saml[-_.\s]*request|saml[-_.\s]*response|nonce|state|"
    r"samlart|csrf|xsrf|"  # NEW
    # ... rest ...
)
```

The bare alternations mirror the existing `nonce|state` style — case-insensitive substring match within the surrounding key=value / Header: Value / JSON pattern. The regex's structural requirements (followed by `=`, `:`, or JSON-quoted form) prevent over-redaction of natural-language prose.

## Threat model

Same per-credential severity ladder as PR #1531 applied to a different consuming function:
- **SAMLArt: HIGH** — 5-min ARS-resolvable bearer credential
- **Bare `csrf` / `xsrf`: MEDIUM-HIGH** — session-lifetime CSRF replay

The propagation is across DOZENS of `sanitize_log_arg(value)` callsites and every `clean_message(text)` invocation in the reporting pipeline (which feeds GitHub Issue bodies, operator-facing `docs/feed-health.md`, and `docs/stations_validation_report.md`).

## Two complementary redaction paths

| Path | Function | Input | Status |
|---|---|---|---|
| 1 | `_sanitize_url_for_error` / `_strip_sensitive_params` | Structured URL parsed by `urlparse` | ✅ Closed by PR #1531 |
| 2 | `sanitize_log_message` (via `_keys` / `_header_keys` regex) | Raw log text (tracebacks, JSON, headers, partial URLs) | ✅ **Closed by this PR** |

## Test plan

- [x] **37 new tests** in `tests/test_sentinel_sanitize_log_message_drift.py` across 7 categories:
  - Query-form PoCs (8 variants including standalone `key=value` and URL-embedded forms)
  - Header-form PoCs (6 variants: `SAMLArt:`, `X-SAMLArt:`, `X-CSRF:`, `CSRF:`, `X-XSRF:`, `XSRF:`)
  - JSON-form PoCs (4 variants including single-quote and double-quote)
  - 6 regression guards for existing alternations (token / password / RelayState via state / _wpnonce via nonce / csrf_token via token / XSRF-TOKEN via token)
  - 9 negative cases proving natural-language prose is NOT over-redacted
  - 3 `sanitize_log_arg` wrapper propagation PoCs
  - 1 combined SP-initiated SSO PoC (SAMLArt + RelayState side by side)
- [x] **6353 tests passed, 2 skipped** in full test suite
- [x] **`python -m mypy --no-pretty src tests`**: 0 errors (CI-equivalent)
- [x] **Ruff**: All checks passed
- [x] **Bandit**: Only pre-existing nosec warnings
- [x] **Secret scanner self-check**: No findings on the repo
- [x] **C901 complexity gate**: 0 new violations
- [x] **pip-audit**: No known vulnerabilities

## Next round (named-but-deferred)

OAuth 1.0 `oauth_verifier`, WordPress action-specific nonces precise attribution, and the five auth-scheme multi-field deferred candidates (Mutual / vapid / SCRAM / Digest / AWS4-HMAC-SHA256).

Marker: `SENTINEL_LOG_SANITIZE_CSRF_SAML_DRIFT`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9eY15EAh1cu5y2XraGj7J)_