### PR TITLE
fix(ci): heal stale-venv torch drift via cache-key + idempotent install

### DIFF
--- a/.github/workflows/update-cycle.yml
+++ b/.github/workflows/update-cycle.yml
@@ -152,7 +152,18 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .venv
-          key: venv-${{ runner.os }}-py${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements.txt', '.github/actions/install-deps/action.yml') }}
+          # ``update-cycle.yml`` itself is hashed in so any inline
+          # change to the install procedure (PR #1600 added the
+          # ``pip install torch …`` line in the cache-miss branch
+          # below; the cache key did NOT change because neither
+          # ``requirements.txt`` nor ``install-deps/action.yml``
+          # was touched, so existing cached venvs from before the
+          # fix kept being restored — the install step was gated
+          # off and ``torch`` stayed missing, leaving the EN feed
+          # stuck on the ``[Partially translated]`` marker for
+          # ~10 items/tick). Hashing the workflow file closes
+          # that class of drift at the cache-key boundary.
+          key: venv-${{ runner.os }}-py${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements.txt', '.github/actions/install-deps/action.yml', '.github/workflows/update-cycle.yml') }}
 
       - name: Install dependencies (cache miss)
         if: steps.venv_cache.outputs.cache-hit != 'true'
@@ -182,6 +193,24 @@ jobs:
         # Persists across subsequent steps; ``$GITHUB_PATH`` is the
         # documented mechanism for cross-step PATH mutation.
         run: echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+
+      # Self-healing torch backstop. The cache-key fix above closes the
+      # drift channel that left ``torch`` missing from cached venvs
+      # after PR #1600, but it only takes effect when the workflow
+      # file itself changes. This idempotent step is the second layer:
+      # ``pip install torch …`` is a no-op (~1-2 s) when torch is
+      # already installed at the requested version, so it costs almost
+      # nothing on the healthy path. If a cached venv ever ends up
+      # missing torch again (silent cache restoration of an older
+      # pre-torch venv from a branch with a hash-collision, a future
+      # refactor that drops torch from the install step, an
+      # actions/cache restore-keys widening, …), this step heals it
+      # before the feed-build step runs and writes ``[Partially
+      # translated]`` markers into ``docs/feed.en.xml``. The ``--index-url``
+      # pin keeps the CPU-only wheel; without it pip would resolve
+      # against PyPI default and pull the multi-GiB CUDA build.
+      - name: Ensure torch CPU wheel is present (self-healing)
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       # ----- Cache fetchers (free APIs, no quota gate) ---------------------
 


### PR DESCRIPTION
## Summary

PR #1600 (commit `e1a5308`) added `pip install torch --index-url https://download.pytorch.org/whl/cpu` to `update-cycle.yml`'s `Install dependencies (cache miss)` step to fix the `[Partially translated]` markers in `docs/feed.en.xml`. **The fix has been ineffective since it landed.** The 2026-05-21 14:00 cycle logs show:

```
Cache restored successfully
Cache restored from key: venv-Linux-py3.11.15-a6dc939c…
Cache Size: ~61 MB                       ← torch wheel ≈200 MB

WARNING transformers: None of PyTorch ... have been found.
WARNING build_feed: Übersetzungs-Pipeline konnte nicht geladen werden (name 'torch' is not defined) – EN-Feed nutzt Originaltext.
WARNING build_feed: Translation incomplete for identity wl|störung|L=9|D=2026-05-21 — emitting partial-translation marker.
[…10× »Translation incomplete« warnings, 10 of 73 items degraded…]
```

## Root cause

The venv cache key:

```yaml
key: venv-${{ runner.os }}-py${{ python-version }}-${{ hashFiles('requirements.txt', '.github/actions/install-deps/action.yml') }}
```

hashes only `requirements.txt` and `install-deps/action.yml`. PR #1600 modified neither file — it added the torch install inline in the workflow. Cache key unchanged → cached venv (built before torch was added) keeps being restored → `Install dependencies (cache miss)` is gated off and never runs → torch stays missing.

## Fix — two layers stacked

| Layer | Catches |
|---|---|
| **Cache-key boundary**: add `.github/workflows/update-cycle.yml` to `hashFiles(...)` | Any inline change to the install procedure invalidates the cache, forcing a rebuild. This PR's own edit triggers it once. |
| **Runtime self-healing**: new `Ensure torch CPU wheel is present (self-healing)` step, no `if:` gate, runs after PATH-prepend | A cached venv that ever loses torch again (refactor drops the line, `restore-keys` widening, hash collision) gets healed before the feed-build step. `pip install` is idempotent — ~1-2 s no-op when satisfied. |

Either layer alone fixes the current `[Partially translated]` incident on the next post-merge cycle tick. Both together close the drift channel against future regressions at near-zero steady-state cost.

## Out of scope (logged in the same investigation)

Two more issues surfaced in the 14:00 logs but are not addressed here:

1. **🟡 Baustellen WFS returns `application/xml`** despite `outputFormat=json` in the URL — fetcher falls back to the 2-entry sample file (`baustellen:ok(2 Items, …)` in the build_feed status line). Could be a transient upstream issue at data.gv.at; monitor and decide whether to widen the MIME allow-list.
2. **🔵 urllib3 `strict` parameter `FutureWarning`** in all fetchers — a transitive dep still uses the deprecated kwarg; will be an error in urllib3 v3.0.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/update-cycle.yml'))"`)
- [x] Cache key includes `.github/workflows/update-cycle.yml` in `hashFiles(...)`
- [x] New `Ensure torch CPU wheel is present (self-healing)` step has no `if:` gate
- [x] New step runs AFTER `Prepend venv to PATH` so `pip` resolves to `.venv/bin/pip`
- [ ] First post-merge cycle: `Install dependencies (cache miss)` runs, ~30 s, fresh venv with torch
- [ ] Build feed step emits 0 `Translation incomplete` warnings; `docs/feed.en.xml` items no longer carry `[Partially translated]`
- [ ] Subsequent ticks: cache hit, self-healing step runs in ~1-2 s with `Requirement already satisfied: torch …`

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhhAoQddkScNq8n5Cmnzgc)_