### PR TITLE
fix(docs): retire VOR/VAO chip and make "Andere" the catch-all

### DIFF
--- a/docs/assets/site.js
+++ b/docs/assets/site.js
@@ -267,9 +267,20 @@
     list.setAttribute("aria-busy", "false");
     clear(list);
 
+    // "Andere" is a catch-all for anything that is not Wiener Linien
+    // or ÖBB – so a hypothetical VOR/VAO item (still labelled green
+    // by detectSource) is also visible under "Andere", not just under
+    // "Alle". The dedicated VOR/VAO chip was removed in 2026-05 because
+    // VOR data now flows only into the Stammstrecken monitor.
     const filtered = feedState.filter === "all"
       ? feedState.items
-      : feedState.items.filter((it) => detectSource(it) === feedState.filter);
+      : feedState.items.filter((it) => {
+          const src = detectSource(it);
+          if (feedState.filter === "other") {
+            return src !== "wienerlinien" && src !== "oebb";
+          }
+          return src === feedState.filter;
+        });
 
     if (countBadge) {
       countBadge.textContent = `${nfInt.format(filtered.length)} aktiv`;

--- a/docs/site.html
+++ b/docs/site.html
@@ -120,7 +120,6 @@
         <button class="chip is-active" type="button" data-filter="all">Alle</button>
         <button class="chip" type="button" data-filter="wienerlinien">Wiener Linien</button>
         <button class="chip" type="button" data-filter="oebb">ÖBB</button>
-        <button class="chip" type="button" data-filter="vor">VOR / VAO</button>
         <button class="chip" type="button" data-filter="other">Andere</button>
       </div>
 


### PR DESCRIPTION
## Summary

Two small, related fixes for the *Aktuelle Meldungen* filter row on `docs/site.html`.

### 1. Remove the obsolete VOR/VAO filter chip (`docs/site.html`)

Since 2026-05-11 the VOR/VAO ReST API is consumed **exclusively** by the Stammstrecken delay/cancel monitor (`docs/index.md`, `data/stats/README.md`) – no VOR items reach the feed anymore, so the chip was a permanent zero-state.

Remaining chips: `Alle · Wiener Linien · ÖBB · Andere`.

### 2. Make "Andere" inclusive of VOR (`docs/assets/site.js`)

The pre-existing filter used strict equality (`detectSource(it) === feedState.filter`). After removing the VOR chip, that meant a hypothetical VOR-shaped feed item would only appear under `Alle` and would be filtered *out* of `Andere` – which contradicts the user's mental model that "Andere = alles außer WL/ÖBB".

The filter is updated so `Andere` returns everything whose detected source is neither `wienerlinien` nor `oebb`. The other chips keep their strict-equality semantics.

The `detectSource()` branch that maps a VOR-shaped link to `"vor"` is deliberately kept – any future VOR item is still labelled and color-coded (green badge) correctly under both `Alle` and `Andere`.

## Test plan

- [x] HTML diff trivial (one button removed).
- [x] JS diff: `node --check` passes; logic walked through with a synthetic VOR item to confirm visibility under `Alle` + `Andere` and *not* under `Wiener Linien` / `ÖBB`.
- [ ] After deploy: confirm the chip row reads `Alle · Wiener Linien · ÖBB · Andere`.

https://claude.ai/code/session_01Y1ejMVEkNVmL2ZKsDdidSJ