### PR TITLE
docs: korrigiere Stammstrecke-Algorithmus + Env-Var-Lücken

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -559,7 +559,7 @@ flowchart LR
 | **Strictly zero data-science dependencies** — no `numpy`, `pandas`, `matplotlib`; CI install stays sub-second | `scripts/generate_markdown_stats.py` imports only `csv`, `collections`, `datetime`, `statistics`, `pathlib`, `zoneinfo`, `argparse` |
 | **Append-only, lock-free producers** — single-line writes on POSIX are atomic below `PIPE_BUF` (4 KiB), so concurrent cycle ticks cannot interleave bytes mid-line | `src/utils/stats.py:_append_row` (mode `"a"`, no `flock`) |
 | **Strict-new gating for disruptions** — long-lived events recorded once, not once per build | `src/build_feed.py:_update_item_state` records only on the *strict* state-cache miss (neither `_identity` nor `guid` had a prior entry) |
-| **Idempotent, byte-stable output** — re-running the aggregator on identical input produces byte-identical Markdown so `git-auto-commit-action` is a no-op when nothing changed | Stable secondary sort (alphabetical) breaks every tie in `render_top_locations`; renderer never reads `now()` outside the timestamp shown in the header |
+| **Idempotent, byte-stable output** — re-running the aggregator on identical input produces byte-identical Markdown so `git-auto-commit-action` is a no-op when nothing changed | Stable secondary sort (alphabetical tie-break, e.g. `key=lambda pair: (-pair[1], pair[0])` in `_format_providers_section`, `_format_ausfall_directions_section`, `_format_ausfall_lines_section`) used in every ranking; renderer never reads `now()` outside the timestamp shown in the header |
 | **Per-year file rotation** — individual ledger size stays bounded even over multi-year operation | Filename derived from the row's Vienna-local `timestamp.year`, not process clock |
 
 ### Resiliency layers
@@ -607,14 +607,22 @@ keyword always wins inside `stats_path`.
 |---|---|
 | **When** do Stammstrecke delays occur? | "Stammstrecke" — weekday + hour distributions of both observation count and average delay |
 | **How often** is the Stammstrecke cancelling trains? | "Ausfälle" — per-direction and per-line tables plus weekday + hour distributions |
-| **Where** (and **when**) are disruption hotspots? | "Störungen" — per-provider table, weekday + hour distributions, top-5 hotspots with per-location hourly profile |
+| **When** do disruption events cluster? | "Störungen" — per-provider table plus weekday + hour distributions |
 
-The location heuristic in `extract_location_name` tries — in order —
-`zwischen X und Y` (capture group 1), then `Wien <Name>`, then the
-first capitalised multi-word token outside a small stopword set
-(`Bauarbeiten`, `Verspätung`, `Linie`, …). Falls back to
-`"unbekannt"` so the dashboard always renders, even on adversarial
-provider input.
+`extract_location_name` ist weiterhin Teil der Producer-Pipeline (siehe
+`src/utils/stats.py` und `src/build_feed.py:2041`) und persistiert die
+abgeleitete Location pro Disruption-Zeile in
+`data/stats/stoerungen_<YYYY>.csv`. Die aktuelle Dashboard-Renderung
+aggregiert die Daten allerdings nur nach `provider`, `weekday` und
+`hour` (siehe `aggregate_stoerungen` in
+`scripts/generate_markdown_stats.py:416`) — eine frühere „Top-5
+Hotspots mit Stundenprofil"-Sektion wurde entfernt, die Roh-Daten in
+der CSV bleiben aber für Ad-hoc-Analysen erhalten. Die Heuristik selbst
+versucht — in dieser Reihenfolge — `zwischen X und Y` (Capture Group 1),
+dann `Wien <Name>`, dann das erste mehrteilige Token außerhalb einer
+kleinen Stoppwortliste (`Bauarbeiten`, `Verspätung`, `Linie`, …). Als
+Fallback bleibt `"unbekannt"`, damit das Dashboard auch bei
+adversarial Provider-Input noch rendert.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -107,14 +107,25 @@ python -m src.cli cache update
 # Nur ausgewählte Provider aktualisieren.
 python -m src.cli cache update wl oebb
 
