### PR TITLE
chore(docs): Kachel „Häufigste Orte" aus Störungs-Statistik entfernen

### DIFF
--- a/docs/assets/site.js
+++ b/docs/assets/site.js
@@ -390,7 +390,6 @@
     const byProvider = countBy(rows, (r) => r.provider || "Unbekannt");
     const byWeekday = countByKey(rows, (r) => r.weekday, WEEKDAYS);
     const byHour = countByKey(rows, (r) => r.hour, HOURS);
-    const byLocation = countBy(rows, (r) => r.location_name || "unbekannt");
 
     const topProvider = topEntry(byProvider);
     const peakHour = topEntry(byHour);
@@ -419,10 +418,6 @@
 
     renderBars("#stoerungen-hour",
       HOURS.map((h) => [`${h}:00`, byHour[h] || 0]),
-      { unit: "", formatValue: (v) => nfInt.format(v) });
-
-    renderBars("#stoerungen-locations",
-      sortedEntries(byLocation).slice(0, 10),
       { unit: "", formatValue: (v) => nfInt.format(v) });
   }
 

--- a/docs/site.html
+++ b/docs/site.html
@@ -162,10 +162,6 @@
           <h3 class="card__title">Nach Tageszeit</h3>
           <div class="bars" id="stoerungen-hour" aria-label="Störungen je Stunde"></div>
         </article>
-        <article class="card card--wide">
-          <h3 class="card__title">Häufigste Orte</h3>
-          <div class="bars" id="stoerungen-locations" aria-label="Häufigste Orte"></div>
-        </article>
       </div>
       <p class="error" id="stoerungen-error" hidden role="alert"></p>
     </section>


### PR DESCRIPTION
## Summary
- Entfernt die Kachel „Häufigste Orte" aus dem Bereich Störungs-Statistik in `docs/site.html`.
- Entfernt die zugehörige `byLocation`-Aggregation und den `renderBars`-Aufruf in `docs/assets/site.js`.

## Test plan
- [ ] `docs/site.html` im Browser laden und prüfen, dass im Bereich „Störungs-Statistik" nur noch die Kacheln „Nach Quelle", „Nach Wochentag" und „Nach Tageszeit" angezeigt werden.
- [ ] KPI-Zeile und Layout des restlichen Statistik-Bereichs unverändert.
- [ ] Keine JS-Fehler in der Konsole.

https://claude.ai/code/session_01CMAbKjJ6kPTiYvQReENNbE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMAbKjJ6kPTiYvQReENNbE)_