### PR TITLE
docs: Bahnsteig-Richtungs-Mapping korrigieren + 6 weitere Doku-Drifts

### DIFF
--- a/.github/workflows/update-cycle.yml
+++ b/.github/workflows/update-cycle.yml
@@ -224,8 +224,10 @@ jobs:
       # ``update_stammstrecke_status.py`` inherited from the VAO API.
       # One ``/departureBoard`` poll returns ALL Stammstrecke trains
       # in the 45-min duration window — a single API call per tick
-      # covers both directions (south = Meidling, north = Floridsdorf),
-      # classified via terminus whitelists. Rollback path: swap the
+      # covers both directions (south = Meidling, north = Praterstern;
+      # the pre-2026-05-15 north label was "Floridsdorf" — see the
+      # rename rationale in update_stammstrecke_hbf.py), classified
+      # via terminus whitelists. Rollback path: swap the
       # script name back to ``update_stammstrecke_status.py`` and
       # bump ``--margin`` above to ``2``.
       - name: Refresh Stammstrecke status

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,7 +64,7 @@ Der Feed-Build folgt einem klaren Ablauf:
 | --------------------- | ------------------------------------------------------------------------------------------------ |
 | `src/`                | Feed-Build, Provider-Adapter, Utilities (Caching, Logging, Textaufbereitung, Stationslogik).     |
 | `scripts/`            | Kommandozeilen-Werkzeuge für Cache-Updates, Stationspflege sowie API-Hilfsfunktionen.            |
-| `cache/`              | Versionierte Provider-Zwischenspeicher (`wl`, `oebb`, `vor`, `baustellen`) für reproduzierbare Feed-Builds. |
+| `cache/`              | Versionierte Provider-Zwischenspeicher (`wl`, `oebb`, `baustellen`) für reproduzierbare Feed-Builds plus die Stammstrecke-Sidecars (`pending_trips.json`, `recently_finalised.json`); VOR hat seit 2026-05-11 kein eigenes Cache-Verzeichnis mehr (siehe Hinweis unten). |
 | `data/`               | Stationsverzeichnis, GTFS-Testdaten und Hilfslisten (z. B. Pendler-Whitelist).                   |
 | `docs/`               | Audit-Berichte, Referenzen, Beispiel-Feeds und das offizielle VAO/VOR-API-Handbuch.              |
 | `.github/workflows/`  | Automatisierte Jobs für Cache-Updates, Stationspflege, Feed-Erzeugung und Tests.                |
@@ -148,7 +148,7 @@ schreibt. Die wichtigsten Parameter:
 | `ENDS_AT_GRACE_MINUTES`  | Kulanzfenster für vergangene Endzeiten (Standard 10 Minuten).                   |
 | `FRESH_PUBDATE_WINDOW_MIN` | Toleranzfenster (Minuten) für „frische" pubDates beim Aging-Check (Standard 5). |
 | `CACHE_MAX_AGE_HOURS`    | Maximalalter der Provider-Cache-Dateien, ab dem eine Warnung im Log erscheint (Standard 24). |
-| `FEED_TITLE_CHAR_LIMIT` / `DESCRIPTION_CHAR_LIMIT` | Maximale Zeichenzahl für Item-Titel/Beschreibungen (Standards 256 / 4000). Nur Verkleinerung wirksam — Sicherheits-Hardening-Ceiling. |
+| `FEED_TITLE_CHAR_LIMIT` / `DESCRIPTION_CHAR_LIMIT` | Maximale Zeichenzahl für Item-Titel/Beschreibungen (Standards 256 / 4000). Negative Werte werden auf `0` geklammert; eine obere Schranke wird derzeit nicht erzwungen (siehe `src/feed/config.py`). |
 | `PROVIDER_TIMEOUT`       | Globales Timeout für Netzwerkprovider (Standard 25 Sekunden). Per Provider via `PROVIDER_TIMEOUT_<NAME>` oder `<NAME>_TIMEOUT` anpassbar. |
 | `PROVIDER_MAX_WORKERS`   | Anzahl paralleler Worker (0 = automatisch). Feiner steuerbar über `PROVIDER_MAX_WORKERS_<GRUPPE>` bzw. `<GRUPPE>_MAX_WORKERS`. |
 | `WL_ENABLE` / `OEBB_ENABLE` / `BAUSTELLEN_ENABLE` / `STAMMSTRECKE_ENABLE` | Aktiviert bzw. deaktiviert die einzelnen Default-Provider (alle Standard: aktiv). `STAMMSTRECKE_ENABLE` steuert den VOR/VAO-basierten Verspätungs- und Ausfall-Monitor. Eine separate `VOR_ENABLE`-Variable existiert seit der 2026-05-11-Konsolidierung **nicht mehr**. |