+# Alle Provider explizit; beim ersten Fehler abbrechen statt
+# alle Läufe durchzuführen.
+python -m src.cli cache update --all --stop-on-error
+
 # Feed generieren (äquivalent zu python -m src.build_feed).
 python -m src.cli feed build
+
+# Aggregierte Items auf strukturelle Probleme prüfen (kein Output-File).
+python -m src.cli feed lint
 
 # Zugangsdaten prüfen und beim ersten Fehler abbrechen.
 python -m src.cli tokens verify --stop-on-error
 
-# Stationsverzeichnis prüfen und Bericht speichern.
-python -m src.cli stations validate --output docs/stations_validation_report.md
+# Alle bekannten Zugangsdaten explizit validieren.
+python -m src.cli tokens verify --all
+
+# Stationsverzeichnis prüfen und Bericht speichern; CI-äquivalentes
+# Fail-on-Issues für eine harte Pipeline-Bremse.
+python -m src.cli stations validate --output docs/stations_validation_report.md --fail-on-issues
 
 # Ruff + mypy wie in der CI ausführen.
 python -m src.cli checks --fix
@@ -141,8 +152,10 @@ schreibt. Die wichtigsten Parameter:
 | Variable                 | Zweck / Standardwert                                                            |
 | ------------------------ | ------------------------------------------------------------------------------- |
 | `OUT_PATH`               | Zielpfad für den RSS-Feed (Standard `docs/feed.xml`).                           |
+| `FEED_HEALTH_PATH` / `FEED_HEALTH_JSON_PATH` | Zielpfade für die nach jedem Build erzeugten Health-Reports (Standards: `docs/feed-health.md` / `docs/feed-health.json`). Beide nicht im Repository versioniert. |
 | `FEED_TITLE` / `FEED_DESC` | Titel und Beschreibung des Feeds (Standards: `"ÖPNV Störungen Wien & Pendler"` / `"Aktive Störungen/Baustellen/Einschränkungen aus offiziellen Quellen"`). |
 | `FEED_LINK`              | Referenz-URL (nur http/https, Standard: GitHub-Repository).                     |
+| `PAGES_BASE_URL`         | Basis-URL der GitHub-Pages-Site für absolute Permalinks (Standard `https://origamihase.github.io/wien-oepnv`). Wird gegen die Pages-Host-Allow-List validiert; abweichende Werte fallen auf den Standard zurück. |
 | `MAX_ITEMS`              | Anzahl der Einträge im Feed (Standard 10).                                      |
 | `FEED_TTL`               | Cache-Hinweis für Clients in Minuten (Standard 15).                             |
 | `MAX_ITEM_AGE_DAYS`      | Maximales Alter von Meldungen aus den Caches (Standard 365).                    |
@@ -157,10 +170,15 @@ schreibt. Die wichtigsten Parameter:
 | `WL_RSS_URL` / `OEBB_RSS_URL` / `BAUSTELLEN_DATA_URL` / `OVERPASS_URL` | Override der Upstream-URLs. Validiert gegen eine Allow-List bekannter Hosts; abweichende Werte werden ignoriert und der Default verwendet (siehe Modul-Docstrings für Details). |
 | `OEBB_ONLY_VIENNA`       | Strikte ÖBB-Filterung (`1`/`true`/`0`/`false`, Standard `false`): nur Meldungen mit explizitem Wien-Bezug akzeptieren — keine Pendlerbahnhof-Fallbacks (siehe [`docs/reference/oebb_provider_logic.md`](reference/oebb_provider_logic.md)). |
 | `WIEN_OEPNV_OSM_ENRICH`  | Setzt `0` im CI, sobald `scripts/check_overpass_status.py` einen Mirror-Outage detektiert; überspringt dann den OSM-Anreicherungs-Schritt in `scripts/update_station_directory.py`. |
