### PR TITLE
fix(feed): strip trailing WL directional marker '&gt;' from summary

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -2211,6 +2211,21 @@ def _format_item_content(
     if time_line:
         time_line = f"[{time_line.strip('[]')}]"
 
+    # Strip a dangling WL directional marker — descriptions like
+    # ``Veranstaltung\nBetrieb ab Schwedenplatz >`` and
+    # ``Gleisbauarbeiten\nBetrieb ab Thaliastraße >`` carry a
+    # trailing ``>`` (or ``<``) that WL uses as a "service onwards"
+    # arrow indicator. Standalone at the end of the summary it
+    # renders as a stray glyph next to the timeframe bracket
+    # (``Schwedenplatz > [Am 16.05.2026]``) and the user reads it
+    # as a broken HTML tag or truncation artifact.
+    # Performed BEFORE the title-body duplicate check below so that
+    # a summary like ``Betrieb ab Schwedenplatz >`` can be matched
+    # against a title body of ``Betrieb ab Schwedenplatz`` and
+    # dropped entirely when redundant.
+    if summary:
+        summary = re.sub(r"\s*[<>]+\s*$", "", summary).rstrip()
+
     # Skip the summary entirely when it would just repeat the title
     # body verbatim. WL Störung items like ``41E: Ersatzbus 41E halten
     # bei Währinger Str 200`` produce a description that's identical

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -111,6 +111,29 @@ _INCOMPLETE_TITLE_TAIL_RE = re.compile(
 # (empty line set) and a title without a leading line marker.
 _WL_LINE_PREFIX_RE = re.compile(r"^[A-Za-z0-9]+(?:/[A-Za-z0-9]+)*\s*:\s+\S")
 
+# WL descriptions sometimes end with a dangling ``>`` / ``<`` that the
+# source uses as a "service onwards" arrow indicator. With a
+# destination after it (``Betrieb ab Schwedenplatz > Praterstern``) it
+# carries meaning; standalone at the end of the summary
+# (``Betrieb ab Schwedenplatz >``) it reads like a broken HTML tag
+# glyph or truncation artifact next to the ``[Am …]`` timeframe
+# bracket. We only strip the *trailing* form — mid-text occurrences
+# stay put.
+_TRAILING_DIRECTIONAL_MARKER_RE = re.compile(r"\s*[<>]+\s*$")
+
+
+def _strip_trailing_directional_marker(summary: str) -> str:
+    """Drop a trailing WL ``>`` / ``<`` arrow with surrounding whitespace.
+
+    Called before the title-body duplicate check in
+    :func:`_format_item_content` so a summary that only differs from
+    the title body by a dangling marker still matches and gets
+    dropped as redundant.
+    """
+    if not summary:
+        return summary
+    return _TRAILING_DIRECTIONAL_MARKER_RE.sub("", summary).rstrip()
+
 
 def _post_filter_wl(items: list[Any]) -> list[Any]:
     """Defence-in-depth: normalise / drop bad WL items loaded from cache.
@@ -2211,20 +2234,7 @@ def _format_item_content(
     if time_line:
         time_line = f"[{time_line.strip('[]')}]"
 
-    # Strip a dangling WL directional marker — descriptions like
-    # ``Veranstaltung\nBetrieb ab Schwedenplatz >`` and
-    # ``Gleisbauarbeiten\nBetrieb ab Thaliastraße >`` carry a
-    # trailing ``>`` (or ``<``) that WL uses as a "service onwards"
-    # arrow indicator. Standalone at the end of the summary it
-    # renders as a stray glyph next to the timeframe bracket
-    # (``Schwedenplatz > [Am 16.05.2026]``) and the user reads it
-    # as a broken HTML tag or truncation artifact.
-    # Performed BEFORE the title-body duplicate check below so that
-    # a summary like ``Betrieb ab Schwedenplatz >`` can be matched
-    # against a title body of ``Betrieb ab Schwedenplatz`` and
-    # dropped entirely when redundant.
-    if summary:
-        summary = re.sub(r"\s*[<>]+\s*$", "", summary).rstrip()
+    summary = _strip_trailing_directional_marker(summary)
 
     # Skip the summary entirely when it would just repeat the title
     # body verbatim. WL Störung items like ``41E: Ersatzbus 41E halten

--- a/tests/test_trailing_directional_marker.py
+++ b/tests/test_trailing_directional_marker.py
@@ -1,0 +1,128 @@
+"""Regression test for Bug 32A (trailing WL directional marker '>').
+
+User feedback: a WL Hinweis surfaced with a dangling ``>`` in the
+description::
+
+    T: "2: Veranstaltung Betrieb ab Schwedenplatz"
+    D: "Betrieb ab Schwedenplatz > [Am 16.05.2026]"
+
+The ``>`` is WL's ASCII "service onwards" arrow. With a destination
+after it (``Betrieb ab Schwedenplatz > Praterstern``) it carries
+meaning. Standalone at the end of the summary it reads like a
+broken HTML tag glyph or a truncation artifact next to the
+``[Am 16.05.2026]`` timeframe bracket.
+
+The fix strips trailing ``>``/``<`` (with optional surrounding
+whitespace) from the summary in ``_format_item_content``. Marker
+characters mid-text are preserved — only the trailing form (which
+has no semantic referent) is removed.
+
+The strip happens BEFORE the title-body duplicate check (Bug 27A)
+so a summary like ``Betrieb ab Schwedenplatz >`` can match against
+a title body of ``Betrieb ab Schwedenplatz`` and be dropped
+entirely when redundant.
+
+Cache items affected (current snapshot): WL Störung #30
+(``Ring, Volkstheater >``), #32 (``Schwedenplatz >``), #42
+(``Thaliastraße >`` — additionally triggers Round 27 dedup after
+the strip).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import cast
+
+from src import build_feed
+from src.feed_types import FeedItem
+
+
+def _format(raw_title: str, raw_desc: str) -> tuple[str, str]:
+    item = cast(
+        FeedItem,
+        {
+            "title": raw_title,
+            "description": raw_desc,
+            "source": "Wiener Linien",
+            "category": "Störung",
+            "guid": "test",
+            "link": "",
+        },
+    )
+    now = datetime(2026, 5, 16, 12, 0, tzinfo=UTC)
+    formatted = build_feed._format_item_content(
+        item, ident="t", starts_at=now, ends_at=None
+    )
+    return formatted.title_out, formatted.desc_text_truncated
+
+
+class TestTrailingDirectionalMarkerStripped:
+    def test_schwedenplatz_marker_stripped(self) -> None:
+        # User's exact reproduction.
+        title = "2: Veranstaltung Betrieb ab Schwedenplatz"
+        desc = "Veranstaltung\nBetrieb ab Schwedenplatz >"
+        _, out = _format(title, desc)
+        # The dangling ">" must NOT appear in the rendered description.
+        assert ">" not in out.replace("[", "")
+        # And the timeframe is still present.
+        assert "[Am" in out or "[Seit" in out
+
+    def test_volkstheater_marker_stripped(self) -> None:
+        title = "2: Veranstaltung Betrieb ab Ring, Volkstheater"
+        desc = "Veranstaltung\nBetrieb ab Ring, Volkstheater >"
+        _, out = _format(title, desc)
+        assert "Volkstheater >" not in out
+        assert "Volkstheater" in out
+
+    def test_thaliastrasse_marker_strip_enables_dedup(self) -> None:
+        # When stripping the trailing ">" makes the summary match the
+        # title body verbatim, Round 27 dedup kicks in and drops the
+        # summary entirely — description becomes just the timeframe.
+        title = "46: Betrieb ab Thaliastraße"
+        desc = "Gleisbauarbeiten\nBetrieb ab Thaliastraße >"
+        _, out = _format(title, desc)
+        # "Betrieb ab Thaliastraße" must NOT appear in description —
+        # it's now recognised as a duplicate of the title body.
+        assert "Betrieb ab Thaliastraße" not in out
+        # Only the timeframe survives.
+        assert out.strip().startswith("[")
+
+
+class TestMidTextDirectionalMarkerPreserved:
+    def test_arrow_with_destination_kept(self) -> None:
+        # ``A > B`` is a legitimate WL directional clause — preserve.
+        title = "U6: Verspätung"
+        desc = "Betrieb ab Schwedenplatz > Praterstern wegen Bauarbeiten."
+        _, out = _format(title, desc)
+        assert "Schwedenplatz > Praterstern" in out
+
+    def test_arrow_in_middle_unchanged(self) -> None:
+        # An arrow inside a sentence stays put — only trailing forms
+        # are noise.
+        title = "U6: Test"
+        desc = "Linie U6 > Floridsdorf umgeleitet."
+        _, out = _format(title, desc)
+        assert "U6 > Floridsdorf" in out
+
+
+class TestNormalTitlesUntouched:
+    def test_no_marker_no_change(self) -> None:
+        title = "U6: Verspätung wegen Schadhaftem Fahrzeug"
+        desc = "Linie U6: Unregelmäßige Intervalle in beiden Richtungen."
+        _, out = _format(title, desc)
+        assert "Unregelmäßige Intervalle" in out
+        assert "<" not in out and ">" not in out
+
+    def test_multiple_trailing_markers_all_stripped(self) -> None:
+        # Defence: ``>>>`` and ``> > >`` patterns also collapse.
+        title = "2: Test Betrieb ab Foo"
+        desc = "Test\nBetrieb ab Foo >>>"
+        _, out = _format(title, desc)
+        assert ">" not in out.replace("[", "").replace("]", "")
+
+    def test_trailing_less_than_marker_stripped(self) -> None:
+        # WL also occasionally uses ``<`` for opposite direction.
+        title = "2: Test Betrieb ab Foo"
+        desc = "Test\nBetrieb ab Foo <"
+        _, out = _format(title, desc)
+        assert "Foo <" not in out


### PR DESCRIPTION
## Summary

User feedback: a WL Hinweis surfaced with a dangling `>` in the description:

```
T: "2: Veranstaltung Betrieb ab Schwedenplatz"
D: "Betrieb ab Schwedenplatz > [Am 16.05.2026]"
```

The `>` is WL's ASCII "service onwards" arrow. With a destination after it (`Betrieb ab Schwedenplatz > Praterstern`) it carries meaning. Standalone at the end of the summary it reads like a broken HTML tag glyph or truncation artifact next to the `[Am …]` timeframe bracket.

### Bug 32A — trailing directional marker

Three real cache items currently carry the dangling marker:
- `Betrieb ab Schwedenplatz >`
- `Betrieb ab Ring, Volkstheater >`
- `Betrieb ab Thaliastraße >`

### Fix

Strip trailing `>`/`<` (with optional surrounding whitespace) from the summary in `_format_item_content`. Markers **mid-text are preserved** — only the trailing form (which has no semantic referent) is removed.

The strip happens **BEFORE** the title-body duplicate check (Bug 27A) so a summary like `Betrieb ab Thaliastraße >` can match against the title body `Betrieb ab Thaliastraße` and be dropped entirely when redundant — that cache item then renders as just the timeframe `[Seit 16.05.2026]` (no duplicate text shown to the user).

### Architectural reasoning (`ULTRATHINK` requested)

| Where to strip? | Why this location? |
|---|---|
| `_post_filter_wl` (cache-read) | Acts only on title, not on description. Wrong layer. |
| `html_to_text` (generic) | Too broad — would risk killing legitimate `>` in non-WL contexts. |
| **`_format_item_content` (output)** | **Chosen:** user-display only, cache stays truthful, runs once per render, integrates cleanly with the existing strip sequence. |

Placing the strip **before** the Round-27 title-body compare is intentional and yields a useful cascade: when `>` is the only thing separating the summary from the title body, dedup now fires correctly.

## Test plan

- [x] 8 new regression tests in `tests/test_trailing_directional_marker.py`
- [x] User's exact reproduction (`Schwedenplatz >`) covered 1:1
- [x] Two siblings in the same cache (`Volkstheater >`, `Thaliastraße >`)
- [x] Mid-text `>` preserved: `Betrieb ab X > Y` stays untouched
- [x] Cascade interaction with Round 27: strip enables duplicate detection for `Thaliastraße >`
- [x] Multiple trailing `>>>` collapse correctly
- [x] `<` (opposite direction) also stripped
- [x] `pytest tests/` — 6614 passed, 2 skipped (no regression)
- [x] `mypy --strict` — clean
- [x] `ruff check` — clean

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_