### PR TITLE
fix(ci): install torch+HF cache in update-cycle.yml & manual-full-refresh.yml

### DIFF
--- a/.github/workflows/manual-full-refresh.yml
+++ b/.github/workflows/manual-full-refresh.yml
@@ -56,6 +56,36 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
+      # Hugging Face Hub cache for the EN translation model
+      # (Helsinki-NLP/opus-mt-de-en, ~300 MB). Without this, every
+      # manual refresh would have to re-download the model and the EN
+      # feed items would flag as ``[Partially translated]`` while the
+      # pipeline initialised. Monthly-rotating cache key with
+      # previous-month restore-key keeps the cache warm without
+      # blocking model autoupdates beyond ~30 days.
+      - name: Resolve Hugging Face cache key
+        id: hf-cache-key
+        shell: bash
+        run: |
+          echo "month=$(date -u +'%Y-%m')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Hugging Face hub
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/huggingface
+          key: huggingface-${{ runner.os }}-${{ steps.hf-cache-key.outputs.month }}
+          restore-keys: |
+            huggingface-${{ runner.os }}-
+
+      # PyTorch (CPU-only wheel) — installed BEFORE the project
+      # requirements so the transformers pipeline shipped in
+      # ``requirements.txt`` finds a working torch backend. Without
+      # this step ``pipeline("translation_de_to_en", …)`` raises a
+      # ``RuntimeError`` and every EN-feed item degrades to the
+      # ``[Partially translated]`` marker.
+      - name: Install PyTorch (CPU-only)
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
       - name: Install dependencies
         uses: ./.github/actions/install-deps
 

--- a/.github/workflows/update-cycle.yml
+++ b/.github/workflows/update-cycle.yml
@@ -91,6 +91,30 @@ jobs:
         with:
           python-version: '3.11'
 
+      # Hugging Face Hub cache for the EN translation model
+      # (Helsinki-NLP/opus-mt-de-en, ~300 MB). Without this, every
+      # ~30-min cycle tick would have to re-download the model — and
+      # the first-time download is what previously caused the EN feed
+      # to flag every item as ``[Partially translated]``: the pipeline
+      # could not initialise inside the workflow, so ``_translate_text``
+      # fell back to the German source for every disruption. The cache
+      # key rotates monthly (``YYYY-MM``) so the upstream model can
+      # autoupdate within ~30 days; ``restore-keys`` falls back to the
+      # previous month to keep the warm cache.
+      - name: Resolve Hugging Face cache key
+        id: hf-cache-key
+        shell: bash
+        run: |
+          echo "month=$(date -u +'%Y-%m')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Hugging Face hub
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/huggingface
+          key: huggingface-${{ runner.os }}-${{ steps.hf-cache-key.outputs.month }}
+          restore-keys: |
+            huggingface-${{ runner.os }}-
+
       # Cache the entire installed virtual environment instead of the
       # pip download cache. ``setup-python``'s ``cache: 'pip'`` only
       # speeds up wheel resolution; pip still spends ~30 s rebuilding
@@ -129,9 +153,21 @@ jobs:
         # inline it here so the cached path produces a venv whose
         # interpreter + pip version match what the composite would
         # have built. Other workflows continue to use the composite.
+        #
+        # PyTorch (CPU-only wheel) is installed BEFORE the project
+        # requirements file so the transformers pipeline shipped in
+        # ``requirements.txt`` finds a working torch backend at runtime.
+        # Without this step ``pipeline("translation_de_to_en", …)``
+        # raises ``RuntimeError: Models won't be available`` and every
+        # EN-feed item degrades to the ``[Partially translated]``
+        # marker (root cause of the partially-untranslated live feed
+        # on 2026-05-21). Once the venv is cached the torch wheel sits
+        # inside ``.venv/lib/…`` so the cache-hit path skips the
+        # re-download (~750 MB saved per cycle tick).
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install "pip<27"
+          .venv/bin/pip install torch --index-url https://download.pytorch.org/whl/cpu
           .venv/bin/pip install -r requirements.txt
 
       - name: Prepend venv to PATH

