### PR TITLE
fix(stations): three-layer defence against DIVA-duplicate drift

### DIFF
--- a/docs/schema/stations.schema.json
+++ b/docs/schema/stations.schema.json
@@ -125,6 +125,18 @@
           "type": "array",
           "items": {"type": "string"},
           "description": "Interne Google-Places-Kategorisierung. Read-only."
+        },
+        "_in_vienna_basis": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "prefixItems": [
+            {"type": "number"},
+            {"type": "number"},
+            {"type": "boolean"}
+          ],
+          "items": false,
+          "description": "Cache-Eintrag von scripts/update_station_directory.py:_resolve_in_vienna_with_cache. Speichert [basis_lat, basis_lon, polygon_result] der letzten LANDESGRENZEOGD-Polygon-Auswertung, damit beim nächsten Cron-Tick nicht erneut der teure Ray-Cast gegen das tausende-Vertex Multipolygon laufen muss. Read-only."
         }
       },
       "additionalProperties": false,

--- a/docs/stations_validation_report.md
+++ b/docs/stations_validation_report.md
@@ -1,19 +1,15 @@
 # Stations Validation Report
 
-*Total stations analysed*: 1951
+*Total stations analysed*: 1941
 *GTFS stops loaded*: 168
-*Geographic duplicates*: 1
+*Geographic duplicates*: 0
 *Alias issues*: 0
-*Coordinate anomalies*: 2
+*Coordinate anomalies*: 0
 *GTFS mismatches*: 0
 *Security warnings*: 0
 *Provider issues*: 0
 *Cross station ID issues*: 0
+*Identity field conflicts*: 0
 *Naming issues*: 0
 
-## Geographic duplicates
-- (48.24718, 16.21895) → wl\_diva:60251355 / source:wl, wl\_diva:60251359 / source:wl
-
-## Coordinate anomalies
-- wl\_diva:60201955 / source:wl (Wien Halblehenweg \(WL\)): coordinates out of bounds \(lat=48.723579, lon=15.067882\)
-- wl\_diva:60201954 / source:wl (Wien Leopoldine-Padaurek-Straße \(WL\)): coordinates out of bounds \(lat=48.403671, lon=15.386479\)
+No issues detected.

--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -1157,6 +1157,15 @@ def merge_into_stations(
     vor_index: dict[str, dict[str, object]] = {}
     bst_index: dict[str, dict[str, object]] = {}
     name_index: dict[str, dict[str, object]] = {}
+    # Added 2026-05-16 (PR #1539): index by ``wl_diva`` so a WL payload
+    # whose name doesn't normalise to the existing ``google_places`` /
+    # ``oebb`` entry's name (the Innenstadt-U-Bahn pattern — payload
+    # ``Wien Herrengasse (WL)`` vs existing ``Herrengasse``) is still
+    # merged into the existing record instead of duplicated. Pre-fix,
+    # ten Innenstadt-U-Bahn DIVAs (Herrengasse, Schwedenplatz,
+    # Volkstheater, …) were silently duplicated each cron tick because
+    # ``_normalize_key`` rendered the two names as distinct keys.
+    wl_diva_index: dict[str, dict[str, object]] = {}
 
     for entry in existing:
         source = entry.get("source")
@@ -1182,14 +1191,29 @@ def merge_into_stations(
             if key and key not in name_index:
                 name_index[key] = entry
 
+        wl_diva = entry.get("wl_diva")
+        if wl_diva is not None:
+            key = str(wl_diva).strip()
+            if key and key not in wl_diva_index:
+                wl_diva_index[key] = entry
+
     log.info("Keeping %d existing non-WL stations", len(filtered))
 
     unmatched: list[dict[str, object]] = []
     for payload in wl_entries:
         merged_into: dict[str, object] | None = None
 
-        vor_id = payload.get("vor_id")
-        merged_into = _lookup_candidates(vor_index, vor_id)
+        # Match precedence: ``wl_diva`` first — strongest WL-domain
+        # identifier and the failure mode the new index was added for.
+        # Then ``vor_id`` / ``bst_id`` / ``name`` as before so cross-
+        # provider stubs (VOR-only / ÖBB-only) continue to consolidate
+        # the same way.
+        wl_diva = payload.get("wl_diva")
+        merged_into = _lookup_candidates(wl_diva_index, wl_diva)
+
+        if merged_into is None:
+            vor_id = payload.get("vor_id")
+            merged_into = _lookup_candidates(vor_index, vor_id)
 
         if merged_into is None:
             bst_id = payload.get("bst_id")

--- a/scripts/validate_stations.py
+++ b/scripts/validate_stations.py
@@ -58,6 +58,21 @@ def main() -> int:
             )
         has_error = True
 
+    if report.identity_field_conflicts:
+        # Blocks the orchestrator commit so a regression of the 2026-05-16
+        # google_places-vs-wl Innenstadt-DIVA drift (PR #1539) cannot land
+        # silently again. Same exit-1 contract as provider_issues so the
+        # auto-quarantine path in update_all_stations.py rolls back the
+        # working tree on detection.
+        for i_issue in report.identity_field_conflicts:
+            joined_ids = ", ".join(i_issue.identifiers)
+            print(
+                f"Identity-field conflict: {i_issue.field}={i_issue.value!r} "
+                f"shared by [{joined_ids}]",
+                file=sys.stderr,
+            )
+        has_error = True
+
     return 1 if has_error else 0
 
 

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -277,16 +277,7 @@ class ValidationReport:
                 )
             lines.append("")
 
