### PR TITLE
docs: korrigiere VAO-URL-Slashes, Beispielskript und Audit-INDEX

### DIFF
--- a/docs/archive/audits/INDEX.md
+++ b/docs/archive/audits/INDEX.md
@@ -15,10 +15,12 @@ Chronologische Übersicht aller archivierten Audits dieses Projekts.
 
 | Datum | Bericht | Schwerpunkt |
 |---|---|---|
-| 2025-05 | [system_audit.md](system_audit.md) | Allgemeiner System-Audit |
+| 2025-07 | [audit-2025-07-08.md](audit-2025-07-08.md) | Manueller Review der Feed-Builder-Robustheit (keine Findings) |
+| 2025-06 | [audit-2025-06-02.md](audit-2025-06-02.md) | `ruff check` als statisches Lint-Gate aufgenommen |
+| 2025-05 | [audit-2025-05-29.md](audit-2025-05-29.md), [audit-2025-05-22.md](audit-2025-05-22.md), [system_audit.md](system_audit.md) | Codebasis-Audits + allgemeiner System-Audit |
 | 2025-04 | [audit-2025-04-05.md](audit-2025-04-05.md) | Periodischer Quartals-Audit |
 | 2025-03 | [audit-2025-03-17.md](audit-2025-03-17.md) | Periodischer Quartals-Audit |
-| 2025-02 | [audit-2025-02-14.md](audit-2025-02-14.md), [code_quality_audit_2025_02.md](code_quality_audit_2025_02.md) | Quartals-Audit + Code Quality |
+| 2025-02 | [audit-2025-02-14.md](audit-2025-02-14.md), [audit_report.md](audit_report.md), [code_quality_audit_2025_02.md](code_quality_audit_2025_02.md) | Quartals-Audit + Code Quality + Februar-Audit-Bericht |
 | 2025-01 | [audit-2025-01.md](audit-2025-01.md), [audit-2025-01-04.md](audit-2025-01-04.md) | Monats-Audits |
 | 2024-12 | [audit-2024-12-31.md](audit-2024-12-31.md) | Monats-Audit |
 
@@ -27,7 +29,7 @@ Chronologische Übersicht aller archivierten Audits dieses Projekts.
 | Bereich | Berichte |
 |---|---|
 | VOR/VAO API | [vor_api_review.md](vor_api_review.md), [vor_api_test.md](vor_api_test.md) |
