### PR TITLE
feat(docs): add client-rendered Live-Dashboard at docs/site.html

### DIFF
--- a/docs/assets/site-favicon.svg
+++ b/docs/assets/site-favicon.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" aria-label="Wien ÖPNV Live-Dashboard">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1f2c5e"/>
+      <stop offset="100%" stop-color="#0F1736"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#bg)"/>
+  <path d="M16 18h6v18a4 4 0 0 0 8 0V18h6v18a10 10 0 0 1-20 0V18z" fill="#FFD95B"/>
+  <rect x="42" y="18" width="6" height="28" rx="2" fill="#FFD95B"/>
+  <circle cx="32" cy="52" r="3.2" fill="#4CA9FF"/>
+</svg>

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -1,0 +1,651 @@
+/* Wien ÖPNV – Live-Dashboard
+ * Vanilla CSS, mobile-first, kein Build-Schritt.
+ * Farbpalette ist abgestimmt auf assets/og-default.svg.
+ */
+
+*, *::before, *::after { box-sizing: border-box; }
+
+:root {
+  --c-bg: #f5f7fb;
+  --c-bg-elev: #ffffff;
+  --c-surface: #ffffff;
+  --c-surface-2: #eef2f9;
+  --c-border: #e2e7f0;
+  --c-border-strong: #cbd2e1;
+  --c-text: #0f172a;
+  --c-text-muted: #475569;
+  --c-text-subtle: #64748b;
+
+  --c-brand: #0F1736;
+  --c-brand-2: #1f2c5e;
+  --c-brand-ink: #FFFFFF;
+  --c-accent: #2563eb;
+  --c-accent-2: #4CA9FF;
+  --c-accent-ink: #FFFFFF;
+
+  --c-wl: #E2002A;
+  --c-oebb: #C03021;
+  --c-vor: #5a8f12;
+  --c-rss: #C77A00;
+
+  --c-success: #0a7a59;
+  --c-warning: #b45309;
+  --c-danger: #b91c1c;
+  --c-info: #1d4ed8;
+
+  --radius-sm: 8px;
+  --radius: 14px;
+  --radius-lg: 22px;
+
+  --shadow-sm: 0 1px 2px rgba(15, 23, 36, 0.06);
+  --shadow: 0 1px 2px rgba(15, 23, 36, 0.05), 0 8px 24px rgba(15, 23, 36, 0.06);
+  --shadow-lg: 0 4px 12px rgba(15, 23, 36, 0.08), 0 24px 60px rgba(15, 23, 36, 0.10);
+
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+  --container: 1200px;
+  --header-h: 64px;
+
+  color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --c-bg: #0a1126;
+    --c-bg-elev: #111a3a;
+    --c-surface: #121e44;
+    --c-surface-2: #1a2654;
+    --c-border: #24336a;
+    --c-border-strong: #2f4286;
+    --c-text: #eaf2ff;
+    --c-text-muted: #b3becf;
+    --c-text-subtle: #8b9ab5;
+
+    --c-brand: #0a1126;
+    --c-brand-2: #1d2b62;
+    --c-brand-ink: #eaf2ff;
+    --c-accent: #4CA9FF;
+    --c-accent-2: #7dc1ff;
+    --c-accent-ink: #0a1126;
+
+    --c-wl: #ff5f7e;
+    --c-oebb: #ff6f5e;
+    --c-vor: #a3d36b;
+    --c-rss: #ffd28a;
+
+    --c-success: #34d3a4;
+    --c-warning: #fbbf24;
+    --c-danger: #fb7185;
+    --c-info: #7dc1ff;
+
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.5);
+    --shadow-lg: 0 4px 12px rgba(0, 0, 0, 0.5), 0 24px 60px rgba(0, 0, 0, 0.65);
+  }
+}
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--c-text);
+  background:
+    radial-gradient(1100px 600px at 20% -10%, rgba(76, 169, 255, 0.10), transparent 60%),
+    radial-gradient(900px 500px at 110% 0%, rgba(226, 0, 42, 0.06), transparent 55%),
+    var(--c-bg);
+  background-attachment: fixed;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+img, svg { max-width: 100%; height: auto; }
+
+a {
+  color: var(--c-accent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
+}
+a:hover { color: var(--c-accent-2); }
+a:focus-visible, button:focus-visible, .chip:focus-visible {
+  outline: 2px solid var(--c-accent);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
+code {
+  font-family: var(--font-mono);
+  background: var(--c-surface-2);
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  padding: 0.05em 0.4em;
+  font-size: 0.92em;
+}
+
+/* Skip-Link */
+.skip-link {
+  position: absolute;
+  left: 1rem; top: -2.5rem;
+  background: var(--c-brand);
+  color: var(--c-brand-ink);
+  padding: 0.5rem 0.85rem;
+  border-radius: 8px;
+  z-index: 1000;
+  transition: top 0.15s ease;
+}
+.skip-link:focus { top: 0.75rem; }
+
+/* Container */
+.container {
+  width: min(100%, var(--container));
+  margin-inline: auto;
+  padding-inline: clamp(1rem, 3vw, 2rem);
+}
+
+/* Header */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: color-mix(in srgb, var(--c-bg-elev) 85%, transparent);
+  backdrop-filter: saturate(180%) blur(12px);
+  -webkit-backdrop-filter: saturate(180%) blur(12px);
+  border-bottom: 1px solid var(--c-border);
+}
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-height: var(--header-h);
+}
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.7rem;
+  text-decoration: none;
+  color: var(--c-text);
+}
+.brand__mark {
+  width: 34px;
+  height: 34px;
+  display: inline-grid;
+  place-items: center;
+  border-radius: 9px;
+  background: linear-gradient(135deg, var(--c-brand) 0%, var(--c-brand-2) 100%);
+  color: #FFD95B;
+  box-shadow: var(--shadow-sm);
+  flex: none;
+}
+.brand__mark svg { width: 100%; height: 100%; display: block; }
+.brand__mark rect { fill: transparent; }
+.brand__mark path { fill: currentColor; }
+.brand__text { display: grid; line-height: 1.1; }
+.brand__name { font-weight: 700; font-size: 1.05rem; letter-spacing: -0.01em; }
+.brand__sub { font-size: 0.78rem; color: var(--c-text-subtle); }
+
+.site-nav ul {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
+}
+.site-nav a {
+  display: inline-block;
+  padding: 0.45rem 0.7rem;
+  border-radius: 8px;
+  color: var(--c-text-muted);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+.site-nav a:hover { background: var(--c-surface-2); color: var(--c-text); }
+.site-nav__cta {
+  border: 1px solid var(--c-border-strong);
+  color: var(--c-text) !important;
+  background: var(--c-surface);
+}
+.site-nav__cta:hover { background: var(--c-accent); color: var(--c-accent-ink) !important; border-color: transparent; }
+
+/* Hero */
+.hero {
+  margin: clamp(1.5rem, 5vw, 3rem) 0 clamp(1.5rem, 4vw, 2.5rem);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--c-bg-elev) 92%, transparent) 0%, var(--c-bg-elev) 100%);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  position: relative;
+  overflow: hidden;
+}
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: -40% -10% auto auto;
+  width: 480px; height: 480px;
+  background:
+    radial-gradient(closest-side, rgba(76, 169, 255, 0.18), transparent 70%),
+    radial-gradient(closest-side, rgba(255, 217, 91, 0.10), transparent 60%);
+  pointer-events: none;
+}
+.hero__eyebrow {
+  margin: 0 0 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--c-text-subtle);
+}
+.hero h1 {
+  margin: 0 0 0.65rem;
+  font-size: clamp(1.65rem, 3.4vw, 2.4rem);
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+}
+.hero__lead {
+  margin: 0;
+  font-size: clamp(1rem, 1.6vw, 1.1rem);
+  color: var(--c-text-muted);
+  max-width: 65ch;
+}
+
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin-top: 1.2rem;
+  padding: 0.45rem 0.85rem 0.45rem 0.65rem;
+  border: 1px solid var(--c-border);
+  background: var(--c-surface);
+  border-radius: 999px;
+  box-shadow: var(--shadow-sm);
+  flex-wrap: wrap;
+}
+.status__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--c-text-subtle);
+  display: inline-block;
+}
+.status__dot[data-status="loading"] { background: var(--c-info); animation: pulse 1.4s ease-in-out infinite; }
+.status__dot[data-status="ok"] { background: var(--c-success); }
+.status__dot[data-status="warning"] { background: var(--c-warning); }
+.status__dot[data-status="error"] { background: var(--c-danger); }
+.status__text { font-size: 0.92rem; color: var(--c-text-muted); }
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.4); opacity: 0.55; }
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.75rem;
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--c-text);
+  background: var(--c-surface);
+  border: 1px solid var(--c-border-strong);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.btn:hover { background: var(--c-accent); color: var(--c-accent-ink); border-color: transparent; }
+.btn[disabled] { opacity: 0.6; cursor: progress; }
+.btn--ghost { background: transparent; }
+
+.hero__meta {
+  margin: 1rem 0 0;
+  font-size: 0.88rem;
+  color: var(--c-text-subtle);
+}
+.hero__meta a { color: inherit; text-decoration-color: var(--c-border-strong); }
+.hero__meta a:hover { color: var(--c-accent); }
+
+/* Sections */
+.section {
+  margin: clamp(2rem, 5vw, 3.5rem) 0;
+  scroll-margin-top: calc(var(--header-h) + 16px);
+}
+.section__header {
+  margin-bottom: clamp(1rem, 3vw, 1.5rem);
+}
+.section__header h2 {
+  margin: 0 0 0.35rem;
+  font-size: clamp(1.3rem, 2.4vw, 1.7rem);
+  letter-spacing: -0.01em;
+}
+.section__header .year {
+  color: var(--c-text-subtle);
+  font-weight: 600;
+}
+.section__sub {
+  margin: 0;
+  color: var(--c-text-muted);
+  font-size: 0.95rem;
+}
+.section__sub code { font-size: 0.85em; }
+
+.badge {
+  display: inline-block;
+  background: var(--c-surface-2);
+  border: 1px solid var(--c-border);
+  border-radius: 999px;
+  padding: 0.05rem 0.55rem;
+  font-size: 0.82rem;
+  color: var(--c-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Filters */
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--c-text-muted);
+  background: var(--c-surface);
+  border: 1px solid var(--c-border-strong);
+  border-radius: 999px;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.chip:hover { color: var(--c-text); background: var(--c-surface-2); }
+.chip.is-active {
+  background: var(--c-brand);
+  color: var(--c-brand-ink);
+  border-color: var(--c-brand);
+}
+
+/* Feed list */
+.feed-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.7rem;
+}
+.feed-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.8rem 1rem;
+  padding: 1rem 1.1rem;
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+.feed-item:hover { transform: translateY(-1px); box-shadow: var(--shadow); }
+.feed-item__source {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 100px;
+  padding: 0.18rem 0.55rem;
+  height: max-content;
+  border-radius: 8px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #fff;
+  background: var(--c-text-subtle);
+  white-space: nowrap;
+}
+.feed-item__source[data-source="wienerlinien"] { background: var(--c-wl); }
+.feed-item__source[data-source="oebb"] { background: var(--c-oebb); }
+.feed-item__source[data-source="vor"] { background: var(--c-vor); }
+.feed-item__source[data-source="other"] { background: var(--c-text-subtle); }
+.feed-item__body { min-width: 0; }
+.feed-item__title {
+  margin: 0 0 0.25rem;
+  font-size: 1.02rem;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: -0.005em;
+}
+.feed-item__title a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+.feed-item__title a:hover { border-bottom-color: var(--c-accent); color: var(--c-accent); }
+.feed-item__desc {
+  margin: 0.25rem 0 0;
+  color: var(--c-text-muted);
+  font-size: 0.95rem;
+  overflow-wrap: anywhere;
+}
+.feed-item__meta {
+  margin-top: 0.55rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1rem;
+  font-size: 0.82rem;
+  color: var(--c-text-subtle);
+}
+.feed-item__meta time { font-variant-numeric: tabular-nums; }
+.feed-item__meta dfn {
+  font-style: normal;
+  font-weight: 600;
+  color: var(--c-text-muted);
+}
+
+@media (max-width: 540px) {
+  .feed-item { grid-template-columns: 1fr; }
+  .feed-item__source { justify-self: start; }
+}
+
+/* Empty / error states */
+.empty, .error {
+  padding: 1rem 1.2rem;
+  border: 1px dashed var(--c-border-strong);
+  border-radius: var(--radius);
+  color: var(--c-text-muted);
+  background: var(--c-surface);
+}
+.error {
+  border-style: solid;
+  border-color: color-mix(in srgb, var(--c-danger) 40%, var(--c-border));
+  background: color-mix(in srgb, var(--c-danger) 5%, var(--c-surface));
+  color: color-mix(in srgb, var(--c-danger) 65%, var(--c-text));
+}
+
+/* KPI grid */
+.kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+.kpi {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius);
+  padding: 1rem 1.1rem;
+  box-shadow: var(--shadow-sm);
+  display: grid;
+  gap: 0.2rem;
+}
+.kpi__label {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--c-text-subtle);
+}
+.kpi__value {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  color: var(--c-text);
+}
+.kpi__sub {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--c-text-subtle);
+}
+
+/* Chart cards */
+.chart-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
+  gap: 0.9rem;
+}
+.card {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius);
+  padding: 1.1rem 1.2rem 1.2rem;
+  box-shadow: var(--shadow-sm);
+  min-width: 0;
+}
+.card--wide { grid-column: 1 / -1; }
+.card__title {
+  margin: 0 0 0.85rem;
+  font-size: 1.02rem;
+  font-weight: 700;
+  letter-spacing: -0.005em;
+}
+
+/* Bars (SVG-based, CSP-friendly) */
+.bars {
+  display: grid;
+  gap: 0.45rem;
+  font-variant-numeric: tabular-nums;
+}
+.bar-row {
+  display: grid;
+  grid-template-columns: minmax(6em, 18ch) 1fr minmax(3em, max-content);
+  gap: 0.6rem;
+  align-items: center;
+  font-size: 0.88rem;
+}
+.bar-row__label {
+  color: var(--c-text-muted);
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.bar-row__chart {
+  display: block;
+  width: 100%;
+  height: 14px;
+  overflow: hidden;
+  border-radius: 7px;
+  background: transparent;
+}
+.bar-row__track { fill: var(--c-surface-2); }
+.bar-row__fill { fill: var(--c-accent); }
+.bar-row__value {
+  text-align: right;
+  color: var(--c-text);
+  font-weight: 600;
+}
+
+/* Themed bar fills */
+.bars--provider .bar-row__fill { fill: #6b7d99; }
+.bars--provider .bar-row[data-key="Wiener Linien"] .bar-row__fill { fill: var(--c-wl); }
+.bars--provider .bar-row[data-key="ÖBB"] .bar-row__fill { fill: var(--c-oebb); }
+.bars--provider .bar-row[data-key^="VOR"] .bar-row__fill { fill: var(--c-vor); }
+.bars--delay .bar-row__fill { fill: var(--c-warning); }
+.bars--cancel .bar-row__fill { fill: var(--c-danger); }
+
+@media (max-width: 560px) {
+  .bar-row { grid-template-columns: minmax(5em, 14ch) 1fr minmax(3em, max-content); gap: 0.5rem; font-size: 0.84rem; }
+}
+
+/* Skeletons */
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background: var(--c-surface-2);
+  border-radius: var(--radius);
+  border: 1px solid var(--c-border);
+  min-height: 80px;
+}
+.skeleton--feed { min-height: 96px; }
+.kpi.skeleton { background: var(--c-surface-2); border: 1px solid var(--c-border); min-height: 92px; }
+.skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--c-bg-elev) 60%, transparent) 50%,
+    transparent 100%);
+  animation: shimmer 1.4s linear infinite;
+}
+@keyframes shimmer {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(100%); }
+}
+
+/* Footer */
+.site-footer {
+  margin-top: clamp(3rem, 8vw, 6rem);
+  padding: clamp(1.5rem, 4vw, 2.5rem) 0;
+  background: var(--c-bg-elev);
+  border-top: 1px solid var(--c-border);
+  color: var(--c-text-muted);
+}
+.site-footer__inner {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+}
+.site-footer__heading {
+  font-size: 0.86rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--c-text);
+  margin: 0 0 0.6rem;
+}
+.site-footer__list { margin: 0; padding-left: 1.1rem; }
+.site-footer__list li { margin: 0.15rem 0; }
+.site-footer a { color: inherit; text-decoration-color: var(--c-border-strong); }
+.site-footer a:hover { color: var(--c-accent); }
+
+/* Reduce motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* Print */
+@media print {
+  .site-header, .site-nav, .filters, #refresh-btn, .skip-link { display: none !important; }
+  body { background: white; color: black; }
+  .card, .kpi, .feed-item, .hero { break-inside: avoid; box-shadow: none; }
+}

