### PR TITLE
fix(ci): cap update-cycle wall-clock with 3-layer timeout defence

### DIFF
--- a/.github/workflows/update-cycle.yml
+++ b/.github/workflows/update-cycle.yml
@@ -63,6 +63,14 @@ concurrency:
 jobs:
   cycle:
     runs-on: ubuntu-latest
+    # Defense-in-depth ceiling for the whole job. A healthy tick runs
+    # in 3-5 min (see step-order comment above); without this cap the
+    # workflow inherits GitHub's 360-min default, so a hung subprocess
+    # in any step burns 6h of billable minutes and — combined with
+    # ``concurrency: cancel-in-progress: false`` above — backs up the
+    # next ~12 IFTTT triggers behind it. 10 min gives ~2x headroom over
+    # the worst legitimate run while still catching hangs quickly.
+    timeout-minutes: 10
     permissions:
       contents: write
     env:
@@ -191,17 +199,42 @@ jobs:
       # ``continue-on-error: true`` raised an orange badge per failed
       # step; the warning emits the same operator-visible signal here.
       - name: Refresh free-API caches in parallel
+        # Defense-in-depth step ceiling. The per-process ``timeout 90``
+        # wrappers below catch a single hung fetcher (their exit code
+        # 124 surfaces via the report() ``::warning::`` annotation, so
+        # the other two fetchers' caches still refresh on the same
+        # tick). This step-level ``timeout-minutes: 3`` is the fallback
+        # if ALL three processes hang past their per-process budget
+        # OR if the ``wait`` plumbing itself misbehaves (e.g. a bash
+        # job-control quirk). 3 min ≈ ``90s parallel + reporting`` —
+        # comfortably above the per-process ceiling but tight enough
+        # to leave 7 min of the job's 10-min budget for VAO + feed
+        # build + commit. Healthy ticks finish this step in ~30s.
+        timeout-minutes: 3
         run: |
           set +e
 
           log_dir="$RUNNER_TEMP/fetcher-logs"
           mkdir -p "$log_dir"
 
-          python scripts/update_wl_cache.py         > "$log_dir/wl.log"         2>&1 &
+          # Per-process Slowloris-defence wrapper. ``timeout`` (GNU
+          # coreutils, ships on ubuntu-latest) sends SIGTERM after 90s
+          # and follows up with SIGKILL 10s later via ``--kill-after``
+          # so a fetcher stuck in an uninterruptible C-extension call
+          # (e.g. a hung HTTPS socket below urllib3's Python-layer
+          # read deadline) cannot survive the SIGTERM-ignore path.
+          # Exit code 124 = SIGTERM-on-timeout, 137 = SIGKILL — the
+          # report() helper prints both via the existing ``(exit ${rc})``
+          # annotation so operators see ``::warning::`` lines for the
+          # killed fetcher. 90s budget covers the WORST documented
+          # legitimate run (WL: 2 endpoints × ~25s timeout × app-retry
+          # ≈ 60-80s under heavy upstream retry-load); healthy fetchers
+          # finish in <10s.
+          timeout --kill-after=10 90 python scripts/update_wl_cache.py         > "$log_dir/wl.log"         2>&1 &
           pid_wl=$!
-          python scripts/update_oebb_cache.py       > "$log_dir/oebb.log"       2>&1 &
+          timeout --kill-after=10 90 python scripts/update_oebb_cache.py       > "$log_dir/oebb.log"       2>&1 &
           pid_oebb=$!
-          python scripts/update_baustellen_cache.py > "$log_dir/baustellen.log" 2>&1 &
+          timeout --kill-after=10 90 python scripts/update_baustellen_cache.py > "$log_dir/baustellen.log" 2>&1 &
           pid_baustellen=$!
 
           wait "$pid_wl";         rc_wl=$?


### PR DESCRIPTION
## Summary

The `cycle` workflow hung 43+ min today (2026-05-21 ~11:30 UTC tick) on the `Refresh free-API caches in parallel` step. Root cause: **zero timeout protection anywhere in the workflow**.

```
$ grep -rn "timeout-minutes" .github/
(nothing)
```

GitHub's 360-min default job timeout was the only safety net. Combined with `concurrency: cancel-in-progress: false`, a single hang would back up ~12 IFTTT triggers behind it before the kill-switch fired.

The Python scripts have per-HTTP-request timeouts (WL/ÖBB 25 s, Baustellen 20 s, enforced via `MAX_*_FETCH_TIMEOUT` + `_compute_total_time_budget` in `src/utils/http.py:1720`), but **no second defence-in-depth layer** — if a subprocess hangs for any reason outside that path (DNS edge cases, urllib3 connection-pool quirks, a slow C extension below the Python read deadline), `wait $pid` in the bash block blocks indefinitely.

## Changes

Three layers added to `.github/workflows/update-cycle.yml`:

| Layer | Setting | Catches |
|---|---|---|
| Job-level | `timeout-minutes: 10` | Anything stuck in any step; bounds billable minutes per failed run at 10 instead of 360 |
| Step-level (fetcher) | `timeout-minutes: 3` | All three processes overrunning together; bash job-control quirks |
| Per-process | `timeout --kill-after=10 90 python …` (×3) | Single hung fetcher — exit 124/137 surfaces via existing `report()` `::warning::`, the other two still refresh |

90 s per process covers the worst documented legitimate run (WL: 2 endpoints × ~25 s timeout × 3-retry app loop ≈ 60-80 s under heavy upstream retry-load); healthy fetchers finish in <10 s. Healthy ticks finish the step in ~30 s and the whole job in 3-5 min — well below all three caps.

## Out of scope

`manual-full-refresh.yml` runs the same three fetcher scripts (as sequential steps, not parallel) and also has no `timeout-minutes`. Same gap exists there but with different semantics (operator-triggered, not 30-min cadence) — handled separately if desired.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/update-cycle.yml'))"`)
- [x] `jobs.cycle.timeout-minutes` = 10
- [x] Fetcher step `timeout-minutes` = 3
- [x] All three Python invocations prefixed with `timeout --kill-after=10 90`
- [ ] Next IFTTT-triggered run completes in <5 min (observable on the next `:00`/`:30` tick after merge)
- [ ] If a future fetcher hangs, exit code 124 appears in the step's `::warning::` annotation

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhhAoQddkScNq8n5Cmnzgc)_