### PR TITLE
feat(docs): ÖBB-Cityjet-Animation im Header-Spalt

### DIFF
--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -213,9 +213,34 @@ code {
 }
 .site-nav__cta:hover { background: var(--c-accent); color: var(--c-accent-ink) !important; border-color: transparent; }
 
+/* Train strip between header and hero */
+.trainline {
+  position: relative;
+  width: 100%;
+  height: clamp(2rem, 4vw, 3rem);
+  overflow: hidden;
+  pointer-events: none;
+}
+.trainline__train {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  height: 100%;
+  width: auto;
+  transform: translate3d(-100%, -50%, 0);
+  animation: trainline-pass 26s linear infinite;
+}
+@keyframes trainline-pass {
+  from { transform: translate3d(-100%, -50%, 0); }
+  to   { transform: translate3d(100vw, -50%, 0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .trainline__train { animation: none; }
+}
+
 /* Hero */
 .hero {
-  margin: clamp(1.5rem, 5vw, 3rem) 0 clamp(1.5rem, 4vw, 2.5rem);
+  margin: clamp(0.5rem, 1.5vw, 1rem) 0 clamp(1.5rem, 4vw, 2.5rem);
   padding: clamp(1.5rem, 4vw, 2.5rem);
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--c-bg-elev) 92%, transparent) 0%, var(--c-bg-elev) 100%);
@@ -701,7 +726,7 @@ code {
 
 /* Print */
 @media print {
-  .site-header, .site-nav, .filters, #refresh-btn, .skip-link { display: none !important; }
+  .site-header, .site-nav, .filters, #refresh-btn, .skip-link, .trainline { display: none !important; }
   body { background: white; color: black; }
   .card, .kpi, .feed-item, .hero { break-inside: avoid; box-shadow: none; }
   .site-footer { background: white; color: black; }

--- a/docs/site.html
+++ b/docs/site.html
@@ -81,6 +81,10 @@
     </div>
   </header>
 
+  <div class="trainline" aria-hidden="true">
+    <img class="trainline__train" src="assets/train.png" alt="" decoding="async" width="3168" height="448">
+  </div>
+
   <main id="main" class="container" tabindex="-1">
     <section class="hero" aria-labelledby="hero-title">
       <p class="hero__eyebrow">Echtzeit · Open Data · Wien &amp; Ostregion</p>


### PR DESCRIPTION
## Summary
- Fügt zwischen Header und Hero einen schmalen Streifen ein, in dem `docs/assets/train.png` (ÖBB Cityjet, 3168×448) als endlose Schleife von links nach rechts durchfährt.
- Der Streifen ist `position: relative` mit `overflow: hidden`, das Bild wird via `transform: translate3d(-100%, …)` → `translate3d(100vw, …)` in 26&nbsp;s linear animiert.
- Höhe `clamp(2rem, 4vw, 3rem)` (32–48&nbsp;px); Hero-Top-Margin wurde auf `clamp(0.5rem, 1.5vw, 1rem)` reduziert, damit der Spalt visuell ähnlich groß bleibt.
- `aria-hidden="true"` + leeres `alt` (rein dekorativ).
- Respektiert `prefers-reduced-motion` (Animation aus) und ist im Druck via Print-Media-Query ausgeblendet.

## Hinweis
`train.png` ist 1.09&nbsp;MB groß bei 3168×448 px – wird aber nur mit ~32–48&nbsp;px Höhe dargestellt. Für bessere Ladezeit könnte das Asset später auf z.&nbsp;B. 800×~113 reskaliert werden, ohne sichtbaren Qualitätsverlust.

## Test plan
- [ ] `docs/site.html` im Browser laden: Zug fährt durchgehend zwischen Header und Hero von links nach rechts.
- [ ] Layout der Hero-Sektion ist unverändert (kein zusätzlicher großer Abstand).
- [ ] Bei Browser-Setting „Reduzierte Bewegung" bleibt der Zug stehen (oder ist links unsichtbar).
- [ ] Druckvorschau zeigt keinen Streifen.
- [ ] Mobile-Ansicht: Animation läuft, Layout nicht gebrochen.

https://claude.ai/code/session_01CMAbKjJ6kPTiYvQReENNbE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMAbKjJ6kPTiYvQReENNbE)_