@@ -557,6 +557,7 @@ Sicherheits-Gates: Der Reporter validiert das Repo-Slug gegen GitHubs Naming-Gra
 
 - **Secrets**: (z. B. `VOR_ACCESS_ID`, `VOR_BASE_URL`) werden ausschließlich über Umgebungsvariablen bereitgestellt und niemals im
   Repository abgelegt. Das Skript `src/utils/secret_scanner.py` schützt proaktiv vor versehentlich eingecheckten Geheimnissen.
+  Optionale Secondary-Variablen für den VOR/VAO-Stack: `VOR_BASE` (Legacy-Alias für `VOR_BASE_URL`, akzeptiert in `src/providers/vor.py:_validated_vor_base_url`), `VOR_VERSION` und `VOR_VERSIONS` (Versions-Strings für die VAO-URL, z. B. `v1.11.0` — `VOR_VERSIONS` ist Fallback-Alias für `VOR_VERSION`). Beide werden in `.github/workflows/update-cycle.yml` als Build-Secrets durchgereicht.
 - **SSRF-Schutz**: Externe Netzwerkanfragen laufen über `fetch_content_safe` (in `src/utils/http.py`). Diese Funktion verhindert Server-Side Request Forgery, indem sie DNS-Rebinding blockiert, private IP-Adressen (Localhost, internes Netzwerk) ablehnt und DNS-Timeouts erzwingt.
 - **Dateisystem**: Schreibvorgänge nutzen `atomic_write`, um Datenkorruption bei Abstürzen zu vermeiden. Pfadeingaben werden strikt validiert (`resolve_env_path` / `validate_path` aus `src/feed/config.py`), um Path-Traversal-Angriffe zu verhindern. Schreibzugriffe sind auf `docs/`, `data/` und `log/` beschränkt.
 - **Logging-Sicherheit**: Kontrollzeichen in Logs werden maskiert, um Log-Injection-Attacken zu unterbinden.

--- a/docs/how-to/google_places_stations.md
+++ b/docs/how-to/google_places_stations.md
@@ -46,7 +46,7 @@ Alle Parameter lassen sich via Umgebungsvariablen steuern. Die wichtigsten:
 
 Die Places API darf nur im Rahmen des kostenlosen Kontingents genutzt werden. Das Repository bringt daher einen Quota-Manager mit, der die monatlichen Aufrufe (UTC-Monatsgrenzen) zählt und bei Erreichen der Limits auf bestehende Caches zurückfällt.
 
-* Limits werden über folgende ENV-Variablen gesteuert (Defaults in Klammern): `PLACES_LIMIT_TOTAL` (4000), `PLACES_LIMIT_NEARBY` (1500), `PLACES_LIMIT_TEXT` (1500), `PLACES_LIMIT_DETAILS` (1000).
+* Limits werden über folgende ENV-Variablen gesteuert (Defaults in Klammern): `PLACES_LIMIT_TOTAL` (4000), `PLACES_LIMIT_NEARBY` (1500), `PLACES_LIMIT_TEXT` (1500), `PLACES_LIMIT_DETAILS` (1000), `PLACES_LIMIT_DAILY` (200).
 * Der Zählerstand wird in `data/places_quota.json` persistiert. Der Speicherort kann über `PLACES_QUOTA_STATE` überschrieben werden (Pfad muss innerhalb von `data/`, `docs/` oder `log/` liegen). Falls `STATE_PATH` gesetzt ist, landet die Datei automatisch dort.
 * Beim Monatswechsel (UTC) wird der Zähler automatisch auf Null zurückgesetzt und der neue Stand gespeichert. Logs enthalten einen Hinweis „Quota reset for new month …“.
 * Sind die Limits erreicht, werden keine externen Requests mehr abgesetzt. Stattdessen erscheint eine Warnung „Quota reached, using existing cache. No files were modified.“ und bestehende Cache-/Zieldateien bleiben unverändert.

--- a/docs/how-to/versions.md
+++ b/docs/how-to/versions.md
@@ -1,35 +1,45 @@
 ---
 title: "API-Versionen prüfen"
-description: "Leitfaden, um aktive VAO ReST API-Versionen über den Versions-Endpunkt abzurufen und Änderungen nachzuverfolgen."
+description: "Leitfaden, um die aktuell genutzte VAO ReST API-Version zu identifizieren und Änderungen zwischen Versionen nachzuverfolgen."
 ---
 
 # API-Versionen prüfen
 
