### PR TITLE
fix(en-feed): translation pipeline audit — eliminate sticky-German cache

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -990,7 +990,14 @@ def _get_translation_pipeline() -> Any:
     return _TRANSLATION_STATE["pipeline"]
 
 
-def _translate_text(text: str) -> str:
+# Sentinel returned when a translation cannot be produced — distinct
+# from an empty string so callers can distinguish "no input" from "the
+# model failed". Mirrors the dual-state pattern used elsewhere in this
+# module (e.g. ``_TRANSLATION_STATE``).
+_TRANSLATION_FAILED_MARKER = "[Partially translated]"
+
+
+def _translate_text_attempt(text: str, ident: str = "") -> str | None:
     """Translate ``text`` from German to English with entity preservation.
 
     Pipeline:
@@ -999,38 +1006,80 @@ def _translate_text(text: str) -> str:
          and ÖPNV line identifiers with alphanumeric placeholders so
          the ML model cannot mistranslate proper nouns.
       2. The masked text goes through the Hugging Face translation
-         pipeline.
+         pipeline. ``truncation=True`` caps long inputs at the model's
+         max context window instead of letting Marian crash on > 512
+         tokens.
       3. :func:`_unmask_entities` restores the original surface forms
          from the placeholder mapping.
 
-    On any failure (model unavailable, runtime error, unexpected
-    shape) the original input is returned unchanged. Failures are
-    logged via :func:`sanitize_log_arg` so a hostile upstream string
-    cannot inject log-line forgery primitives into the diagnostics
-    stream.
+    Returns ``None`` on ANY failure (pipeline unavailable, runtime
+    error, malformed output, empty result) so callers can distinguish
+    "translated" from "had to fall back to the German source". Use
+    :func:`_translate_text` if you want a safe fallback that always
+    returns a string.
+
+    ``ident`` is included in warning logs (sanitised) so the GitHub
+    Actions log shows exactly which feed identities failed to
+    translate — critical for diagnosing partial-translation drift.
+    """
+    if not text or not text.strip():
+        return None
+    pipe = _get_translation_pipeline()
+    if pipe is None:
+        return None
+    masked_text, entity_mapping = _mask_entities(text)
+    try:
+        # ``truncation=True`` enforces the model's input cap (512 tokens
+        # for opus-mt-de-en) BEFORE Marian asserts and crashes the
+        # whole feed build. Without it, a single long disruption text
+        # would abort the EN-feed pass for every item that follows.
+        result = pipe(masked_text, max_length=512, truncation=True)
+    except Exception as exc:
+        log.warning(
+            "Translation failed for identity %s — pipeline raised %s: %s",
+            sanitize_log_arg(ident or "<unknown>"),
+            type(exc).__name__,
+            sanitize_log_arg(str(exc)),
+        )
+        return None
+    if not isinstance(result, list) or not result:
+        log.warning(
+            "Translation failed for identity %s — empty/invalid result shape.",
+            sanitize_log_arg(ident or "<unknown>"),
+        )
+        return None
+    first = result[0]
+    if not isinstance(first, dict):
+        log.warning(
+            "Translation failed for identity %s — result[0] not a dict.",
+            sanitize_log_arg(ident or "<unknown>"),
+        )
+        return None
+    translated = first.get("translation_text")
+    if not isinstance(translated, str) or not translated.strip():
+        log.warning(
+            "Translation failed for identity %s — translator returned empty text.",
+            sanitize_log_arg(ident or "<unknown>"),
+        )
+        return None
+    return _unmask_entities(translated, entity_mapping)
+
+
+def _translate_text(text: str, ident: str = "") -> str:
+    """Translate ``text`` from German to English; fall back to the source on failure.
+
+    Thin wrapper around :func:`_translate_text_attempt` that converts
+    the ``None`` failure signal into a safe-fallback string return.
+    Kept as a public-style helper so callers that do not need to
+    distinguish success from fallback have a single-string API; the
+    cache-aware path inside :func:`_cached_translation` uses
+    :func:`_translate_text_attempt` directly so a failed translation
+    is NEVER cached as the canonical English text.
     """
     if not text or not text.strip():
         return text
