### PR TITLE
docs: konsistente Schreibweise „S-Bahn-Stammstrecke"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Die S-Bahn-Stammstrecke ist das Rückgrat des Pendlerverkehrs. Wir erfassen und 
 Mehr Statistiken findest du hier:
 [**📊 Zum detaillierten Dashboard**](docs/statistik.md)
 
-### Verspätungen auf der S-Bahn Stammstrecke
+### Verspätungen auf der S-Bahn-Stammstrecke
 
 <!-- STATS:STAMMSTRECKE_LIVE:BEGIN -->
 > _Letzte 60 Minuten – automatisch aktualisiert vom Workflow_ [`update-cycle.yml`](.github/workflows/update-cycle.yml).
@@ -58,7 +58,7 @@ Mehr Statistiken findest du hier:
 | Letzte Aktualisierung | 2026-05-20 00:30 CEST |
 <!-- STATS:STAMMSTRECKE:END -->
 
-### Ausfälle auf der S-Bahn Stammstrecke
+### Ausfälle auf der S-Bahn-Stammstrecke
 
 <!-- STATS:AUSFAELLE_LIVE:BEGIN -->
 > _Letzte 60 Minuten – automatisch aktualisiert vom Workflow_ [`update-cycle.yml`](.github/workflows/update-cycle.yml).

--- a/docs/reference/oebb_provider_logic.md
+++ b/docs/reference/oebb_provider_logic.md
@@ -38,7 +38,7 @@ Aktuell gibt es im Projekt zwei separate Stellen, an denen Schlüsselwörter fü
 
 ## Verwandte Dokumentation
 
-* **S-Bahn Stammstrecke Monitor** — siehe
+* **S-Bahn-Stammstrecke-Monitor** — siehe
   [`stammstrecke_provider_logic.md`](stammstrecke_provider_logic.md).
   Das Stammstrecken-Verspätungs-Monitoring lief ursprünglich über
   `pyhafas` mit dem ÖBB-HAFAS-Endpunkt; seit der 2026-05-09 Migration

--- a/docs/reference/stammstrecke_provider_logic.md
+++ b/docs/reference/stammstrecke_provider_logic.md
@@ -1,4 +1,4 @@
-# S-Bahn Stammstrecke Provider Logic
+# S-Bahn-Stammstrecke Provider Logic
 
 Das Stammstrecken-Verspätungs-Monitoring überwacht die Stammstrecke
 am Wien Hauptbahnhof auf signifikante Verspätungen und Ausfälle und


### PR DESCRIPTION
## Summary

Folge-Sweep nach #1592 mit drei parallelen Audit-Agenten — PR-Verifikation hat 48 von 48 Punkten als korrekt bestätigt, Smoke-Test bestätigt JSON/YAML/Markdown-Hierarchie sauber. Restbefund: drei Stellen mit nicht durchgekoppelter Schreibweise „S-Bahn Stammstrecke".

## Korrektur: Bindestrich-Konsistenz

Im Deutschen werden mehrgliedrige Komposita durchgekoppelt. Die Doku verwendete bereits an 5+ Stellen die korrekte Form „S-Bahn-Stammstrecke" (z.B. README Z. 15, 22, 32; alle docs/development.md-Stellen), aber drei prominent platzierte Überschriften/Verweise hatten die gekoppelte Schreibweise verfehlt:

| Datei | Vorher | Nachher |
|---|---|---|
| `README.md:37` | `### Verspätungen auf der S-Bahn Stammstrecke` | `### Verspätungen auf der S-Bahn-Stammstrecke` |
| `README.md:61` | `### Ausfälle auf der S-Bahn Stammstrecke` | `### Ausfälle auf der S-Bahn-Stammstrecke` |
| `docs/reference/oebb_provider_logic.md:41` | `**S-Bahn Stammstrecke Monitor**` | `**S-Bahn-Stammstrecke-Monitor**` |
| `docs/reference/stammstrecke_provider_logic.md:1` | `# S-Bahn Stammstrecke Provider Logic` | `# S-Bahn-Stammstrecke Provider Logic` |

## Bewusst nicht geändert

* **`EVENT_TITLE = "S-Bahn Stammstrecke Verspätungen"`** in `src/feed/stammstrecke.py:60` — die String-Konstante wird verbatim als RSS-Item-Titel emittiert. Eine Änderung wäre ein Verhaltens-Patch (kippt sichtbare Feed-Item-Titel für Downstream-Konsumenten) und liegt außerhalb des Doku-Scopes. Die Doku zitiert die Konstante also korrekt.

* **`docs/statistik.md`** zeigt einen kleinen Counter-Drift (Stammstrecke 356 vs CSV 358, Ausfälle 54 vs CSV 55, Störungen 330 vs CSV 333). Das Dokument ist vom `update-cycle.yml`-Workflow generiert und wird beim nächsten Tick automatisch nachgezogen — keine manuelle Korrektur.

## Im Sweep bestätigt korrekt

| Audit | Ergebnis |
|---|---|
| Env-Var-Tabelle gegen `src/config/defaults.py` und Provider-Module | 48/48 Defaults stimmen exakt |
| Neue Sektion „Manuelle Station-Overrides" gegen `scripts/apply_station_overrides.py:_ALLOWED_OPS` | OK (`restore`/`patch_coords`/`remove`) |
| Sidecar-Files-Tabelle | alle 6 Dateien/Verzeichnisse existieren |
| `stations validate`-Flags + Defaults | OK |
| `--enforce-free-cap` (`BooleanOptionalAction`, default True) | OK |
| `HBF_REFERENCE_LATITUDE = 48.1851` | exakt im Code |
| Pytest: `test_apply_station_overrides.py` (13 Tests), `test_stations_metadata.py` (1 Test) | alle PASS in &lt;1s |
| `data/stations_overrides.json` JSON-Validität | OK |
| Alle 11 Workflow-YAMLs | parsen sauber |
| Markdown-Heading-Hierarchie in `docs/development.md` | korrekt (H1→H2→H3, keine Sprünge) |

## Test plan

- [x] `grep -n 'S-Bahn Stammstrecke' README.md` liefert keine Treffer mehr (außer als literales Code-Quote in den `.md`-Sektionen wo es `EVENT_TITLE` zitiert).
- [x] Lokale `git diff` zeigt nur 4 Zeilen Änderung in 3 Dateien.
- [ ] CI grün (pytest, ruff, mypy, secret-scan).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vd99CUzv3w3sx1HLFzz6UY)_