+| `WIEN_OEPNV_MANUAL_ENRICH` | Toggle (Standard `1`) für die Nachreicherung manuell gepflegter Auslands-/Distant-AT-Knoten (`type=manual_*`) in `scripts/update_station_directory.py:_enrich_manual_stations`. Auf `0` gesetzt, um in Test-Sandboxen die ~296 realen HAFAS-Round-trips zu vermeiden (siehe `tests/test_update_all_stations_wrapper.py`). |
+| `WIEN_OEPNV_PROVIDER_PLUGINS` | Komma-separierte Liste optionaler Provider-Plugin-Module (siehe [`docs/how-to/provider_plugins.md`](how-to/provider_plugins.md)). Standard leer; nicht gesetzte Module werden ignoriert. |
+| `WIEN_OEPNV_ENV_FILES` | Komma-separierte Liste zusätzlicher `.env`-Dateien, die vor der Konfiguration eingelesen werden (`src/utils/env.py`). Standard liest `.env`, `data/secrets.env`, `config/secrets.env`. |
 | `LOG_LEVEL`, `LOG_DIR`, `LOG_MAX_BYTES`, `LOG_BACKUP_COUNT`, `LOG_FORMAT` | Steuerung der Logging-Ausgabe (`log/errors.log`, `log/diagnostics.log`). `LOG_LEVEL` Standard `INFO`; `LOG_FORMAT=json` aktiviert JSON-Logs. |
 | `STATE_PATH`, `STATE_RETENTION_DAYS` | Pfad & Aufbewahrungstage für `data/first_seen.json` (Standard 60 Tage).        |
 | `WIEN_OEPNV_CACHE_PRETTY` | Steuert die Formatierung der Cache-Dateien (`1` = gut lesbar, `0` = kompakt). |
 | `WIEN_OEPNV_DEBUG`       | Auf `1` gesetzt zeigt die CLI (`python -m src.cli`) bei Fehlern den vollständigen Traceback; Standard verhält sich fail-secure (keine Trace-Ausgabe). |
+| `VOR_USER_AGENT`         | Custom User-Agent für VOR/VAO-API-Calls (Standard `wien-oepnv/1.0 (+https://github.com/Origamihase/wien-oepnv)`). |
+| `VOR_REQUEST_COUNT_FILE` | Override für den Persistenzpfad des VAO-Tagesbudget-Counters (Standard `data/vor_request_count.json`). |
 
 Alle Pfade werden durch `resolve_env_path` (in `src/feed/config.py`) auf `docs/`, `data/` oder `log/` beschränkt, um Path-Traversal zu verhindern.
 

--- a/docs/reference/stammstrecke_provider_logic.md
+++ b/docs/reference/stammstrecke_provider_logic.md
@@ -88,12 +88,19 @@ Aus den zurückgegebenen `Departure`-Objekten überlebt nur, wer
    deterministisch ausgeschlossen. `rtTrack` überschreibt das
    geplante `track`, sodass eine kurzfristige Bahnsteig-Verlegung
    weg von Bahnsteig 1/2 das Sample korrekt verlässt.