-    pipe = _get_translation_pipeline()
-    if pipe is None:
-        return text
-    masked_text, entity_mapping = _mask_entities(text)
-    try:
-        result = pipe(masked_text, max_length=512)
-    except Exception as exc:
-        log.warning(
-            "Übersetzung fehlgeschlagen (%s) – Rückfall auf Originaltext.",
-            sanitize_log_arg(str(exc)),
-        )
-        return text
-    if not isinstance(result, list) or not result:
-        return text
-    first = result[0]
-    if isinstance(first, dict):
-        translated = first.get("translation_text")
-        if isinstance(translated, str) and translated:
-            return _unmask_entities(translated, entity_mapping)
-    return text
+    attempt = _translate_text_attempt(text, ident=ident)
+    return attempt if attempt is not None else text
 
 
 def _translate_time_line_en(time_line: str) -> str:
@@ -1059,18 +1108,33 @@ def _cached_translation(
     field: str,
     ident: str,
     state: dict[str, dict[str, Any]] | None,
-) -> str:
+) -> tuple[str, bool]:
     """Return the cached EN translation of ``text`` for ``ident``/``field``.
 
-    On cache miss the translation is computed via :func:`_translate_text`
-    and persisted to ``state[ident]["translations"]["en"][field]`` so a
-    later run reuses the work (one translation per disruption identity
-    per lifecycle, by design).
+    Returns a tuple ``(translation, succeeded)`` where ``succeeded`` is
+    ``True`` only when the ML pipeline actually produced a translation
+    (either fresh or from the persistent cache). On failure the German
+    source is returned with ``succeeded=False`` and **nothing is
+    cached** — this fixes the "Sticky German" cache-corruption bug
+    where a transient pipeline failure (model not yet downloaded,
+    transformers import error, OOM) would poison the cache with the
+    German source text and lock the item in German forever.
+
+    Two further drift-protection guards:
+
+      * If the persisted "translation" is byte-identical to the
+        German source, treat it as a stale fallback from an earlier
+        buggy build and retry. Real translations from a successful
+        ML pass almost never equal the source verbatim (and the few
+        that do — e.g. ``ÖBB`` alone — round-trip safely).
+      * If ``state`` or ``ident`` is missing, fall through to a
+        cache-less translation via :func:`_translate_text_attempt`.
     """
     if not text:
-        return text
+        return text, True  # empty input is trivially "translated"
     if state is None or not ident:
-        return _translate_text(text)
+        attempt = _translate_text_attempt(text, ident=ident)
+        return (attempt, True) if attempt is not None else (text, False)
     entry = state.setdefault(ident, {})
     translations_raw = entry.get("translations")
     if not isinstance(translations_raw, dict):