-Dieser Leitfaden zeigt, wie die aktiven VAO ReST API-Versionen per `${VOR_VERSIONS}` abgefragt werden.
+Dieser Leitfaden zeigt, wie sich die im Projekt aktive VAO ReST API-Version identifizieren lässt und wie sich aktive Versionen am VAO-Endpunkt prüfen lassen.
+
+## Hinweis zur Namensgebung
+
+Im Projekt-Code (`src/providers/vor.py`) sind `VOR_VERSION` (primär) und `VOR_VERSIONS` (Fallback-Alias) **beide Versions-Strings**, die in die Basis-URL eingebaut werden (z. B. `v1.11.0`), **keine URLs zu einem „/versions"-Endpunkt**. Eine zentrale „Liste aller aktiven API-Versionen" stellt die VAO-API selbst nicht als REST-Endpoint bereit; verbindliche Quelle bleibt das offizielle PDF-Handbuch (`docs/reference/manuals/Handbuch_VAO_ReST_API_latest.pdf`, Kapitel 3).
 
 ## Voraussetzungen
 
-- Zugriff auf die Repository-Secrets als Umgebungsvariablen (`VOR_ACCESS_ID`, `VOR_VERSIONS`).
+- Zugriff auf die Repository-Secrets als Umgebungsvariablen (`VOR_ACCESS_ID`, `VOR_BASE_URL`).
 - `curl` zum Senden von HTTP-Anfragen.
 
 ## Schritte
 
-1. **Umgebungsvariablen setzen**
+1. **Im Projekt aktive Version inspizieren**
+
    ```bash
-   export VOR_ACCESS_ID="${VOR_ACCESS_ID}"
-   export VOR_VERSIONS="${VOR_VERSIONS}"
+   python -c "from src.providers.vor import VOR_BASE_URL, VOR_VERSION; print(VOR_BASE_URL, VOR_VERSION)"
    ```
-2. **Versionen abfragen**
+
+   Ausgabe ist die zur Build-Zeit aufgelöste Basis-URL plus der Versions-String, der in den eigentlichen API-Pfad eingebaut wird.
+
+2. **Metadaten am VAO-Endpunkt abfragen** (`/datainfo` liefert Produkt- und Betreiber-Metadaten):
+
    ```bash
-   curl -sS "${VOR_VERSIONS}" \
-     -H "Accept: application/json" \
-     -H "Authorization: Bearer ${VOR_ACCESS_ID}"
+   curl -G "${VOR_BASE_URL}datainfo" \
+     --data-urlencode "accessId=${VOR_ACCESS_ID}" \
+     -H "Accept: application/json"
    ```
+
+   Die Antwort enthält keinen expliziten Versionswert, aber die Produkt- und Operator-Listen geben Aufschluss darüber, welche Daten in der aktuellen Version verfügbar sind. Details siehe [`docs/reference/datainfo.md`](../reference/datainfo.md).
+
 3. **Antwort interpretieren**
-   - Die JSON-Antwort listet verfügbare Versionen (z. B. `v1.11.0`) samt Gültigkeitszeitraum (`validFrom`, `validUntil`).
-   - Änderungen sind dem Handbuch Kapitel 3 zu entnehmen; bei Unsicherheiten: „TBD – siehe PDF“.
+   - Änderungen zwischen API-Versionen sind dem Handbuch Kapitel 3 zu entnehmen; bei Unsicherheiten: „TBD – siehe PDF".
 
 ## Nächste Schritte
 
-- Version in `${VOR_BASE_URL}` aktualisieren.
+- Falls eine neue Version aktiviert werden soll, `VOR_VERSION` als Umgebungsvariable setzen (Default ist im Code gepinnt).
 - Referenzkapitel der PDF konsultieren, falls Parameter zwischen Versionen variieren.

--- a/docs/reference/stammstrecke_provider_logic.md
+++ b/docs/reference/stammstrecke_provider_logic.md
@@ -80,8 +80,8 @@ Aus den zurückgegebenen `Departure`-Objekten überlebt nur, wer
 **alle drei Filter** passiert:
 
 1. **Bahnsteig-Filter** (`STAMMSTRECKE_HBF_TRACK_TRUNKS = {"1", "2"}`):
-   Wien Hbf hat zwei Stammstrecken-Bahnsteige — Bahnsteig 1 nordwärts
-   (Praterstern), Bahnsteig 2 südwärts (Meidling). Alle anderen
+   Wien Hbf hat zwei Stammstrecken-Bahnsteige — Bahnsteig 1 südwärts
+   (Meidling), Bahnsteig 2 nordwärts (Praterstern). Alle anderen
    Bahnsteige (3–12 inkl. Halb-Bahnsteige „1A"/„10A-B") tragen
    Fernverkehr (RJ/IC/EC/NJ), Hbf-endende REX-Züge, die Marchegger
    Ostbahn, die Pottendorfer Linie, die Westbahn — sie werden


