### PR TITLE
fix(docs): rechts-Rahmen entfernen (html-Bg + overflow-x clip)

### DIFF
--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -85,7 +85,11 @@
   }
 }
 
-html { -webkit-text-size-adjust: 100%; }
+html {
+  -webkit-text-size-adjust: 100%;
+  background: var(--c-bg);
+  overflow-x: clip;
+}
 
 body {
   margin: 0;


### PR DESCRIPTION
## Summary
Behebt die asymmetrisch rechts sichtbare vertikale Kante neben dem Scrollbar-Bereich.

### Root cause
`body` setzt einen Radial-Gradient mit `background-attachment: fixed`, aber `html` selbst hat keinen Hintergrund. Im Bereich rechts (Scrollbar-Gutter) bleibt also der Default-Hintergrund des `html`-Elements sichtbar – das erzeugt die wahrgenommene vertikale Trennlinie zwischen Page-Content und Scrollbar.

### Fix
- `html { background: var(--c-bg); }` → Scrollbar-Gutter blendet sich nahtlos in den Page-Hintergrund ein.
- `html { overflow-x: clip; }` → Schutz gegen evtl. horizontalen Overflow durch `translateX(100vw)` in der Zug-Animation. `clip` (statt `hidden`) wird verwendet, damit der `position: sticky`-Header weiterhin funktioniert.

## Test plan
- [ ] Hard-Reload, rechte Seite prüfen: keine vertikale Linie zwischen Content und Scrollbar mehr sichtbar.
- [ ] Header bleibt beim Scrollen sticky.
- [ ] Light- und Dark-Mode beide korrekt (var(--c-bg) wechselt automatisch).
- [ ] Zug-Animation läuft unverändert.

https://claude.ai/code/session_01CMAbKjJ6kPTiYvQReENNbE

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMAbKjJ6kPTiYvQReENNbE)_