@@ -1081,11 +1145,24 @@ def _cached_translation(
         en_raw = {}
         translations_raw["en"] = en_raw
     cached = en_raw.get(field)
-    if isinstance(cached, str) and cached:
-        return cached
-    translated = _translate_text(text)
-    en_raw[field] = translated
-    return translated
+    if isinstance(cached, str) and cached and cached != text:
+        return cached, True
+    if isinstance(cached, str) and cached == text:
+        # Stale-fallback heuristic: a prior run cached the German
+        # source as the "translation" — re-attempt now that the
+        # pipeline may be healthy.
+        log.info(
+            "Cached EN translation for %s/%s equals source; retrying.",
+            sanitize_log_arg(ident),
+            sanitize_log_arg(field),
+        )
+    attempt = _translate_text_attempt(text, ident=ident)
+    if attempt is None:
+        # Translation failed — do NOT persist the German source as
+        # the "translation". The next run gets a clean retry.
+        return text, False
+    en_raw[field] = attempt
+    return attempt, True
 
 
 def _parse_lines_from_title(title: str) -> list[str]:
@@ -2597,18 +2674,40 @@ def _apply_lang_overlay(
     EN strings are persisted in ``state[ident]["translations"]["en"]``
     and round-trip through :func:`_save_state`).
 
+    If either the title or the summary cannot be translated, the
+    description is annotated with the ``[Partially translated]``
+    marker so subscribers can see the degradation rather than silently
+    consuming a mostly-German item in the EN feed.
+
     For ``lang != "en"`` the input is returned unchanged.
     """
     if lang != "en":
         return base
 
-    title_en = _sanitize_text(
-        _cached_translation(base.title_out, "title", ident, state)
+    title_raw, title_ok = _cached_translation(
+        base.title_out, "title", ident, state
     )
-    summary_en = _sanitize_text(
-        _cached_translation(summary_de, "summary", ident, state)
-    ) if summary_de else ""
+    title_en = _sanitize_text(title_raw)
+    if summary_de:
+        summary_raw, summary_ok = _cached_translation(
+            summary_de, "summary", ident, state
+        )
+        summary_en = _sanitize_text(summary_raw)
+    else:
+        summary_en = ""
+        summary_ok = True
     time_line_en = _translate_time_line_en(time_line_de)
+
+    if not (title_ok and summary_ok):
+        log.warning(
+            "Translation incomplete for identity %s "
+            "(title_ok=%s, summary_ok=%s) — emitting partial-translation marker.",
+            sanitize_log_arg(ident or "<unknown>"),
+            title_ok,
+            summary_ok,
+        )
+        summary_en = _append_partial_translation_marker(summary_en)
+
     desc_text_truncated_en, desc_html_en = _compose_description(
         summary_en, time_line_en
     )
@@ -2622,6 +2721,20 @@ def _apply_lang_overlay(
         title_out=title_en,
         desc_html=desc_html_en,
     )
+
+
+def _append_partial_translation_marker(summary: str) -> str:
+    """Append :data:`_TRANSLATION_FAILED_MARKER` to ``summary`` once.
+
+    Idempotent: if the marker is already present the summary is
+    returned unchanged. Empty summaries are replaced with the marker
+    alone so the user-facing feed still flags the partial state.
+    """
+    if not summary:
+        return _TRANSLATION_FAILED_MARKER
+    if _TRANSLATION_FAILED_MARKER in summary:
+        return summary
+    return f"{summary} {_TRANSLATION_FAILED_MARKER}"
 
 
 def _format_item_content(

--- a/tests/test_feed_entity_masking.py
+++ b/tests/test_feed_entity_masking.py
@@ -114,10 +114,11 @@ def test_translate_text_pipes_masked_text_through_pipeline(
 ) -> None:
     """The pipeline receives the MASKED text (not the original) so a
     real Helsinki model cannot mistranslate proper nouns."""
-    seen: dict[str, str] = {}
+    seen: dict[str, Any] = {}
 
-    def fake_pipeline(text: str, max_length: int) -> list[dict[str, str]]:
+    def fake_pipeline(text: str, **kwargs: Any) -> list[dict[str, str]]:
         seen["input"] = text
+        seen["kwargs"] = kwargs
         # The fake model echoes the input as the translation so we can
         # verify the unmask step preserves the original entities.
         return [{"translation_text": text}]
@@ -130,6 +131,8 @@ def test_translate_text_pipes_masked_text_through_pipeline(
     assert "Stephansplatz" not in seen["input"]
     assert "Wiener Linien" not in seen["input"]
     assert "U6" not in seen["input"]
+    # ``truncation=True`` is forwarded so long inputs don't crash Marian.
+    assert seen["kwargs"].get("truncation") is True
     # The final output must restore the proper nouns verbatim.
     assert out == text
 
@@ -139,7 +142,7 @@ def test_translate_text_handles_dropped_placeholder_gracefully(
 ) -> None:
     """If the translator drops a placeholder the rest of the output is
     still restored and no stray ``XENT…`` token leaks to subscribers."""
-    def fake_pipeline(text: str, max_length: int) -> list[dict[str, str]]:
+    def fake_pipeline(text: str, **kwargs: Any) -> list[dict[str, str]]:
         # Strip every placeholder from the "translation" — simulates a
         # model that aggressively rewrites unfamiliar tokens.
         return [{"translation_text": build_feed._ENTITY_PLACEHOLDER_RE.sub("", text)}]

--- a/tests/test_feed_translation.py
+++ b/tests/test_feed_translation.py
@@ -38,21 +38,37 @@ def test_translate_text_returns_original_without_pipeline(
     assert build_feed._translate_text("Verspätung") == "Verspätung"
 
 
-def test_cached_translation_persists_in_state(monkeypatch: Any) -> None:
+def test_cached_translation_returns_success_flag(monkeypatch: Any) -> None:
+    """A pipeline failure must NOT cache the German source as the EN
+    "translation" — that was the Sticky-German cache-corruption bug.
+
+    Pre-fix behaviour: ``_cached_translation`` returned the German
+    fallback AND wrote it under ``state[ident]["translations"]["en"]``,
+    so subsequent runs (with a healthy pipeline) still served the
+    cached German text.
+    """
     monkeypatch.setattr(build_feed, "_get_translation_pipeline", lambda: None)
     state: dict[str, dict[str, Any]] = {}
-    first = build_feed._cached_translation("Hallo", "title", "ident-1", state)
-    assert first == "Hallo"  # fallback to original (no pipeline)
-    # State now carries the translation under the canonical layout.
-    assert state["ident-1"]["translations"]["en"]["title"] == "Hallo"
-
-    # Overwrite the cached value — second lookup must read from state and
-    # NOT re-trigger ``_translate_text``.
-    state["ident-1"]["translations"]["en"]["title"] = "Hello (cached)"
-    assert (
-        build_feed._cached_translation("Hallo", "title", "ident-1", state)
-        == "Hello (cached)"
+    text, succeeded = build_feed._cached_translation(
+        "Hallo", "title", "ident-1", state
     )
+    assert text == "Hallo"  # fallback to original (no pipeline)
+    assert succeeded is False  # explicit failure flag
+    # Cache MUST NOT carry the German fallback — the next run gets a
+    # clean retry.
+    translations = state.get("ident-1", {}).get("translations", {})
+    assert "title" not in translations.get("en", {})
+
+    # Once the cache has a real translation, the second lookup reads
+    # from state without re-invoking the (still-broken) pipeline.
+    state.setdefault("ident-1", {}).setdefault("translations", {}).setdefault(
+        "en", {}
+    )["title"] = "Hello (cached)"
+    text2, succeeded2 = build_feed._cached_translation(
+        "Hallo", "title", "ident-1", state
+    )
+    assert text2 == "Hello (cached)"
+    assert succeeded2 is True
 
 
 def test_format_item_content_en_falls_back_when_pipeline_unavailable(
@@ -63,6 +79,9 @@ def test_format_item_content_en_falls_back_when_pipeline_unavailable(
     The pipeline is stubbed to ``None`` so the title/summary stay as the
     German original; the time-line prefix is translated via the static
     dictionary so the EN feed still carries the English bracketed form.
+    The partial-translation marker must surface so subscribers can see
+    the degradation, and the cache MUST NOT persist the German source
+    as a "translation" (Sticky-German fix).
     """
     monkeypatch.setattr(build_feed, "_get_translation_pipeline", lambda: None)
     item = cast(
@@ -85,9 +104,13 @@ def test_format_item_content_en_falls_back_when_pipeline_unavailable(
     assert "[Since" in formatted_en.desc_text_truncated
     # German fallback preserved for title because the model is unreachable.
     assert formatted_en.title_out == "U6: Verspätung"
-    # Cache populated for the second call.
-    assert "title" in state["wl-1"]["translations"]["en"]
-    assert "summary" in state["wl-1"]["translations"]["en"]
+    # Partial-translation marker surfaces in the rebuilt description.
+    assert build_feed._TRANSLATION_FAILED_MARKER in formatted_en.desc_text_truncated
+    # Cache MUST NOT contain the German fallback for either field —
+    # the next run gets a clean retry once the pipeline is healthy.
+    translations = state.get("wl-1", {}).get("translations", {}).get("en", {})
+    assert "title" not in translations
+    assert "summary" not in translations
 
 
 def test_make_rss_en_writes_english_metadata_and_atom_self(

--- a/tests/test_translation_coverage.py
+++ b/tests/test_translation_coverage.py
@@ -1,0 +1,292 @@
+"""Coverage audit for the EN translation pipeline.
+
+After the "feed.en.xml partially translated" bug report, this module
+exercises the full ``_format_item_content(lang="en")`` path with a
+realistic Wiener Linien disruption sentence containing every entity
+class (operator brand, ÖPNV line identifier, station name) plus a
+small German clause that the ML model is expected to handle. The
+mocked translator simulates the canonical Marian/Helsinki-NLP
+behaviour: a word-for-word substitution on the German remainder
+that preserves the entity placeholders verbatim.
+
+The asserts pin three invariants:
+
+  (a) Entity preservation: every brand / line / station name appears
+      in the final English output **verbatim** (no mistranslation).
+  (b) Full-message translation: the German remainder around the
+      entities is fully translated; no German connector words
+      survive into the rendered EN feed.
+  (c) Sticky-German guard: when the pipeline succeeds, the resulting
+      cache entry is the real English translation (never the German
+      source).
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any, cast
+
+import pytest
+
+from src import build_feed
+from src.feed_types import FeedItem
+
+
+# A minimal German→English dictionary that the fake pipeline applies
+# word-for-word. Matches the kind of substitution a real opus-mt-de-en
+# pass produces around the masked entities (the entities themselves
+# pass through verbatim because the masker turned them into
+# ``XENT<n>X`` placeholders before the fake pipeline saw them).
+_FAKE_DICT: dict[str, str] = {
+    "Aufgrund": "Due to",
+    "wegen": "due to",
+    "einer": "a",
+    "eines": "a",
+    "technischen": "technical",
+    "Störung": "disruption",
+    "kommt": "comes",
+    "es": "it",
+    "auf": "on",
+    "der": "the",
+    "die": "the",
+    "Linie": "line",
+    "zwischen": "between",
+    "und": "and",
+    "zu": "to",
+    "Verzögerungen": "delays",
+    "Schienenersatzverkehr": "rail replacement service",
+    "informieren": "inform",
+    "Reisende": "Travellers",
+    "werden": "are",
+    "gebeten": "asked",
+    "alternative": "alternative",
+    "Routen": "routes",
+    "Reisepläne": "travel plans",
+    "anzupassen": "to adjust",
+    "Es": "There",
+    "im": "in",
+    "Abschnitt": "section",
+    "Bauarbeiten": "construction works",
+    "ist": "is",
+}
+
+
+def _fake_marian_translation(text: str, **kwargs: Any) -> list[dict[str, str]]:
+    """Mock Helsinki-NLP/opus-mt-de-en that rewrites German via
+    :data:`_FAKE_DICT`. Placeholders (``XENT0X``..) and unknown words
+    are passed through verbatim, mirroring real Marian behaviour."""
+    tokens = re.split(r"(\W+)", text)
+    out: list[str] = []
+    for token in tokens:
+        if token in _FAKE_DICT:
+            out.append(_FAKE_DICT[token])
+        elif token.lower() in _FAKE_DICT:
+            out.append(_FAKE_DICT[token.lower()])
+        else:
+            out.append(token)
+    return [{"translation_text": "".join(out)}]
+
+
+@pytest.fixture(autouse=True)
+def _isolate_translation_state() -> Iterator[None]:
+    """Snapshot and restore the global translation state so an early
+    failure inside one test does not leak its load_failed=True flag
+    into the next."""
+    saved_pipeline = build_feed._TRANSLATION_STATE["pipeline"]
+    saved_failed = build_feed._TRANSLATION_STATE["load_failed"]
+    try:
+        yield
+    finally:
+        build_feed._TRANSLATION_STATE["pipeline"] = saved_pipeline
+        build_feed._TRANSLATION_STATE["load_failed"] = saved_failed
+
+
+def test_complex_disruption_is_fully_translated_with_entity_preservation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end audit on a realistic complex disruption message.
+
+    Assertions:
+      (a) Entities (operator brand, U-Bahn line, station names) are
+          preserved verbatim in the EN output.
+      (b) The German remainder around the entities is fully translated
+          (no German connectors survive in the rendered description).
+    """
+    monkeypatch.setattr(
+        build_feed, "_get_translation_pipeline", lambda: _fake_marian_translation
+    )
+    item = cast(
+        FeedItem,
+        {
+            "title": "U6: Verspätung wegen technischer Störung",
+            "description": (
+                "Aufgrund einer technischen Störung kommt es auf der Linie "
+                "U6 zwischen Wien Hauptbahnhof und Stephansplatz zu "
+                "Verzögerungen. Wiener Linien informieren."
+            ),
+            "source": "Wiener Linien",
+            "category": "Störung",
+            "guid": "wl-cov-1",
+            "link": "",
+        },
+    )
+    starts = datetime(2026, 5, 16, 10, 0, tzinfo=UTC)
+    state: dict[str, dict[str, Any]] = {}
+
+    formatted_en = build_feed._format_item_content(
+        item,
+        ident="wl-cov-1",
+        starts_at=starts,
+        ends_at=None,
+        lang="en",
+        state=state,
+    )
+
+    title_en = formatted_en.title_out
+    desc_en = formatted_en.desc_text_truncated
+
+    # (a) Entity preservation — every proper noun survives the
+    #     round trip.
+    assert "U6" in title_en
+    assert "U6" in desc_en
+    assert "Wien Hauptbahnhof" in desc_en
+    assert "Stephansplatz" in desc_en
+    assert "Wiener Linien" in desc_en
+
+    # (b) Full-message translation — German connectors are gone and
+    #     the English equivalents are present.
+    for de_token in (
+        "Aufgrund",
+        "wegen",
+        "einer",
+        "technischen",
+        "Störung",
+        "zwischen",
+        "informieren",
+    ):
+        assert de_token not in title_en, (
+            f"German token {de_token!r} leaked into translated title: {title_en!r}"
+        )
+        assert de_token not in desc_en, (
+            f"German token {de_token!r} leaked into translated description: {desc_en!r}"
+        )
+    for en_token in ("Due to", "technical", "disruption", "between", "inform"):
+        assert en_token in desc_en, (
+            f"Expected English token {en_token!r} missing from {desc_en!r}"
+        )
+
+    # (c) Sticky-German cache guard — the cached translation must NOT
+    #     equal the German source.
+    translations = state["wl-cov-1"]["translations"]["en"]
+    assert translations["title"] != item["title"]
+    assert "Stephansplatz" in translations["summary"]
+    # No partial-translation marker because every field translated
+    # successfully.
+    assert build_feed._TRANSLATION_FAILED_MARKER not in desc_en
+
+
+def test_partially_translated_marker_surfaces_on_pipeline_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the pipeline fails (e.g. model not yet downloaded), the
+    description must carry the ``[Partially translated]`` marker so
+    subscribers see the degradation instead of silently consuming a
+    mostly-German item."""
+    monkeypatch.setattr(build_feed, "_get_translation_pipeline", lambda: None)
+    item = cast(
+        FeedItem,
+        {
+            "title": "U6: Verspätung",
+            "description": "Zwischen Wien Hauptbahnhof und Stephansplatz.",
+            "source": "Wiener Linien",
+            "category": "Störung",
+            "guid": "wl-cov-2",
+            "link": "",
+        },
+    )
+    state: dict[str, dict[str, Any]] = {}
+
+    formatted_en = build_feed._format_item_content(
+        item,
+        ident="wl-cov-2",
+        starts_at=datetime(2026, 5, 16, 10, 0, tzinfo=UTC),
+        ends_at=None,
+        lang="en",
+        state=state,
+    )
+
+    assert build_feed._TRANSLATION_FAILED_MARKER in formatted_en.desc_text_truncated
+    # And: the German fallback was NOT cached as the EN translation
+    # (sticky-German fix).
+    translations = state.get("wl-cov-2", {}).get("translations", {}).get("en", {})
+    assert "title" not in translations
+    assert "summary" not in translations
+
+
+def test_truncation_kwarg_is_forwarded_to_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Long inputs must reach the pipeline with ``truncation=True`` so
+    Marian truncates at its 512-token context window instead of
+    asserting and aborting the entire EN-feed build."""
+    captured: dict[str, Any] = {}
+
+    def fake_pipeline(text: str, **kwargs: Any) -> list[dict[str, str]]:
+        captured["kwargs"] = kwargs
+        return [{"translation_text": text}]
+
+    monkeypatch.setattr(build_feed, "_get_translation_pipeline", lambda: fake_pipeline)
+    build_feed._translate_text("Eine Meldung über die U6.")
+    assert captured["kwargs"].get("truncation") is True
+    assert captured["kwargs"].get("max_length") == 512
+
+
+def test_failure_log_includes_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A translation failure must log the feed item's identity so
+    operators can grep the GitHub Actions log for partial-translation
+    drift."""
+    def fake_pipeline(text: str, **kwargs: Any) -> list[dict[str, str]]:
+        raise RuntimeError("simulated model crash")
+
+    monkeypatch.setattr(build_feed, "_get_translation_pipeline", lambda: fake_pipeline)
+
+    import logging
+    with caplog.at_level(logging.WARNING, logger="build_feed"):
+        attempt = build_feed._translate_text_attempt("Eine Meldung.", ident="wl-fail-1")
+    assert attempt is None
+    failure_logs = [r.getMessage() for r in caplog.records if r.levelname == "WARNING"]
+    assert any("wl-fail-1" in msg for msg in failure_logs), failure_logs
+
+
+def test_cache_repair_after_sticky_german(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A state file inherited from a buggy pre-fix build where the
+    cached "translation" equals the German source must be repaired on
+    the next healthy run instead of serving the stale German text
+    forever."""
+    state: dict[str, dict[str, Any]] = {
+        "wl-cov-3": {
+            "first_seen": "2026-05-01T00:00:00+00:00",
+            "translations": {
+                "en": {"title": "Verspätung"},  # stale: equals source
+            },
+        },
+    }
+    # Healthy pipeline now produces a real translation.
+    monkeypatch.setattr(
+        build_feed,
+        "_get_translation_pipeline",
+        lambda: lambda text, **kwargs: [{"translation_text": "Delay"}],
+    )
+    text, succeeded = build_feed._cached_translation(
+        "Verspätung", "title", "wl-cov-3", state
+    )
+    assert succeeded is True
+    assert text == "Delay"
+    # Cache repaired with the real translation.
+    assert state["wl-cov-3"]["translations"]["en"]["title"] == "Delay"


### PR DESCRIPTION
## Summary
Folgeauftrag nach Report: `feed.en.xml` war nur teilweise übersetzt. Das Audit der Übersetzungspipeline fand **vier sich überlagernde Bugs** in `src/build_feed.py`, von denen einer (Sticky-German Cache) die Hauptursache ist.

## Root-Cause-Analyse

### 1. Sticky-German Cache-Korruption (PRIMÄR)
`_cached_translation` persistierte den Rückgabewert von `_translate_text` **bedingungslos** im State:
```python
translated = _translate_text(text)
en_raw[field] = translated  # ← speichert auch Fehlschläge als "Übersetzung"!
```
Wenn `_translate_text` fehlschlug (Pipeline nicht geladen, transformers ImportError, OOM, leeres Modell-Output, …) gab es den **deutschen Originaltext** zurück. Dieser wurde dann unter `state[ident]["translations"]["en"][field]` als wäre er die englische Übersetzung gespeichert. Bei jedem späteren Lauf — selbst mit gesunder Pipeline — lieferte der Cache den deutschen Text zurück. Items, die einmal bei einem Pipeline-Fehler durchgelaufen waren, blieben **für immer auf Deutsch** im EN-Feed.

### 2. Fehlende Input-Truncation
`pipe(text, max_length=512)` begrenzte nur **Output**-Tokens, nicht Input. Lange Störungstexte (>512 Tokens) crashten Marian mit Assertion-Failure und brachen den gesamten EN-Feed-Pass ab.

### 3. Identity-loses Failure-Logging
Das Log sagte nur `"Übersetzung fehlgeschlagen"` — ohne Feed-Identity. In GitHub Actions Logs konnte man nicht nachvollziehen, welche Items konkret betroffen waren.

### 4. Stille Degradation
Subscribers sahen mostly-German Items im "Englischen" Feed ohne sichtbares Signal.

## Korrekturen

| Bug | Fix |
|---|---|
| Sticky-German | Neuer Low-Level-Helper `_translate_text_attempt(text, ident="") -> str \| None`. `_cached_translation` gibt jetzt `tuple[str, bool]` zurück und persistiert **nur erfolgreiche** Übersetzungen. Eine Stale-Fallback-Heuristik (cached == source) erkennt vorhandene Korruption aus früheren Läufen und repariert sie automatisch beim nächsten gesunden Lauf. |
| Input-Truncation | `pipe(text, max_length=512, truncation=True)` |
| Logging | `log.warning("Translation failed for identity %s — pipeline raised %s: %s", ident, type, exc)` mit `sanitize_log_arg` für jeden Failure-Pfad |
| Stille Degradation | `_apply_lang_overlay` hängt `[Partially translated]` an die Description, wenn Title oder Summary nicht übersetzt werden konnten |

## Verifizierung

`tests/test_translation_coverage.py` (5 neue Tests) pinnt das korrekte Verhalten:

1. **Komplexer realistischer Disruption-Text** mit Eigennamen (U6, Wien Hauptbahnhof, Stephansplatz, Wiener Linien) wird vollständig übersetzt — alle Eigennamen verbatim erhalten, alle deutschen Konnektoren übersetzt.
2. **`[Partially translated]` Marker** taucht bei Pipeline-Failure auf.
3. **`truncation=True`** wird tatsächlich an die Pipeline weitergereicht.
4. **Failure-Log enthält die Identity** (via `caplog`).
5. **Cache-Repair** funktioniert für State-Dateien mit altem korrumpierten Cache.

Bestehende Tests (`tests/test_feed_translation.py`, `tests/test_feed_entity_masking.py`) wurden auf den neuen `tuple[str, bool]` Vertrag von `_cached_translation` und die `**kwargs` Signatur der Pipeline-Fakes angepasst.

## Test plan
- [x] `python -m pytest tests/` — 7935 passed, 2 skipped (5 neue Tests in `test_translation_coverage.py`, drei bestehende Tests angepasst)
- [x] `python scripts/check_complexity.py` — 0 neue C901-Verstöße
- [x] `ruff check src/build_feed.py` — clean
- [x] `mypy --no-pretty src/build_feed.py` — 0 neue Fehler
- [x] `python scripts/run_static_checks.py` — alles grün (0 Secrets, 9 ignored pip-audit, 0 neue mypy)
- [ ] Live-Verifizierung: nächster CI-Run produziert eine `feed.en.xml`, in der eine zufällige Stichprobe aus den ~10 letzten Störungen vollständig auf Englisch ist (keine deutschen Konnektoren), Eigennamen verbatim erhalten sind, und keine `[Partially translated]` Marker im Normalbetrieb auftauchen
- [ ] Manuelle Inspektion einer eventuell vorhandenen `data/first_seen.json` mit Sticky-German-Cache-Einträgen: ein neuer Build sollte die korrumpierten Einträge automatisch reparieren

https://claude.ai/code/session_01YNjxtfNC9cowFQpTAQo1jk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNjxtfNC9cowFQpTAQo1jk)_