### PR DESCRIPTION
## Summary

Doku-Review (ULTRATHINK) gegen den Quellcode. **1 kritischer + 6 kleinere Befunde** gefunden und korrigiert.

### 🔴 Kritisch

- **`docs/reference/stammstrecke_provider_logic.md`**: Die Bahnsteig-Richtungs-Zuordnung im Bahnsteig-Filter war **vertauscht**.
  - Doku sagte: `Bahnsteig 1 nordwärts (Praterstern), Bahnsteig 2 südwärts (Meidling)`
  - Code (`scripts/update_stammstrecke_hbf.py:867-870`, Docstring Z. 76-77 + 787): `Bahnsteig 1 → Meidling (south)`, `Bahnsteig 2 → Praterstern (north)`
  - Auswirkung: Operator:innen, die der Doku folgen, hätten ein falsches mentales Modell vom Filter und würden das Verhalten bei Bahnsteig-Verlegungen falsch debuggen.

### 🟡 Minor / Inkonsistenzen

- **`docs/development.md` Env-Tabelle**: `FEED_TITLE_CHAR_LIMIT` / `DESCRIPTION_CHAR_LIMIT` waren als „Nur Verkleinerung wirksam — Sicherheits-Hardening-Ceiling" beschrieben. Tatsächlich enforced `src/feed/config.py:388-393` nur einen `max(N, 0)`-Clamp; eine obere Schranke gibt es **nicht**. Beschreibung an Code-Realität angepasst.

- **`docs/development.md` Cache-Tabelle**: listete `vor` als Provider-Zwischenspeicher, obwohl seit der 2026-05-11-Migration kein VOR-Cache-Verzeichnis mehr existiert. Tabelle bereinigt, Stammstrecke-Sidecars erwähnt.

- **`docs/development.md` Security-Sektion**: `VOR_BASE` (Legacy-Alias) und `VOR_VERSION`/`VOR_VERSIONS` (Versions-Strings) als optionale Secondary-Secrets ergänzt — beide werden in `update-cycle.yml` durchgereicht, waren aber undokumentiert.

- **`docs/how-to/versions.md`**: stellte `VOR_VERSIONS` fälschlich als URL-Endpoint dar (`curl -sS "${VOR_VERSIONS}"`). Im Projekt-Code (`src/providers/vor.py:476-478`) ist `VOR_VERSIONS` ein Fallback-Alias für den Versions-String `VOR_VERSION` — keine curl-bare URL. How-to umgestellt auf `/datainfo`-Endpoint + Hinweis zur Namenskollision.

- **`docs/how-to/google_places_stations.md`**: `PLACES_LIMIT_DAILY` (Default 200) fehlte in der Quota-Variablen-Liste; ergänzt.

- **`.github/workflows/update-cycle.yml:227`**: Workflow-Kommentar nannte `north = Floridsdorf` — das ist das Legacy-Label vor der 2026-05-15-Umbenennung auf `Praterstern`. Code verwendet seit 2026-05-15 `DIRECTION_LABEL_NORTHBOUND = "Praterstern"`.

### ✅ Bestätigt korrekt (kein Fix nötig)

Provider-Registry (`src/feed/providers.py:96-104` ohne VOR), VOR-Modul-Exports (kein `fetch_events`), Cache-Hash-Suffixe (SHA256 verifiziert), Stammstrecke-Konstanten (`HAUPTBAHNHOF_VOR_ID=490134900` etc.), Workflow-Schedule `0 1 * * 0` für `update-stations.yml`, CLI-Subbefehle, conftest-Fixtures, alle Default-Werte (`MAX_ITEMS=10`, `FEED_TTL=15`, `STATE_RETENTION_DAYS=60` etc.), Daten-Dateien, JSON-Schemas.

## Test plan

- [ ] Manuelle Sichtprüfung der 5 geänderten Dateien
- [ ] CI: `seo-guard.yml` darf nicht regressieren (nur Doku-Touches in `docs/`)
- [ ] CI: `test.yml` (Tests sollten unverändert grün laufen — pure Doku-Änderungen)
- [ ] CI: `complexity-gate.yml`, `bandit.yml`, `mypy-strict.yml` (Code-Änderungen nur in Workflow-Kommentar, keine Python-Semantik)

https://claude.ai/code/session_01SCZNFc9rKMrTPYj6Q5Qqcu

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCZNFc9rKMrTPYj6Q5Qqcu)_