-2. **Richtungs-Klassifikation** (`HBF_SOUTHBOUND_SUBSTRINGS` /
-   `HBF_NORTHBOUND_SUBSTRINGS` + `HBF_SOUTHBOUND_TERMINI` /
-   `HBF_NORTHBOUND_TERMINI`): Substring-Match gegen
-   `direction.lower()` zuerst, dann exakter Whitelist-Match.
-   Unbekannte Termini werden mit deduplizierter INFO-Log-Zeile
-   verworfen, damit Operator:innen die Whitelist erweitern können.
+2. **Richtungs-Klassifikation** (hybrider Lookup gegen
+   `station_info` + Geo-Vergleich gegen `HBF_REFERENCE_LATITUDE`):
+   Der `direction`-String der Departure wird über
+   `src.utils.stations.station_info` im Stationsverzeichnis
+   nachgeschlagen. Liefert der Lookup eine Latitude, klassifiziert ein
+   reiner Geo-Vergleich gegen `HBF_REFERENCE_LATITUDE = 48.1851`:
+   nördlich (`lat > 48.1851`) → `"Praterstern"`, südlich
+   (`lat < 48.1851`) → `"Meidling"`. Unbekannte Termini oder Einträge
+   ohne Koordinaten fallen auf die im Bahnsteig-Filter bereits
+   etablierte Track-Trunk-Klassifikation zurück: Trunk `"1"` →
+   `"Meidling"`, Trunk `"2"` → `"Praterstern"`. Der Fallback ist
+   erschöpfend, weil der Bahnsteig-Filter `track_trunk` bereits auf
+   `{"1", "2"}` eingeschränkt hat — kein Zug wird hier verworfen.
 3. **S-Bahn-Linien-Filter** (`_is_sbahn_line`, Regex
    `_S_BAHN_LINE_RE`): Nur Linien, die das `S\d+`-Muster matchen.
    `REX`/`R`/`IC`/`Railjet` werden trotz Bahnsteig 1/2 verworfen.
@@ -374,11 +381,14 @@ Architektur-Kontext und Diagramm: siehe Section 6 in
 * **Bahnsteig-Whitelist**: `STAMMSTRECKE_HBF_TRACK_TRUNKS` (aktuell
   `{"1", "2"}`) im Hbf-Producer. Erweiterung nur sinnvoll, wenn ÖBB
   einen weiteren Hbf-Bahnsteig auf die Stammstrecke umlenkt.
-* **Richtungs-Klassifikation**: `HBF_SOUTHBOUND_SUBSTRINGS` /
-  `HBF_NORTHBOUND_SUBSTRINGS` für den schnellen Substring-Match,
-  `HBF_SOUTHBOUND_TERMINI` / `HBF_NORTHBOUND_TERMINI` für die
-  exakte Whitelist seltener Termini. Erweiterung über die
-  `Unbekannter Endpunkt am Hbf`-INFO-Logs des Hbf-Producers.
+* **Richtungs-Klassifikation**: `HBF_REFERENCE_LATITUDE` im Hbf-Producer
+  (aktuell `48.1851`, gepinnt am Wien-Hauptbahnhof-Eintrag in
+  `data/stations.json`). Eine Verschiebung des Stationsverzeichnis-
+  Eintrags würde diesen Anker mitverschieben — daher die explizite
+  Konstante. Neue Termini brauchen keine Whitelist-Pflege: solange
+  sie im `stations.json` mit einer Koordinate vorhanden sind, klappt
+  die Klassifikation automatisch; fehlt der Eintrag, übernimmt die
+  Track-Trunk-Klassifikation (`"1"` → Meidling, `"2"` → Praterstern).
 * **Direction-Labels**: `DIRECTION_LABEL_SOUTHBOUND` /
   `DIRECTION_LABEL_NORTHBOUND` (Producer) und `DIRECTIONS` (Renderer)
   müssen byteweise übereinstimmen — die CSV-`direction`-Spalte


### PR DESCRIPTION
## Summary

Folge-Review nach #1590: vertiefte Mehrebenen-Prüfung (Link-Integrität, Code-Symbol-Drift, Doc-Konsistenz, Vollständigkeit) der gesamten Dokumentation. Behebt **zwei Bugs** in Reference-/Architektur-Docs und schließt **mehrere Vollständigkeitslücken** im zentralen Konfigurations- und CLI-Bereich.

## Code-vs-Doc-Drifts (Bugs)