-        if self.identity_field_conflicts:
-            lines.append("## Identity field conflicts")
-            for conflict in self.identity_field_conflicts:
-                joined_ids = ", ".join(_safe_md(ident) for ident in conflict.identifiers)
-                joined_names = ", ".join(_safe_md(name) for name in conflict.names)
-                lines.append(
-                    f"- {_safe_md(conflict.field)}={_safe_md(conflict.value)} "
-                    f"shared by [{joined_ids}] ({joined_names})"
-                )
-            lines.append("")
+        lines.extend(self._render_identity_field_conflicts())
 
         if self.duplicates:
             lines.append("## Geographic duplicates")
@@ -334,6 +325,26 @@ class ValidationReport:
             lines.append("No issues detected.")
 
         return "\n".join(lines).rstrip() + "\n"
+
+    def _render_identity_field_conflicts(self) -> list[str]:
+        """Render the ``## Identity field conflicts`` section.
+
+        Split out of :meth:`to_markdown` so the parent method stays
+        below the C901 complexity baseline (15) — adding the section
+        inline pushed it from 18 to 20, above the project floor.
+        """
+        if not self.identity_field_conflicts:
+            return []
+        lines = ["## Identity field conflicts"]
+        for conflict in self.identity_field_conflicts:
+            joined_ids = ", ".join(_safe_md(ident) for ident in conflict.identifiers)
+            joined_names = ", ".join(_safe_md(name) for name in conflict.names)
+            lines.append(
+                f"- {_safe_md(conflict.field)}={_safe_md(conflict.value)} "
+                f"shared by [{joined_ids}] ({joined_names})"
+            )
+        lines.append("")
+        return lines
 
 
 class StationValidationError(RuntimeError):

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -115,6 +115,35 @@ class NamingIssue:
     reason: str
 
 
+@dataclass(frozen=True)
+class IdentityFieldConflict:
+    """Two stations declaring the same value in a structural identifier field.
+
+    Caught the 2026-05-16 Innenstadt-U-Bahn drift: ten ``wl_diva`` values
+    (Herrengasse, Schwedenplatz, Volkstheater, …) were shared between a
+    ``google_places``-sourced stub and the canonical ``source: wl`` entry
+    because ``scripts/update_wl_stations.py:merge_into_stations``
+    indexed existing entries by ``vor_id`` / ``bst_id`` / ``name`` but
+    not by ``wl_diva``. ``_find_cross_station_id_conflicts`` did not
+    fire — it only compares aliases against other stations' identity
+    fields, not identity-vs-identity. ``_find_duplicate_coordinate_
+    groups`` did not fire either — the stub and the master coordinates
+    differed by ~7-50 m, below the rounding granularity but above the
+    5-decimal-place bucket boundary.
+
+    Distinct from :class:`CrossStationIDIssue`: this dataclass flags a
+    raw identity-field collision (same ``wl_diva`` declared by two
+    entries), whereas ``CrossStationIDIssue`` captures the more
+    indirect case where one entry's *alias* shadows another entry's
+    identity field.
+    """
+
+    field: str
+    value: str
+    identifiers: tuple[str, ...]
+    names: tuple[str, ...]
+
+
 # Per-cell length cap applied at every ``stations.json``-derived
 # Markdown sink in :meth:`ValidationReport.to_markdown`. Mirrors the
 # canonical ``_DASHBOARD_FIELD_MAX_LEN`` constant in
