### PR TITLE
docs: fix CoC contact placeholder and add mandatory secrets to env table

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,11 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+reported to the community leaders responsible for enforcement via the
+contact channels documented in [`SECURITY.md`](SECURITY.md#how-to-report)
+— please prefer the confidential GitHub Security Advisory channel for
+non-public reports, or contact the repository maintainers directly via
+their GitHub profile.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/docs/development.md
+++ b/docs/development.md
@@ -177,9 +177,13 @@ schreibt. Die wichtigsten Parameter:
 | `STATE_PATH`, `STATE_RETENTION_DAYS` | Pfad & Aufbewahrungstage für `data/first_seen.json` (Standard 60 Tage).        |
 | `WIEN_OEPNV_CACHE_PRETTY` | Steuert die Formatierung der Cache-Dateien (`1` = gut lesbar, `0` = kompakt). |
 | `WIEN_OEPNV_DEBUG`       | Auf `1` gesetzt zeigt die CLI (`python -m src.cli`) bei Fehlern den vollständigen Traceback; Standard verhält sich fail-secure (keine Trace-Ausgabe). |
+| `VOR_ACCESS_ID`          | **Pflicht-Secret** für den Stammstrecken-Monitor (VAO-Access-Token). Niemals committen — laden via `.env`, `data/secrets.env` oder `config/secrets.env`. Validierbar mit `python -m src.cli tokens verify vor`. |
+| `VOR_BASE_URL`           | **Pflicht-Secret** für den Stammstrecken-Monitor: Basis-URL der VAO-ReST-API (validiert in `src/providers/vor.py:_validated_vor_base_url`). Legacy-Alias `VOR_BASE`. |
 | `VOR_USER_AGENT`         | Custom User-Agent für VOR/VAO-API-Calls (Standard `wien-oepnv/1.0 (+https://github.com/Origamihase/wien-oepnv)`). |
 | `VOR_REQUEST_COUNT_FILE` | Override für den Persistenzpfad des VAO-Tagesbudget-Counters (Standard `data/vor_request_count.json`). |
 | `VOR_AUTH_TYPE`          | Erzwingt das Auth-Schema bei der VAO-Token-Normalisierung (`bearer` oder `basic`, Standard: automatische Erkennung aus dem Token-Format in `src/providers/vor.py:_normalise_access_token`). |
+| `VOR_VERSION` / `VOR_VERSIONS` | Versions-String für die VAO-URL (z. B. `v1.11.0`); `VOR_VERSIONS` ist Fallback-Alias für `VOR_VERSION`. Optional, Default folgt der API-Vorgabe. |
+| `GOOGLE_ACCESS_ID`       | Pflicht für den Tier-3-Notausgang (Google Places). Fallback-Alias `GOOGLE_MAPS_API_KEY` (deprecated). Details im How-to [`docs/how-to/google_places_stations.md`](how-to/google_places_stations.md). |
 | `BAUSTELLEN_TIMEOUT`     | Per-Request-Timeout (Sekunden) für `scripts/update_baustellen_cache.py` (Standard `20`, hart geklammert auf `MAX_BAUSTELLEN_TIMEOUT`). |
 | `BAUSTELLEN_FALLBACK_PATH` | Pfad zur lokalen JSON-Fallback-Datei (Standard `data/samples/baustellen_sample.geojson`), die verwendet wird, wenn der OGD-Endpoint der Stadt Wien nicht erreichbar ist. |
 | `SITE_BASE_URL`          | Basis-URL für die Sitemap-Generierung (`scripts/generate_sitemap.py`). Standard identisch mit `PAGES_BASE_URL`; gegen die GitHub-Pages-Allow-List validiert. |
@@ -632,9 +636,7 @@ Sicherheits-Gates: Der Reporter validiert das Repo-Slug gegen GitHubs Naming-Gra
 
 ## Authentifizierung & Sicherheit
 
-- **Secrets**: (z. B. `VOR_ACCESS_ID`, `VOR_BASE_URL`) werden ausschließlich über Umgebungsvariablen bereitgestellt und niemals im
-  Repository abgelegt. Das Skript `src/utils/secret_scanner.py` schützt proaktiv vor versehentlich eingecheckten Geheimnissen.
-  Optionale Secondary-Variablen für den VOR/VAO-Stack: `VOR_BASE` (Legacy-Alias für `VOR_BASE_URL`, akzeptiert in `src/providers/vor.py:_validated_vor_base_url`), `VOR_VERSION` und `VOR_VERSIONS` (Versions-Strings für die VAO-URL, z. B. `v1.11.0` — `VOR_VERSIONS` ist Fallback-Alias für `VOR_VERSION`). Beide werden in `.github/workflows/update-cycle.yml` als Build-Secrets durchgereicht.
+- **Secrets**: Pflicht- und optionale Variablen (`VOR_ACCESS_ID`, `VOR_BASE_URL`, `VOR_VERSION` / `VOR_VERSIONS`, `GOOGLE_ACCESS_ID`, …) sind im Tabellenblock [„Konfiguration des Feed-Builds"](#konfiguration-des-feed-builds) gelistet. Sie werden ausschließlich über Umgebungsvariablen bereitgestellt und niemals im Repository abgelegt; das Skript `src/utils/secret_scanner.py` schützt proaktiv vor versehentlich eingecheckten Geheimnissen. In `.github/workflows/update-cycle.yml` werden diese Werte als Build-Secrets durchgereicht.
 - **SSRF-Schutz**: Externe Netzwerkanfragen laufen über `fetch_content_safe` (in `src/utils/http.py`). Diese Funktion verhindert Server-Side Request Forgery, indem sie DNS-Rebinding blockiert, private IP-Adressen (Localhost, internes Netzwerk) ablehnt und DNS-Timeouts erzwingt.
 - **Dateisystem**: Schreibvorgänge nutzen `atomic_write`, um Datenkorruption bei Abstürzen zu vermeiden. Pfadeingaben werden strikt validiert (`resolve_env_path` / `validate_path` aus `src/feed/config.py`), um Path-Traversal-Angriffe zu verhindern. Schreibzugriffe sind auf `docs/`, `data/` und `log/` beschränkt.
 - **Logging-Sicherheit**: Kontrollzeichen in Logs werden maskiert, um Log-Injection-Attacken zu unterbinden.


### PR DESCRIPTION
## Summary

Documentation audit of the entire repository against the actual code. Two concrete issues found and fixed; everything else was verified accurate.

### Issues fixed

1. **`CODE_OF_CONDUCT.md` line 63** — the Contributor Covenant template's `[INSERT CONTACT METHOD]` placeholder was never filled in, leaving the enforcement channel literally undefined. Replaced with a reference to the existing `SECURITY.md#how-to-report` contact channels (confidential GitHub Security Advisory + maintainer GitHub profile), so the CoC enforcement story matches the security-reporting story.

2. **`docs/development.md` env-var table inconsistency** — the optional VOR tuning vars (`VOR_USER_AGENT`, `VOR_REQUEST_COUNT_FILE`, `VOR_AUTH_TYPE`) were already in the configuration table, but the **mandatory** secrets `VOR_ACCESS_ID` / `VOR_BASE_URL` / `GOOGLE_ACCESS_ID` were only documented in prose lower down. The table is the canonical config reference, so they belonged there. Added rows for:
   - `VOR_ACCESS_ID` — marked as Pflicht-Secret, with the `tokens verify vor` validation hint
   - `VOR_BASE_URL` — marked as Pflicht-Secret, references the `_validated_vor_base_url` allowlist, notes the `VOR_BASE` legacy alias
   - `VOR_VERSION` / `VOR_VERSIONS` — fallback alias relationship
   - `GOOGLE_ACCESS_ID` — Tier-3 Google Places key with cross-link to the dedicated how-to
   - Streamlined the `Authentifizierung & Sicherheit` bullet to point at the consolidated table instead of duplicating the VOR/VAO variable list.

### Verification scope (all confirmed accurate, no action needed)

- All CLI subcommands and flags in `src/cli.py` match `docs/development.md`'s documented invocations.
- All 11 workflow files exist with the documented triggers (IFTTT `repository_dispatch` for `update-cycle.yml`, weekly Sunday-01:00-UTC cron for `update-stations.yml`, no cron on `build-feed.yml`).
- All 30 documented scripts exist in `scripts/`.
- The 2026-05-11 VOR consolidation is correctly reflected: `fetch_events` removed from `src/providers/vor.py`, no `cache/vor/` directory, no `update_vor_cache.py` / `update_vor_stations.py` / `fetch_vor_haltestellen.py`, no `VOR_ENABLE` env var in production code, daily quota 100 with ~48 used by the Hbf monitor (1× `/departureBoard` per tick since 2026-05-15).
- 39 env vars in the table verified against `src/feed/config.py`, `src/config/defaults.py`, `src/utils/env.py`, `src/providers/vor.py`, `scripts/update_baustellen_cache.py`.
- `docs/architecture.md` §§1–8 all map to real code symbols and file paths.
- How-to and reference docs in `docs/how-to/` and `docs/reference/` internally consistent.
- Schema files in `docs/schema/` validate the actual JSON data.
- Test counts: 3270 tests in 453 modules — matches "über 3200 Tests in rund 450 Modulen" claim.
- Python target `py311` in `pyproject.toml` matches "Python 3.11+" docs claim.
- `docs/feed-health.{md,json}` correctly marked as gitignored.

## Test plan
- [x] `git diff` review of both files
- [x] Verified `SECURITY.md#how-to-report` anchor resolves (heading exists at line 15)
- [x] Verified the new table entries reference real symbols (`_validated_vor_base_url` at `src/providers/vor.py`, `tokens verify vor` is a real CLI subcommand)
- [x] No code changes — pre-commit hooks for Markdown (`trailing-whitespace`, `end-of-file-fixer`) won't be triggered by Python-only checks

https://claude.ai/code/session_01LzsbxHYpihBJ2KznPhaaQd

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzsbxHYpihBJ2KznPhaaQd)_