### PR TITLE
docs: schließe verbleibende Vollständigkeits- und Korrektheitslücken

### DIFF
--- a/data/stations_overrides.json
+++ b/data/stations_overrides.json
@@ -5,7 +5,7 @@
     "added": "2026-05-16",
     "see_also": [
       "scripts/apply_station_overrides.py",
-      "docs/development.md#manual-station-overrides"
+      "docs/development.md#manuelle-station-overrides"
     ]
   },
   "overrides": [

--- a/docs/archive/audits/stations_coverage_2026-05.md
+++ b/docs/archive/audits/stations_coverage_2026-05.md
@@ -18,7 +18,7 @@ des VOR-Kerngebiets) und resultierende Anpassungen am Updater.
 
 Falsch. `data/stations.json` enthält den Eintrag:
 
-```json
+```text
 {
   "name": "Wien Mitte-Landstraße",
   "vor_id": "490074300",
@@ -67,7 +67,7 @@ ein:
 
 ### Neue Datei `data/pendler_candidates.json`
 
-```json
+```text
 {
   "candidates": [
     {"name": "Pfaffstätten", "line": "S-Bahn Südbahn", "priority": 1},

--- a/docs/development.md
+++ b/docs/development.md
@@ -179,6 +179,11 @@ schreibt. Die wichtigsten Parameter:
 | `WIEN_OEPNV_DEBUG`       | Auf `1` gesetzt zeigt die CLI (`python -m src.cli`) bei Fehlern den vollständigen Traceback; Standard verhält sich fail-secure (keine Trace-Ausgabe). |
 | `VOR_USER_AGENT`         | Custom User-Agent für VOR/VAO-API-Calls (Standard `wien-oepnv/1.0 (+https://github.com/Origamihase/wien-oepnv)`). |
 | `VOR_REQUEST_COUNT_FILE` | Override für den Persistenzpfad des VAO-Tagesbudget-Counters (Standard `data/vor_request_count.json`). |
+| `VOR_AUTH_TYPE`          | Erzwingt das Auth-Schema bei der VAO-Token-Normalisierung (`bearer` oder `basic`, Standard: automatische Erkennung aus dem Token-Format in `src/providers/vor.py:_normalise_access_token`). |
+| `BAUSTELLEN_TIMEOUT`     | Per-Request-Timeout (Sekunden) für `scripts/update_baustellen_cache.py` (Standard `20`, hart geklammert auf `MAX_BAUSTELLEN_TIMEOUT`). |
+| `BAUSTELLEN_FALLBACK_PATH` | Pfad zur lokalen JSON-Fallback-Datei (Standard `data/samples/baustellen_sample.geojson`), die verwendet wird, wenn der OGD-Endpoint der Stadt Wien nicht erreichbar ist. |
+| `SITE_BASE_URL`          | Basis-URL für die Sitemap-Generierung (`scripts/generate_sitemap.py`). Standard identisch mit `PAGES_BASE_URL`; gegen die GitHub-Pages-Allow-List validiert. |
+| `WIEN_TOKEN`             | Override des Wien-Token-Matches für die `in_vienna`-Heuristik in `src/utils/stations.py` (Standard `wien`). Diakritik wird automatisch geklammert; nur für Test-Sandboxen interessant. |
 
 Alle Pfade werden durch `resolve_env_path` (in `src/feed/config.py`) auf `docs/`, `data/` oder `log/` beschränkt, um Path-Traversal zu verhindern.
 
@@ -451,11 +456,48 @@ zu `in_vienna` (Vienna-Station vs. Pendler) wird sowohl vom Updater als
 auch vom Validator und JSON-Schema erzwungen — Verstöße führen zu einer
 WARNING bzw. blockieren den Atomic-Write.
 
+### Manuelle Station-Overrides
+
+`data/stations_overrides.json` ist eine schmal definierte
+Korrekturschicht, die `scripts/apply_station_overrides.py` zwischen
+WL-Merge und Validator-Gate auf `data/stations.json` anwendet.
+Sie behebt Upstream-Defekte der Wiener-Linien-OGD, die sich nicht
+durch Tuning der Merge-Logik beheben lassen (etwa fehlerhaft
+fehlende Haltepunkte, falsche Koordinaten einzelner DIVAs).
+
+Drei Operationen sind erlaubt — andere Schemata werden hart
+abgelehnt, damit ein bösartiger oder unaufmerksamer Override nicht
+das gesamte Verzeichnis umformen kann:
+
+| `op` | Wirkung |
+| ---- | ------- |
+| `restore` | Schreibt einen kompletten Station-Eintrag (inkl. `wl_stops`) zurück, wenn er beim letzten Cron-Tick verschwunden war. |
+| `patch_coords` | Setzt `latitude` / `longitude` auf der bestehenden Station neu — z. B. bei nachweislich falscher OGD-Koordinate. |
+| `remove` | Entfernt einen kompletten Eintrag (selten benötigt). |
+
+Jeder Eintrag trägt zwingend `reason` (kurze Begründung) und
+`expires_when` (Bedingung, unter der der Override retire-bar wird) —
+damit verfallene Workarounds beim nächsten Audit auffallen.
+Implementierung und Tests: `scripts/apply_station_overrides.py`,
+`tests/test_apply_station_overrides.py`.
+
 ### Zusätzliche Datenquellen
 
 Weitere offene Datensätze (z. B. ÖBB-GTFS, Streckendaten, Wiener OGD, INSPIRE-Geodaten) können lokal in `data/` abgelegt und mit
 Feed- oder Stationsdaten verknüpft werden. Hinweise zu Lizenzierung und Verknüpfung stehen in diesem Abschnitt, um eine saubere
 Nachnutzung zu gewährleisten.
+
+Wichtige Sidecar-Dateien unter `data/`, die im obigen Lizenz-Block
+nicht einzeln gelistet sind:
+
+| Datei / Verzeichnis | Zweck |
+| ------------------- | ----- |
+| `data/stations_metadata.json` | Kurate VZG-Streckennummern → Kilometer-Mapping für Stammstrecken-Auswertungen. Testabgesichert via `tests/test_stations_metadata.py`. |
+| `data/places_quota.json` | Persistenter Monats-Quota-State des Google-Places-Tiers (siehe [`docs/how-to/google_places_stations.md`](how-to/google_places_stations.md)). Vom Cron-Runner geschrieben. |
+| `data/new_places.json` | Optionales Diff-Artefakt aus `scripts/fetch_google_places_stations.py --dump-new`. |
+| `data/streckendaten/` | Platzhalter-Verzeichnis für lokale VZG-Schnittdaten (per `.gitignore` versioniert, Inhalt nicht commited). |
+| `data/stations_last_run.json` | Heartbeat des wöchentlichen Stations-Refreshs (Validation-Summary, Sub-Skript-Laufzeiten). |
+| `data/stations_overrides.json` | Manuelle Korrekturschicht — siehe Abschnitt darüber. |
 
 ## Automatisierte Workflows
 
@@ -551,7 +593,15 @@ Die neue Kommandozeile (`python -m src.cli`) bündelt bisher verstreute Skripte.
 
 ### Qualitätsberichte für das Stationsverzeichnis
 
-`python -m src.cli stations validate --output docs/stations_validation_report.md` erstellt den Report `docs/stations_validation_report.md`. Die Ausgabe enthält zusammengefasste Kennzahlen und detaillierte Listen der gefundenen Probleme. Über `--decimal-places` lässt sich die Toleranz für Dubletten steuern.
+`python -m src.cli stations validate --output docs/stations_validation_report.md` erstellt den Report `docs/stations_validation_report.md`. Die Ausgabe enthält zusammengefasste Kennzahlen und detaillierte Listen der gefundenen Probleme.
+
+| Flag | Zweck |
+| ---- | ----- |
+| `--stations PATH` | Alternativer Pfad zur `stations.json` (Default `data/stations.json`). |
+| `--gtfs PATH` | Alternativer Pfad zur GTFS-`stops.txt` (Default `data/gtfs/stops.txt`). |
+| `--decimal-places N` | Toleranz beim Koordinaten-Matching (Default 5 Nachkommastellen). |
+| `--output PATH` | Schreibt den Markdown-Bericht zusätzlich an den angegebenen Ort. |
+| `--fail-on-issues` | Beendet den Lauf mit Exit-Code 1, sobald irgendeine Issue-Kategorie nicht leer ist (CI-Gate). |
 
 ### Logging & Beobachtbarkeit
 

--- a/docs/how-to/google_places_stations.md
+++ b/docs/how-to/google_places_stations.md
@@ -11,7 +11,7 @@ description: "Anleitung zum Tier-3-Fallback-Abruf von Bahnhofs- und Haltestellen
 > 2. **Tier 2 — HAFAS (ÖBB Scotty).** `scripts/update_station_directory.py:_enrich_with_hafas` läuft direkt im Anschluss über jede Station ohne OSM-Koordinaten. Liefert hochpräzise Koordinaten und die EVA-Nummer (`hafas_extId`); ist nicht durch ein Tagesbudget limitiert und schont damit das Google-Kontingent. Implementiert in `src/places/hafas_client.py`, abgesichert durch einen eigenen `CircuitBreaker` und eingebettet in `request_safe`.
 > 3. **Tier 3 — Google Places.** Erst danach prüft `_stations_missing_coordinates`, welche Einträge **noch immer** keine `latitude`/`longitude` tragen. Nur diese strikte Restmenge wird über `_enrich_with_google_places(..., missing_subset=…)` an die Places API weitergereicht. Decken OSM und HAFAS gemeinsam alles ab, wird der Google-Aufruf vollständig übersprungen — das Monatskontingent bleibt unangetastet.
 >
-> Stationen, deren Koordinaten OSM oder HAFAS bereits aufgelöst haben, werden **nicht** neu verschlüsselt — selbst wenn ein Google Place denselben Namen trägt. Die Demotion ist absichtlich harsch: Open-Data-Erstanbieter (Overpass), gefolgt vom kostenfreien Operator-Backend (HAFAS), kommen vor dem kommerziellen Anbieter (Google).
+> Stationen, deren Koordinaten OSM oder HAFAS bereits aufgelöst haben, werden **nicht** neu zugeordnet — selbst wenn ein Google Place denselben Namen trägt. Die Demotion ist absichtlich harsch: Open-Data-Erstanbieter (Overpass), gefolgt vom kostenfreien Operator-Backend (HAFAS), kommen vor dem kommerziellen Anbieter (Google).
 
 Dieses Dokument beschreibt die *Mechanik* des Tier-3-Imports — den Quota-Manager, die Health-Checks und den Workflow. Wer einen reinen, vollständigen Stationskatalog mit Koordinaten benötigt, sollte zuerst den OSM-Pfad verifizieren (siehe `scripts/check_overpass_status.py`) und das HAFAS-Profil prüfen (`data/hafas_profile.json`, befüllt durch `scripts/sync_hafas_profile.py`); Google Places wird nur dann ausgelöst, wenn beide vorgelagerten Tiers nachweislich Lücken hinterlassen.
 
@@ -54,7 +54,7 @@ Die Places API darf nur im Rahmen des kostenlosen Kontingents genutzt werden. Da
 
 ## Nutzung des Skripts
 
-```
+```bash
 python scripts/fetch_google_places_stations.py --dry-run
 ```
 
@@ -65,16 +65,17 @@ python scripts/fetch_google_places_stations.py --dry-run
 
 Um Änderungen persistent zu speichern:
 
-```
+```bash
 python scripts/fetch_google_places_stations.py --write
 ```
 
-Für manuelle Tests gegen die API muss der Header `X-Goog-Api-Key` gesetzt sein:
+Für manuelle Tests gegen die API muss der Header `X-Goog-Api-Key` gesetzt sein, und der POST-Body verlangt einen `Content-Type: application/json`-Header:
 
-```
+```bash
 curl \
   -H "X-Goog-Api-Key: ${GOOGLE_ACCESS_ID}" \
   -H "X-Goog-FieldMask: places.id" \
+  -H "Content-Type: application/json" \
   "https://places.googleapis.com/v1/places:searchNearby" \
   -d '{"includedTypes": ["train_station"], "locationRestriction": {"circle": {"center": {"latitude": 48.2082, "longitude": 16.3738}, "radius": 2000}}}'
 ```
@@ -83,12 +84,13 @@ Zusatzoptionen:
 
 * `--dump-new data/new_places.json` – schreibt nur neue & aktualisierte Einträge in eine separate Datei (hilfreich für Review/Artefakte).
 * `--tiles-file tiles.json` – überschreibt `PLACES_TILES` mit einer lokalen Datei.
+* `--enforce-free-cap` / `--no-enforce-free-cap` – aktiviert (Default) bzw. deaktiviert die strikte Quota-Cap-Enforcement aus `src/places/quota.py`. Mit `--no-enforce-free-cap` läuft das Skript auch dann weiter, wenn ein Limit überschritten würde — ausschließlich für gezielte Operator-Reruns gedacht; produktive Cron-Pfade müssen den Default behalten.
 
 ## Zugang schnell prüfen
 
 Bevor der eigentliche Import läuft, kann der API-Schlüssel mit einem leichten Health-Check validiert werden:
 
-```
+```bash
 python scripts/verify_google_places_access.py
 ```
 


### PR DESCRIPTION
## Summary

Folge-Review nach #1591 mit sechs parallelen Audit-Agenten (Env-Vars, CLI-Flags, Code-Symbole, Section-Anker, Markdown-Validität, Workflow-/Skript-/Datendatei-Coverage). Behebt **acht** voneinander unabhängige Befunde — der Code-Symbol-Audit hat dabei 90+ Referenzen geprüft und 0 Drifts gefunden, der Anker-Audit 20/20 Anker bestätigt; der Restaufwand konzentriert sich auf Vollständigkeit und einen Wortfehler.

## Korrektheit

### Wortfehler
`docs/how-to/google_places_stations.md` Z. 14: „werden **nicht** neu **verschlüsselt**" → „neu **zugeordnet**". Tier-3-Demotion hat nichts mit Verschlüsselung zu tun.

### Cross-Reference-Anker
`data/stations_overrides.json:_meta.see_also` verwies auf den englischen Anker `docs/development.md#manual-station-overrides` — Anker existiert nicht in der (deutschsprachigen) Doku. Behoben durch:
- Update der JSON-Referenz auf `#manuelle-station-overrides`
- Neue Sektion „Manuelle Station-Overrides" in `docs/development.md` mit Operation-Tabelle (`restore` / `patch_coords` / `remove`) und Pflichtfeld-Erläuterung (`reason`, `expires_when`).

### Markdown-Validität
- `docs/archive/audits/stations_coverage_2026-05.md` Z. 21+70: JSON-Blöcke mit `…`-Auslassungen und Klartext-Kommentaren — JSON-Parsing-bricht. Umgetaggt auf `text` (rein illustrativ).
- `docs/how-to/google_places_stations.md`: `places:searchNearby`-curl ergänzt um `Content-Type: application/json` (Google Places (New) verlangt den Header für POST-Bodies).
- Drei untagged Code-Fences in `google_places_stations.md` als ` ```bash ` ausgezeichnet (Z. 57, 68, 91).

## Vollständigkeit

### 5 fehlende Env-Vars in `docs/development.md`-Tabelle
| Variable | Quelle | Was |
|---|---|---|
| `VOR_AUTH_TYPE` | `src/providers/vor.py:537` | Auth-Schema-Override (`bearer`/`basic`) |
| `BAUSTELLEN_TIMEOUT` | `scripts/update_baustellen_cache.py:635` | OGD-Timeout-Override |
| `BAUSTELLEN_FALLBACK_PATH` | `scripts/update_baustellen_cache.py:634` | Lokale Fallback-GeoJSON |
| `SITE_BASE_URL` | `scripts/generate_sitemap.py:132` | Sitemap-Basis-URL |
| `WIEN_TOKEN` | `src/utils/stations.py:828` | `in_vienna`-Heuristik-Override |

### CLI-Flags
- `stations validate`: vollständige Flag-Tabelle ergänzt (`--stations`, `--gtfs`, `--decimal-places`, `--output`, `--fail-on-issues`).
- `scripts/fetch_google_places_stations.py --enforce-free-cap` / `--no-enforce-free-cap` dokumentiert.

### Data-Files
Neue Tabelle „Sidecar-Dateien unter `data/`" in `docs/development.md`:
- `stations_metadata.json` — VZG-Streckennummern → Kilometer
- `places_quota.json` — Google-Places-Monatsbudget-Counter
- `new_places.json` — `--dump-new`-Diff-Artefakt
- `streckendaten/` — Platzhalter via `.gitignore`
- `stations_last_run.json` — Wöchentlicher Stations-Refresh-Heartbeat
- `stations_overrides.json` — Cross-Referenz zur neuen Sektion

## Im Sweep bestätigt korrekt (keine Änderung nötig)

| Audit | Ergebnis |
|---|---|
| Code-Symbol-Drift (90+ Refs) | 0 broken |
| Section-Anker (20 Links) | 0 broken |
| TOC vs Headings in `development.md` | 19/19 deckungsgleich |
| Workflow-Beschreibungen | 11/11 korrekt |
| Skript-Coverage | 30/30 dokumentiert |
| Default-Werte in Env-Var-Tabelle | alle stimmen exakt mit `src/config/defaults.py` |
| Doku-Geister (Env-Vars in Doku, die nicht im Code existieren) | 0 |

## Test plan

- [x] `grep -rn "VOR_AUTH_TYPE\|BAUSTELLEN_TIMEOUT\|BAUSTELLEN_FALLBACK_PATH\|SITE_BASE_URL\|WIEN_TOKEN" src/ scripts/` bestätigt, dass die 5 Env-Vars im Code existieren.
- [x] `grep -n "Manuelle Station-Overrides" docs/development.md` bestätigt die neue Sektion.
- [x] JSON-Validität der `stations_overrides.json` nach String-Edit geprüft (Single-line `replace_all`).
- [ ] CI grün (pytest, ruff, mypy, secret-scan).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vd99CUzv3w3sx1HLFzz6UY)_