@@ -155,6 +184,11 @@ class ValidationReport:
     provider_issues: tuple[ProviderIssue, ...]
     naming_issues: tuple[NamingIssue, ...]
     gtfs_stop_count: int
+    # Defaulted last so existing call sites that built ``ValidationReport``
+    # positionally before the 2026-05-16 PR #1539 addition keep working
+    # — adopted by the test fixtures + ``scripts/update_all_stations.py``
+    # auto-quarantine path.
+    identity_field_conflicts: tuple[IdentityFieldConflict, ...] = ()
 
     @property
     def has_issues(self) -> bool:
@@ -167,6 +201,7 @@ class ValidationReport:
             or self.cross_station_id_issues
             or self.provider_issues
             or self.naming_issues
+            or self.identity_field_conflicts
         )
 
     def to_markdown(self) -> str:
@@ -211,6 +246,7 @@ class ValidationReport:
         lines.append(f"*Security warnings*: {len(self.security_issues)}")
         lines.append(f"*Provider issues*: {len(self.provider_issues)}")
         lines.append(f"*Cross station ID issues*: {len(self.cross_station_id_issues)}")
+        lines.append(f"*Identity field conflicts*: {len(self.identity_field_conflicts)}")
         lines.append(f"*Naming issues*: {len(self.naming_issues)}")
         lines.append("")
 
@@ -238,6 +274,17 @@ class ValidationReport:
                     f"alias '{_safe_md(cross.alias)}' collides with "
                     f"{_safe_md(cross.colliding_field)} of "
                     f"{_safe_md(cross.colliding_identifier)} ({_safe_md(cross.colliding_name)})"
+                )
+            lines.append("")
+
+        if self.identity_field_conflicts:
+            lines.append("## Identity field conflicts")
+            for conflict in self.identity_field_conflicts:
+                joined_ids = ", ".join(_safe_md(ident) for ident in conflict.identifiers)
+                joined_names = ", ".join(_safe_md(name) for name in conflict.names)
+                lines.append(
+                    f"- {_safe_md(conflict.field)}={_safe_md(conflict.value)} "
+                    f"shared by [{joined_ids}] ({joined_names})"
                 )
             lines.append("")
 
