### PR TITLE
docs: fix outdated counts and missing references

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -68,7 +68,7 @@ Der Feed-Build folgt einem klaren Ablauf:
 | `data/`               | Stationsverzeichnis, GTFS-Testdaten und Hilfslisten (z. B. Pendler-Whitelist).                   |
 | `docs/`               | Audit-Berichte, Referenzen, Beispiel-Feeds und das offizielle VAO/VOR-API-Handbuch.              |
 | `.github/workflows/`  | Automatisierte Jobs für Cache-Updates, Stationspflege, Feed-Erzeugung und Tests.                |
-| `tests/`              | Umfangreiche Pytest-Suite (über 2600 Tests in rund 400 Modulen) für Feed-Logik, Provider-Adapter und Utility-Funktionen. |
+| `tests/`              | Umfangreiche Pytest-Suite (über 3200 Tests in rund 450 Modulen) für Feed-Logik, Provider-Adapter und Utility-Funktionen. |
 
 
 > **Hinweis zu Cache-Pfaden:** Die tatsächlichen Verzeichnisse unter `cache/` tragen einen Hash-Suffix zur Cache-Versionierung (Stand Mai 2026: `cache/wl_9d709a/`, `cache/oebb_c40d21/`, `cache/baustellen_d438c3/`). In dieser Dokumentation werden aus Lesbarkeitsgründen verkürzte Schreibweisen wie `cache/wl/events.json` verwendet — sie verweisen jeweils auf das aktuelle Provider-Verzeichnis. Ein eigenes VOR-Cache-Verzeichnis existiert seit der 2026-05-11-Migration nicht mehr (VOR ist auf den Stammstrecken-Monitor beschränkt). Der **Stammstrecke-Monitor** schreibt seit der 2026-05-09-Migration **kein** `events.json` mehr — der Feed-Builder liest die Beobachtungen direkt aus dem CSV-Ledger `data/stats/stammstrecke_<YYYY>.csv`. Unter `cache/stammstrecke/` liegen weiterhin die internen Sidecar-Dateien `pending_trips.json` und `recently_finalised.json`, mit denen der Hbf-Producer (siehe [`docs/reference/stammstrecke_provider_logic.md`](reference/stammstrecke_provider_logic.md)) Trip-IDs zur Doppel-Vermeidung über mehrere Cron-Ticks hinweg trackt.
@@ -396,10 +396,12 @@ Die GitHub Action `.github/workflows/update-stations.yml` aktualisiert
 #### Automatisierte Qualitätsberichte
 
 `python -m src.cli stations validate` erzeugt einen Markdown-Bericht mit
-acht Issue-Kategorien: **geographic duplicates**, **alias issues**,
+neun Issue-Kategorien: **geographic duplicates**, **alias issues**,
 **coordinate anomalies**, **GTFS mismatches**, **security warnings**,
 **provider issues** (VOR-/OEBB-Konsistenz), **cross-station ID
