### PR TITLE
fix(stations): token-match oebb source + autouse wrapper-test pollution fixture

### DIFF
--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -709,18 +709,47 @@ def _load_existing_station_entries(
             if bst_id is None:
                 is_manual = True
             elif source != "oebb":
-                if isinstance(source, str) and "oebb" in source:
-                    is_manual = False
+                if isinstance(source, str):
+                    stripped = source.strip()
+                    if stripped:
+                        # Token-based classification: a substring match for
+                        # ``"oebb"`` inside a comma-separated source string
+                        # would mis-classify entries whose ``source`` carries
+                        # only a metadata provider whose name *contains* the
+                        # canonical ``oebb`` token (e.g. ``oebb_geonetz`` —
+                        # the GeoNetz EVA/IFOPT enrichment, not the ÖBB
+                        # Excel ``Verzeichnis der Verkehrsstationen``).
+                        # Pre-fix the substring check at this site bucketed
+                        # the synthetic ``Wien Hauptbahnhof`` (``bst_id=
+                        # 900100``, ``source=google_places,oebb_geonetz,
+                        # vor,wl``) and ``Wien Kaiserebersdorf`` (``bst_id=
+                        # 900105``, ``source=oebb_geonetz,vor``) into the
+                        # ÖBB-Excel ``mapping`` even though the underlying
+                        # ``bst_id`` is never present in the live ÖBB
+                        # workbook. The entries therefore failed to round-
+                        # trip through the rebuild and dropped out of
+                        # ``data/stations.json`` on every weekly cron tick —
+                        # the regression visible in commit ``484c1f6``'s
+                        # post-mortem (the file fix there did not address
+                        # the underlying classifier bug).
+                        tokens = {t.strip() for t in stripped.split(",") if t.strip()}
+                        is_manual = "oebb" not in tokens
+                    else:
+                        # Backward-compat: entries written before the
+                        # ``as_dict`` source-default fix lack a source
+                        # field entirely (empty string). If they carry the
+                        # typical ÖBB Excel fields (``bst_id`` +
+                        # ``bst_code``), treat them as ÖBB — otherwise the
+                        # next Excel pull would create a duplicate and
+                        # trip the canonical-name uniqueness gate (see
+                        # PR #1203 cron failure post-mortem).
+                        bst_code = entry.get("bst_code")
+                        is_manual = not (isinstance(bst_code, str) and bst_code.strip())
                 elif isinstance(source, list) and "oebb" in source:
                     is_manual = False
                 elif not source:
-                    # Backward-compat: entries written before the
-                    # `as_dict` source-default fix lack a source field
-                    # entirely. If they carry the typical ÖBB Excel
-                    # fields (bst_id + bst_code), treat them as ÖBB —
-                    # otherwise the next Excel pull would create a
-                    # duplicate and trip the canonical-name uniqueness
-                    # gate (see PR #1203 cron failure post-mortem).
+                    # Backward-compat (non-string variant): ``None`` / unset
+                    # ``source`` falls through to the same ``bst_code`` guard.
                     bst_code = entry.get("bst_code")
                     is_manual = not (isinstance(bst_code, str) and bst_code.strip())
                 else:

--- a/tests/test_sentinel_sanitize_log_message_drift.py
+++ b/tests/test_sentinel_sanitize_log_message_drift.py
@@ -21,7 +21,7 @@ Pre-fix state inventory (PoC verified):
     ``sanitize_log_message`` invocation.
   * Bare ``csrf`` (Spring ``_csrf`` normalised) — NOT in ``_keys``,
     NOT in ``_header_keys``. Leaks verbatim. Note that the existing
-    ``[a-z0-9_.\-]*token`` alternation catches the SUFFIXED form
+    ``[a-z0-9_.\\-]*token`` alternation catches the SUFFIXED form
     (``csrf_token``, ``XSRF-TOKEN``) but NOT the bare form.
   * Bare ``xsrf`` (Angular bare form) — NOT in ``_keys``, NOT in
     ``_header_keys``. Leaks verbatim. Same suffix asymmetry as csrf.

--- a/tests/test_update_all_stations_wrapper.py
+++ b/tests/test_update_all_stations_wrapper.py
@@ -18,6 +18,24 @@ gegen ein Temp-File und kopiert nur nach Auto-Quarantine zurück.
 Janitor PR #1321: file-level S603 suppression. The single
 subprocess.run(...) in this file invokes sys.executable against a
 hard-coded path under REPO_ROOT, so the call is safe.
+
+Test-Hygiene contract: every test below either calls ``wrapper.main([])``
+or invokes ``scripts/update_all_stations.py`` as a subprocess. The
+wrapper hardcodes three output paths (``data/stations.json``,
+``data/stations_last_run.json``, ``docs/stations_diff.md`` — see lines
+89-91 of the script and ``Path("data/stations.json").resolve()`` at
+line 648). All three sit inside the repository root, so a green test
+run necessarily mutates the working tree. Pre-fix this leaked into
+subsequent station-dependent tests in the same pytest session
+(``test_hauptbahnhof_id_matches_stations_directory``,
+``test_clean_title_expands_wien_hbf_abbreviation`` and the
+``test_oebb_*`` cluster all silently depended on the unmodified
+on-disk state) — the cascade that masked the classifier regression at
+``scripts/update_station_directory.py:_load_existing_station_entries``
+for weeks. The autouse ``_restore_wrapper_outputs`` fixture below
+snapshots the bytes of all three paths before each test and restores
+them in teardown so test order can never matter again. A passing
+pytest run leaves no diff in ``git status``.
 """
 from __future__ import annotations
 
@@ -25,12 +43,56 @@ import json
 import os
 import subprocess
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Paths the wrapper hardcodes — see ``scripts/update_all_stations.py``
+# lines 89-91 (``_DEFAULT_HEARTBEAT_PATH`` / ``_DEFAULT_DIFF_REPORT_PATH``)
+# and line 648 (``target_stations_json = Path("data/stations.json")``).
+_WRAPPER_OUTPUT_PATHS: tuple[Path, ...] = (
+    REPO_ROOT / "data" / "stations.json",
+    REPO_ROOT / "data" / "stations_last_run.json",
+    REPO_ROOT / "docs" / "stations_diff.md",
+)
+
+
+@pytest.fixture(autouse=True)
+def _restore_wrapper_outputs() -> Iterator[None]:
+    """Snapshot and restore the wrapper's hardcoded output files.
+
+    The wrapper writes to three repo-root paths regardless of any
+    monkeypatching the test sets up, because the path constants are
+    captured at module import time. Without this fixture a green run
+    of any test below leaves the three files modified in ``git status``
+    and poisons downstream station-related tests via order-dependent
+    file-state coupling — exactly the cascade that masked the
+    ``_load_existing_station_entries`` classifier bug.
+
+    The fixture runs the test inside a try/finally so the snapshot is
+    restored even on test failure or skip. ``autouse=True`` applies it
+    to every test in this module, including any future addition.
+    """
+    snapshots: dict[Path, bytes | None] = {
+        path: (path.read_bytes() if path.exists() else None)
+        for path in _WRAPPER_OUTPUT_PATHS
+    }
+    try:
+        yield
+    finally:
+        for path, original in snapshots.items():
+            if original is None:
+                # The path did not exist before the test. If the test
+                # created it, remove it so the post-test state matches
+                # the pre-test state bit-for-bit.
+                if path.exists():
+                    path.unlink()
+            else:
+                path.write_bytes(original)
 
 
 def test_wrapper_proceeds_when_no_quarantineable_match(
@@ -155,7 +217,14 @@ def test_wrapper_preserves_stations_json_on_atomic_write_failure(
 
 @pytest.mark.timeout(180)
 def test_wrapper_atomic_on_success(tmp_path: Path) -> None:
-    """Bei Erfolg ist data/stations.json nach dem Lauf valide."""
+    """Bei Erfolg ist data/stations.json nach dem Lauf valide.
+
+    The ``_restore_wrapper_outputs`` autouse fixture above snapshots
+    every working-tree path the wrapper writes into and restores them
+    in teardown, so an end-to-end run that drives the live merge
+    pipeline against ``cwd=REPO_ROOT`` no longer leaks state into
+    sibling tests.
+    """
     # Mock the OSM Overpass call by env-disabling it inside the
     # subprocess: the wrapper test exists to verify atomicity of the
     # update pipeline, NOT to exercise real network round-trips. The

--- a/tests/test_update_station_directory_classification.py
+++ b/tests/test_update_station_directory_classification.py
@@ -1,0 +1,298 @@
+"""Regression tests for the ``_load_existing_station_entries`` classifier.
+
+The classifier decides whether an existing station entry came from the
+ÖBB ``Verzeichnis der Verkehrsstationen`` Excel workbook (and therefore
+needs to round-trip through the upcoming Excel re-pull) or is a manual /
+synthetic entry that must survive the rebuild verbatim.
+
+Pre-fix the classifier used a naive substring check ``"oebb" in source``
+which mis-matched the canonical ``oebb`` token against any source value
+that *contained* the substring — most notably ``oebb_geonetz`` (the
+GeoNetz EVA/IFOPT enrichment provenance token added in PR β,
+2026-05-21). Synthetic entries whose ``source`` listed ``oebb_geonetz``
+but never the bare ``oebb`` token (``Wien Hauptbahnhof`` / ``Wien
+Kaiserebersdorf``, both with ``bst_id`` in the 900xxx synthetic range
+that the live ÖBB workbook does not carry) were therefore bucketed as
+ÖBB-Excel entries, landed in ``mapping`` instead of
+``manual_stations``, and dropped out of ``data/stations.json`` on every
+weekly cron tick because the Excel re-pull couldn't re-emit a
+``bst_id`` it had never seen.
+
+The fix at ``scripts/update_station_directory.py:_load_existing_station_entries``
+switches to a token-based check that splits the comma-separated source
+field and looks for the exact ``oebb`` token. The cases pinned below
+cover the substring trap, the legitimate ÖBB-with-extras case, the
+empty-source backward-compat path, and the list-source variant.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.update_station_directory import _load_existing_station_entries
+
+
+def _write_stations(path: Path, entries: list[dict[str, object]]) -> None:
+    path.write_text(
+        json.dumps({"stations": entries}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def test_synthetic_entry_with_oebb_geonetz_provenance_is_manual(tmp_path: Path) -> None:
+    """``oebb_geonetz`` substring must NOT classify the entry as ÖBB.
+
+    Pre-fix the substring check at ``_load_existing_station_entries`` mis-
+    matched ``oebb_geonetz`` against the bare ``oebb`` token. The synthetic
+    Wien Hauptbahnhof entry (the canonical regression vector — see the
+    post-mortem in commit ``484c1f6``) therefore vanished from the
+    rebuilt directory on every cron tick because the Excel re-pull
+    couldn't re-emit its 900xxx synthetic ``bst_id``.
+    """
+    path = tmp_path / "stations.json"
+    _write_stations(
+        path,
+        [
+            {
+                "bst_id": 900100,
+                "bst_code": "900100",
+                "name": "Wien Hauptbahnhof",
+                "source": "google_places,oebb_geonetz,vor,wl",
+                "in_vienna": True,
+                "pendler": False,
+            }
+        ],
+    )
+
+    mapping, manual = _load_existing_station_entries(path)
+
+    assert "900100" not in mapping, (
+        "Wien Hauptbahnhof (synthetic) must NOT land in the ÖBB-Excel "
+        "mapping — its 900100 bst_id is not in the live workbook so the "
+        "Excel re-pull cannot re-emit it; dropping it from the manual list "
+        "is the exact bug the token-based classifier fixes."
+    )
+    assert any(e.get("name") == "Wien Hauptbahnhof" for e in manual), (
+        "Wien Hauptbahnhof (synthetic) must land in the manual_stations "
+        "list so the wrapper can append it verbatim to the rebuilt set."
+    )
+
+
+def test_synthetic_kaiserebersdorf_with_oebb_geonetz_is_manual(tmp_path: Path) -> None:
+    """``Wien Kaiserebersdorf`` — sibling synthetic entry to Hauptbahnhof.
+
+    Same substring trap as :func:`test_synthetic_entry_with_oebb_geonetz_provenance_is_manual`
+    but with ``source=oebb_geonetz,vor`` (no leading provider names). Pins
+    that the token-based classifier rejects the substring match at the
+    very start of the source string too.
+    """
+    path = tmp_path / "stations.json"
+    _write_stations(
+        path,
+        [
+            {
+                "bst_id": 900105,
+                "bst_code": "900105",
+                "name": "Wien Kaiserebersdorf",
+                "source": "oebb_geonetz,vor",
+                "in_vienna": True,
+                "pendler": False,
+            }
+        ],
+    )
+
+    mapping, manual = _load_existing_station_entries(path)
+
+    assert "900105" not in mapping
+    assert any(e.get("name") == "Wien Kaiserebersdorf" for e in manual)
+
+
+def test_real_oebb_entry_with_extras_stays_in_mapping(tmp_path: Path) -> None:
+    """A real ÖBB-Excel entry that also picked up enrichment tokens.
+
+    A legitimate ÖBB entry like Wiener Neustadt Hbf carries
+    ``source=oebb,oebb_geonetz,osm`` — the bare ``oebb`` token IS present
+    (alongside enrichment provenance). The classifier must keep this in
+    ``mapping`` so the Excel re-pull re-emits it; the bare ``oebb``
+    token is the canonical "this came from the Excel" signal.
+    """
+    path = tmp_path / "stations.json"
+    _write_stations(
+        path,
+        [
+            {
+                "bst_id": 1499,
+                "bst_code": "WrNs",
+                "name": "Wiener Neustadt Hauptbahnhof",
+                "source": "oebb,oebb_geonetz,osm",
+                "in_vienna": False,
+                "pendler": True,
+            }
+        ],
+    )
+
+    mapping, manual = _load_existing_station_entries(path)
+
+    assert "1499" in mapping, (
+        "A real ÖBB-Excel entry (bare ``oebb`` token present in the source "
+        "set) must stay in the mapping so the next Excel re-pull keeps it."
+    )
+    assert not any(e.get("name") == "Wiener Neustadt Hauptbahnhof" for e in manual)
+
+
+def test_bare_oebb_source_string_stays_in_mapping(tmp_path: Path) -> None:
+    """The pre-PR-β canonical ÖBB source — ``source="oebb"`` exactly.
+
+    The existing fast-path at ``elif source != "oebb"`` already handles
+    this; the test pins that the token-based replacement preserves that
+    path so legacy entries don't silently flip to manual.
+    """
+    path = tmp_path / "stations.json"
+    _write_stations(
+        path,
+        [
+            {
+                "bst_id": 1234,
+                "bst_code": "ABCD",
+                "name": "Legacy ÖBB Entry",
+                "source": "oebb",
+            }
+        ],
+    )
+
+    mapping, manual = _load_existing_station_entries(path)
+
+    assert "1234" in mapping
+    assert manual == []
+
+
+def test_empty_source_with_bst_code_treats_as_oebb(tmp_path: Path) -> None:
+    """Empty ``source`` + present ``bst_code`` → ÖBB (backward-compat).
+
+    Entries written before the ``as_dict`` source-default fix lacked a
+    ``source`` field entirely. If they carry the typical ÖBB Excel
+    fields (``bst_id`` + ``bst_code``), treat them as ÖBB so the next
+    Excel pull does not create a duplicate (see PR #1203 cron-failure
+    post-mortem). The token-based classifier preserves this branch.
+    """
+    path = tmp_path / "stations.json"
+    _write_stations(
+        path,
+        [
+            {
+                "bst_id": 5678,
+                "bst_code": "XYZ1",
+                "name": "Pre-source-default Entry",
+                "source": "",
+            }
+        ],
+    )
+
+    mapping, manual = _load_existing_station_entries(path)
+
+    assert "5678" in mapping
+    assert manual == []
+
+
+def test_empty_source_without_bst_code_is_manual(tmp_path: Path) -> None:
+    """Empty ``source`` + missing ``bst_code`` → manual (backward-compat)."""
+    path = tmp_path / "stations.json"
+    _write_stations(
+        path,
+        [
+            {
+                "bst_id": 5678,
+                "name": "Backward-compat manual entry",
+                "source": "",
+            }
+        ],
+    )
+
+    mapping, manual = _load_existing_station_entries(path)
+
+    assert "5678" not in mapping
+    assert any(e.get("name") == "Backward-compat manual entry" for e in manual)
+
+
+def test_non_oebb_source_only_is_manual(tmp_path: Path) -> None:
+    """``source=wl,vor`` (no ÖBB token at all) → manual.
+
+    The historical else-branch already covered this. The token-based
+    rewrite must keep it because WL-only / VOR-only entries are
+    real-world (any DIVA-carrying haltestelle, every VOR-derived stop).
+    """
+    path = tmp_path / "stations.json"
+    _write_stations(
+        path,
+        [
+            {
+                "bst_id": 7890,
+                "name": "WL-only Entry",
+                "source": "wl,vor",
+            }
+        ],
+    )
+
+    mapping, manual = _load_existing_station_entries(path)
+
+    assert "7890" not in mapping
+    assert any(e.get("name") == "WL-only Entry" for e in manual)
+
+
+def test_list_source_with_oebb_token_stays_in_mapping(tmp_path: Path) -> None:
+    """The legacy list-shape source (``["oebb", "wl"]``) — list path.
+
+    A small number of pre-PR-β entries carried the ``source`` as a
+    JSON list rather than a comma-separated string. The classifier
+    preserves the legacy element-wise membership check at
+    ``isinstance(source, list) and "oebb" in source``.
+    """
+    path = tmp_path / "stations.json"
+    _write_stations(
+        path,
+        [
+            {
+                "bst_id": 4321,
+                "bst_code": "ABCD",
+                "name": "Legacy list-source ÖBB",
+                "source": ["oebb", "wl"],
+            }
+        ],
+    )
+
+    mapping, manual = _load_existing_station_entries(path)
+
+    assert "4321" in mapping
+    assert manual == []
+
+
+def test_real_stations_json_keeps_wien_hauptbahnhof_as_manual() -> None:
+    """End-to-end pin against the committed ``data/stations.json``.
+
+    The committed file carries the two synthetic Wien-area entries the
+    regression bit on (``Wien Hauptbahnhof`` = 900100, ``Wien
+    Kaiserebersdorf`` = 900105). Pin that the classifier puts them in
+    ``manual_stations`` so the wrapper's ``final_stations.extend(
+    manual_stations)`` re-emits them after the Excel re-pull.
+    """
+    stations_path = Path("data/stations.json")
+    if not stations_path.exists():  # pragma: no cover - fresh clone
+        pytest.skip("data/stations.json not present in this checkout")
+
+    mapping, manual = _load_existing_station_entries(stations_path)
+
+    assert "900100" not in mapping, (
+        "Regression: Wien Hauptbahnhof (synthetic 900100) leaked into the "
+        "ÖBB-Excel mapping — see commit 484c1f6 post-mortem for the "
+        "cascade this triggers."
+    )
+    assert "900105" not in mapping, (
+        "Regression: Wien Kaiserebersdorf (synthetic 900105) leaked into "
+        "the ÖBB-Excel mapping."
+    )
+
+    manual_names = {e.get("name") for e in manual}
+    assert "Wien Hauptbahnhof" in manual_names
+    assert "Wien Kaiserebersdorf" in manual_names


### PR DESCRIPTION
## Summary

A comprehensive audit of the repo surfaced two coupled bugs (the second masked the first for weeks) plus a `DeprecationWarning` in a sentinel docstring.

### Bug 1 — Pipeline drops synthetic Wien-area stations on every cron tick

`scripts/update_station_directory.py:_load_existing_station_entries` classified entries via a naive substring check `"oebb" in source`. That substring also matched `oebb_geonetz` — the GeoNetz EVA/IFOPT enrichment provenance token added in PR β (`e8042de`). The synthetic Wien-area entries

  * `Wien Hauptbahnhof` — `bst_id=900100`, `source=google_places,oebb_geonetz,vor,wl`
  * `Wien Kaiserebersdorf` — `bst_id=900105`, `source=oebb_geonetz,vor`

were therefore bucketed into the ÖBB-Excel `mapping` instead of `manual_stations`. The Excel re-pull cannot re-emit a `bst_id` it has never seen (the live workbook does not carry 900xxx synthetic IDs), so the entries dropped out of the rebuilt `data/stations.json` every weekly tick.

Commit `484c1f6` patched the file content manually but did NOT address the classifier bug — the next scheduled `update-stations.yml` run (Sundays 01:00 UTC) would have reproduced the regression.

The fix splits the comma-separated `source` field into discrete tokens and looks for the exact `oebb` token. Nine new regression tests in `tests/test_update_station_directory_classification.py` pin both the bug case (`oebb_geonetz` substring trap) and every backward-compat branch.

**End-to-end verification:** with the fix, running `python scripts/update_all_stations.py` against the committed `data/stations.json` produces byte-identical output (`2236 → 2236, Δ +0`). Pre-fix the same run yielded `2236 → 2235` with both synthetic entries listed under `Removed`.

### Bug 2 — Wrapper tests mutated the working tree

`tests/test_update_all_stations_wrapper.py` exercised the wrapper end-to-end. The wrapper hardcodes three output paths (`Path("data/stations.json").resolve()` + `_DEFAULT_HEARTBEAT_PATH` + `_DEFAULT_DIFF_REPORT_PATH`) that all sit inside the repo root, so each test necessarily mutated the working tree. The pollution leaked into subsequent station-dependent tests in the same pytest session (`test_hauptbahnhof_id_matches_stations_directory`, `test_clean_title_expands_wien_hbf_abbreviation` and the `test_oebb_*` cluster) — the order-dependent cascade that masked Bug 1 for weeks.

The fix adds an `autouse=True` snapshot/restore fixture that captures the bytes of all three wrapper output paths before each test and restores them in teardown. The fixture's `try/yield/finally` shape preserves the tests' own assertions while pinning that a passing pytest run leaves no diff in `git status`.

### Bug 3 — `DeprecationWarning: invalid escape sequence '\-'`

`tests/test_sentinel_sanitize_log_message_drift.py:24` carried `[a-z0-9_.\-]*token` in the module docstring. `\-` isn't a recognised escape (DeprecationWarning today, `SyntaxError` eventually). Escape the backslash (`\\-`).

## Test plan

- [x] `ruff check src/ scripts/ tests/` — All checks passed
- [x] `mypy --strict src/` — Success: no issues found in 46 source files
- [x] `bandit -ll -r src/ scripts/` — 0 issues across all severity tiers
- [x] `pytest tests/` — 7999 passed, 2 skipped (+9 new tests; `git status` clean after the run, both at unit-isolation and full-suite scope)
- [x] End-to-end `update_all_stations.py` against committed `data/stations.json` — byte-identical output, both synthetic Wien-area entries preserved
- [x] Confirmed pre-fix order-dependent failures (15 tests in the `test_oebb_*` + `test_hauptbahnhof_*` cluster) no longer reproduce

https://claude.ai/code/session_01AL926vUh8tim89iYQnx7CN

---
_Generated by [Claude Code](https://claude.ai/code/session_01AL926vUh8tim89iYQnx7CN)_