### PR TITLE
feat(stammstrecke): accept Cityjet Express (CJX) trains in the S-Bahn filter

### DIFF
--- a/scripts/update_stammstrecke_hbf.py
+++ b/scripts/update_stammstrecke_hbf.py
@@ -429,8 +429,8 @@ def _query_departure_board(
         "duration": str(duration_min),
         # Filter on product classes Train (1) + S-Bahn (2). The
         # post-filter in :func:`_is_sbahn_line` narrows further to
-        # S/R/REX line patterns, but the upstream filter saves us a
-        # ton of long-distance (RJ, IC, EC, NJ) entries in the
+        # S/R/REX/CJX line patterns, but the upstream filter saves us
+        # a ton of long-distance (RJ, IC, EC, NJ) entries in the
         # response payload.
         "products": "3",
         # Enable server-side realtime data so ``rtTime`` is populated
@@ -521,7 +521,7 @@ def _query_departure_board(
 
 
 def _is_sbahn_line(name: str) -> bool:
-    """Return ``True`` if *name* matches the S/R/REX line-code pattern.
+    """Return ``True`` if *name* matches the S/R/REX/CJX line-code pattern.
 
     Mirrors the legacy ``_is_sbahn_leg`` line-name check but operates
     on a bare string (the departure's ``name`` field) rather than a

--- a/scripts/update_stammstrecke_status.py
+++ b/scripts/update_stammstrecke_status.py
@@ -51,11 +51,13 @@ Design contract
   under ``maxChange=0`` does not bleed into the signal.
 - **S-Bahn product filter**: the eligible leg must carry an S-Bahn or regional train
   product label. The VAO `/trip` call uses `products=3` to pre-filter Train (1) + S-Bahn (2).
-  We accept either ``leg.category in {"S", "R", "REX"}``,
-  ``leg.name`` matching ``(S|R|REX)\\d+``, or ``leg.Product[].catOut`` /
+  We accept either ``leg.category in {"S", "R", "REX", "CJX"}``,
+  ``leg.name`` matching ``(S|R|REX|CJX)\\d+``, or ``leg.Product[].catOut`` /
   ``Product[].line`` matching the same — covering the known
-  upstream-shape variants without committing to a single one. Long-distance
-  trains (Railjet, IC, etc.) are filtered out.
+  upstream-shape variants without committing to a single one. Cityjet Express
+  (``CJX``) was added 2026-05-17 after ÖBB rebranded selected REX rolling-
+  stock; the corridor coverage is unchanged. Long-distance trains
+  (Railjet, IC, etc.) are filtered out.
 - **Self-Healing on degradation**: if either condition holds the
   events file is *unconditionally* reset to ``[]``:
 
@@ -282,11 +284,12 @@ MAX_QUERY_TIMEOUT = 30
 BREAKER_FAILURE_THRESHOLD = 10
 BREAKER_RECOVERY_TIMEOUT = 3600.0
 
-# Pattern that identifies an S-Bahn, R, or REX line label (``S 1``, ``S 7``,
-# ``REX 3``, ``R 81`` …). Used as the secondary signal when the VAO ``category``
-# field is missing or non-canonical; primary signal is
-# ``category in {"S", "R", "REX"}`` / ``Product.catOut in {"S", "R", "REX"}``.
-_S_BAHN_LINE_RE = re.compile(r"^\s*(S|REX|R)\s*\d+\s*$", re.IGNORECASE)
+# Pattern that identifies an S-Bahn, R, REX, or CJX line label (``S 1``, ``S 7``,
+# ``REX 3``, ``R 81``, ``CJX 9`` …). Used as the secondary signal when the VAO
+# ``category`` field is missing or non-canonical; primary signal is
+# ``category in {"S", "R", "REX", "CJX"}`` /
+# ``Product.catOut in {"S", "R", "REX", "CJX"}``.
+_S_BAHN_LINE_RE = re.compile(r"^\s*(S|REX|R|CJX)\s*\d+\s*$", re.IGNORECASE)
 
 VIENNA_TZ = ZoneInfo("Europe/Vienna")
 
@@ -637,8 +640,8 @@ def _save_pending_trips(path: Path, state: Mapping[str, _PendingTrip]) -> bool:
     (``_load_pending_trips`` recovers the original string from the
     literal escape via ``json.loads``). Legitimate payload content
     is exclusively ASCII (hardcoded direction labels, short S-Bahn
-    / R / REX line designations, ISO-8601 timestamps), so the diff
-    shape is unchanged on the happy path.
+    / R / REX / CJX line designations, ISO-8601 timestamps), so the
+    diff shape is unchanged on the happy path.
     """
 
     payload = {key: _trip_to_json(trip) for key, trip in state.items()}
@@ -1036,25 +1039,30 @@ def _is_sbahn_leg(leg: object) -> bool:
     """Return ``True`` when *leg* represents a Vienna S-Bahn or regional rail product.
 
     The filter targets regional rail: the Vienna S-Bahn product
-    family (``S 1``, ``S 2``, ``S 7``, ``S 80`` …) as well as Regional (``R``)
-    and Regional Express (``REX``) trains are accepted. InterCity (``IC``),
-    Railjet (``RJ``), and any non-rail products are rejected.
+    family (``S 1``, ``S 2``, ``S 7``, ``S 80`` …) as well as Regional
+    (``R``), Regional Express (``REX``), and Cityjet Express (``CJX``)
+    trains are accepted. InterCity (``IC``), Railjet (``RJ``), and any
+    non-rail products are rejected.
 
     Checks (any single signal is sufficient):
 
-    * ``leg.category in {"S", "R", "REX"}`` — VAO's preferred field;
-    * ``leg.name`` matching ``^\\s*(S|REX|R)\\s*\\d+\\s*$`` — fallback for older
-      VAO peers that only set the human-readable label;
-    * ``leg.Product[].catOut in {"S", "R", "REX"}`` or ``Product[].line`` matching
-      ``^\\s*(S|REX|R)\\s*\\d+\\s*$`` — the JSON-RPC nested form some VAO
-      releases use.
+    * ``leg.category in {"S", "R", "REX", "CJX"}`` — VAO's preferred field;
+    * ``leg.name`` matching ``^\\s*(S|REX|R|CJX)\\s*\\d+\\s*$`` — fallback for
+      older VAO peers that only set the human-readable label;
+    * ``leg.Product[].catOut in {"S", "R", "REX", "CJX"}`` or
+      ``Product[].line`` matching ``^\\s*(S|REX|R|CJX)\\s*\\d+\\s*$`` — the
+      JSON-RPC nested form some VAO releases use.
 
     The previous-generation matcher also accepted ``"SB"`` as category;
     the 2026-05-09 Senior-API-Integration audit removed it because
     ``SB`` is ambiguous in the German-speaking ÖV space (it can denote
     *Schnellbahn* — a synonym for S-Bahn — but also *Schnellbus* in
     some VAO/ÖBB regional dialects, and there is no SB service on the
-    Stammstrecke).
+    Stammstrecke). ``CJX`` was added 2026-05-17 once ÖBB rebranded
+    selected REX rolling-stock as Cityjet Express; the line still
+    serves Stammstrecke-axis corridors (CJX 9 to Payerbach-Reichenau,
+    CJX 5 to Wiener Neustadt) and must not be dropped from the sample
+    just because of the new product label.
 
     Accepts ``object`` (rather than ``Mapping``) so the defensive
     ``isinstance(leg, Mapping)`` gate is reachable at type-check time
@@ -1067,7 +1075,7 @@ def _is_sbahn_leg(leg: object) -> bool:
         return False
 
     category = (str(leg.get("category") or "")).strip().upper()
-    if category in {"S", "R", "REX"}:
+    if category in {"S", "R", "REX", "CJX"}:
         return True
 
     name = str(leg.get("name") or "").strip()
@@ -1086,7 +1094,7 @@ def _is_sbahn_leg(leg: object) -> bool:
 
     for product in candidates:
         cat_out = str(product.get("catOut") or "").strip().upper()
-        if cat_out in {"S", "R", "REX"}:
+        if cat_out in {"S", "R", "REX", "CJX"}:
             return True
         line = str(product.get("line") or "").strip()
         if _S_BAHN_LINE_RE.match(line):

--- a/tests/scripts/test_update_stammstrecke_hbf.py
+++ b/tests/scripts/test_update_stammstrecke_hbf.py
@@ -68,6 +68,13 @@ def _isolated_quota_counter(
         ("REX3", True),
         ("R 81", True),
         ("R81", True),
+        # Cityjet Express (``CJX``) joined the accepted set on
+        # 2026-05-17 after ÖBB rebranded selected REX rolling-stock.
+        # The corridor coverage is unchanged; the line label is the
+        # only thing that flips.
+        ("CJX 9", True),
+        ("CJX9", True),
+        ("cjx 5", True),
         ("RJ 65", False),  # Railjet, not Stammstrecke
         ("IC 533", False), # InterCity
         ("EC 24", False),  # EuroCity
@@ -79,7 +86,7 @@ def _isolated_quota_counter(
     ],
 )
 def test_is_sbahn_line(name: str, expected: bool) -> None:
-    """Line-pattern filter accepts S/R/REX and rejects everything else."""
+    """Line-pattern filter accepts S/R/REX/CJX and rejects everything else."""
 
     assert script._is_sbahn_line(name) is expected
 

--- a/tests/scripts/test_update_stammstrecke_status.py
+++ b/tests/scripts/test_update_stammstrecke_status.py
@@ -233,19 +233,35 @@ def _low_trips() -> list[dict[str, Any]]:
 
 
 def test_is_sbahn_leg_matches_canonical_category() -> None:
-    """The primary signal is ``leg.category == "S"`` (strict-S only)."""
+    """The primary signal is ``leg.category`` in the accepted-category set.
+
+    The set covers Vienna S-Bahn (``S``), Regional (``R``), Regional
+    Express (``REX``), and Cityjet Express (``CJX``). ``CJX`` joined
+    on 2026-05-17 after ÖBB rebranded selected REX rolling-stock; the
+    same Stammstrecke-axis corridors are served.
+    """
     assert script._is_sbahn_leg({"category": "S", "name": "S 1"})
     assert script._is_sbahn_leg({"category": "S", "name": "S 80"})
+    assert script._is_sbahn_leg({"category": "R", "name": "R 81"})
+    assert script._is_sbahn_leg({"category": "REX", "name": "REX 3"})
+    assert script._is_sbahn_leg({"category": "CJX", "name": "CJX 9"})
     # Lowercase / mixed case is still accepted (the matcher upcases).
     assert script._is_sbahn_leg({"category": "s", "name": "S 7"})
+    assert script._is_sbahn_leg({"category": "cjx", "name": "CJX 5"})
 
 
 def test_is_sbahn_leg_matches_name_when_category_missing() -> None:
-    """Fallback signal: ``leg.name`` matches ``S\\d+``."""
+    """Fallback signal: ``leg.name`` matches ``(S|R|REX|CJX)\\d+``."""
     assert script._is_sbahn_leg({"name": "S 1"})
     assert script._is_sbahn_leg({"name": "S 7"})
     assert script._is_sbahn_leg({"name": "S 80"})
     assert script._is_sbahn_leg({"name": "s 2"})
+    assert script._is_sbahn_leg({"name": "REX 3"})
+    assert script._is_sbahn_leg({"name": "R 81"})
+    # Cityjet Express — added 2026-05-17 after the ÖBB product rebrand.
+    assert script._is_sbahn_leg({"name": "CJX 9"})
+    assert script._is_sbahn_leg({"name": "CJX9"})
+    assert script._is_sbahn_leg({"name": "cjx 5"})
 
 
 def test_is_sbahn_leg_matches_nested_product_field() -> None:
@@ -256,6 +272,10 @@ def test_is_sbahn_leg_matches_nested_product_field() -> None:
     assert script._is_sbahn_leg({"Product": [{"line": "S 80"}]})
     # Single Product object (not list) — also accepted.
     assert script._is_sbahn_leg({"Product": {"catOut": "S"}})
+    # CJX via the nested-product shape (both catOut and line paths).
+    assert script._is_sbahn_leg({"Product": [{"catOut": "CJX"}]})
+    assert script._is_sbahn_leg({"Product": [{"line": "CJX 9"}]})
+    assert script._is_sbahn_leg({"Product": {"catOut": "cjx"}})
 
 
 def test_is_sbahn_leg_rejects_non_regional() -> None:


### PR DESCRIPTION
## Summary

ÖBB has been rebranding selected REX rolling-stock as Cityjet Express (CJX). On Stammstrecke-axis corridors (CJX 9 to Payerbach-Reichenau, CJX 5 to Wiener Neustadt) the new product label was causing eligible trains to be silently dropped from the delay sample. This PR widens the regional-rail filter to accept CJX.

## Changes

- `scripts/update_stammstrecke_status.py`
  - `_S_BAHN_LINE_RE`: widened from `^\s*(S|REX|R)\s*\d+\s*$` to `^\s*(S|REX|R|CJX)\s*\d+\s*$` (case-insensitive).
  - `_is_sbahn_leg`: accepted-category set extended from `{"S", "R", "REX"}` to `{"S", "R", "REX", "CJX"}` at **both** the top-level `category` check and the nested `Product[].catOut` check.
  - Module-level docstring, the regex comment, and the `_is_sbahn_leg` docstring updated to mention CJX with a brief rationale (the rolling-stock rebrand; corridor coverage is unchanged).
- `scripts/update_stammstrecke_hbf.py`
  - Picks up CJX for free via the shared `_S_BAHN_LINE_RE` import.
  - Comment + docstring pair that referenced `S/R/REX` line patterns updated to `S/R/REX/CJX` for consistency.

## Tests

- `tests/scripts/test_update_stammstrecke_status.py`: extended the canonical-category, name-fallback, and nested-`Product` cases with CJX assertions (covers `category=CJX`, `category=cjx`, `name="CJX 9"`, `name="CJX9"`, `name="cjx 5"`, `Product[].catOut=CJX`, `Product[].line="CJX 9"`).
- `tests/scripts/test_update_stammstrecke_hbf.py`: added `CJX 9` / `CJX9` / `cjx 5` parametrized cases to `test_is_sbahn_line`.

## Test plan

- [x] `pytest tests/scripts/test_update_stammstrecke_status.py tests/scripts/test_update_stammstrecke_hbf.py` — 205 passed
- [x] `pytest tests/test_sentinel_network_tainted_non_finite_drift.py` — 38 passed (no regressions in the source-grep sentinel pins)
- [x] `ruff check scripts/update_stammstrecke_status.py scripts/update_stammstrecke_hbf.py …` — clean
- [x] `mypy scripts/update_stammstrecke_status.py` — zero errors in the refactored script (8 pre-existing errors in `src/utils/http.py` are unrelated)
- [x] Manual smoke test: `_S_BAHN_LINE_RE` matches `CJX 9` / `CJX9` / `cjx 5`, `_is_sbahn_leg` accepts CJX via category / name / nested-Product paths, still rejects `RJ`, `IC`, `SB`, and the empty string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014AgdyAVoZyH4sXaHkzccaz)_