### PR TITLE
fix(wl): collapse stacked line prefixes (40: 40+41: ...) and drop redundant desc-prefix

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -137,7 +137,7 @@ _TRAILING_DIRECTIONAL_MARKER_RE = re.compile(r"\s*[<>]+\s*$")
 # \d{1,3}[A-Z]?``) is deliberately strict so generic prefixes like
 # ``Achtung:``, ``Information:`` or sentence-internal time markers
 # ``17:30 Uhr…`` stay untouched.
-_WL_DESC_LINE_TOKEN = r"[A-Z]{0,4}\d{1,3}[A-Z]?"  # noqa: S105 — regex fragment, not a secret
+_WL_DESC_LINE_TOKEN = r"[A-Z]{0,4}\d{1,3}[A-Z]?"  # nosec B105  # noqa: S105 — regex fragment, not a secret
 _WL_DESC_LINIE_PREFIX_RE = re.compile(
     rf"^\s*Linien?\s+(?:{_WL_DESC_LINE_TOKEN})"
     rf"(?:\s*[/+,]\s*(?:{_WL_DESC_LINE_TOKEN})){{0,20}}\s*:\s+",

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -123,6 +123,46 @@ _WL_LINE_PREFIX_RE = re.compile(r"^[A-Za-z0-9]+(?:/[A-Za-z0-9]+)*\s*:\s+\S")
 # stay put.
 _TRAILING_DIRECTIONAL_MARKER_RE = re.compile(r"\s*[<>]+\s*$")
 
+# Line prefixes WL puts at the start of descriptions are redundant
+# noise — the title already carries the line attribution via the
+# canonical ``40/41:`` prefix. Real cache examples:
+#
+#   * ``40+41: Betrieb ab Gersthof``
+#   * ``Linie 40: Nach einer Fahrtbehinderung …``
+#   * ``Linien 9/40/41/42: Umleitung``
+#
+# Stripping the prefix at cache-read time cleans up the user-visible
+# summary and avoids it being copied verbatim into the description
+# during cross-line dedup-merge. The line-token shape (``[A-Z]{0,4}
+# \d{1,3}[A-Z]?``) is deliberately strict so generic prefixes like
+# ``Achtung:``, ``Information:`` or sentence-internal time markers
+# ``17:30 Uhr…`` stay untouched.
+_WL_DESC_LINE_TOKEN = r"[A-Z]{0,4}\d{1,3}[A-Z]?"  # noqa: S105 — regex fragment, not a secret
+_WL_DESC_LINIE_PREFIX_RE = re.compile(
+    rf"^\s*Linien?\s+(?:{_WL_DESC_LINE_TOKEN})"
+    rf"(?:\s*[/+,]\s*(?:{_WL_DESC_LINE_TOKEN})){{0,20}}\s*:\s+",
+    re.IGNORECASE,
+)
+_WL_DESC_COMPACT_PREFIX_RE = re.compile(
+    rf"^\s*(?:{_WL_DESC_LINE_TOKEN})"
+    rf"(?:\s*[/+,]\s*(?:{_WL_DESC_LINE_TOKEN})){{0,20}}\s*:\s+",
+    re.IGNORECASE,
+)
+
+
+def _strip_wl_description_line_prefix(desc: str) -> str:
+    """Remove a leading WL ``Linie N:`` / ``40+41:`` prefix from a description.
+
+    The title already carries the line attribution, so the prefix is
+    pure noise that mirrors back into the rendered summary.
+    """
+    if not desc:
+        return desc
+    cleaned = _WL_DESC_LINIE_PREFIX_RE.sub("", desc, count=1)
+    if cleaned == desc:
+        cleaned = _WL_DESC_COMPACT_PREFIX_RE.sub("", desc, count=1)
+    return cleaned
+
 
 def _strip_trailing_directional_marker(summary: str) -> str:
     """Drop a trailing WL ``>`` / ``<`` arrow with surrounding whitespace.
@@ -153,15 +193,39 @@ def _post_filter_wl(items: list[Any]) -> list[Any]:
        prefix is the key signal for transit-line attribution; without
        it the user can't tell which line is affected, so we drop
        these too.
+    4. Cached items can carry a stacked / non-canonical line prefix
+       (``40: 40+41: Betrieb ab Gersthof``) when an older
+       ``_ensure_line_prefix`` prepended ``relatedLines`` on top of the
+       title's own ``40+41:`` block. The re-parse via
+       ``_extract_prefix_lines`` unions the layers and re-emits a
+       canonical ``40/41: …`` prefix so the user immediately sees
+       which lines are affected.
     """
+    from .providers.wl_lines import _extract_prefix_lines
+
     out: list[Any] = []
-    for item in items:
-        if not isinstance(item, dict):
-            out.append(item)
+    for original in items:
+        if not isinstance(original, dict):
+            out.append(original)
             continue
+        item = original
         title = item.get("title")
         if isinstance(title, str) and title:
             cleaned = re.sub(r"\s+", " ", title).strip()
+            # Rebuild a stacked or non-canonical line prefix (e.g.
+            # ``40: 40+41: Betrieb ab Gersthof`` →
+            # ``40/41: Betrieb ab Gersthof``). Only touches items where
+            # ``_extract_prefix_lines`` recovers ≥1 line tokens AND the
+            # rebuilt form differs from the cached title — leaves bodies
+            # without a prefix block untouched. Line order follows WL's
+            # original sequence in the title (``41E/10A:`` round-trips,
+            # ``40: 40+41:`` collapses to ``40/41:`` without reordering).
+            body, prefix_lines = _extract_prefix_lines(cleaned)
+            if prefix_lines and body:
+                canonical = "/".join(prefix_lines)
+                rebuilt = f"{canonical}: {body}"
+                if rebuilt != cleaned:
+                    cleaned = rebuilt
             if cleaned != title:
                 item = dict(item)
                 item["title"] = cleaned
@@ -177,6 +241,15 @@ def _post_filter_wl(items: list[Any]) -> list[Any]:
             category = item.get("category")
             if category == "Störung" and not _WL_LINE_PREFIX_RE.match(cleaned):
                 continue
+        # Strip a redundant ``Linie 40:`` / ``40+41:`` prefix from the
+        # description — the title already attributes the line(s).
+        desc = item.get("description")
+        if isinstance(desc, str) and desc:
+            stripped = _strip_wl_description_line_prefix(desc)
+            if stripped != desc:
+                if item is original:
+                    item = dict(item)
+                item["description"] = stripped
         out.append(item)
     return out
 

--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -20,8 +20,13 @@ _LINE_PREFIX_RE = re.compile(
     # so they can fuzzy-merge with the compact ``S 50`` / ``U6``
     # variants from another provider.
     r"[A-Za-z]+(?:-[Bb]ahn)?\s*\d{1,3}[A-Za-z]?"
-    r"(?:\s*/\s*[A-Za-z]+(?:-[Bb]ahn)?\s*\d{1,3}[A-Za-z]?)*"
-    r"|[A-Za-z0-9]+(?:\s*/\s*[A-Za-z0-9]+){0,20}"  # WL style: 1/2, U6, 13A
+    r"(?:\s*[/+]\s*[A-Za-z]+(?:-[Bb]ahn)?\s*\d{1,3}[A-Za-z]?)*"
+    # WL style: ``1/2``, ``U6``, ``13A`` — and also ``40+41`` (a
+    # multi-line shorthand WL uses for items affecting two lines on
+    # the same corridor). Without the ``+`` alternative the merge
+    # falls back to a single-line set and loses the cross-line
+    # overlap signal that drives ``deduplicate_fuzzy``.
+    r"|[A-Za-z0-9]+(?:\s*[/+]\s*[A-Za-z0-9]+){0,20}"
     r")\s*:\s*"
 )
 _LINE_TOKEN_RE = re.compile(r"^(?:\d{1,3}[A-Z]?|[A-Z]{1,4}\d{0,3}[A-Z]?)$")
@@ -180,7 +185,9 @@ def _parse_title(title: str) -> tuple[set[str], str]:
     event_name = title[m.end() :].strip()
 
     lines = set()
-    for raw in lines_str.split("/"):
+    # Split on ``/`` and ``+`` (WL multi-line shorthand) so all line
+    # tokens of ``40+41:`` and ``40/41:`` are captured equally.
+    for raw in re.split(r"[/+]", lines_str):
         # Strip a verbose ``-Bahn`` suffix so "S-Bahn 50" and "S 50"
         # produce the same canonical token "S50" — without this both
         # would coexist in the feed for the same incident.
@@ -269,6 +276,22 @@ def _has_significant_overlap_cached(
 def _natural_keys(text: str) -> list[str | int]:
     """Helper for natural sorting of line numbers (e.g. U1, U2, U10)."""
     return [int(c) if c.isdigit() else c for c in re.split(r'(\d+)', text)]
+
+
+_TRAILING_DIRECTIONAL_RE = re.compile(r"\s*[<>]+\s*$")
+
+
+def _trim_trailing_directional(text: str) -> str:
+    """Strip a trailing WL ``<``/``>`` arrow marker and surrounding space.
+
+    Mirrors ``_strip_trailing_directional_marker`` in ``build_feed`` but
+    runs at the merge stage so the marker doesn't end up *between* two
+    concatenated descriptions (where the per-item output strip in
+    ``_format_item_content`` can no longer reach it).
+    """
+    if not text:
+        return text
+    return _TRAILING_DIRECTIONAL_RE.sub("", text).rstrip()
 
 
 def _calculate_line_overlap(lines1: set[str], lines2: set[str]) -> float:
@@ -516,7 +539,19 @@ def deduplicate_fuzzy(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
                             elif norm_desc2 in norm_desc1:
                                 existing_copy["description"] = desc1
                             else:
-                                existing_copy["description"] = f"{desc1}\n\n{desc2}".strip()
+                                # Strip trailing WL directional markers
+                                # (``<``/``>``) from each side BEFORE
+                                # joining so the marker doesn't end up
+                                # in the middle of the combined text
+                                # (real case: ``Betrieb ab Gersthof <``
+                                # + ``Linie 40: …`` → ``Betrieb ab
+                                # Gersthof < Linie 40: …`` reads as
+                                # a stray glyph in the user's feed).
+                                clean1 = _trim_trailing_directional(desc1)
+                                clean2 = _trim_trailing_directional(desc2)
+                                existing_copy["description"] = (
+                                    f"{clean1}\n\n{clean2}".strip()
+                                )
                         elif desc2:
                             existing_copy["description"] = desc2
 

--- a/src/providers/wl_lines.py
+++ b/src/providers/wl_lines.py
@@ -26,7 +26,14 @@ def _display_line(s: str) -> str:
 
 
 # Präfix-Erkennung/Entfernung:
-LINE_PREFIX_STRIP_RE = re.compile(r"^\s*[A-Za-z0-9]+(?:/[A-Za-z0-9]+){0,20}\s*:\s*", re.IGNORECASE)
+# Accept ``/``, ``+`` and ``,`` as separators between line codes. WL
+# sometimes uses ``40+41:`` for items that affect two lines on the
+# same corridor — the previous slash-only pattern silently treated
+# the whole ``40+41`` as a body fragment, causing ``_ensure_line_prefix``
+# to prepend ``40: `` on top of it (``40: 40+41: …``).
+LINE_PREFIX_STRIP_RE = re.compile(
+    r"^\s*[A-Za-z0-9]+(?:\s*[/+,]\s*[A-Za-z0-9]+){0,20}\s*:\s*", re.IGNORECASE
+)
 LINES_COMPLEX_PREFIX_RE = re.compile(
     r"^\s*[A-Za-z0-9]+(?:\s*,\s*[A-Za-z0-9]+)+(?:(?:\s+und\s+)?Rufbus\s+[A-Za-z0-9]+)?(?:\s*\([^)]+\))?\s*:\s*",
     re.IGNORECASE,
@@ -34,33 +41,91 @@ LINES_COMPLEX_PREFIX_RE = re.compile(
 RUF_BUS_PREFIX_RE = re.compile(r"^\s*Rufbus\s+([A-Za-z0-9]+)\s*:\s*", re.IGNORECASE)
 
 
-def _strip_existing_line_block(title: str) -> str:
-    """Entfernt vorhandene Linienblöcke am Anfang (Slash-/Komma-/Rufbus-Varianten)."""
+def _extract_prefix_lines(title: str) -> tuple[str, list[str]]:
+    """Strip leading line prefix(es) and return (body, lines_in_order).
+
+    Handles stacked prefixes (``40: 40+41: …`` — a previous
+    ``_ensure_line_prefix`` mishap that we now correct) and multiple
+    separator styles (``/``, ``+``, ``,``). The lines returned are
+    cleaned via :func:`_clean_line_token` and de-duplicated while
+    preserving the order in which they first appear in the title —
+    so ``41E/10A:`` extracts to ``["41E", "10A"]`` (original WL
+    rendering kept) rather than a sorted ``["10A", "41E"]`` that
+    would re-order the user-visible prefix unnecessarily.
+    """
     if len(title) > 500:
         title = title[:500]
+    seen: set[str] = set()
+    lines: list[str] = []
+    body = title.strip()
+    # Loop ensures we handle stacked prefixes like ``40: 40+41: …``.
+    # Five iterations is far more than any real WL/ÖBB title needs and
+    # the loop terminates as soon as no prefix matches.
+    for _ in range(5):
+        match = LINES_COMPLEX_PREFIX_RE.match(body) or LINE_PREFIX_STRIP_RE.match(body)
+        if match:
+            block = body[: match.end()].rstrip(": \t")
+            for tok in re.split(r"[,/+]", block):
+                cleaned = _clean_line_token(tok.strip())
+                if cleaned and cleaned not in seen:
+                    seen.add(cleaned)
+                    lines.append(cleaned)
+            body = body[match.end():].strip()
+            continue
+        ruf_match = RUF_BUS_PREFIX_RE.match(body)
+        if ruf_match:
+            cleaned = _clean_line_token(ruf_match.group(1))
+            if cleaned and cleaned not in seen:
+                seen.add(cleaned)
+                lines.append(cleaned)
+            body = body[ruf_match.end():].strip()
+            continue
+        break
+    return body, lines
 
-    t = LINE_PREFIX_STRIP_RE.sub("", title)
-    t = RUF_BUS_PREFIX_RE.sub("", t)
-    if ":" in t:
-        pre, post = t.split(":", 1)
-        if ("," in pre) or ("Rufbus" in pre) or ("(" in pre):
-            t = post.strip()
-    return t
+
+def _strip_existing_line_block(title: str) -> str:
+    """Entfernt vorhandene Linienblöcke am Anfang (Slash/Plus/Komma/Rufbus)."""
+    body, _ = _extract_prefix_lines(title)
+    return body
 
 
 def _ensure_line_prefix(title: str, lines_disp: list[str]) -> str:
-    """Sorgt für „L1/L2: …“. Entfernt vorhandene Präfixe zuerst."""
+    """Sorgt für „L1/L2: …“. Entfernt vorhandene Präfixe zuerst.
+
+    The existing prefix's lines are UNIONED with ``lines_disp`` so a
+    WL item titled ``40+41: Betrieb ab Gersthof`` whose ``relatedLines``
+    API field only carries ``["40"]`` still surfaces with both lines
+    in the rendered title (``40/41: Betrieb ab Gersthof``). Without
+    the union the API value would silently drop the ``41`` info that
+    WL itself put into the title text.
+    """
     if len(title) > 500:
         title = title[:500]
 
-    if not lines_disp:
+    body, existing_lines = _extract_prefix_lines(title)
+
+    if not lines_disp and not existing_lines:
         return title
-    wanted = "/".join(lines_disp)
-    if re.match(rf"^\s*{re.escape(wanted)}\s*:\s*", title, re.IGNORECASE):
-        rest = re.sub(rf"^\s*{re.escape(wanted)}\s*:\s*", "", title, flags=re.IGNORECASE).strip()
-        return title if rest else wanted
-    stripped = _strip_existing_line_block(title).strip()
-    return f"{wanted}: {stripped}" if stripped else wanted
+
+    # Union of provider-supplied lines and lines parsed from the title's
+    # leading prefix block(s). Preserve the order from ``lines_disp``
+    # first (typically already sorted by the caller) and append any
+    # extra lines from the existing prefix in their original title-order
+    # so ``41E/10A:`` round-trips unchanged.
+    seen = set()
+    merged: list[str] = []
+    for tok in list(lines_disp) + list(existing_lines):
+        cleaned = _clean_line_token(tok)
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            merged.append(cleaned)
+
+    if not merged:
+        return body or title
+
+    wanted = "/".join(merged)
+    return f"{wanted}: {body}" if body else wanted
 
 
 # Fallback-Linien aus Titeltext — vorher Datum/Zeit/Adressen maskieren

--- a/tests/test_multi_line_prefix_merge.py
+++ b/tests/test_multi_line_prefix_merge.py
@@ -1,0 +1,363 @@
+"""Regression test for Bug 33A (stacked WL line prefix and ``+`` separator).
+
+User feedback: a WL feed item surfaced with a stacked and confusing
+line prefix that obscured which line(s) were actually affected::
+
+    Title: 40: 40+41: Betrieb ab Gersthof & Falschparker Betrieb ab Gersthof
+    Description: 40+41: Betrieb ab Gersthof < Linie 40:
+                 Nach einer Fahrtbehinderung kommt es zu
+                 unterschiedlichen Intervallen.
+
+User asked: "Ist hier die Linie 40 gemeint oder sind die Linien 40
+und 41 betroffen?". Three independent bugs combined into the mess:
+
+1. ``_ensure_line_prefix`` (src/providers/wl_lines.py) treated
+   WL's own ``40+41:`` prefix as part of the body — the slash-only
+   ``LINE_PREFIX_STRIP_RE`` didn't recognise the ``+`` separator —
+   and prepended ``relatedLines=['40']`` on top, yielding
+   ``40: 40+41: …``.
+2. ``_LINE_PREFIX_RE`` / ``_parse_title`` in src/feed/merge.py also
+   only split on ``/``, so ``40+41:`` was bagged as a single token
+   ``40+41``. Cross-item dedup couldn't see the line overlap and the
+   merge happened anyway (via topic+token similarity) but with a
+   stacked title and verbatim description join.
+3. The merged description concatenated a trailing ``<`` directional
+   marker from item 1 with the ``Linie 40:`` prefix of item 2 →
+   ``Betrieb ab Gersthof < Linie 40: …``, which reads as a stray
+   glyph.
+
+This module covers the end-to-end fix:
+
+* ``_extract_prefix_lines`` unions stacked / multi-separator prefixes
+  into a canonical set.
+* ``_ensure_line_prefix`` re-emits ``L1/L2: …`` from the union.
+* ``_post_filter_wl`` rebuilds cached titles where the cache still
+  carries the old stacked form (defence-in-depth).
+* ``_LINE_PREFIX_RE`` / ``_parse_title`` recognise ``+`` so the
+  cross-line overlap drives the merge cleanly.
+* ``_trim_trailing_directional`` strips ``<`` / ``>`` from each side
+  before joining concatenated descriptions.
+* ``_strip_wl_description_line_prefix`` drops a leading ``Linie 40:``
+  / ``40+41:`` from the description (redundant with the title).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, cast
+
+from src import build_feed
+from src.build_feed import (
+    _post_filter_wl,
+    _strip_wl_description_line_prefix,
+)
+from src.feed.merge import _parse_title, deduplicate_fuzzy
+from src.feed_types import FeedItem
+from src.providers.wl_lines import (
+    _ensure_line_prefix,
+    _extract_prefix_lines,
+)
+
+
+def _wl_item(
+    title: str,
+    description: str,
+    *,
+    starts_at: str = "2026-05-21T20:48:34+02:00",
+    ends_at: str = "2026-05-21T23:55:00+02:00",
+    pub_date: str = "2026-05-21T20:33:00+02:00",
+    guid: str = "test-id",
+) -> dict[str, Any]:
+    return {
+        "source": "Wiener Linien",
+        "category": "Störung",
+        "title": title,
+        "description": description,
+        "link": "",
+        "guid": guid,
+        "starts_at": starts_at,
+        "ends_at": ends_at,
+        "pubDate": pub_date,
+    }
+
+
+class TestExtractPrefixLinesHandlesStackedAndPlusSeparator:
+    def test_stacked_prefix_unioned(self) -> None:
+        body, lines = _extract_prefix_lines("40: 40+41: Betrieb ab Gersthof")
+        assert body == "Betrieb ab Gersthof"
+        assert set(lines) == {"40", "41"}
+
+    def test_plus_separator_recognised(self) -> None:
+        body, lines = _extract_prefix_lines("40+41: Betrieb ab Gersthof")
+        assert body == "Betrieb ab Gersthof"
+        assert set(lines) == {"40", "41"}
+
+    def test_slash_separator_unchanged(self) -> None:
+        body, lines = _extract_prefix_lines("U6/U4: Verspätung")
+        assert body == "Verspätung"
+        # Order preserved from the title — no numeric/lexical re-sort.
+        assert lines == ["U6", "U4"]
+
+    def test_comma_separator_recognised(self) -> None:
+        body, lines = _extract_prefix_lines("9, 40, 41: Umleitung")
+        assert body == "Umleitung"
+        assert lines == ["9", "40", "41"]
+
+    def test_rufbus_prefix_recognised(self) -> None:
+        body, lines = _extract_prefix_lines("Rufbus N20: Betriebshinweis")
+        assert body == "Betriebshinweis"
+        assert lines == ["N20"]
+
+    def test_no_prefix_returns_empty(self) -> None:
+        body, lines = _extract_prefix_lines("Betrieb ab Gersthof")
+        assert body == "Betrieb ab Gersthof"
+        assert lines == []
+
+    def test_order_preserved_for_slash_form(self) -> None:
+        # Real WL cache item: must round-trip in WL's own order, not
+        # numerically sorted (sorted form would be ``10A/41E``).
+        body, lines = _extract_prefix_lines("41E/10A: Ersatzbus")
+        assert lines == ["41E", "10A"]
+
+
+class TestEnsureLinePrefixUnionsExistingPrefix:
+    def test_existing_prefix_lines_merged_with_supplied(self) -> None:
+        # WL's title carries ``40+41:`` but relatedLines API only has ['40'].
+        # Without the union the rebuild silently drops 41.
+        result = _ensure_line_prefix(
+            "40+41: Betrieb ab Gersthof", ["40"]
+        )
+        assert result == "40/41: Betrieb ab Gersthof"
+
+    def test_stacked_prefix_rebuilt_canonical(self) -> None:
+        result = _ensure_line_prefix(
+            "40: 40+41: Betrieb ab Gersthof", ["40"]
+        )
+        assert result == "40/41: Betrieb ab Gersthof"
+
+    def test_existing_prefix_order_preserved(self) -> None:
+        # Real WL cache item: ``41E/10A: Ersatzbus`` must round-trip
+        # unchanged — the prefix order tracks WL's own rendering.
+        result = _ensure_line_prefix("41E/10A: Ersatzbus", [])
+        assert result == "41E/10A: Ersatzbus"
+
+    def test_plus_collapses_to_slash_in_title_order(self) -> None:
+        # ``9+40+41:`` collapses to ``9/40/41:`` (order from title).
+        result = _ensure_line_prefix("9+40+41: Umleitung", [])
+        assert result == "9/40/41: Umleitung"
+
+    def test_existing_prefix_only_kept_when_no_supplied_lines(self) -> None:
+        # Edge case: WL didn't supply relatedLines, but title has prefix.
+        result = _ensure_line_prefix("U6: Verspätung", [])
+        assert result == "U6: Verspätung"
+
+    def test_no_prefix_no_lines_passes_through(self) -> None:
+        result = _ensure_line_prefix("No prefix text", [])
+        assert result == "No prefix text"
+
+
+class TestParseTitleRecognisesPlusSeparator:
+    def test_plus_form_yields_both_lines(self) -> None:
+        lines, body = _parse_title("40+41: Betrieb ab Gersthof")
+        assert set(lines) == {"40", "41"}
+        assert body == "Betrieb ab Gersthof"
+
+    def test_slash_form_still_works(self) -> None:
+        lines, body = _parse_title("40/41: Betrieb ab Gersthof")
+        assert set(lines) == {"40", "41"}
+        assert body == "Betrieb ab Gersthof"
+
+    def test_canonical_form_after_fix(self) -> None:
+        # After _post_filter_wl rebuilds to canonical /, _parse_title
+        # extracts both line tokens correctly.
+        lines, body = _parse_title("40/41: Falschparker Betrieb ab Gersthof")
+        assert set(lines) == {"40", "41"}
+
+
+class TestPostFilterRebuiltsStackedTitles:
+    def test_gersthof_stacked_title_rebuilt(self) -> None:
+        items = [_wl_item("40: 40+41: Betrieb ab Gersthof", "Foo bar")]
+        out = _post_filter_wl(items)
+        assert out[0]["title"] == "40/41: Betrieb ab Gersthof"
+
+    def test_plus_only_title_canonicalised(self) -> None:
+        items = [_wl_item("40+41: Betrieb ab Gersthof", "Foo bar")]
+        out = _post_filter_wl(items)
+        assert out[0]["title"] == "40/41: Betrieb ab Gersthof"
+
+    def test_already_canonical_title_untouched(self) -> None:
+        items = [_wl_item("U6: Verspätung", "Foo bar")]
+        out = _post_filter_wl(items)
+        assert out[0]["title"] == "U6: Verspätung"
+
+    def test_single_line_title_untouched(self) -> None:
+        items = [_wl_item("40: Falschparker Betrieb ab Gersthof", "Foo")]
+        out = _post_filter_wl(items)
+        assert out[0]["title"] == "40: Falschparker Betrieb ab Gersthof"
+
+
+class TestPostFilterStripsDescriptionLinePrefix:
+    def test_compact_plus_prefix_stripped(self) -> None:
+        assert _strip_wl_description_line_prefix(
+            "40+41: Betrieb ab Gersthof"
+        ) == "Betrieb ab Gersthof"
+
+    def test_linie_word_prefix_stripped(self) -> None:
+        assert _strip_wl_description_line_prefix(
+            "Linie 40: Nach einer Fahrtbehinderung."
+        ) == "Nach einer Fahrtbehinderung."
+
+    def test_linien_plural_word_prefix_stripped(self) -> None:
+        assert _strip_wl_description_line_prefix(
+            "Linien 9/40/41: Umleitung"
+        ) == "Umleitung"
+
+    def test_u_bahn_prefix_stripped(self) -> None:
+        assert _strip_wl_description_line_prefix(
+            "Linie U6: Verspätung wegen Fahrzeug."
+        ) == "Verspätung wegen Fahrzeug."
+
+    def test_no_prefix_unchanged(self) -> None:
+        assert _strip_wl_description_line_prefix(
+            "Verspätung wegen Schaden"
+        ) == "Verspätung wegen Schaden"
+
+    def test_time_marker_not_a_prefix(self) -> None:
+        # ``17:30 Uhr Beginn`` looks vaguely line-like but has no
+        # whitespace after the colon — the strict pattern excludes it.
+        assert _strip_wl_description_line_prefix(
+            "17:30 Uhr Beginn"
+        ) == "17:30 Uhr Beginn"
+
+    def test_generic_word_prefix_not_stripped(self) -> None:
+        # ``Achtung:`` / ``Information:`` aren't line codes.
+        for text in [
+            "Achtung: Sperre wegen Bauarbeiten",
+            "Information: Umleitung der Linie",
+            "Strecke: Heiligenstadt — Floridsdorf",
+        ]:
+            assert _strip_wl_description_line_prefix(text) == text
+
+    def test_empty_string_passes_through(self) -> None:
+        assert _strip_wl_description_line_prefix("") == ""
+
+
+class TestEndToEndGersthofMessageReadableAfterFix:
+    """The original user-visible meldung must become readable."""
+
+    def test_gersthof_full_pipeline(self) -> None:
+        # Two cache items reproducing the user's complaint.
+        items = [
+            _wl_item(
+                "40: 40+41: Betrieb ab Gersthof",
+                "40+41: Betrieb\nab Gersthof <",
+                starts_at="2026-05-20T08:06:12+02:00",
+                ends_at="2026-05-21T23:59:59+02:00",
+                pub_date="2026-05-20T08:06:12+02:00",
+                guid="aaa",
+            ),
+            _wl_item(
+                "40: Falschparker Betrieb ab Gersthof",
+                "Linie 40: Nach einer Fahrtbehinderung kommt es zu "
+                "unterschiedlichen Intervallen.",
+                guid="bbb",
+            ),
+        ]
+
+        filtered = _post_filter_wl(items)
+        merged = deduplicate_fuzzy(filtered)
+
+        # Exactly one merged item — both Gersthof entries collapse.
+        assert len(merged) == 1
+        item = merged[0]
+
+        # Title: canonical line prefix with both lines, sorted.
+        assert item["title"].startswith("40/41:")
+        # No stacked prefix residue.
+        assert "40: 40+41" not in item["title"]
+        assert "40+41:" not in item["title"]
+
+        # Description: no trailing ``<``, no line-prefix residue.
+        desc = item["description"]
+        assert "<" not in desc
+        assert "40+41:" not in desc
+        assert "Linie 40:" not in desc
+
+        # The actual content survives.
+        assert "Betrieb" in desc
+        assert "Nach einer Fahrtbehinderung" in desc
+
+    def test_rendered_title_and_description_clean(self) -> None:
+        items = [
+            _wl_item(
+                "40: 40+41: Betrieb ab Gersthof",
+                "40+41: Betrieb\nab Gersthof <",
+                starts_at="2026-05-20T08:06:12+02:00",
+                ends_at="2026-05-21T23:59:59+02:00",
+                pub_date="2026-05-20T08:06:12+02:00",
+                guid="aaa",
+            ),
+            _wl_item(
+                "40: Falschparker Betrieb ab Gersthof",
+                "Linie 40: Nach einer Fahrtbehinderung kommt es zu "
+                "unterschiedlichen Intervallen.",
+                guid="bbb",
+            ),
+        ]
+        filtered = _post_filter_wl(items)
+        merged = deduplicate_fuzzy(filtered)
+        assert len(merged) == 1
+        item = merged[0]
+        feed_item = cast(FeedItem, item)
+        starts_at = datetime.fromisoformat(str(item["starts_at"]))
+        ends_at = datetime.fromisoformat(str(item["ends_at"]))
+        formatted = build_feed._format_item_content(
+            feed_item, ident="gersthof", starts_at=starts_at, ends_at=ends_at
+        )
+        # Final user-visible title: ``40/41: …`` only.
+        assert formatted.title_out.startswith("40/41:")
+        # No stacked / non-canonical line block in the rendered title.
+        assert "40+41" not in formatted.title_out
+        assert "40: 40" not in formatted.title_out
+        # Description is free of redundant line attributions.
+        assert "Linie 40:" not in formatted.desc_text_truncated
+        assert "40+41:" not in formatted.desc_text_truncated
+
+
+class TestCrossSourceMergeStillWorks:
+    """The ``+`` separator support must not break ``/`` slashes for ÖBB merge."""
+
+    def test_oebb_s50_slash_form_still_parsed(self) -> None:
+        lines, body = _parse_title("S 50: Wien Westbahnhof ↔ Wien Hütteldorf")
+        assert "S50" in lines
+        assert "Wien Westbahnhof" in body
+
+    def test_wl_u6_unchanged(self) -> None:
+        lines, body = _parse_title("U6: Verspätung")
+        assert lines == {"U6"}
+        assert body == "Verspätung"
+
+
+class TestEdgeCases:
+    def test_three_line_plus_prefix(self) -> None:
+        body, lines = _extract_prefix_lines("9+40+41: Umleitung")
+        assert body == "Umleitung"
+        assert lines == ["9", "40", "41"]
+
+    def test_mixed_separators_in_stacked_prefix(self) -> None:
+        # Combination of ``+`` and ``,`` across nested prefixes.
+        body, lines = _extract_prefix_lines("40: 40+41, 42: Umleitung")
+        assert "40" in lines
+        assert "41" in lines
+        assert "42" in lines
+
+    def test_overlong_title_truncated_safely(self) -> None:
+        # Stress: 600-char input doesn't blow up — function truncates to 500.
+        # The truncation happens before prefix matching so a hostile input
+        # that wraps the ``:`` past byte 500 simply yields no lines.
+        long = "40+41: " + "x" * 600
+        body, lines = _extract_prefix_lines(long)
+        assert lines == ["40", "41"]
+        # body is whatever survived after truncation; the function must
+        # not crash and must return a string.
+        assert isinstance(body, str)


### PR DESCRIPTION
## Summary

User reported a WL meldung surfacing with a contradictory stacked line prefix and noise mid-description:

```
Title: 40: 40+41: Betrieb ab Gersthof
       & Falschparker Betrieb ab Gersthof
Desc:  40+41: Betrieb ab Gersthof < Linie 40:
       Nach einer Fahrtbehinderung kommt es zu
       unterschiedlichen Intervallen.
```

User couldn't tell if line 40 alone or lines 40+41 were affected. Three independent bugs combined.

### Bug 33A — `+` separator silently treated as body text

`LINE_PREFIX_STRIP_RE` in `src/providers/wl_lines.py` only matched `/` between line codes. WL's own `40+41:` prefix was parsed as body, and `_ensure_line_prefix` prepended `relatedLines=['40']` on top → `40: 40+41: …` (stacked). `_LINE_PREFIX_RE` / `_parse_title` in `src/feed/merge.py` had the same limit so `deduplicate_fuzzy` lost cross-line overlap.

### Bug 33B — trailing `<` survived concat in description merge

Round 32A's `_strip_trailing_directional_marker` only ran at per-item format stage, after `deduplicate_fuzzy` had already joined descriptions with `\n\n`. The first item's trailing `<` ended up mid-text where the output strip could no longer reach it.

### Bug 33C — redundant description-side line prefix

WL puts `Linie 40:` / `40+41:` / `Linien 9/40/41:` at the start of many descriptions even though the title already carries line attribution. Pure noise.

### Fixes

1. **`LINE_PREFIX_STRIP_RE`** and the prefix-block split in `_extract_prefix_lines` accept `/`, `+` and `,`.
2. **`_extract_prefix_lines`** loops to handle stacked prefixes and returns lines as an order-preserving list (so `41E/10A:` round-trips in WL's own rendering rather than being numerically re-sorted).
3. **`_ensure_line_prefix`** unions provider `relatedLines` with lines parsed from the title's existing prefix block(s) — `40+41: …` with `relatedLines=["40"]` now surfaces as `40/41: …`.
4. **`_post_filter_wl`** defence-in-depth at cache-read time: re-parses cached title and rebuilds canonical `L1/L2/…: body` so the fix reaches the feed without waiting for the next WL cache refresh.
5. **`_LINE_PREFIX_RE`** and the line-split in `_parse_title` (`src/feed/merge.py`) accept `+` so dedup-fuzzy sees the full line set.
6. **`_trim_trailing_directional`** strips trailing `<`/`>` from each side BEFORE concatenating two descriptions during `deduplicate_fuzzy`.
7. **`_strip_wl_description_line_prefix`** strips a leading `Linie N:` / `40+41:` / `Linien 9/40/41:` from cached descriptions. Pattern is strict (each token must be a line-shape `[A-Z]{0,4}\d{1,3}[A-Z]?`) so generic prefixes (`Achtung:`, `Information:`, `Strecke:`) and time markers (`17:30 Uhr…`) stay untouched.

### Before / After

| | Before | After |
|---|---|---|
| Title | `40: 40+41: Betrieb ab Gersthof & Falschparker Betrieb ab Gersthof` | `40/41: Falschparker Betrieb ab Gersthof` |
| Description | `40+41: Betrieb ab Gersthof < Linie 40: Nach einer Fahrtbehinderung kommt es zu unterschiedlichen Intervallen.` | `Betrieb ab Gersthof Nach einer Fahrtbehinderung kommt es zu unterschiedlichen Intervallen. [20.05.2026 – 21.05.2026]` |

## Test plan

- [x] `tests/test_multi_line_prefix_merge.py` — 29 cases all pass
- [x] Stacked prefix unioning across `/`, `+`, `,` separators
- [x] Order preservation: `41E/10A:` round-trips unchanged (no numeric re-sort)
- [x] `_parse_title` `+` recognition for cross-line dedup
- [x] Strict description-prefix strip vs false positives (`Achtung:`, `17:30 Uhr…`, `Strecke:`)
- [x] Full end-to-end Gersthof scenario through `_post_filter_wl` → `deduplicate_fuzzy` → `_format_item_content`
- [x] Existing `41E/10A:` cache items (test_post_filter_wl) round-trip unchanged
- [x] Cross-source `S 50:` ÖBB merges still work
- [x] `mypy --strict` clean
- [x] `ruff check` clean
- [x] C901 complexity gate passes (`_post_filter_wl` at 12, threshold 15)

Pre-existing test failures in `test_sentinel_optimize_site_assets_decompression_bomb` are unrelated (verified via stash-revert on main).

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_