### 1. `docs/reference/stammstrecke_provider_logic.md`
Zeilen 91-99 und 377-384 beschrieben vier Konstanten und einen Algorithmus, die im Code **nicht existieren**:
- `HBF_SOUTHBOUND_SUBSTRINGS`, `HBF_NORTHBOUND_SUBSTRINGS` (Substring-Match) → existieren nicht
- `HBF_SOUTHBOUND_TERMINI`, `HBF_NORTHBOUND_TERMINI` (Whitelist-Match) → existieren nicht

Tatsächliche Implementierung in `scripts/update_stammstrecke_hbf.py:338-378`:
- Hybrider `station_info`-Lookup gegen das zentrale Stationsverzeichnis
- Geo-Vergleich gegen `HBF_REFERENCE_LATITUDE = 48.1851`
- Track-Trunk-Fallback bei unbekannten Termini

Doku jetzt mit der echten Implementierung synchronisiert.

### 2. `docs/architecture.md` §6
- Verwies auf `render_top_locations` → Funktion wurde refaktoriert, existiert nicht mehr
- Verwies auf "Top-5 Hotspots mit Stundenprofil"-Sektion → diese Sektion ist aus dem Dashboard entfernt (`aggregate_stoerungen` aggregiert nur noch `provider`/`weekday`/`hour`)

Korrektur benennt die aktuell tatsächlich verwendeten Renderer-Funktionen explizit (`_format_providers_section`, `_format_ausfall_directions_section`, `_format_ausfall_lines_section`) und dokumentiert, dass `location_name` weiterhin in die CSV-Ledger geschrieben wird (für Ad-hoc-Analysen), aber nicht mehr im Markdown-Dashboard aggregiert wird.

## Vollständigkeitslücken in `docs/development.md`

### Env-Var-Tabelle ergänzt um 7 reale Env-Vars
- `FEED_HEALTH_PATH` / `FEED_HEALTH_JSON_PATH` (`src/feed/config.py:344-348`)
- `PAGES_BASE_URL` (GitHub Pages Allow-List-validiert)
- `WIEN_OEPNV_MANUAL_ENRICH` (war nur in Prosa Z. 449)
- `WIEN_OEPNV_PROVIDER_PLUGINS` (war nur in Prosa Z. 252)
- `WIEN_OEPNV_ENV_FILES` (war nur in Prosa Z. 93)
- `VOR_USER_AGENT` / `VOR_REQUEST_COUNT_FILE`

### CLI-Quickstart ergänzt
Bisher nicht gezeigte Flags:
- `cache update --all --stop-on-error`
- `tokens verify --all`
- `feed lint`
- `stations validate --fail-on-issues`

Damit spiegelt der Quickstart-Block alle in `src/cli.py` konfigurierten Subkommandos und Flags.

## Im Sweep bestätigt korrekt (keine Änderung nötig)

| Prüfung | Ergebnis |
|---|---|
| 136 interne Markdown-Links | 0 broken |
| 28+ Code-Symbol-Referenzen (Funktionen, Konstanten, Module) | alle existieren |
| Doc-vs-Doc-Konsistenz | 8/8 Themen (VOR-Budget, Provider-Liste, Cache-Pfade, Migrationsdaten 2026-05-09/-11/-14/-15, mypy-Status, Feed-Health-Disclaimer, Stations-Zahlen, Test-Anzahl) |
| Workflow-Coverage in `development.md` | 11/11 Workflows |
| Skript-Coverage in `development.md` | 30/30 Skripte |

## Test plan

- [x] `grep -rn 'HBF_SOUTHBOUND_SUBSTRINGS\|HBF_NORTHBOUND_SUBSTRINGS\|HBF_SOUTHBOUND_TERMINI\|HBF_NORTHBOUND_TERMINI\|render_top_locations' docs/` → 0 Treffer
- [x] Alle neuen Env-Vars existieren in Code (`grep -rn` bestätigt)
- [x] Alle neuen CLI-Flags existieren in `src/cli.py`
- [ ] CI grün (pytest, ruff, mypy, secret-scan).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vd99CUzv3w3sx1HLFzz6UY)_