-collisions** und **naming issues** (kanonische Namens-Eindeutigkeit +
+collisions**, **identity field conflicts** (raw `wl_diva`/`bst_id`/
+`vor_id`/`bst_code`-Kollisionen zwischen Stationen, ergänzt 2026-05-16
+in PR #1539) und **naming issues** (kanonische Namens-Eindeutigkeit +
 no-space-Source-Format + Vienna/Pendler Mutual-Exclusivity).
 Über `--output docs/stations_validation_report.md` wird der Bericht
 persistiert; mit `--fail-on-issues` bricht die CLI bei jedem Befund mit
@@ -504,10 +506,11 @@ benötigt werden (z. B. `--no-download` für die WL-OGD-CSVs).
 | `regen_mypy_baseline.sh` | Regeneriert `.mypy-baseline.txt` (gleiche Mechanik wie c901). |
 | `generate_sitemap.py` | Generiert `docs/sitemap.xml` und `docs/feed.xml`-Hinweise; läuft im `seo-guard.yml`-Workflow. |
 | `gtfs.py` | GTFS-Hilfsmodul (`read_gtfs_stops`); wird von Tests und vom Stations-Validator konsumiert. |
+| `optimize_site_assets.py` | Erzeugt minifizierte `site.min.css` / `site.min.js` aus den lesbaren Quellen sowie WebP-Geschwister für `train.png` / `footer-bg.jpg`. Wird vom Pre-Commit-Hook `site-assets-minified --check` aufgerufen, um Drift zwischen Quelle und committetem Bundle zu verhindern. Idempotent (`--check`/`--skip-images` ohne Image-Tools nutzbar). |
 
 ## Entwicklung & Qualitätssicherung
 
-- **Tests**: `python -m pytest` führt über 2600 Unit- und Integrationstests in rund 400 Modulen unter `tests/` aus.
+- **Tests**: `python -m pytest` führt über 3200 Unit- und Integrationstests in rund 450 Modulen unter `tests/` aus.
 - **Kontinuierliche Tests**: Die GitHub Action `test.yml` automatisiert die im Audit empfohlene regelmäßige Testausführung und bricht Builds bei fehlschlagender Test-Suite ab.
 - **Statische Analyse & Typprüfung**: `ruff check` (Stil/Konsistenz, Regelgruppen `E`, `F`, `S`, `B`, `UP` — siehe `pyproject.toml`) und `mypy --strict` (vollständige Typabdeckung über `src/` und `tests/`, derzeit 0 Errors) laufen identisch zur CI via `python -m src.cli checks`. Optional lassen sich über `--fix` Ruff-Autofixes aktivieren oder zusätzliche Argumente an Ruff durchreichen. Ein zusätzlicher `mypy-strict.yml`-Workflow setzt das Allowlist-Gate auf Pull Requests durch.
 - **Pre-Commit-Hooks**: `.pre-commit-config.yaml` aktiviert lokale Checks bei jedem `git commit`: Ruff, `mypy --strict`, Bandit, der eigene Secret-Scanner (`scripts/scan_secrets.py`), das C901-Komplexitäts-Gate (`scripts/check_complexity.py`) sowie Whitespace-/Merge-Conflict-/YAML-/TOML-/JSON-/Large-File-Hygiene. Einmalig nach dem Klonen `pre-commit install` ausführen — Details in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/reference/departureboard.md
+++ b/docs/reference/departureboard.md
@@ -1,9 +1,9 @@
 ---
-title: "GET /DepartureBoard"
+title: "GET /departureBoard"
 description: "Referenz für den DepartureBoard-Endpunkt mit Pflichtparametern, Filtern und Hinweisen zum Scrollen durch weitere Abfahrten."
 ---
 
-# GET /DepartureBoard
+# GET /departureBoard
 
 ## Kurzbeschreibung
 Gibt eine Abfahrtstafel für eine Station oder einen Steig zurück. Enthält Abfahrtszeiten, Echtzeitinformationen, Linienangaben und eine `JourneyDetailRef` zur Detailabfrage.
@@ -40,7 +40,7 @@ Zur Verlängerung des Zeitraums wird die Abfahrtszeit der letzten Fahrt um eine 
 ## Beispiel
 
 ```bash
-curl -G "${VOR_BASE_URL}/DepartureBoard" \
+curl -G "${VOR_BASE_URL}/departureBoard" \
   --data-urlencode "accessId=${VOR_ACCESS_ID}" \
   --data-urlencode "id=490118400" \
   --data-urlencode "date=2025-05-22" \


### PR DESCRIPTION
## Summary

Documentation review against the live codebase surfaced four drift bugs. Each one is a clearly verifiable mismatch between documentation and reality — no architectural change.

### 1. `docs/development.md` — outdated test-suite counts (lines 71, 513)

The doc claimed `über 2600 Tests in rund 400 Modulen`. Actual numbers, counted from the current `tests/` tree:

```
Test functions: 3243
Test modules:   447
```

Updated to `über 3200 Tests in rund 450 Modulen` (same rounding convention).

### 2. `docs/development.md` — missing 9th validator category (line 399)

`python -m src.cli stations validate` is documented as producing `acht Issue-Kategorien`. The current `ValidationReport` in `src/utils/stations_validation.py` (line 191, added 2026-05-16 in PR #1539) exposes a ninth category — `identity_field_conflicts` — and the live `docs/stations_validation_report.md` already lists it on its own line.

Updated count to `neun` and added the category description (non-blocking, raw `wl_diva`/`bst_id`/`vor_id`/`bst_code` collisions across stations).

### 3. `docs/development.md` — missing `optimize_site_assets.py` script entry

The script lives in `scripts/`, is wired into `.pre-commit-config.yaml` (`site-assets-minified --check`), and is referenced repeatedly by recent CHANGELOG entries — but had no row in the script inventory. Added a row to the "Statische Analyse & Build-Hygiene" table describing the minified CSS/JS + WebP encoding and the pre-commit drift check.

### 4. `docs/reference/departureboard.md` — endpoint case mismatch

Title, heading and `curl` example used `/DepartureBoard` (PascalCase), inconsistent with:

* the actual code path — `scripts/update_stammstrecke_hbf.py:446` builds `f"{VOR_BASE_URL}departureBoard"` (camelCase), and
* every sibling reference doc (`/arrivalBoard`, `/location.name`, `/location.nearbystops`, `/location.details`, `/trip`, `/tti`, `/datainfo`) which uses lowercase-initial camelCase.

Renamed to `/departureBoard` in the title, the `# GET` heading and the `curl` example. The prose mention of `DepartureBoard-Endpunkt` in the front-matter description was left as-is — that matches the sibling pattern in `arrivalboard.md` ("Dokumentation des ArrivalBoard-Endpunkts").

## Test plan

- [x] `grep -rn "2600\|über 3200" docs/development.md` shows only the new value.
- [x] `grep -n "neun\|acht Issue" docs/development.md` shows the updated count.
- [x] `grep -n "optimize_site_assets" docs/development.md` returns the new table row.
- [x] `grep -E "^title:|^# GET" docs/reference/*.md` shows uniform camelCase across all endpoint references.
- [x] No CI surface is affected — pure Markdown edits, no Python or workflow changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkBKxNHsCwg9oSdy6Y2Rt3)_