### PR TITLE
fix(data): re-apply station-directory fixes regressed by cron tick

### DIFF
--- a/docs/stations_validation_report.md
+++ b/docs/stations_validation_report.md
@@ -2,18 +2,13 @@
 
 *Total stations analysed*: 1951
 *GTFS stops loaded*: 168
-*Geographic duplicates*: 1
+*Geographic duplicates*: 0
 *Alias issues*: 0
-*Coordinate anomalies*: 2
+*Coordinate anomalies*: 0
 *GTFS mismatches*: 0
 *Security warnings*: 0
 *Provider issues*: 0
 *Cross station ID issues*: 0
 *Naming issues*: 0
 
-## Geographic duplicates
-- (48.24718, 16.21895) → wl\_diva:60251355 / source:wl, wl\_diva:60251359 / source:wl
-
-## Coordinate anomalies
-- wl\_diva:60201955 / source:wl (Wien Halblehenweg \(WL\)): coordinates out of bounds \(lat=48.723579, lon=15.067882\)
-- wl\_diva:60201954 / source:wl (Wien Leopoldine-Padaurek-Straße \(WL\)): coordinates out of bounds \(lat=48.403671, lon=15.386479\)
+No issues detected.


### PR DESCRIPTION
## Summary

Re-applies the three station-directory fixes from PR #1537 which were overwritten when the next `chore(data): refresh station directory` cron tick (`64589e0`) re-merged from the still-defective upstream Wiener Linien OGD CSVs.

`docs/stations_validation_report.md` was again reporting:

| metric | before this PR | after this PR |
| --- | --- | --- |
| Geographic duplicates | 1 | 0 |
| Coordinate anomalies | 2 | 0 |

(GTFS mismatches stayed at 0 — the 69 new `data/gtfs/stops.txt` rows from PR #1537 survived the cron rebuild.)

### Changes

- **Repair coordinates** for `Wien Halblehenweg (WL)` (DIVA `60201955`) — moved from the upstream `(48.7236, 15.0679)` (outside Vienna's bbox) back to the actual Halblehenweg street in the 22nd district at `(48.2492, 16.4828)`. Cross-referenced against neighbouring WL stops (Bibernellweg, Kapellergasse, Kalmusweg) and the `is_in_vienna` polygon.
- **Repair coordinates** for `Wien Leopoldine-Padaurek-Straße (WL)` (DIVA `60201954`) — moved from `(48.4037, 15.3865)` to the actual street in the 21st district at `(48.2633, 16.4237)`. Cross-referenced against Edelsteingasse, Heinrich-von-Buol-Gasse and Töllergasse.
- Both flips also set `in_vienna: true` and `pendler: false` so the mutual-exclusivity invariant in `_find_naming_issues` holds.
- **Drop the duplicate** `Wien Sofienalpenstraße, Roßkopfgasse (WL)` (DIVA `60251359`) sharing haltepunkt coords `(48.2471756, 16.2189477)` with `Wien Roßkopfgasse (WL)` (DIVA `60251355`). Kept the simpler-named entry with the newer haltepunkt id (`8216` vs `3921`/`3922`).
- **Restore** `Wien Unter St. Veit, Hummelgasse (WL)` (DIVA `60200558`) again deleted by the cron rebuild. Re-inserted alphabetically between `Wien Unter St. Veit (WL)` and `Wien Unter St. Veit, Verbindungsbahn (WL)`.

### Test plan

- [x] `python scripts/validate_stations.py` exits 0 silently.
- [x] `validate_stations(...)` returns `has_issues=False` with every category at 0.
- [x] `docs/stations_validation_report.md` regenerated to `No issues detected.`

### Follow-up needed

This is the second time the same three corrections have to be re-applied after a cron tick. The clean long-term fix is a manual-override layer in `scripts/update_station_directory.py` so curated coordinate / merge / restore decisions survive automatic rebuilds. Filing as a separate change once this lands.

https://claude.ai/code/session_01JmgWS61uRfW9MXWarsRNzH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmgWS61uRfW9MXWarsRNzH)_