--- a/docs/assets/site.js
+++ b/docs/assets/site.js
@@ -1,0 +1,752 @@
+/* Wien ÖPNV – Live-Dashboard
+ *
+ * Vanilla JS, kein Build, keine Drittabhängigkeiten. Lädt:
+ *  - feed.xml (same-origin)
+ *  - data/stats/<datei>_<jahr>.csv via raw.githubusercontent.com
+ * und rendert alles im Browser. Alle Fremddaten werden ausschließlich
+ * über textContent in den DOM eingefügt – keine innerHTML-Pfade für
+ * Daten aus Feed oder CSV. URLs werden vor der Verwendung als href
+ * mit dem WHATWG-URL-Parser geprüft.
+ */
+"use strict";
+
+(() => {
+  const REPO = "Origamihase/wien-oepnv";
+  const RAW_BASE = `https://raw.githubusercontent.com/${REPO}/main/data/stats`;
+  const FEED_URL = "feed.xml";
+  const REFRESH_MS = 5 * 60 * 1000; // 5 Minuten
+
+  const WEEKDAYS = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"];
+  const WEEKDAY_LONG = {
+    Mo: "Montag", Di: "Dienstag", Mi: "Mittwoch", Do: "Donnerstag",
+    Fr: "Freitag", Sa: "Samstag", So: "Sonntag",
+  };
+  const HOURS = Array.from({ length: 24 }, (_, h) => String(h).padStart(2, "0"));
+
+  const dtfFull = new Intl.DateTimeFormat("de-AT", {
+    timeZone: "Europe/Vienna",
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+  const dtfTime = new Intl.DateTimeFormat("de-AT", {
+    timeZone: "Europe/Vienna",
+    timeStyle: "short",
+  });
+  const dtfDate = new Intl.DateTimeFormat("de-AT", {
+    timeZone: "Europe/Vienna",
+    dateStyle: "medium",
+  });
+  const rtf = new Intl.RelativeTimeFormat("de", { numeric: "auto" });
+  const nfInt = new Intl.NumberFormat("de-AT");
+  const nf1 = new Intl.NumberFormat("de-AT", {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+
+  // ----- DOM helper -----
+
+  const $ = (sel, root) => (root || document).querySelector(sel);
+  const $$ = (sel, root) => Array.from((root || document).querySelectorAll(sel));
+
+  function el(tag, opts = {}, ...children) {
+    const node = document.createElement(tag);
+    if (opts.class) node.className = opts.class;
+    if (opts.text != null) node.textContent = String(opts.text);
+    if (opts.attrs) {
+      for (const [k, v] of Object.entries(opts.attrs)) {
+        if (v == null || v === false) continue;
+        node.setAttribute(k, v === true ? "" : String(v));
+      }
+    }
+    if (opts.dataset) {
+      for (const [k, v] of Object.entries(opts.dataset)) {
+        if (v == null) continue;
+        node.dataset[k] = String(v);
+      }
+    }
+    for (const child of children) {
+      if (child == null) continue;
+      node.append(child instanceof Node ? child : document.createTextNode(String(child)));
+    }
+    return node;
+  }
+
+  function clear(node) {
+    while (node && node.firstChild) node.removeChild(node.firstChild);
+  }
+
+  function safeHttpsUrl(raw) {
+    if (typeof raw !== "string" || !raw) return null;
+    try {
+      const u = new URL(raw, location.href);
+      if (u.protocol !== "https:" && u.protocol !== "http:") return null;
+      return u.toString();
+    } catch {
+      return null;
+    }
+  }
+
+  function setStatus(state, message) {
+    const dot = $(".status__dot");
+    const text = $("#status-text");
+    if (dot) dot.dataset.status = state;
+    if (text) text.textContent = message;
+  }
+
+  function setLastUpdate(date) {
+    const t = $("#last-update");
+    if (!t) return;
+    const iso = date.toISOString();
+    t.setAttribute("datetime", iso);
+    t.textContent = dtfFull.format(date) + " Uhr (Europe/Vienna)";
+  }
+
+  function showError(elId, message) {
+    const node = document.getElementById(elId);
+    if (!node) return;
+    node.hidden = false;
+    node.textContent = message;
+  }
+
+  function hideError(elId) {
+    const node = document.getElementById(elId);
+    if (node) node.hidden = true;
+  }
+
+  // ----- Fetching -----
+
+  async function fetchText(url, { signal } = {}) {
+    const buster = Math.floor(Date.now() / 60000);
+    const sep = url.includes("?") ? "&" : "?";
+    const res = await fetch(url + sep + "t=" + buster, {
+      cache: "no-store",
+      credentials: "omit",
+      redirect: "follow",
+      mode: "cors",
+      signal,
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status} – ${url}`);
+    return await res.text();
+  }
+
+  async function fetchCsvForYear(name, { signal } = {}) {
+    const year = new Date().getFullYear();
+    for (const candidate of [year, year - 1]) {
+      try {
+        const text = await fetchText(`${RAW_BASE}/${name}_${candidate}.csv`, { signal });
+        return { year: candidate, text };
+      } catch (err) {
+        if (signal && signal.aborted) throw err;
+        // try previous year
+      }
+    }
+    throw new Error(`Keine CSV-Daten für ${name} verfügbar.`);
+  }
+
+  // ----- CSV parser (RFC-4180 light) -----
+
+  function parseCSV(text) {
+    const rows = [];
+    let i = 0;
+    let field = "";
+    let row = [];
+    let inQuotes = false;
+    const len = text.length;
+    while (i < len) {
+      const c = text[i];
+      if (inQuotes) {
+        if (c === '"') {
+          if (text[i + 1] === '"') { field += '"'; i += 2; continue; }
+          inQuotes = false; i++; continue;
+        }
+        field += c; i++; continue;
+      }
+      if (c === '"') { inQuotes = true; i++; continue; }
+      if (c === ",") { row.push(field); field = ""; i++; continue; }
+      if (c === "\r") { i++; continue; }
+      if (c === "\n") { row.push(field); rows.push(row); row = []; field = ""; i++; continue; }
+      field += c; i++;
+    }
+    if (field !== "" || row.length > 0) { row.push(field); rows.push(row); }
+    return rows;
+  }
+
+  function rowsToObjects(rows) {
+    if (rows.length === 0) return [];
+    const header = rows[0].map((h) => h.trim());
+    const out = [];
+    for (let i = 1; i < rows.length; i++) {
+      const r = rows[i];
+      if (r.length === 1 && r[0] === "") continue;
+      const o = {};
+      for (let j = 0; j < header.length; j++) {
+        o[header[j]] = (r[j] ?? "").trim();
+      }
+      out.push(o);
+    }
+    return out;
+  }
+
+  // ----- XML/RSS parser -----
+
+  const NS_EXT = "https://wien-oepnv.example/schema";
+
+  function parseFeed(xmlText) {
+    const doc = new DOMParser().parseFromString(xmlText, "application/xml");
+    const err = doc.querySelector("parsererror");
+    if (err) throw new Error("Feed konnte nicht geparst werden");
+    const channel = doc.querySelector("channel");
+    if (!channel) throw new Error("Feed ohne <channel>-Element");
+
+    const lastBuild = channelChildText(channel, "lastBuildDate");
+    const items = Array.from(doc.getElementsByTagName("item")).map((it) => {
+      const get = (tag) => firstChildText(it, tag);
+      const ns = (tag) => firstChildTextNs(it, NS_EXT, tag);
+      return {
+        title: get("title"),
+        link: get("link"),
+        guid: get("guid"),
+        pubDate: get("pubDate"),
+        description: get("description"),
+        firstSeen: ns("first_seen"),
+        startsAt: ns("starts_at"),
+        endsAt: ns("ends_at"),
+      };
+    });
+    return { lastBuild, items };
+  }
+
+  function channelChildText(channel, name) {
+    return firstChildText(channel, name);
+  }
+
+  function firstChildText(parent, name) {
+    for (let i = 0; i < parent.children.length; i++) {
+      const ch = parent.children[i];
+      if (ch.localName === name && (!ch.namespaceURI || !ch.namespaceURI.startsWith("http"))) {
+        return ch.textContent ? ch.textContent.trim() : "";
+      }
+      if (ch.tagName === name) {
+        return ch.textContent ? ch.textContent.trim() : "";
+      }
+    }
+    return "";
+  }
+
+  function firstChildTextNs(parent, ns, name) {
+    const list = parent.getElementsByTagNameNS(ns, name);
+    if (list.length === 0) return "";
+    return list[0].textContent ? list[0].textContent.trim() : "";
+  }
+
+  // ----- Feed rendering -----
+
+  function detectSource(item) {
+    const haystack = `${item.link} ${item.title}`.toLowerCase();
+    if (/(wienerlinien|wiener\s*linien|wl-disp|ogd_realtime)/.test(haystack)) return "wienerlinien";
+    if (/(oebb|öbb|scotty)/.test(haystack)) return "oebb";
+    if (/(vor\.at|verkehrsverbund|vao\.|anachb)/.test(haystack)) return "vor";
+    return "other";
+  }
+
+  function sourceLabel(key) {
+    return key === "wienerlinien" ? "Wiener Linien"
+         : key === "oebb" ? "ÖBB"
+         : key === "vor" ? "VOR / VAO"
+         : "Andere";
+  }
+
+  let feedState = { items: [], filter: "all" };
+
+  function renderFeed() {
+    const list = $("#feed-list");
+    const empty = $("#feed-empty");
+    const countBadge = $("#feed-count");
+    if (!list) return;
+
+    list.setAttribute("aria-busy", "false");
+    clear(list);
+
+    const filtered = feedState.filter === "all"
+      ? feedState.items
+      : feedState.items.filter((it) => detectSource(it) === feedState.filter);
+
+    if (countBadge) {
+      countBadge.textContent = `${nfInt.format(filtered.length)} aktiv`;
+    }
+
+    if (filtered.length === 0) {
+      empty.hidden = false;
+      return;
+    }
+    empty.hidden = true;
+
+    const frag = document.createDocumentFragment();
+    for (const it of filtered) {
+      frag.append(renderFeedItem(it));
+    }
+    list.append(frag);
+  }
+
+  function renderFeedItem(item) {
+    const li = el("li", { class: "feed-item", attrs: { "data-source": detectSource(item) } });
+    const src = detectSource(item);
+    li.append(el("span", {
+      class: "feed-item__source",
+      attrs: { "data-source": src, title: sourceLabel(src) },
+      text: sourceLabel(src),
+    }));
+
+    const body = el("div", { class: "feed-item__body" });
+
+    const titleNode = el("h3", { class: "feed-item__title" });
+    const link = safeHttpsUrl(item.link);
+    const titleText = item.title || "(ohne Titel)";
+    if (link) {
+      const a = el("a", {
+        text: titleText,
+        attrs: { href: link, rel: "external noopener noreferrer", target: "_blank" },
+      });
+      titleNode.append(a);
+    } else {
+      titleNode.textContent = titleText;
+    }
+    body.append(titleNode);
+
+    if (item.description) {
+      body.append(el("p", { class: "feed-item__desc", text: collapseWhitespace(item.description) }));
+    }
+
+    const meta = el("div", { class: "feed-item__meta" });
+    const pub = parseRfc2822(item.pubDate);
+    if (pub) {
+      const d = document.createElement("div");
+      d.append(el("dfn", { text: "Beginn: " }));
+      const t = el("time", { attrs: { datetime: pub.toISOString() }, text: dtfFull.format(pub) });
+      d.append(t);
+      meta.append(d);
+    }
+    const ends = parseRfc2822(item.endsAt);
+    if (ends) {
+      const d = document.createElement("div");
+      d.append(el("dfn", { text: "Bis: " }));
+      d.append(el("time", { attrs: { datetime: ends.toISOString() }, text: dtfFull.format(ends) }));
+      meta.append(d);
+    }
+    const seen = parseRfc2822(item.firstSeen);
+    if (seen) {
+      const d = document.createElement("div");
+      d.append(el("dfn", { text: "Erstmals: " }));
+      d.append(document.createTextNode(humanRelative(seen)));
+      meta.append(d);
+    }
+    if (meta.childElementCount > 0) body.append(meta);
+
+    li.append(body);
+    return li;
+  }
+
+  function collapseWhitespace(s) {
+    return s.replace(/\s+/g, " ").trim();
+  }
+
+  function parseRfc2822(s) {
+    if (!s) return null;
+    const t = Date.parse(s);
+    if (Number.isNaN(t)) return null;
+    return new Date(t);
+  }
+
+  function humanRelative(date) {
+    const diffMs = date.getTime() - Date.now();
+    const absMin = Math.abs(diffMs) / 60000;
+    const sign = diffMs < 0 ? -1 : 1;
+    if (absMin < 1) return "gerade eben";
+    if (absMin < 60) return rtf.format(sign * Math.round(absMin), "minute");
+    const hours = absMin / 60;
+    if (hours < 24) return rtf.format(sign * Math.round(hours), "hour");
+    const days = hours / 24;
+    if (days < 30) return rtf.format(sign * Math.round(days), "day");
+    return dtfDate.format(date);
+  }
+
+  // ----- Statistics (stoerungen) -----
+
+  function renderStoerungenStats(year, rows) {
+    setYearLabels(year);
+
+    const total = rows.length;
+    const byProvider = countBy(rows, (r) => r.provider || "Unbekannt");
+    const byWeekday = countByKey(rows, (r) => r.weekday, WEEKDAYS);
+    const byHour = countByKey(rows, (r) => r.hour, HOURS);
+    const byLocation = countBy(rows, (r) => r.location_name || "unbekannt");
+
+    const topProvider = topEntry(byProvider);
+    const peakHour = topEntry(byHour);
+    const peakWeekday = topEntry(byWeekday);
+
+    renderKpis("#stoerungen-kpis", [
+      { label: "Erfasste Störungen", value: nfInt.format(total), sub: `Jahr ${year}` },
+      { label: "Häufigste Quelle",
+        value: topProvider ? topProvider[0] : "–",
+        sub: topProvider ? `${nfInt.format(topProvider[1])} Meldungen` : "" },
+      { label: "Spitzenstunde",
+        value: peakHour ? `${peakHour[0]}:00` : "–",
+        sub: peakHour ? `${nfInt.format(peakHour[1])} Meldungen` : "" },
+      { label: "Stärkster Tag",
+        value: peakWeekday ? (WEEKDAY_LONG[peakWeekday[0]] || peakWeekday[0]) : "–",
+        sub: peakWeekday ? `${nfInt.format(peakWeekday[1])} Meldungen` : "" },
+    ]);
+
+    renderBars("#stoerungen-providers",
+      sortedEntries(byProvider).slice(0, 8),
+      { variant: "provider", formatValue: (v) => nfInt.format(v) });
+
+    renderBars("#stoerungen-weekday",
+      WEEKDAYS.map((d) => [WEEKDAY_LONG[d] || d, byWeekday[d] || 0]),
+      { unit: "", formatValue: (v) => nfInt.format(v) });
+
+    renderBars("#stoerungen-hour",
+      HOURS.map((h) => [`${h}:00`, byHour[h] || 0]),
+      { unit: "", formatValue: (v) => nfInt.format(v) });
+
+    renderBars("#stoerungen-locations",
+      sortedEntries(byLocation).slice(0, 10),
+      { unit: "", formatValue: (v) => nfInt.format(v) });
+  }
+
+  function renderStammstreckeStats(year, rows) {
+    setYearLabels(year);
+
+    const valid = rows
+      .map((r) => ({ ...r, delay: parseFloat(r.delay_minutes) }))
+      .filter((r) => Number.isFinite(r.delay));
+    const total = valid.length;
+    const avg = total ? valid.reduce((a, r) => a + r.delay, 0) / total : 0;
+    const max = total ? valid.reduce((m, r) => (r.delay > m ? r.delay : m), 0) : 0;
+    const over9 = valid.filter((r) => r.delay >= 9).length;
+    const byDirection = countBy(valid, (r) => r.direction || "unbekannt");
+
+    const avgByWeekday = averageBy(valid, (r) => r.weekday, (r) => r.delay, WEEKDAYS);
+    const avgByHour = averageBy(valid, (r) => r.hour, (r) => r.delay, HOURS);
+
+    renderKpis("#stammstrecke-kpis", [
+      { label: "Beobachtungen", value: nfInt.format(total), sub: `Jahr ${year}` },
+      { label: "Ø Verspätung", value: `${nf1.format(avg)} min`, sub: "alle Beobachtungen" },
+      { label: "Max. Verspätung", value: `${nf1.format(max)} min`, sub: "Tickwert" },
+      { label: "Schwerverspätungen", value: nfInt.format(over9), sub: "≥ 9 Minuten" },
+    ]);
+
+    renderBars("#stammstrecke-hour",
+      HOURS.map((h) => [`${h}:00`, avgByHour[h] || 0]),
+      { unit: " min", variant: "delay", formatValue: (v) => nf1.format(v) });
+
+    renderBars("#stammstrecke-weekday",
+      WEEKDAYS.map((d) => [WEEKDAY_LONG[d] || d, avgByWeekday[d] || 0]),
+      { unit: " min", variant: "delay", formatValue: (v) => nf1.format(v) });
+
+    renderBars("#stammstrecke-direction",
+      sortedEntries(byDirection),
+      { unit: "", formatValue: (v) => nfInt.format(v) });
+  }
+
+  function renderAusfaelleStats(year, rows) {
+    setYearLabels(year);
+    const total = rows.length;
+    const byLine = countBy(rows, (r) => r.line || "unbekannt");
+    const byDirection = countBy(rows, (r) => r.direction || "unbekannt");
+    const byHour = countByKey(rows, (r) => r.hour, HOURS);
+    const byWeekday = countByKey(rows, (r) => r.weekday, WEEKDAYS);
+
+    const topLine = topEntry(byLine);
+    const topWeekday = topEntry(byWeekday);
+
+    renderKpis("#ausfaelle-kpis", [
+      { label: "Ausfälle", value: nfInt.format(total), sub: `Jahr ${year}` },
+      { label: "Häufigste Linie",
+        value: topLine ? topLine[0] : "–",
+        sub: topLine ? `${nfInt.format(topLine[1])} Ausfälle` : "keine Daten" },
+      { label: "Stärkster Tag",
+        value: topWeekday ? (WEEKDAY_LONG[topWeekday[0]] || topWeekday[0]) : "–",
+        sub: topWeekday ? `${nfInt.format(topWeekday[1])} Ausfälle` : "keine Daten" },
+    ]);
+
+    renderBars("#ausfaelle-line",
+      sortedEntries(byLine).slice(0, 10),
+      { unit: "", variant: "cancel", formatValue: (v) => nfInt.format(v) });
+
+    renderBars("#ausfaelle-direction",
+      sortedEntries(byDirection),
+      { unit: "", variant: "cancel", formatValue: (v) => nfInt.format(v) });
+
+    renderBars("#ausfaelle-hour",
+      HOURS.map((h) => [`${h}:00`, byHour[h] || 0]),
+      { unit: "", variant: "cancel", formatValue: (v) => nfInt.format(v) });
+  }
+
+  // ----- Aggregation helpers -----
+
+  function countBy(rows, keyFn) {
+    const out = Object.create(null);
+    for (const r of rows) {
+      const k = keyFn(r);
+      out[k] = (out[k] || 0) + 1;
+    }
+    return out;
+  }
+
+  function countByKey(rows, keyFn, order) {
+    const out = Object.create(null);
+    for (const k of order) out[k] = 0;
+    for (const r of rows) {
+      const k = keyFn(r);
+      if (k in out) out[k] += 1;
+    }
+    return out;
+  }
+
+  function averageBy(rows, keyFn, valueFn, order) {
+    const sum = Object.create(null);
+    const cnt = Object.create(null);
+    for (const k of order) { sum[k] = 0; cnt[k] = 0; }
+    for (const r of rows) {
+      const k = keyFn(r);
+      const v = valueFn(r);
+      if (!(k in sum) || !Number.isFinite(v)) continue;
+      sum[k] += v;
+      cnt[k] += 1;
+    }
+    const out = Object.create(null);
+    for (const k of order) out[k] = cnt[k] ? sum[k] / cnt[k] : 0;
+    return out;
+  }
+
+  function sortedEntries(obj) {
+    return Object.entries(obj).sort((a, b) => b[1] - a[1]);
+  }
+
+  function topEntry(obj) {
+    const entries = sortedEntries(obj);
+    if (entries.length === 0 || entries[0][1] === 0) return null;
+    return entries[0];
+  }
+
+  // ----- Render primitives -----
+
+  function setYearLabels(year) {
+    for (const node of $$("[data-year-label]")) {
+      node.textContent = String(year);
+    }
+  }
+
+  function renderKpis(selector, items) {
+    const root = $(selector);
+    if (!root) return;
+    clear(root);
+    const frag = document.createDocumentFragment();
+    for (const it of items) {
+      const card = el("article", { class: "kpi" });
+      card.append(el("p", { class: "kpi__label", text: it.label }));
+      card.append(el("p", { class: "kpi__value", text: it.value }));
+      if (it.sub) card.append(el("p", { class: "kpi__sub", text: it.sub }));
+      frag.append(card);
+    }
+    root.append(frag);
+  }
+
+  const SVG_NS = "http://www.w3.org/2000/svg";
+
+  function svg(tag, attrs) {
+    const node = document.createElementNS(SVG_NS, tag);
+    if (attrs) {
+      for (const [k, v] of Object.entries(attrs)) {
+        if (v == null || v === false) continue;
+        node.setAttribute(k, v === true ? "" : String(v));
+      }
+    }
+    return node;
+  }
+
+  function renderBars(selector, entries, opts = {}) {
+    const root = $(selector);
+    if (!root) return;
+    clear(root);
+    if (opts.variant) root.classList.add(`bars--${opts.variant}`);
+    if (entries.length === 0) {
+      root.append(el("p", { class: "empty", text: "Keine Daten verfügbar." }));
+      return;
+    }
+    const max = entries.reduce((m, [, v]) => (Number.isFinite(v) && v > m ? v : m), 0);
+    const fmt = opts.formatValue || ((v) => String(v));
+    const unit = opts.unit || "";
+    const frag = document.createDocumentFragment();
+    for (const [label, value] of entries) {
+      const row = el("div", { class: "bar-row", dataset: { key: label } });
+      row.append(el("span", { class: "bar-row__label", text: label, attrs: { title: label } }));
+
+      // SVG bar chart cell. Using SVG presentation attributes (width="X")
+      // instead of CSS `style.width = ...` keeps us strictly within
+      // `style-src 'self'` – no inline style attribute is written.
+      const valueText = `${fmt(value)}${unit}`;
+      const width = max > 0 && Number.isFinite(value) ? (value / max) * 100 : 0;
+      const chart = svg("svg", {
+        class: "bar-row__chart",
+        viewBox: "0 0 100 12",
+        preserveAspectRatio: "none",
+        role: "progressbar",
+        "aria-valuemin": "0",
+        "aria-valuemax": String(max || 0),
+        "aria-valuenow": String(Number.isFinite(value) ? value : 0),
+        "aria-label": `${label}: ${valueText}`,
+      });
+      chart.append(svg("rect", { class: "bar-row__track", x: "0", y: "0", width: "100", height: "12" }));
+      chart.append(svg("rect", {
+        class: "bar-row__fill",
+        x: "0", y: "0",
+        width: width.toFixed(2),
+        height: "12",
+      }));
+      row.append(chart);
+
+      row.append(el("span", { class: "bar-row__value", text: valueText }));
+      frag.append(row);
+    }
+    root.append(frag);
+  }
+
+  // ----- Loading orchestration -----
+
+  let refreshTimer = null;
+  let currentAbort = null;
+
+  async function loadAll() {
+    if (currentAbort) currentAbort.abort();
+    const ctrl = new AbortController();
+    currentAbort = ctrl;
+
+    setStatus("loading", "Daten werden geladen …");
+    const refreshBtn = $("#refresh-btn");
+    if (refreshBtn) refreshBtn.disabled = true;
+
+    const tasks = await Promise.allSettled([
+      loadFeed(ctrl.signal),
+      loadStoerungen(ctrl.signal),
+      loadStammstrecke(ctrl.signal),
+      loadAusfaelle(ctrl.signal),
+    ]);
+
+    if (refreshBtn) refreshBtn.disabled = false;
+
+    const errors = tasks.filter((t) => t.status === "rejected");
+    if (errors.length === 0) {
+      setStatus("ok", "Alle Daten aktuell.");
+    } else if (errors.length === tasks.length) {
+      setStatus("error", "Daten konnten nicht geladen werden.");
+    } else {
+      setStatus("warning", `Teilweise geladen (${tasks.length - errors.length}/${tasks.length}).`);
+    }
+    setLastUpdate(new Date());
+  }
+
+  async function loadFeed(signal) {
+    try {
+      hideError("feed-error");
+      const text = await fetchText(FEED_URL, { signal });
+      const feed = parseFeed(text);
+      feedState.items = feed.items;
+      renderFeed();
+    } catch (err) {
+      const list = $("#feed-list");
+      if (list) { list.setAttribute("aria-busy", "false"); clear(list); }
+      showError("feed-error", `Feed konnte nicht geladen werden: ${err.message}`);
+      throw err;
+    }
+  }
+
+  async function loadStoerungen(signal) {
+    try {
+      hideError("stoerungen-error");
+      const { year, text } = await fetchCsvForYear("stoerungen", { signal });
+      const rows = rowsToObjects(parseCSV(text));
+      renderStoerungenStats(year, rows);
+    } catch (err) {
+      showError("stoerungen-error", `Störungs-Statistik nicht verfügbar: ${err.message}`);
+      throw err;
+    }
+  }
+
+  async function loadStammstrecke(signal) {
+    try {
+      hideError("stammstrecke-error");
+      const { year, text } = await fetchCsvForYear("stammstrecke", { signal });
+      const rows = rowsToObjects(parseCSV(text));
+      renderStammstreckeStats(year, rows);
+    } catch (err) {
+      showError("stammstrecke-error", `Stammstrecke-Statistik nicht verfügbar: ${err.message}`);
+      throw err;
+    }
+  }
+
+  async function loadAusfaelle(signal) {
+    try {
+      hideError("ausfaelle-error");
+      const { year, text } = await fetchCsvForYear("ausfaelle", { signal });
+      const rows = rowsToObjects(parseCSV(text));
+      renderAusfaelleStats(year, rows);
+    } catch (err) {
+      showError("ausfaelle-error", `Ausfall-Statistik nicht verfügbar: ${err.message}`);
+      throw err;
+    }
+  }
+
+  // ----- Wiring -----
+
+  function attachFilterHandlers() {
+    const root = $("#feed-filters");
+    if (!root) return;
+    root.addEventListener("click", (ev) => {
+      const target = ev.target;
+      if (!(target instanceof HTMLElement)) return;
+      const btn = target.closest("[data-filter]");
+      if (!btn || !root.contains(btn)) return;
+      const filter = btn.getAttribute("data-filter") || "all";
+      feedState.filter = filter;
+      for (const c of root.querySelectorAll(".chip")) c.classList.remove("is-active");
+      btn.classList.add("is-active");
+      renderFeed();
+    });
+  }
+
+  function attachRefresh() {
+    const btn = $("#refresh-btn");
+    if (btn) btn.addEventListener("click", () => loadAll());
+    document.addEventListener("visibilitychange", () => {
+      if (!document.hidden) {
+        const t = $("#last-update");
+        const stamp = t && t.getAttribute("datetime") ? Date.parse(t.getAttribute("datetime")) : 0;
+        if (!stamp || Date.now() - stamp > REFRESH_MS) loadAll();
+      }
+    });
+  }
+
+  function startAutoRefresh() {
+    if (refreshTimer) clearInterval(refreshTimer);
+    refreshTimer = setInterval(() => {
+      if (!document.hidden) loadAll();
+    }, REFRESH_MS);
+  }
+
+  function init() {
+    setYearLabels(new Date().getFullYear());
+    attachFilterHandlers();
+    attachRefresh();
+    loadAll();
+    startAutoRefresh();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ Alle Datenquellen werden revisionssicher versioniert, inklusive Lizenzhinweisen.
 
 ## Feed abonnieren & weiterempfehlen
 
+- **Live-Dashboard**: Unter [`site.html`](site.html) steht ein leichtgewichtiges, vollständig client-seitig gerendertes Dashboard bereit. Es bündelt den aktuellen Feed, die Störungs-Statistik des laufenden Jahres und die Stammstrecken-Kennzahlen ohne Tracker, Cookies oder Drittanbieter-Skripte.
 - **Direkter RSS-Link**: `https://origamihase.github.io/wien-oepnv/feed.xml` liefert stets die aktuellen Meldungen mit sprechenden GUIDs und permalinks. Die Elemente enthalten eindeutige Titel und Links, damit News-Aggregatoren wie Feedly oder Inoreader sie korrekt erkennen.
 - **Sitemap & Robots**: `docs/sitemap.xml` und `docs/robots.txt` weisen Suchmaschinen aktiv auf den Feed hin. Der `<link rel="alternate">`-Eintrag im HTML-Head macht den Feed außerdem für Google Discover und andere „Folgen“-Funktionen sichtbar.
 - **Weiterführende Signale**: Verlinke das Projekt auf deiner Website, in Blogposts oder passenden Community-Foren (z. B. Reddit, Mastodon, lokale ÖPNV-Gruppen). Jede Empfehlung erzeugt wertvolle Backlinks und hilft Suchmaschinen, die Relevanz des Angebots einzuordnen.
@@ -84,6 +85,7 @@ Der Code steht unter der MIT-Lizenz. Prüfe bei externen Datenquellen die indivi
 - Feed-Health-Report: `docs/feed-health.md` (+ `docs/feed-health.json` für maschinelle Konsumenten) – beide lokal nach jedem Build erzeugt
 - [Eventschema für Integrationen](schema/events.schema.json)
 - [Feed als RSS-Dokument](feed.xml)
+- [Live-Dashboard (`site.html`)](site.html) mit aktueller Feed-, Störungs- und Stammstrecken-Auswertung
 
 <script type="application/ld+json">
 {

--- a/docs/site.html
+++ b/docs/site.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; base-uri 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self' https://raw.githubusercontent.com; font-src 'self'; form-action 'none'; manifest-src 'none'; object-src 'none'; frame-src 'none'; worker-src 'none'; media-src 'none'">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
+  <meta name="color-scheme" content="light dark">
+  <meta name="theme-color" content="#0F1736" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#0a1126" media="(prefers-color-scheme: dark)">
+  <meta name="format-detection" content="telephone=no">
+  <meta name="robots" content="index,follow">
+
+  <title>Wien ÖPNV – Live-Dashboard | Störungen, Stammstrecke &amp; Statistik</title>
+  <meta name="description" content="Live-Dashboard für Wiener Linien, ÖBB und VOR: aktuelle Störungen aus dem RSS-Feed, Jahresstatistik der Störungsmeldungen sowie Verspätungs- und Ausfalldaten der S-Bahn-Stammstrecke.">
+
+  <link rel="canonical" href="https://origamihase.github.io/wien-oepnv/site.html">
+  <link rel="alternate" type="application/rss+xml" title="Wien ÖPNV Feed" href="feed.xml">
+  <link rel="icon" type="image/svg+xml" href="assets/site-favicon.svg">
+  <link rel="stylesheet" href="assets/site.css">
+
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="de_AT">
+  <meta property="og:site_name" content="Wien ÖPNV Feed">
+  <meta property="og:title" content="Wien ÖPNV – Live-Dashboard">
+  <meta property="og:description" content="Echtzeit-Übersicht zu Störungen, Stammstrecken-Verspätungen und Ausfällen im Wiener ÖPNV.">
+  <meta property="og:url" content="https://origamihase.github.io/wien-oepnv/site.html">
+  <meta property="og:image" content="https://origamihase.github.io/wien-oepnv/assets/og-default.svg">
+  <meta property="og:image:alt" content="Wien ÖPNV Feed – Social Preview mit eingebautem Wappen">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Wien ÖPNV – Live-Dashboard">
+  <meta name="twitter:description" content="Echtzeit-Übersicht zu Störungen, Stammstrecken-Verspätungen und Ausfällen im Wiener ÖPNV.">
+  <meta name="twitter:image" content="https://origamihase.github.io/wien-oepnv/assets/og-default.svg">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebApplication",
+    "name": "Wien ÖPNV – Live-Dashboard",
+    "applicationCategory": "TransportationApplication",
+    "operatingSystem": "Cross-platform",
+    "url": "https://origamihase.github.io/wien-oepnv/site.html",
+    "inLanguage": "de-AT",
+    "isAccessibleForFree": true,
+    "description": "Live-Dashboard für Störungen, Stammstrecken-Verspätungen und Ausfälle im Wiener ÖPNV. Datenquellen: Wiener Linien, ÖBB, VOR/VAO.",
+    "publisher": {
+      "@type": "Organization",
+      "name": "Wien ÖPNV Projektteam",
+      "url": "https://github.com/Origamihase/wien-oepnv"
+    },
+    "offers": { "@type": "Offer", "price": "0", "priceCurrency": "EUR" }
+  }
+  </script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Zum Inhalt springen</a>
+
+  <header class="site-header" role="banner">
+    <div class="container site-header__inner">
+      <a class="brand" href="./" aria-label="Wien ÖPNV – Startseite">
+        <span class="brand__mark" aria-hidden="true">
+          <svg viewBox="0 0 32 32" focusable="false" aria-hidden="true">
+            <rect width="32" height="32" rx="8"></rect>
+            <path d="M9 9h3v9a2 2 0 0 0 4 0V9h3v9a5 5 0 0 1-10 0V9zm12 0h2v14h-2z"></path>
+          </svg>
+        </span>
+        <span class="brand__text">
+          <span class="brand__name">Wien ÖPNV</span>
+          <span class="brand__sub">Live-Dashboard</span>
+        </span>
+      </a>
+      <nav class="site-nav" aria-label="Hauptnavigation">
+        <ul>
+          <li><a href="#feed">Meldungen</a></li>
+          <li><a href="#stoerungen">Störungs-Statistik</a></li>
+          <li><a href="#stammstrecke">Stammstrecke</a></li>
+          <li><a href="#ausfaelle">Ausfälle</a></li>
+          <li><a href="feed.xml" type="application/rss+xml" class="site-nav__cta">RSS</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" class="container" tabindex="-1">
+    <section class="hero" aria-labelledby="hero-title">
+      <p class="hero__eyebrow">Echtzeit · Open Data · Wien &amp; Ostregion</p>
+      <h1 id="hero-title">Störungen, Verspätungen &amp; Ausfälle auf einen Blick</h1>
+      <p class="hero__lead">
+        Konsolidierte Verkehrsinformationen aus
+        <strong>Wiener Linien</strong>, <strong>ÖBB</strong> und <strong>VOR/VAO</strong> –
+        live aus dem RSS-Feed, ergänzt um die aktuelle Jahresstatistik der
+        S-Bahn-Stammstrecke.
+      </p>
+      <div class="status" role="status" aria-live="polite">
+        <span class="status__dot" data-status="loading" aria-hidden="true"></span>
+        <span class="status__text" id="status-text">Daten werden geladen …</span>
+        <button type="button" id="refresh-btn" class="btn btn--ghost">
+          <span aria-hidden="true">⟳</span>
+          <span>Aktualisieren</span>
+        </button>
+      </div>
+      <p class="hero__meta">
+        Datenstand:&nbsp;<time id="last-update" datetime="">–</time>
+        · <a href="feed.xml" type="application/rss+xml">Feed (RSS)</a>
+        · <a href="https://github.com/Origamihase/wien-oepnv" rel="external noopener noreferrer" target="_blank">Quellcode</a>
+      </p>
+    </section>
+
+    <section id="feed" class="section" aria-labelledby="feed-title">
+      <header class="section__header">
+        <h2 id="feed-title">Aktuelle Meldungen</h2>
+        <p class="section__sub">
+          Live aus <a href="feed.xml" type="application/rss+xml"><code>feed.xml</code></a>
+          · konsolidiert aus offiziellen Quellen
+          · <span id="feed-count" class="badge" aria-live="polite">–</span>
+        </p>
+      </header>
+
+      <div class="filters" role="group" aria-label="Meldungen nach Quelle filtern" id="feed-filters">
+        <button class="chip is-active" type="button" data-filter="all">Alle</button>
+        <button class="chip" type="button" data-filter="wienerlinien">Wiener Linien</button>
+        <button class="chip" type="button" data-filter="oebb">ÖBB</button>
+        <button class="chip" type="button" data-filter="vor">VOR / VAO</button>
+        <button class="chip" type="button" data-filter="other">Andere</button>
+      </div>
+
+      <ol class="feed-list" id="feed-list" aria-busy="true" aria-describedby="feed-empty">
+        <li class="skeleton skeleton--feed"></li>
+        <li class="skeleton skeleton--feed"></li>
+        <li class="skeleton skeleton--feed"></li>
+      </ol>
+      <p class="empty" id="feed-empty" hidden>Keine Meldungen für den gewählten Filter.</p>
+      <p class="error" id="feed-error" hidden role="alert"></p>
+    </section>
+
+    <section id="stoerungen" class="section" aria-labelledby="stoerungen-title">
+      <header class="section__header">
+        <h2 id="stoerungen-title">Störungs-Statistik <span class="year" data-year-label>–</span></h2>
+        <p class="section__sub">
+          Jahresledger aus
+          <code>data/stats/stoerungen_<span data-year-label>–</span>.csv</code>
+          – eine Zeile pro neu erkannter Ereignis-Identität.
+        </p>
+      </header>
+
+      <div class="kpis" id="stoerungen-kpis" aria-label="Kennzahlen Störungen">
+        <article class="kpi skeleton"></article>
+        <article class="kpi skeleton"></article>
+        <article class="kpi skeleton"></article>
+        <article class="kpi skeleton"></article>
+      </div>
+
+      <div class="chart-grid">
+        <article class="card">
+          <h3 class="card__title">Verteilung je Quelle</h3>
+          <div class="bars" id="stoerungen-providers" aria-label="Störungen je Quelle"></div>
+        </article>
+        <article class="card">
+          <h3 class="card__title">Nach Wochentag</h3>
+          <div class="bars" id="stoerungen-weekday" aria-label="Störungen je Wochentag"></div>
+        </article>
+        <article class="card">
+          <h3 class="card__title">Nach Tageszeit</h3>
+          <div class="bars" id="stoerungen-hour" aria-label="Störungen je Stunde"></div>
+        </article>
+        <article class="card card--wide">
+          <h3 class="card__title">Häufigste Orte</h3>
+          <div class="bars" id="stoerungen-locations" aria-label="Häufigste Orte"></div>
+        </article>
+      </div>
+      <p class="error" id="stoerungen-error" hidden role="alert"></p>
+    </section>
+
+    <section id="stammstrecke" class="section" aria-labelledby="stammstrecke-title">
+      <header class="section__header">
+        <h2 id="stammstrecke-title">Stammstrecke – Verspätungen <span class="year" data-year-label>–</span></h2>
+        <p class="section__sub">
+          S-Bahn-Beobachtungen am Wien Hauptbahnhof
+          – <code>data/stats/stammstrecke_<span data-year-label>–</span>.csv</code>.
+        </p>
+      </header>
+
+      <div class="kpis" id="stammstrecke-kpis" aria-label="Kennzahlen Stammstrecke">
+        <article class="kpi skeleton"></article>
+        <article class="kpi skeleton"></article>
+        <article class="kpi skeleton"></article>
+        <article class="kpi skeleton"></article>
+      </div>
+
+      <div class="chart-grid">
+        <article class="card">
+          <h3 class="card__title">Ø Verspätung nach Tageszeit</h3>
+          <div class="bars" id="stammstrecke-hour" aria-label="Ø Verspätung je Stunde"></div>
+        </article>
+        <article class="card">
+          <h3 class="card__title">Ø Verspätung nach Wochentag</h3>
+          <div class="bars" id="stammstrecke-weekday" aria-label="Ø Verspätung je Wochentag"></div>
+        </article>
+        <article class="card card--wide">
+          <h3 class="card__title">Beobachtungen je Richtung</h3>
+          <div class="bars" id="stammstrecke-direction" aria-label="Beobachtungen je Richtung"></div>
+        </article>
+      </div>
+      <p class="error" id="stammstrecke-error" hidden role="alert"></p>
+    </section>
+
+    <section id="ausfaelle" class="section" aria-labelledby="ausfaelle-title">
+      <header class="section__header">
+        <h2 id="ausfaelle-title">Stammstrecke – Ausfälle <span class="year" data-year-label>–</span></h2>
+        <p class="section__sub">
+          Annullierte S-Bahn-Züge – deduplizierter Ledger
+          <code>data/stats/ausfaelle_<span data-year-label>–</span>.csv</code>.
+        </p>
+      </header>
+
+      <div class="kpis" id="ausfaelle-kpis" aria-label="Kennzahlen Ausfälle">
+        <article class="kpi skeleton"></article>
+        <article class="kpi skeleton"></article>
+        <article class="kpi skeleton"></article>
+      </div>
+
+      <div class="chart-grid">
+        <article class="card">
+          <h3 class="card__title">Nach Linie</h3>
+          <div class="bars" id="ausfaelle-line" aria-label="Ausfälle je Linie"></div>
+        </article>
+        <article class="card">
+          <h3 class="card__title">Nach Richtung</h3>
+          <div class="bars" id="ausfaelle-direction" aria-label="Ausfälle je Richtung"></div>
+        </article>
+        <article class="card card--wide">
+          <h3 class="card__title">Nach Tageszeit</h3>
+          <div class="bars" id="ausfaelle-hour" aria-label="Ausfälle je Stunde"></div>
+        </article>
+      </div>
+      <p class="error" id="ausfaelle-error" hidden role="alert"></p>
+    </section>
+  </main>
+
+  <footer class="site-footer" role="contentinfo">
+    <div class="container site-footer__inner">
+      <div>
+        <h2 class="site-footer__heading">Datenquellen</h2>
+        <ul class="site-footer__list">
+          <li><strong>Wiener Linien</strong> – Echtzeit-Störungsmeldungen (OGD)</li>
+          <li><strong>ÖBB</strong> – bundesweite Bahnmeldungen, Wien-gefiltert</li>
+          <li><strong>VOR/VAO</strong> – Stammstrecken-Beobachtungen am Wien Hbf</li>
+          <li><strong>Stadt Wien (OGD)</strong> – Baustellen mit Bezirk &amp; Zeitraum</li>
+        </ul>
+      </div>
+      <div>
+        <h2 class="site-footer__heading">Über das Dashboard</h2>
+        <p>
+          Open-Source unter MIT-Lizenz. Aktualisierungs-Cadence des Feeds: rund alle 30&nbsp;Minuten.
+          Dieses Dashboard ruft Feed und Statistik-CSVs <em>direkt im Browser</em> ab –
+          es gibt keinen Tracker, keine Cookies, keine Drittanbieter-Skripte.
+        </p>
+        <p>
+          <a href="https://github.com/Origamihase/wien-oepnv" rel="external noopener noreferrer" target="_blank">Repository auf GitHub</a>
+          · <a href="https://github.com/Origamihase/wien-oepnv/blob/main/data/stats/README.md" rel="external noopener noreferrer" target="_blank">CSV-Schema</a>
+          · <a href="feed.xml" type="application/rss+xml">RSS-Feed</a>
+          · <a href="./">Projekt-Startseite</a>
+        </p>
+      </div>
+    </div>
+  </footer>
+
+  <script src="assets/site.js" defer></script>
+</body>
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,162 +2,162 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>daily</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/architecture.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/INDEX.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/audit-2024-12-31.html</loc>
-    <lastmod>2026-02-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/audit-2025-01-04.html</loc>
-    <lastmod>2026-02-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/audit-2025-01.html</loc>
-    <lastmod>2026-02-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/audit-2025-02-14.html</loc>
-    <lastmod>2026-02-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/audit-2025-03-17.html</loc>
-    <lastmod>2026-02-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/audit-2025-04-05.html</loc>
-    <lastmod>2026-02-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/audit-2025-05-22.html</loc>
-    <lastmod>2026-02-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/audit-2025-05-29.html</loc>
-    <lastmod>2026-02-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/audit-2025-06-02.html</loc>
-    <lastmod>2026-02-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/audit-2025-07-08.html</loc>
-    <lastmod>2026-02-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/audit_report.html</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/code_audit.html</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/code_quality_audit_2025_02.html</loc>
-    <lastmod>2026-02-02</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/code_quality_review.html</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/code_review_summary.html</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/deduplication_report.html</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/oebb_stammstrecke_audit.html</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/performance_report.html</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/security_report.html</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/stammstrecke_vor_migration_qa_2026-05-09.html</loc>
-    <lastmod>2026-05-09</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/stations_coverage_2026-05.html</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/stations_data_audit_2026-05-05.html</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/stations_data_audit_2026-05-05_followup.html</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/stations_data_audit_2026-05-05_official_polygon.html</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/system_audit.html</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/system_health_review.html</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/system_review.html</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/vor_api_review.html</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/archive/audits/vor_api_test.html</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
@@ -172,103 +172,107 @@
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/how-to/google_places_stations.html</loc>
-    <lastmod>2026-05-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/how-to/provider_plugins.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/how-to/test-api-secrets.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/how-to/trip-request.html</loc>
-    <lastmod>2025-10-19</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/how-to/versions.html</loc>
-    <lastmod>2025-10-19</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/performance_monitoring_plan.html</loc>
-    <lastmod>2026-05-10</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/reference/arrivalboard.html</loc>
-    <lastmod>2025-10-19</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/reference/datainfo.html</loc>
-    <lastmod>2025-10-19</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/reference/departureboard.html</loc>
-    <lastmod>2025-10-19</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/reference/location-details.html</loc>
-    <lastmod>2025-10-19</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/reference/location-name.html</loc>
-    <lastmod>2025-10-19</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/reference/location-nearbystops.html</loc>
-    <lastmod>2025-10-19</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/reference/manuals/Handbuch_VAO_ReST_API_latest.pdf</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>yearly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/reference/oebb_provider_logic.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/reference/stammstrecke_provider_logic.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/reference/timetable-info.html</loc>
-    <lastmod>2025-10-19</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/reference/trip.html</loc>
-    <lastmod>2025-10-19</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/robots.txt</loc>
-    <lastmod>2025-10-19</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/schema/events.schema.json</loc>
-    <lastmod>2026-05-01</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/schema/pendler_candidates.schema.json</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-16</lastmod>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/schema/stations.schema.json</loc>
+    <lastmod>2026-05-16</lastmod>
+  </url>
+  <url>
+    <loc>https://origamihase.github.io/wien-oepnv/site.html</loc>
     <lastmod>2026-05-16</lastmod>
   </url>
   <url>
@@ -283,17 +287,17 @@
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/statistik.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/strict-typing-attr-defined-investigation.html</loc>
-    <lastmod>2026-05-15</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
   <url>
     <loc>https://origamihase.github.io/wien-oepnv/strict-typing-migration.html</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

Adds a fully responsive, professionally styled **Live-Dashboard** at `docs/site.html` that consolidates the existing `feed.xml` with the per-year statistic ledgers in `data/stats/` into a single overview page.

Reachable after deploy at:
**https://origamihase.github.io/wien-oepnv/site.html**

### What it shows

| Block | Source |
|---|---|
| Aktuelle Meldungen (mit Filter Wiener Linien / ÖBB / VOR) | `docs/feed.xml` (same-origin fetch) |
| Störungs-Statistik (Quellen, Wochentag, Tageszeit, Top-Orte) | `data/stats/stoerungen_<year>.csv` |
| Stammstrecke-Verspätungen (Ø/Max, Wochentag, Tageszeit, Richtung) | `data/stats/stammstrecke_<year>.csv` |
| Stammstrecke-Ausfälle (Linie, Richtung, Tageszeit) | `data/stats/ausfaelle_<year>.csv` |

Year is detected from `Date.now()` at runtime with a fallback to the previous year if the current year's CSV is missing — so the page transitions cleanly across calendar boundaries.

### Architecture

- **Three files**, no build step:
  - `docs/site.html` — semantic markup, ARIA roles, skip link, JSON-LD
  - `docs/assets/site.css` — vanilla CSS with custom properties, light + dark via `prefers-color-scheme`
  - `docs/assets/site.js` — vanilla JS, DOMParser + RFC-4180-light CSV parser
- **Client-side rendering.** Auto-refresh every 5 min, plus refetch when the tab becomes visible after being hidden.
- **No third-party scripts, fonts, or CSS.** Bar charts are SVG built from the DOM — no Chart.js / D3.

### Security posture

- **Strict CSP via `<meta http-equiv>`:**
  ```
  default-src 'none'; base-uri 'none';
  script-src 'self'; style-src 'self';
  img-src 'self' data:;
  connect-src 'self' https://raw.githubusercontent.com;
  font-src 'self'; form-action 'none';
  manifest-src 'none'; object-src 'none';
  frame-src 'none'; worker-src 'none'; media-src 'none'
  ```
  No `'unsafe-inline'`, no `'unsafe-eval'`. To keep this strict the bar widths are written as SVG presentation attributes (`<rect width="73">`), never as `style="width: …"`.
- **No `innerHTML` path for fetched data.** Every value from the feed or CSV reaches the DOM via `textContent` (or an SVG attribute set via `setAttribute`).
- **URL validation.** Item links are parsed via the WHATWG `URL` constructor and rejected if the protocol isn't `http(s):`; external links carry `rel="noopener noreferrer" target="_blank"`.
- **Referrer policy** `strict-origin-when-cross-origin`.
- No tracking, no cookies, no analytics.

### Accessibility & UX

- `<header>`, `<main>`, `<footer>`, `<nav>` landmarks; `tabindex="-1"` skip target.
- Skip link, `aria-live="polite"` status, `aria-busy` on the live list.
- Every bar is a `role="progressbar"` with `aria-valuemin/max/now` and a descriptive `aria-label`.
- Mobile-first CSS, fluid typography via `clamp()`, `repeat(auto-fit, minmax(...))` grids.
- `prefers-reduced-motion` disables animations.
- Print stylesheet hides controls and de-shadows the cards.

### Discovery

- Linked from `docs/index.md` in the "Feed abonnieren" section and the "Weiterführende Ressourcen" list.
- `docs/sitemap.xml` regenerated via `scripts/generate_sitemap.py` (now includes `/site.html`).
- `<link rel="alternate" type="application/rss+xml" href="feed.xml">` keeps the existing RSS discovery intact.
- Open Graph / Twitter Card metadata + WebApplication JSON-LD.

### Test plan

- [x] Local HTML5 syntax check — well-formed (Python HTMLParser, no errors / no unclosed tags).
- [x] `node --check docs/assets/site.js` — passes.
- [x] CSV parser smoke-tested against all three real CSVs in `data/stats/` (incl. a row with embedded `,` inside quotes).
- [x] Feed parser smoke-tested against the real `docs/feed.xml`; all 10 items + namespaced `ext:first_seen` / `ext:starts_at` / `ext:ends_at` extracted correctly.
- [x] Headless Chromium render at 1280×900 (light), 390×844 (mobile), and 1280×900 (dark) — no console errors, all KPIs / bars / feed items rendered.
- [x] CORS verified: `raw.githubusercontent.com` returns `access-control-allow-origin: *` for the CSVs.
- [x] Filter chips (Alle / WL / ÖBB / VOR / Andere) actually filter the rendered list.
- [x] `python3 scripts/scan_secrets.py docs/site.html docs/assets/site.*` — clean.
- [ ] After deploy: open `https://origamihase.github.io/wien-oepnv/site.html` and confirm no CSP / mixed-content warnings in the DevTools console.

https://claude.ai/code/session_01Y1ejMVEkNVmL2ZKsDdidSJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1ejMVEkNVmL2ZKsDdidSJ)_