@@ -317,6 +364,7 @@ def validate_stations(
     cross_station_id_issues = tuple(_find_cross_station_id_conflicts(stations))
     provider_issues = tuple(_find_provider_issues(stations))
     naming_issues = tuple(_find_naming_issues(stations))
+    identity_field_conflicts = tuple(_find_identity_field_conflicts(stations))
 
     return ValidationReport(
         total_stations=len(stations),
@@ -329,6 +377,7 @@ def validate_stations(
         provider_issues=provider_issues,
         naming_issues=naming_issues,
         gtfs_stop_count=gtfs_count,
+        identity_field_conflicts=identity_field_conflicts,
     )
 
 
@@ -743,6 +792,51 @@ def _find_cross_station_id_conflicts(
                             colliding_name=str(colliding_entry.get("name", "")).strip() or "<unknown>",
                             colliding_field=field,
                         )
+
+
+def _find_identity_field_conflicts(
+    stations: Sequence[Mapping[str, object]]
+) -> Iterator[IdentityFieldConflict]:
+    """Yield one issue per value that appears on more than one station.
+
+    Checks each of the four structural identifier fields
+    (``wl_diva`` / ``vor_id`` / ``bst_id`` / ``bst_code``). The
+    project's eindeutigkeits-Garantie pins these as primary keys; any
+    duplicate means two stations claim the same physical asset (post
+    PR #1538 a ``google_places`` stub and a ``source: wl`` master
+    shared the same DIVA for ten Innenstadt-U-Bahn stops because the
+    WL merge step indexed by name and ``_normalize_key`` rendered
+    ``Herrengasse`` and ``Wien Herrengasse (WL)`` as distinct keys).
+
+    Whitespace-stripped + lower-cased ``int`` / ``str`` values are
+    compared; ``None`` and empty strings are ignored.  Distinct from
+    :func:`_find_cross_station_id_conflicts`, which fires only when an
+    *alias* on one station shadows an *identity* field on a different
+    station — this function fires on raw identity collisions.
+    """
+    for field in ("wl_diva", "vor_id", "bst_id", "bst_code"):
+        seen: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+        for entry in stations:
+            val = entry.get(field)
+            if not isinstance(val, str | int):
+                continue
+            key = str(val).strip()
+            if not key:
+                continue
+            seen[key].append(entry)
+        for value, entries in seen.items():
+            if len(entries) <= 1:
+                continue
+            identifiers = tuple(_format_identifier(e) for e in entries)
+            names = tuple(
+                str(e.get("name", "")).strip() or "<unknown>" for e in entries
+            )
+            yield IdentityFieldConflict(
+                field=field,
+                value=value,
+                identifiers=identifiers,
+                names=names,
+            )
 
 
 def _extract_source_tokens(value: object) -> set[str]:

--- a/tests/test_stations_validation_identity_conflicts.py
+++ b/tests/test_stations_validation_identity_conflicts.py
@@ -1,0 +1,223 @@
+"""Tests for ``_find_identity_field_conflicts``.
+
+Pin the 2026-05-16 Innenstadt-U-Bahn DIVA-drift regression: two
+stations sharing the same ``wl_diva`` (or any of ``vor_id`` /
+``bst_id`` / ``bst_code``) must trip a blocking ``IdentityFieldConflict``
+even when they have different names and slightly different
+coordinates.
+
+Distinct from ``test_stations_validation_cross_id.py`` which exercises
+alias-vs-identity collisions; this module exercises identity-vs-identity.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from src.utils.stations_validation import validate_stations
+
+
+def _make_entry(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "name": "Default",
+        "latitude": 48.2,
+        "longitude": 16.3,
+        "in_vienna": True,
+        "pendler": False,
+        "source": "wl",
+        "aliases": ["Default"],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_wl_diva_duplicate_flagged_even_with_distinct_names(tmp_path: Path) -> None:
+    """The Innenstadt-U-Bahn failure mode: ``Herrengasse`` (google_places)
+    and ``Wien Herrengasse (WL)`` (wl) sharing DIVA 60200506 must be
+    detected even though the names normalise differently and the
+    coordinates differ by ~12 m (below the duplicate-coord bucket
+    boundary of 5 decimal places)."""
+    path = tmp_path / "stations.json"
+    entries = [
+        _make_entry(
+            name="Herrengasse",
+            wl_diva="60200506",
+            source="google_places",
+            latitude=48.209648,
+            longitude=16.366380,
+            aliases=["Herrengasse"],
+        ),
+        _make_entry(
+            name="Wien Herrengasse (WL)",
+            wl_diva="60200506",
+            source="wl",
+            latitude=48.209750,
+            longitude=16.365304,
+            aliases=["Wien Herrengasse (WL)"],
+        ),
+    ]
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+    report = validate_stations(path)
+
+    # Sanity: the geographic-duplicates and cross-station-id checks
+    # both miss this case under the conditions the regression
+    # was discovered with.
+    assert report.duplicates == ()
+    assert report.cross_station_id_issues == ()
+
+    # The new check fires.
+    assert len(report.identity_field_conflicts) == 1
+    conflict = report.identity_field_conflicts[0]
+    assert conflict.field == "wl_diva"
+    assert conflict.value == "60200506"
+    assert set(conflict.names) == {"Herrengasse", "Wien Herrengasse (WL)"}
+    assert report.has_issues
+
+
+def test_vor_id_duplicate_flagged(tmp_path: Path) -> None:
+    path = tmp_path / "stations.json"
+    entries = [
+        _make_entry(
+            name="Station A",
+            vor_id="430420200",
+            bst_id="200",
+            bst_code="A1",
+            source="oebb,osm",
+            aliases=["A"],
+        ),
+        _make_entry(
+            name="Station B",
+            vor_id="430420200",
+            bst_id="201",
+            bst_code="A2",
+            source="oebb,osm",
+            aliases=["B"],
+        ),
+    ]
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+    report = validate_stations(path)
+
+    assert any(
+        c.field == "vor_id" and c.value == "430420200"
+        for c in report.identity_field_conflicts
+    )
+
+
+def test_bst_id_and_bst_code_duplicates_flagged(tmp_path: Path) -> None:
+    """Two stations colliding on both ``bst_id`` and ``bst_code`` produce
+    two distinct conflicts — one per field."""
+    path = tmp_path / "stations.json"
+    entries = [
+        _make_entry(
+            name="A",
+            bst_id="42",
+            bst_code="Aw",
+            source="oebb,osm",
+            aliases=["A"],
+        ),
+        _make_entry(
+            name="B",
+            bst_id="42",
+            bst_code="Aw",
+            source="oebb,osm",
+            aliases=["B"],
+        ),
+    ]
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+    report = validate_stations(path)
+    fields = {c.field for c in report.identity_field_conflicts}
+    assert fields == {"bst_id", "bst_code"}
+
+
+def test_unique_identifiers_produce_no_conflicts(tmp_path: Path) -> None:
+    path = tmp_path / "stations.json"
+    entries = [
+        _make_entry(name="A", wl_diva="60200001", aliases=["A"]),
+        _make_entry(name="B", wl_diva="60200002", aliases=["B"]),
+        _make_entry(name="C", wl_diva="60200003", aliases=["C"]),
+    ]
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+    report = validate_stations(path)
+    assert report.identity_field_conflicts == ()
+
+
+def test_none_and_whitespace_values_ignored(tmp_path: Path) -> None:
+    """``wl_diva = None`` or `` `` must not falsely fire the conflict
+    check — only structurally meaningful values count."""
+    path = tmp_path / "stations.json"
+    entries = [
+        _make_entry(name="A", wl_diva=None, aliases=["A"]),
+        _make_entry(name="B", wl_diva=None, aliases=["B"]),
+        _make_entry(name="C", wl_diva="   ", aliases=["C"]),
+        _make_entry(name="D", wl_diva="   ", aliases=["D"]),
+    ]
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+    report = validate_stations(path)
+    assert report.identity_field_conflicts == ()
+
+
+def test_three_way_collision_yields_single_conflict(tmp_path: Path) -> None:
+    path = tmp_path / "stations.json"
+    entries = [
+        _make_entry(name=f"S{i}", wl_diva="60200506", aliases=[f"S{i}"])
+        for i in range(3)
+    ]
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+    report = validate_stations(path)
+    assert len(report.identity_field_conflicts) == 1
+    assert len(report.identity_field_conflicts[0].identifiers) == 3
+
+
+def test_real_data_has_no_identity_conflicts() -> None:
+    """Regression test against the committed ``data/stations.json``.
+
+    The 2026-05-16 heal (PR #1539) merged the ten ``google_places`` <->
+    ``wl`` DIVA-sharing stubs into their masters and added the
+    ``wl_diva`` index in ``scripts/update_wl_stations.py:merge_into_
+    stations`` so they cannot reappear via cron. This test pins the
+    invariant.
+    """
+    report = validate_stations(Path("data/stations.json"))
+    assert report.identity_field_conflicts == (), (
+        f"Identity-field conflicts reappeared in data/stations.json: "
+        f"{report.identity_field_conflicts}"
+    )
+
+
+def test_has_issues_flips_on_identity_conflict(tmp_path: Path) -> None:
+    """``ValidationReport.has_issues`` must include identity_field_conflicts."""
+    path = tmp_path / "stations.json"
+    entries = [
+        _make_entry(name="A", wl_diva="60200506", aliases=["A"]),
+        _make_entry(name="B", wl_diva="60200506", aliases=["B"]),
+    ]
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+    report = validate_stations(path)
+    assert report.identity_field_conflicts != ()
+    assert report.has_issues is True
+
+
+def test_markdown_renders_identity_conflict_section(tmp_path: Path) -> None:
+    path = tmp_path / "stations.json"
+    # Distinct coordinates avoid Geographic-duplicates noise so the
+    # rendered Markdown isolates the identity-conflict section.
+    entries = [
+        _make_entry(name="A", wl_diva="60200506", aliases=["A"], latitude=48.20),
+        _make_entry(name="B", wl_diva="60200506", aliases=["B"], latitude=48.21),
+    ]
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+    report = validate_stations(path)
+    rendered = report.to_markdown()
+
+    assert "## Identity field conflicts" in rendered
+    # ``_safe_md`` HTML-escapes ``_`` to ``\_`` per CommonMark protocol.
+    assert "wl\\_diva" in rendered
+    assert "60200506" in rendered

--- a/tests/test_update_wl_stations_merge.py
+++ b/tests/test_update_wl_stations_merge.py
@@ -139,6 +139,79 @@ def test_merge_wl_data_into_existing_vor_entry(stations_path: Path) -> None:
     assert rerun == merged
 
 
+def test_merge_into_existing_google_places_stub_via_wl_diva_index(
+    stations_path: Path,
+) -> None:
+    """The 2026-05-16 PR #1539 fix: a WL payload whose ``name`` doesn't
+    normalise to the existing entry's ``name`` (Innenstadt-U-Bahn pattern
+    — payload ``Wien Herrengasse (WL)`` vs existing ``Herrengasse``) must
+    still merge via the new ``wl_diva`` index instead of producing a
+    duplicate entry.
+
+    Pre-fix, ``_normalize_key`` rendered the two names as ``herrengasse``
+    vs ``wienherrengassewl`` so the name-index lookup missed, ``vor_id`` /
+    ``bst_id`` were both absent, and the WL payload landed in
+    ``unmatched`` — creating the ten Innenstadt-U-Bahn DIVA duplicates.
+    """
+    stations_path.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "Herrengasse",
+                    "wl_diva": "60200506",
+                    "_google_place_id": "ChIJBa9sJZgHbUcRrekncb64g2M",
+                    "_types": ["subway_station"],
+                    "aliases": ["Herrengasse", "Bahnhof Herrengasse"],
+                    "latitude": 48.2096482,
+                    "longitude": 16.36638,
+                    "in_vienna": True,
+                    "pendler": False,
+                    "source": "google_places",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    wl_entries = [
+        {
+            "name": "Wien Herrengasse (WL)",
+            "wl_diva": "60200506",
+            "aliases": ["Wien Herrengasse (WL)", "Herrengasse U"],
+            "wl_stops": [
+                {"stop_id": "2938", "name": "Herrengasse U"},
+                {"stop_id": "4907", "name": "Herrengasse"},
+            ],
+            "latitude": 48.20975,
+            "longitude": 16.365304,
+            "in_vienna": True,
+            "pendler": False,
+            "source": "wl",
+        }
+    ]
+
+    update_wl_stations.merge_into_stations(stations_path, wl_entries)
+
+    merged = _read_entries(stations_path)
+
+    # The critical invariant: exactly ONE entry, not two.
+    assert len(merged) == 1, (
+        "WL payload must merge into the google_places stub via wl_diva, "
+        f"got {len(merged)} entries"
+    )
+    entry = merged[0]
+    assert entry["wl_diva"] == "60200506"
+    assert entry["source"] == "google_places,wl"
+    # Google Places identity bits survive the merge.
+    assert entry["_google_place_id"] == "ChIJBa9sJZgHbUcRrekncb64g2M"
+    assert entry["_types"] == ["subway_station"]
+    # WL payload contributes wl_stops + new aliases.
+    assert entry["wl_stops"] == wl_entries[0]["wl_stops"]
+    from typing import cast
+    aliases = set(cast(list[str], entry["aliases"]))
+    assert {"Herrengasse", "Wien Herrengasse (WL)"} <= aliases
+
+
 def test_unmatched_wl_entry_is_appended(stations_path: Path) -> None:
     wl_entries = [
         {


### PR DESCRIPTION
## Summary

Drei-Schichten-Defense gegen wiederkehrende `wl_diva`-Duplikat-Drift im Stationsverzeichnis. Ein Tiefen-Audit hat zehn Innenstadt-U-Bahn-Stops gefunden, die je zweifach im Verzeichnis stehen: `source: google_places`-Stub + `source: wl`-Master mit identischer DIVA, ~7-50m Koordinaten-Drift und unterschiedlicher Namens-Normalisierung. Existierende Validatoren haben das übersehen (Geographic-duplicate-Check rundet auf 5 Dezimalstellen, Cross-station-ID-Check prüft nur Alias-vs-Identity). Beim Naked-Name-Lookup wie `"Herrengasse"` hat der schwächere `google_places`-Stub (1 wl_stop) den vollwertigen WL-Master (3 echte Plattform-IDs) verdrängt.

### Die drei Schichten

| Schicht | Datei | Wirkung |
| --- | --- | --- |
| **1. Wurzel-Fix** | `scripts/update_wl_stations.py` | `merge_into_stations()` bekommt einen `wl_diva`-Index, **vor** `vor_id`/`bst_id`/`name`-Lookup abgefragt. Pre-Fix matchte `_normalize_key("Herrengasse")` nie `_normalize_key("Wien Herrengasse (WL)")` — das WL-Payload landete in `unmatched` und erzeugte bei jedem Cron-Tick einen Zweiteintrag. |
| **2. Defense in Depth** | `src/utils/stations_validation.py` + `scripts/validate_stations.py` | Neue `IdentityFieldConflict`-Klasse + `_find_identity_field_conflicts()` meldet jede zwei-Stations-Kollision auf `wl_diva`/`vor_id`/`bst_id`/`bst_code`. Im CLI als blocking gate verdrahtet (Exit 1, gleicher Contract wie `provider_issues`), sodass eine Regression vom Auto-Quarantine-Pfad in `update_all_stations.py` aufgefangen wird. |
| **3. Daten-Heilung** | `data/stations.json` | 10 `google_places`-Stubs in ihre WL-Master gemerged (`_google_place_id`, `_types`, fehlende generische Aliase übernommen; `source` auf `google_places,wl` promoted; Stub entfernt). Plus der wiederkehrende Drei-Issue-Heal aus PR #1537/#1538 (Hummelgasse-Restore, Halblehenweg/Leopoldine-Padaurek-Koords, Sofienalpenstraße-Roßkopfgasse-Duplikat). |

### Geheilte DIVAs

| DIVA | google_places-Stub | WL-Master |
| ---: | --- | --- |
| 60200506 | Herrengasse | Wien Herrengasse (WL) |
| 60200670 | Kettenbrückengasse | Wien Kettenbrückengasse (WL) |
| 60201892 | Messe - Prater | Wien Messe-Prater (WL) |
| 60200056 | Neubaugasse | Wien Neubaugasse (WL) |
| 60201018 | Pilgramgasse | Wien Pilgramgasse (WL) |
| 60201182 | Schottenring | Wien Schottenring (WL) |
| 60201198 | Schwedenplatz | Wien Schwedenplatz (WL) |
| 60201305 | Stadtpark | Wien Stadtpark (WL) |
| 60200245 | Stubentor | Wien Stubentor (WL) |
| 60201430 | Volkstheater | Wien Volkstheater (WL) |

### Bonus

`docs/schema/stations.schema.json` erlaubt jetzt das interne `_in_vienna_basis`-Cache-Feld (149 Stationen) — das war ein Schema-Drift, kein Daten-Bug.

### Net Effect

- `data/stations.json`: 1951 → 1941 Stationen (10 redundante Stubs entfernt)
- Validator: alle 9 Kategorien bei 0
- GTFS-Mappings unverändert (168 stops)

### Test Plan

- [x] `python scripts/validate_stations.py` → exit 0, silent success
- [x] `tests/test_stations_validation_identity_conflicts.py` (neu, 9 Tests) — Innenstadt-U-Bahn-Pattern, `vor_id`/`bst_id`/`bst_code` parallel, Whitespace/None-Ignorierung, 3-fach-Kollision, Real-Daten-Invariante, Markdown-Renderer
- [x] `tests/test_update_wl_stations_merge.py` (erweitert) — pin den `wl_diva`-Index-Match: `google_places`-Stub bleibt EIN Eintrag (nicht zwei), `_google_place_id`/`_types` überleben, `source = "google_places,wl"`
- [x] `tests/test_stations_schema.py` — `data/stations.json` validiert gegen das aktualisierte Schema (`_in_vienna_basis` zugelassen)
- [x] Volltest-Suite Subset (286 Tests rund um Validation, WL-Stations, Schema, Meta): grün
- [x] Test-Suite `-k "stations"` ohne Subprocess-Wrapper: 309/309 passed

### Warum dieser Ansatz nicht regression-prone ist

Die früheren PRs #1537/#1538 mussten zweimal denselben Heal anwenden, weil der nächste Cron-Lauf die Korrekturen aus den (immer noch defekten) Upstream-CSVs zurückrollte. Diesmal:

1. Der **`wl_diva`-Index** verhindert, dass der nächste Cron die Stubs überhaupt wieder erzeugt.
2. Falls die Merge-Logik jemals wieder bricht, blockt der **Identity-Field-Conflict-Validator** den Auto-Commit (Exit 1 wie `provider_issues`).
3. Falls beide oben versagen, ist der Snapshot **heute schon clean**, also nicht "zeitkritisch fragile".

https://claude.ai/code/session_01JmgWS61uRfW9MXWarsRNzH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmgWS61uRfW9MXWarsRNzH)_