-| ÖBB Stammstrecke | [oebb_stammstrecke_audit.md](oebb_stammstrecke_audit.md) (2026-05-09: PRs #1365 – #1368, `max_journeys=5`-Anpassung, vollständige Audit-Abnahme) |
+| ÖBB Stammstrecke | [oebb_stammstrecke_audit.md](oebb_stammstrecke_audit.md) (2026-05-09: PRs #1365 – #1368, `max_journeys=5`-Anpassung, vollständige Audit-Abnahme); [stammstrecke_vor_migration_qa_2026-05-09.md](stammstrecke_vor_migration_qa_2026-05-09.md) (Senior-Architect-QA der `pyhafas`→VOR/VAO-Migration) |
 | Security | [security_report.md](security_report.md) |
 | Performance | [performance_report.md](performance_report.md) |
 | Deduplication | [deduplication_report.md](deduplication_report.md) |

--- a/docs/development.md
+++ b/docs/development.md
@@ -126,8 +126,10 @@ python -m src.cli config wizard
 python -m src.cli security scan
 ```
 
-Die Unterbefehle akzeptieren standardmäßig alle bekannten Ziele (z. B. Provider `wl`, `oebb`, `vor`) und lassen sich bei Bedarf
-präzise einschränken. Über `--python` kann ein alternativer Interpreter für die Hilfsskripte gesetzt werden.
+Die Unterbefehle akzeptieren standardmäßig alle bekannten Ziele (z. B. Provider `wl`, `oebb`, `baustellen`) und lassen sich bei Bedarf
+präzise einschränken. Der Stations-Refresh-Wrapper `scripts/update_all_stations.py` (aufgerufen via
+`python -m src.cli stations update all`) akzeptiert zusätzlich `--python`, um einen alternativen Interpreter für die internen
+Sub-Skripte zu setzen — die unified CLI selbst kennt diese Option nicht.
 
 ## Konfiguration des Feed-Builds
 

--- a/docs/examples/version-check.sh
+++ b/docs/examples/version-check.sh
@@ -1,12 +1,29 @@
 #!/usr/bin/env bash
+# Inspect the VAO ReST API metadata for the currently configured project version.
+#
+# Background:
+#   VOR_VERSION (and the deprecated alias VOR_VERSIONS) is a *version string*
+#   (e.g. "v1.11.0") that the project embeds into VOR_BASE_URL — it is NOT a
+#   URL to a "/versions" endpoint (the VAO API does not expose one). The
+#   canonical way to verify which version the API is actually serving is to
+#   query the /datainfo endpoint, whose Operator/Product/ProductCategory
+#   payload changes between releases.
+#
+# Usage:
+#   VOR_ACCESS_ID=<token> VOR_BASE_URL=https://routenplaner.../v1.11.0/ \
+#     bash docs/examples/version-check.sh
+#
+# VOR_BASE_URL is expected to include a trailing slash, mirroring
+# src/providers/vor.py:DEFAULT_BASE_URL.
+
 set -euo pipefail
 
 : "${VOR_ACCESS_ID:?VOR_ACCESS_ID muss gesetzt sein}"
-: "${VOR_VERSIONS:?VOR_VERSIONS muss gesetzt sein}"
+: "${VOR_BASE_URL:?VOR_BASE_URL muss gesetzt sein (inkl. Versions-Pfad und Trailing-Slash)}"
 
-response=$(curl -sS "${VOR_VERSIONS}" \
-  -H "Accept: application/json" \
-  -H "Authorization: Bearer ${VOR_ACCESS_ID}")
+response=$(curl -sS -G "${VOR_BASE_URL}datainfo" \
+  --data-urlencode "accessId=${VOR_ACCESS_ID}" \
+  -H "Accept: application/json")
 
 if command -v jq >/dev/null 2>&1; then
   jq '.' <<<"${response}"

--- a/docs/how-to/google_places_stations.md
+++ b/docs/how-to/google_places_stations.md
@@ -39,8 +39,8 @@ Alle Parameter lassen sich via Umgebungsvariablen steuern. Die wichtigsten:
 | `MERGE_MAX_DIST_M` | `150` | Distanzschwelle für Duplikate (Meter). |
 | `BOUNDINGBOX_VIENNA` | – | JSON-Objekt mit `min_lat`, `min_lng`, `max_lat`, `max_lng` zur Heuristik `in_vienna`. |
 | `OUT_PATH_STATIONS` | `data/stations.json` | Zielpfad für das Stations-JSON. |
-| `REQUEST_TIMEOUT_S` | `25` | HTTP Timeout je Request (Sekunden). |
-| `REQUEST_MAX_RETRIES` | `4` | Maximale Retry-Versuche bei 429/5xx. |
+| `REQUEST_TIMEOUT_S` | `25` | HTTP Timeout je Request (Sekunden). Hart auf `MAX_TIMEOUT_S = 25.0` geklammert (`src/places/client.py`); Werte darüber werden TIGHTEN-only auf den Cap abgesenkt, um Slowloris-Angriffe über eine kompromittierte Env zu verhindern. |
+| `REQUEST_MAX_RETRIES` | `4` | Maximale Retry-Versuche bei 429/5xx. Hart auf `MAX_REQUEST_RETRIES = 10` geklammert (`src/places/client.py`); ein `REQUEST_MAX_RETRIES=99999` führt nicht zu Endlos-Retries. |
 
 ## Kostenkontrolle & Free-Cap
 

--- a/docs/how-to/provider_plugins.md
+++ b/docs/how-to/provider_plugins.md
@@ -41,6 +41,26 @@ def register_providers(register_provider):
     register_provider("CUSTOM_PROVIDER_ENABLE", load_custom_events, cache_key="custom")
 ```
 
+### Alternative: deklarative `PROVIDERS`-Konstante
+
+Statt einer `register_providers`-Funktion kann das Plugin auch eine
+`PROVIDERS`-Konstante exportieren — die Loader-Engine
+(`src/feed/providers.py:_register_plugin_providers`) akzeptiert beide
+Stile. Jeder Eintrag ist ein Tupel `(env_var, loader)` bzw.
+`(env_var, loader, cache_key)`. Wird `cache_key` weggelassen, leitet das
+Framework ihn aus der Env-Variable ab.
+
+```python
+PROVIDERS = [
+    ("CUSTOM_PROVIDER_ENABLE", load_custom_events, "custom"),
+]
+```
+
+Sind beide vorhanden, wird zuerst `register_providers` aufgerufen und
+zusätzlich die Konstante ausgewertet. Falls keiner der beiden Hooks
+existiert, protokolliert das Framework eine Warnung und das Plugin wird
+übersprungen.
+
 ## 3. Plugin laden
 
 Aktiviere das Plugin über die Umgebungsvariable

--- a/docs/how-to/trip-request.md
+++ b/docs/how-to/trip-request.md
@@ -13,7 +13,7 @@ Diese Anleitung zeigt die grundlegenden Schritte, um mit der VAO ReST API eine V
 2. Wähle aus der Antwort eine passende `id` oder `extId` aus (`CoordLocation`/`StopLocation`).
 
 ```bash
-curl -G "${VOR_BASE_URL}/location.name" \
+curl -G "${VOR_BASE_URL}location.name" \
   --data-urlencode "accessId=${VOR_ACCESS_ID}" \
   --data-urlencode "input=Schottentor" \
   --data-urlencode "maxNo=3"
@@ -22,7 +22,7 @@ curl -G "${VOR_BASE_URL}/location.name" \
 ## 2. Trip-Service aufrufen
 
 ```bash
-curl -G "${VOR_BASE_URL}/trip" \
+curl -G "${VOR_BASE_URL}trip" \
   --data-urlencode "accessId=${VOR_ACCESS_ID}" \
   --data-urlencode "originId=<START_ID>" \
   --data-urlencode "destId=<ZIEL_ID>" \

--- a/docs/reference/arrivalboard.md
+++ b/docs/reference/arrivalboard.md
@@ -41,7 +41,7 @@ Analog zur Abfahrtstafel: letzte Ankunftszeit um eine Minute erhöhen und erneut
 ## Beispiel
 
 ```bash
-curl -G "${VOR_BASE_URL}/arrivalBoard" \
+curl -G "${VOR_BASE_URL}arrivalBoard" \
   --data-urlencode "accessId=${VOR_ACCESS_ID}" \
   --data-urlencode "id=490118400" \
   --data-urlencode "date=2025-05-22" \

--- a/docs/reference/datainfo.md
+++ b/docs/reference/datainfo.md
@@ -27,7 +27,7 @@ Liefert Metadaten zu Betreibern, Verwaltungen, Produktklassen und Produkten, die
 ## Beispiel
 
 ```bash
-curl -G "${VOR_BASE_URL}/datainfo" \
+curl -G "${VOR_BASE_URL}datainfo" \
   --data-urlencode "accessId=${VOR_ACCESS_ID}" \
   -H "Accept: application/json"
 ```

--- a/docs/reference/departureboard.md
+++ b/docs/reference/departureboard.md
@@ -40,7 +40,7 @@ Zur Verlängerung des Zeitraums wird die Abfahrtszeit der letzten Fahrt um eine 
 ## Beispiel
 
 ```bash
-curl -G "${VOR_BASE_URL}/departureBoard" \
+curl -G "${VOR_BASE_URL}departureBoard" \
   --data-urlencode "accessId=${VOR_ACCESS_ID}" \
   --data-urlencode "id=490118400" \
   --data-urlencode "date=2025-05-22" \

--- a/docs/reference/location-details.md
+++ b/docs/reference/location-details.md
@@ -29,7 +29,7 @@ Liefert Detailinformationen zu einem Ortspunkt aus vorherigen Location-Services,
 ## Beispiel
 
 ```bash
-curl -G "${VOR_BASE_URL}/location.details" \
+curl -G "${VOR_BASE_URL}location.details" \
   --data-urlencode "accessId=${VOR_ACCESS_ID}" \
   --data-urlencode "id=A=1@O=Graz%20Hauptbahnhof@X=15417507@Y=47072481@U=81@L=460304000@" \
   --data-urlencode "weather=true" \

--- a/docs/reference/location-name.md
+++ b/docs/reference/location-name.md
@@ -38,7 +38,7 @@ Sucht Ortspunkte (Adressen, Haltestellen, POIs) anhand eines Namenseingabe und l
 ## Beispiel
 
 ```bash
-curl -G "${VOR_BASE_URL}/location.name" \
+curl -G "${VOR_BASE_URL}location.name" \
   --data-urlencode "accessId=${VOR_ACCESS_ID}" \
   --data-urlencode "input=Hauptbahnhof" \
   --data-urlencode "maxNo=5" \

--- a/docs/reference/location-nearbystops.md
+++ b/docs/reference/location-nearbystops.md
@@ -34,7 +34,7 @@ Führt eine Umkreissuche um eine Koordinate durch und liefert Stationen, POIs so
 ## Beispiel
 
 ```bash
-curl -G "${VOR_BASE_URL}/location.nearbystops" \
+curl -G "${VOR_BASE_URL}location.nearbystops" \
   --data-urlencode "accessId=${VOR_ACCESS_ID}" \
   --data-urlencode "originCoordLat=48.20849" \
   --data-urlencode "originCoordLong=16.37208" \

--- a/docs/reference/timetable-info.md
+++ b/docs/reference/timetable-info.md
@@ -27,7 +27,7 @@ Gibt die Eckdaten der aktuellen Fahrplanperiode zurück (Beginn, Ende, letzter D
 ## Beispiel
 
 ```bash
-curl -G "${VOR_BASE_URL}/tti" \
+curl -G "${VOR_BASE_URL}tti" \
   --data-urlencode "accessId=${VOR_ACCESS_ID}" \
   -H "Accept: application/json"
 ```

--- a/docs/reference/trip.md
+++ b/docs/reference/trip.md
@@ -64,7 +64,7 @@ Weitere Parameter (z. B. für detaillierte Rad-/Auto-Profile) sind im Handbuch
 ## Beispiel
 
 ```bash
-curl -G "${VOR_BASE_URL}/trip" \
+curl -G "${VOR_BASE_URL}trip" \
   --data-urlencode "accessId=${VOR_ACCESS_ID}" \
   --data-urlencode "originId=490118400" \
   --data-urlencode "destId=490190301" \

--- a/docs/strict-typing-migration.md
+++ b/docs/strict-typing-migration.md
@@ -406,7 +406,16 @@ korrigiert. Faustregel: Das Regen-Skript läuft nur in einer Umgebung,
 in der `pip install -r requirements-dev.txt` bereits durchgelaufen
 ist.
 
-## 7. Offene Backlog (Stand C34, Baseline = 414 Zeilen)
+## 7. Offene Backlog (historischer Stand C34, Baseline = 414 Zeilen)
+
+> ℹ️ **Aktueller Stand (Mai 2026):** `.mypy-baseline.txt` ist **0 Bytes**
+> — alle 414 ursprünglich allowlisteten Errors wurden zwischenzeitlich
+> gefixt. `mypy --no-pretty src tests` läuft inzwischen ohne Errors
+> durch (siehe `mypy-strict.yml`-Workflow); die Tabelle unten ist als
+> Aufstellung des damaligen Backlogs erhalten, gibt aber **nicht** den
+> aktuellen Zustand wieder. Wenn künftig wieder Errors allowlistet
+> werden müssen (selten — Standardansatz ist „fix in PR"), spiegelt
+> §6.2 das Regen-Verfahren.
 
 | Code                    | Anzahl | Hauptklasse                                   |
 |-------------------------|--------|-----------------------------------------------|
@@ -423,7 +432,7 @@ ist.
 | sonstige                | 19     | union-attr, name-defined, dict-item, …        |
 | **Σ**                   | **414**|                                               |
 
-Ungefähr 24 Zeilen entfallen auf `scripts/` (über Imports ins Gate
+Ungefähr 24 Zeilen entfielen auf `scripts/` (über Imports ins Gate
 gezogen), der Rest auf `tests/`.
 
 C25–C33 waren **selektiv** zugeschnitten — nicht jeder Error in den


### PR DESCRIPTION
## Summary

Ergebnis einer systematischen Vollständigkeits- und Korrektheits-Prüfung der gesamten Dokumentation (75 Dateien, ~250 KB Markdown) gegen den aktuellen Code- und Repository-Stand. Insgesamt 8 voneinander unabhängige Drifts identifiziert und behoben — alle anderen Dokumente (`architecture.md`, README, AGENTS, CONTRIBUTING, SECURITY, schemas, statistik, performance plan etc.) sind durchgängig konsistent.

## Korrigierte Drifts

### 1. VAO-URL-Slash-Drift (10 Dateien)
`VOR_BASE_URL` endet bereits mit `/` (`src/providers/vor.py:51`: `DEFAULT_BASE_URL = f"{DEFAULT_BASE}/{DEFAULT_VERSION}/"`). Die curl-Beispiele in allen 9 VAO-Reference-Docs und `how-to/trip-request.md` enthielten aber `${VOR_BASE_URL}/<endpoint>` und hätten so Doppelslashes produziert. Jetzt konsistent mit dem korrekten Vorbild aus `stammstrecke_provider_logic.md` und `how-to/versions.md`.

### 2. `docs/examples/version-check.sh` — Skript war gebrochen
Skript benutzte `VOR_VERSIONS` als URL (`curl -sS "${VOR_VERSIONS}"`). Tatsächlich ist `VOR_VERSIONS` laut `versions.md` und `src/providers/vor.py:478` ein Versions-**String**-Alias (z. B. `v1.11.0`). Umgeschrieben auf `/datainfo` mit `accessId`-Query-Param (analog `verify_vor_access_id.py`), inkl. Doc-Header.

### 3. `docs/development.md:129` — `vor` als Cache-Provider gelistet
VOR ist seit 2026-05-11 nicht mehr in `_PROVIDER_CACHE_SCRIPTS` (`src/cli.py:28-35`). Beispielliste auf `wl, oebb, baustellen` korrigiert. `--python`-Hinweis dem Wrapper `update_all_stations.py` zugeordnet (statt fälschlich der unified CLI).

### 4. `docs/archive/audits/INDEX.md` — sechs fehlende Files
Nachgetragen: `audit-2025-05-22.md`, `audit-2025-05-29.md`, `audit-2025-06-02.md`, `audit-2025-07-08.md`, `audit_report.md`, `stammstrecke_vor_migration_qa_2026-05-09.md`.

### 5. `docs/strict-typing-migration.md` §7 — Baseline-Drift
"Baseline = 414 Zeilen" widerspricht dem aktuellen 0-Byte-Stand von `.mypy-baseline.txt`. Hinweis ergänzt, dass alle Allowlist-Einträge gefixt wurden; Tabelle bleibt als historischer Snapshot.

### 6. `docs/how-to/provider_plugins.md` — `PROVIDERS`-Konstante nachdokumentiert
`src/feed/providers.py:_register_plugin_providers` akzeptiert sowohl `register_providers`-Funktion als auch `PROVIDERS`-Konstante. Die Doku erwähnte nur erstere.

### 7. `docs/how-to/google_places_stations.md` — Hard-Caps fehlten
Die ENV-Variablen `REQUEST_TIMEOUT_S` und `REQUEST_MAX_RETRIES` werden TIGHTEN-only an `MAX_TIMEOUT_S=25.0` und `MAX_REQUEST_RETRIES=10` (`src/places/client.py`) geklammert — Operator-relevante Slowloris-Defense, jetzt dokumentiert.

## Test plan

- [x] Alle 10 betroffenen Reference- und How-to-Files: `grep -rn 'VOR_BASE_URL}/' docs/` liefert keine Treffer mehr.
- [x] `docs/examples/version-check.sh` benutzt jetzt `VOR_BASE_URL` mit `accessId`-Query-Param.
- [x] INDEX.md verlinkt alle 31 vorhandenen Audit-Dateien (`ls docs/archive/audits/*.md | wc -l`).
- [ ] CI grün (pytest, ruff, mypy, secret-scan).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vd99CUzv3w3sx1HLFzz6UY)_