--- a/tests/test_en_feed_workflow_deps.py
+++ b/tests/test_en_feed_workflow_deps.py
@@ -1,0 +1,149 @@
+"""Regression tests for the EN-feed CI workflow dependencies.
+
+The bug behind the partially-untranslated live feed on 2026-05-21 was
+NOT in the Python code at all — it was a missing ``torch`` install in
+the workflows that actually build the feed on the production cadence
+(``update-cycle.yml`` every ~30 minutes; ``manual-full-refresh.yml``
+on the operator's "alles neu" button). The transformers package was
+installed (it ships in ``requirements.txt``), but without a torch
+backend ``pipeline("translation_de_to_en", …)`` raises a
+``RuntimeError: Models won't be available`` at construction time, the
+audit fix's ``_translate_text_attempt`` returns ``None`` for every
+item, and every disruption ends up flagged ``[Partially translated]``
+with the German source verbatim.
+
+The original 2026-05 multilingual-feed PR only patched
+``build-feed.yml`` (the code-verification workflow). The two other
+feed-producing workflows kept running without torch. This module
+locks the torch/HF-cache contract into the workflows directly so a
+future maintainer cannot remove either step without an explicit test
+failure surfacing the regression.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# Workflows that build the feed and therefore require both the
+# torch CPU-only install AND the Hugging Face Hub cache. The third
+# entry (``build-feed.yml``) was already patched by the original
+# bilingual-feed PR; including it here pins the contract for ALL
+# feed producers in one place.
+_FEED_BUILD_WORKFLOWS = (
+    "build-feed.yml",
+    "update-cycle.yml",
+    "manual-full-refresh.yml",
+)
+
+
+def _workflow_yaml(name: str) -> dict[str, object]:
+    path = WORKFLOWS / name
+    assert path.is_file(), f"workflow {name} missing"
+    with path.open(encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle)
+    assert isinstance(loaded, dict), f"{name} did not parse to a dict"
+    return loaded
+
+
+def _iter_steps(workflow: dict[str, object]) -> list[dict[str, object]]:
+    """Flatten ``jobs.*.steps`` so a single check can scan them all."""
+    out: list[dict[str, object]] = []
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        return out
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for step in steps:
+            if isinstance(step, dict):
+                out.append(step)
+    return out
+
+
+def _step_text(step: dict[str, object]) -> str:
+    """Concatenate the searchable text of a step (name + run + uses +
+    every value inside ``with:``). The ``with:`` payload carries the
+    cache path / key, which the assertions below scan for."""
+    parts: list[str] = []
+    for key in ("name", "run", "uses"):
+        value = step.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+    with_block = step.get("with")
+    if isinstance(with_block, dict):
+        for value in with_block.values():
+            if isinstance(value, str):
+                parts.append(value)
+    return "\n".join(parts)
+
+
+@pytest.mark.parametrize("workflow_name", _FEED_BUILD_WORKFLOWS)
+def test_feed_workflow_installs_torch_cpu_only(workflow_name: str) -> None:
+    """Every feed-producing workflow must install the CPU-only PyTorch
+    wheel from the official PyTorch index BEFORE the transformers
+    pipeline is asked to translate. Without this step the live EN feed
+    silently degrades to German under the ``[Partially translated]``
+    marker."""
+    workflow = _workflow_yaml(workflow_name)
+    blob = "\n".join(_step_text(step) for step in _iter_steps(workflow))
+    assert "pytorch.org/whl/cpu" in blob, (
+        f"{workflow_name} does not install the CPU-only torch wheel; "
+        f"the EN feed will degrade to '[Partially translated]' for every "
+        f"item produced by this workflow. Add a step that runs "
+        f"`pip install torch --index-url "
+        f"https://download.pytorch.org/whl/cpu`."
+    )
+    assert "torch" in blob.lower(), (
+        f"{workflow_name} mentions the PyTorch CPU index but the literal "
+        f"``torch`` package is missing from the install command."
+    )
+
+
+@pytest.mark.parametrize("workflow_name", _FEED_BUILD_WORKFLOWS)
+def test_feed_workflow_caches_huggingface_hub(workflow_name: str) -> None:
+    """Every feed-producing workflow must cache ``~/.cache/huggingface``
+    with a monthly-rotating key. Without the cache, every ~30-min
+    cycle would re-download the ~300 MB Helsinki-NLP model and the
+    first item processed before the download completes degrades to
+    ``[Partially translated]``."""
+    workflow = _workflow_yaml(workflow_name)
+    steps = _iter_steps(workflow)
+    blob = "\n".join(_step_text(step) for step in steps)
+    assert "~/.cache/huggingface" in blob, (
+        f"{workflow_name} does not cache ~/.cache/huggingface; the "
+        f"Helsinki-NLP/opus-mt-de-en model would have to be downloaded "
+        f"on every workflow run, which can race the first feed items "
+        f"into the ``[Partially translated]`` fallback."
+    )
+    # The actions/cache step must be present and its key must include
+    # a rotating component (``YYYY-MM``) — i.e. it must depend on a
+    # ``date`` output. We check for the literal ``hf-cache-key`` step
+    # id used in the three workflows for consistency.
+    assert "hf-cache-key" in blob, (
+        f"{workflow_name} caches huggingface but is missing the "
+        f"monthly-rotating ``hf-cache-key`` step that drives the cache "
+        f"key. Without monthly rotation the cache can never auto-pick-up "
+        f"an upstream model bump."
+    )
+
+
+@pytest.mark.parametrize("workflow_name", _FEED_BUILD_WORKFLOWS)
+def test_feed_workflow_runs_build_step(workflow_name: str) -> None:
+    """Sanity guard: the workflow actually invokes ``feed build`` —
+    so the previous two assertions are not vacuously true on a
+    workflow that no longer builds the feed at all."""
+    workflow = _workflow_yaml(workflow_name)
+    blob = "\n".join(_step_text(step) for step in _iter_steps(workflow))
+    assert "feed build" in blob, (
+        f"{workflow_name} does not run ``feed build`` — if this is "
+        f"intentional, remove the workflow from "
+        f"``_FEED_BUILD_WORKFLOWS`` in this test module."
+    )


### PR DESCRIPTION
## Summary

Auf https://origamihase.github.io/wien-oepnv/feed.en.xml zeigen alle neuen Meldungen den `[Partially translated]`-Marker plus deutschen Originaltext:

```xml
<title><[CDATA[5A: Schadhafter LKW]]></title>
<description>Linie 5A: Nach einer Fahrtbehinderung kommt es zu
unterschiedlichen Intervallen. [Partially translated] [On 21.05.2026]
</description>
```

Das ist exakt mein dokumentierter Safe-Fail-Pfad aus PR #1597 — die Pipeline initialisiert sich im CI nicht. Diese Symptomatik tritt auf wenn `transformers` ohne torch geladen wird: `pipeline("translation_de_to_en", …)` wirft `RuntimeError: Models won't be available`, `_translate_text_attempt` gibt `None` für jeden Item zurück, `_apply_lang_overlay` stempelt den Marker.

## Diagnose

Drei Workflows können den Feed bauen, **nur einer wurde gepatcht** beim ursprünglichen Bilingual-PR:

| Workflow | Trigger | torch + HF cache? |
|---|---|---|
| `build-feed.yml` | manual / push-driven (Code-Verifikation) | ✅ (#1595) |
| `update-cycle.yml` | IFTTT alle ~30 Min — **das ist der Produktions-Pfad** | ❌ |
| `manual-full-refresh.yml` | operator-driven full rebuild | ❌ |

`transformers` ist korrekt in `requirements.txt`. `torch` ist absichtlich NICHT in `requirements.txt` (default CUDA-Wheel ~2 GB; wir wollen die CPU-Version vom dedizierten PyTorch-Index). Beide fehlenden Workflows installieren also nur `transformers` ohne Backend und enden im Safe-Fail-Pfad.

State-File-Inspektion bestätigt: 54 von 961 Items haben `translations.en` Key, davon nur **16 gefüllt** — alle anderen sind das No-Cache-On-Failure-Verhalten aus PR #1597.

## Fix

- **`update-cycle.yml`**: Das inline `Install dependencies (cache miss)`-Step installiert jetzt die CPU-only torch-Wheel BEVOR die project requirements. Dadurch enthält die gecachte venv torch auf dem common-cache-hit-Pfad (kein Re-Download pro Cycle-Tick = ~750 MB gespart). Separater `Cache Hugging Face hub`-Step persistiert den ~300 MB Modell-Download mit monatlich rotierendem Key (identisch zu `build-feed.yml`).

- **`manual-full-refresh.yml`**: Gleicher HF-Cache-Step. Expliziter `Install PyTorch (CPU-only)` Step VOR dem bestehenden `install-deps` Composite. Das Composite wird NICHT modifiziert um torch zu inkludieren — andere Workflows (`test.yml`, `mypy-strict.yml`) brauchen torch nicht und sollen nicht ~250 MB extra runterladen.

- **`build-feed.yml`**: bereits korrekt (PR #1595), unverändert.

## Regression Guard

`tests/test_en_feed_workflow_deps.py` (9 parametrisierte Assertions) zementiert den Vertrag:

1. Jeder Feed-bauende Workflow MUSS `torch --index-url pytorch.org/whl/cpu` installieren
2. Jeder Feed-bauende Workflow MUSS `~/.cache/huggingface` mit rotating `hf-cache-key` cachen
3. Sanity: jeder gelistete Workflow ruft tatsächlich `feed build` auf (so dass die ersten beiden Asserts nicht vacuous true sind)

Ein zukünftiger Maintainer der einen Step entfernt bekommt einen failing Test, BEVOR der Live-Feed wieder degradiert.

## Nach dem Merge

Sobald der erste `update-cycle.yml`-Run mit den neuen Deps läuft, übersetzt der nächste neu erkannte Disruption-Item end-to-end. Items mit bereits leerem `translations.en` Cache werden von der Stale-Fallback-Heuristik in `_cached_translation` (PR #1597) erneut versucht. Die DE-Source-Items aus der Pre-Audit-Ära können durch Löschen ihrer State-Einträge geflusht werden — das ist operative Remediation, nicht Teil dieses PRs.

## Test plan
- [x] `python -m pytest tests/test_en_feed_workflow_deps.py -v` — 9 passed
- [x] `python scripts/run_static_checks.py` — alle Gates grün
- [x] YAML-Validierung aller drei Workflows
- [ ] **Live-Verifizierung**: nächster `update-cycle.yml`-Run nach Merge produziert `feed.en.xml` mit vollständig übersetzten Items (kein `[Partially translated]` mehr bei Pipeline-success)
- [ ] HF-Cache-Hit beim zweiten Run reduziert Build-Zeit signifikant

https://claude.ai/code/session_01YNjxtfNC9cowFQpTAQo1jk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNjxtfNC9cowFQpTAQo1jk)_