### PR TITLE
fix(wl): reject generic-word and time-shaped prefix matches in _extract_prefix_lines

### DIFF
--- a/src/providers/wl_lines.py
+++ b/src/providers/wl_lines.py
@@ -25,20 +25,51 @@ def _display_line(s: str) -> str:
     return _clean_line_token(s)
 
 
+# Strict line-token shape used by ``_extract_prefix_lines`` to gate the
+# prefix-strip decision. A token must look like a real Vienna or ÖBB
+# line code (digits + optional letter, OR a known operator letter
+# prefix followed by digits) to count. Without this gate the
+# permissive ``[A-Za-z0-9]+`` regex below would happily classify a
+# generic word like ``Achtung``, ``Information`` or ``Hinweis`` (every
+# titlecased noun that ends with ``:``) as a "line code", causing the
+# downstream ``_post_filter_wl`` rebuild to mangle the title into
+# ``ACHTUNG: …``. The pattern requires AT LEAST one digit so single-
+# letter / pure-word tokens cannot slip through; ``[A-Z]{0,4}`` covers
+# ÖBB carrier prefixes (REX, RJ, RJX, EC, ICE, IC, WB, NJ, CJX, S, U,
+# N, R, D) and the WL bus-suffix ``A``/``E`` is captured by the
+# optional trailing ``[A-Z]?``.
+_STRICT_LINE_TOKEN_RE = re.compile(r"^[A-Z]{0,4}\d{1,3}[A-Z]?$")
+
+
 # Präfix-Erkennung/Entfernung:
 # Accept ``/``, ``+`` and ``,`` as separators between line codes. WL
 # sometimes uses ``40+41:`` for items that affect two lines on the
 # same corridor — the previous slash-only pattern silently treated
 # the whole ``40+41`` as a body fragment, causing ``_ensure_line_prefix``
 # to prepend ``40: `` on top of it (``40: 40+41: …``).
+# Require whitespace OR end-of-string AFTER the colon
+# (``:(?:\s+|$)``) so a sentence-starting time fragment like
+# ``17:30 Uhr Verspätung`` doesn't match as a line prefix. Pre-fix
+# the lenient ``:\s*`` regex consumed ``17:`` and left the body as
+# ``30 Uhr Verspätung`` with lines=``[17]`` — the strict-line-token
+# gate alone cannot catch this because ``17`` IS a valid line-code
+# shape (the disambiguator is what comes after the colon, not what
+# comes before it). Every real WL/ÖBB title in the cache carries
+# ``: `` with a space, and the empty-body shape ``5:`` (returning
+# just the prefix marker after a previous render dropped the body)
+# is covered by the ``$`` alternative so ``_ensure_line_prefix``'s
+# empty-body contract still holds.
 LINE_PREFIX_STRIP_RE = re.compile(
-    r"^\s*[A-Za-z0-9]+(?:\s*[/+,]\s*[A-Za-z0-9]+){0,20}\s*:\s*", re.IGNORECASE
-)
-LINES_COMPLEX_PREFIX_RE = re.compile(
-    r"^\s*[A-Za-z0-9]+(?:\s*,\s*[A-Za-z0-9]+)+(?:(?:\s+und\s+)?Rufbus\s+[A-Za-z0-9]+)?(?:\s*\([^)]+\))?\s*:\s*",
+    r"^\s*[A-Za-z0-9]+(?:\s*[/+,]\s*[A-Za-z0-9]+){0,20}\s*:(?:\s+|$)",
     re.IGNORECASE,
 )
-RUF_BUS_PREFIX_RE = re.compile(r"^\s*Rufbus\s+([A-Za-z0-9]+)\s*:\s*", re.IGNORECASE)
+LINES_COMPLEX_PREFIX_RE = re.compile(
+    r"^\s*[A-Za-z0-9]+(?:\s*,\s*[A-Za-z0-9]+)+(?:(?:\s+und\s+)?Rufbus\s+[A-Za-z0-9]+)?(?:\s*\([^)]+\))?\s*:(?:\s+|$)",
+    re.IGNORECASE,
+)
+RUF_BUS_PREFIX_RE = re.compile(
+    r"^\s*Rufbus\s+([A-Za-z0-9]+)\s*:(?:\s+|$)", re.IGNORECASE
+)
 
 
 def _extract_prefix_lines(title: str) -> tuple[str, list[str]]:
@@ -52,6 +83,20 @@ def _extract_prefix_lines(title: str) -> tuple[str, list[str]]:
     so ``41E/10A:`` extracts to ``["41E", "10A"]`` (original WL
     rendering kept) rather than a sorted ``["10A", "41E"]`` that
     would re-order the user-visible prefix unnecessarily.
+
+    Defence against false-positive matches on titles that *look*
+    line-prefixed but aren't: the underlying regex
+    :data:`LINE_PREFIX_STRIP_RE` is intentionally permissive
+    (``[A-Za-z0-9]+`` before the colon) so it can absorb operator
+    letter prefixes (``REX7``, ``RJX12``, ``41E``, ``10A``, ``N20``).
+    That same permissiveness, pre-fix, treated generic word prefixes
+    like ``Achtung: Sperre`` / ``Information: Test`` and sentence-
+    starting numerics like ``17:30 Verspätung`` as line prefixes,
+    producing a mangled rebuild (``ACHTUNG: Sperre``, lines=``[17]``).
+    The :data:`_STRICT_LINE_TOKEN_RE` gate below rejects the strip
+    when ANY extracted token fails strict line-code validation —
+    leaving the title body untouched so the user-visible text stays
+    readable even if WL ever ships a non-line-prefixed title.
     """
     if len(title) > 500:
         title = title[:500]
@@ -65,21 +110,34 @@ def _extract_prefix_lines(title: str) -> tuple[str, list[str]]:
         match = LINES_COMPLEX_PREFIX_RE.match(body) or LINE_PREFIX_STRIP_RE.match(body)
         if match:
             block = body[: match.end()].rstrip(": \t")
+            candidates: list[str] = []
             for tok in re.split(r"[,/+]", block):
                 cleaned = _clean_line_token(tok.strip())
-                if cleaned and cleaned not in seen:
-                    seen.add(cleaned)
-                    lines.append(cleaned)
-            body = body[match.end():].strip()
-            continue
+                if cleaned:
+                    candidates.append(cleaned)
+            # Only commit the strip when EVERY extracted token looks
+            # like a real line code. Otherwise the prefix is a generic
+            # word (``Achtung:``, ``Hinweis:``) or a time fragment
+            # (``17:30``) and stripping it would mangle the title.
+            if candidates and all(_STRICT_LINE_TOKEN_RE.match(c) for c in candidates):
+                for cleaned in candidates:
+                    if cleaned not in seen:
+                        seen.add(cleaned)
+                        lines.append(cleaned)
+                body = body[match.end():].strip()
+                continue
+            # No strip — abandon the prefix-loop so the body keeps its
+            # original ``Achtung: …`` / ``17:30 …`` shape.
+            break
         ruf_match = RUF_BUS_PREFIX_RE.match(body)
         if ruf_match:
             cleaned = _clean_line_token(ruf_match.group(1))
-            if cleaned and cleaned not in seen:
+            if cleaned and _STRICT_LINE_TOKEN_RE.match(cleaned) and cleaned not in seen:
                 seen.add(cleaned)
                 lines.append(cleaned)
-            body = body[ruf_match.end():].strip()
-            continue
+                body = body[ruf_match.end():].strip()
+                continue
+            break
         break
     return body, lines
 

--- a/tests/places/test_tiling_limits.py
+++ b/tests/places/test_tiling_limits.py
@@ -18,15 +18,19 @@ def test_load_tiles_from_env_limits_entries() -> None:
         tiling.load_tiles_from_env(payload)
 
 
-def test_load_tiles_from_file_limits_entries() -> None:
-    data_path = Path("data/test_tiles_limit.json")
+def test_load_tiles_from_file_limits_entries(tmp_path: Path) -> None:
+    # Pre-fix this test wrote to the production-adjacent path
+    # ``data/test_tiles_limit.json`` with a ``finally``-based cleanup —
+    # not robust against pytest signal termination or a write-time
+    # exception that fires before the ``try`` block. ``tmp_path`` is
+    # the canonical fixture for test-owned files: pytest cleans it up
+    # automatically and the path lives outside the repository root,
+    # so a failure cannot leak into ``git status`` either way.
+    data_path = tmp_path / "test_tiles_limit.json"
     too_many = [{"lat": 48.2, "lng": 16.3}] * (tiling.MAX_TILE_COUNT + 1)
-    try:
-        data_path.write_text(json.dumps(too_many), encoding="utf-8")
-        with pytest.raises(ValueError, match="Tile configuration exceeds the limit"):
-            tiling.load_tiles_from_file(data_path)
-    finally:
-        data_path.unlink(missing_ok=True)
+    data_path.write_text(json.dumps(too_many), encoding="utf-8")
+    with pytest.raises(ValueError, match="Tile configuration exceeds the limit"):
+        tiling.load_tiles_from_file(data_path)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_wl_lines_strict_prefix_gate.py
+++ b/tests/test_wl_lines_strict_prefix_gate.py
@@ -1,0 +1,140 @@
+"""Regression tests for ``_extract_prefix_lines`` false-positive guards.
+
+The Wiener Linien title parser at
+``src/providers/wl_lines.py:_extract_prefix_lines`` historically
+matched anything of the shape ``<alphanumeric>: <body>`` as a line
+prefix. Two pathological inputs slipped through:
+
+1. **Time-shaped prefix** — ``17:30 Uhr Verspätung`` was parsed as
+   ``lines=["17"], body="30 Uhr Verspätung"``. The leading ``17``
+   coincidentally matches the regex ``[A-Za-z0-9]+`` (and the
+   strict line-token pattern, since ``17`` IS a valid line-code
+   shape), so only the disambiguator ``:`` -> digit / ``:`` -> space
+   can tell time from line prefix. The fix tightens the trailing
+   ``\\s*`` to ``\\s+`` so the colon must be followed by whitespace.
+
+2. **Generic word prefix** — ``Achtung: Sperre`` /
+   ``Information: Test`` / ``Hinweis: Umleitung`` was parsed as
+   ``lines=["ACHTUNG"], body="Sperre"`` etc. The fix gates the
+   prefix-strip on a strict line-token pattern requiring at least one
+   digit, so pure-word prefixes are now passed through unchanged.
+
+Both bugs were latent — current WL data always starts with a real
+line code, so neither has triggered in production. The guards close
+the surface against future upstream format changes (or hand-edited
+cache entries) that could otherwise leak into ``_post_filter_wl``'s
+title rebuild and mangle ``Achtung: Sperre`` into ``ACHTUNG: Sperre``.
+"""
+from __future__ import annotations
+
+from src.providers.wl_lines import _extract_prefix_lines
+
+
+def test_time_prefix_not_stripped() -> None:
+    """``17:30 Uhr Verspätung`` keeps the time fragment intact."""
+    body, lines = _extract_prefix_lines("17:30 Uhr Verspätung")
+    assert lines == [], (
+        f"Time fragment was parsed as line code: lines={lines}"
+    )
+    assert body == "17:30 Uhr Verspätung", (
+        f"Time-prefixed title was mangled: body={body!r}"
+    )
+
+
+def test_word_prefix_not_stripped() -> None:
+    """``Achtung: Sperre`` and siblings stay intact."""
+    for title in (
+        "Achtung: Sperre wegen Bauarbeiten",
+        "Information: Umleitung der Linie",
+        "Hinweis: Verspätung erwartet",
+        "Linie: 40 wird umgeleitet",
+    ):
+        body, lines = _extract_prefix_lines(title)
+        assert lines == [], (
+            f"Generic word was parsed as line code in {title!r}: lines={lines}"
+        )
+        assert body == title, (
+            f"Word-prefixed title was mangled: body={body!r}"
+        )
+
+
+def test_valid_line_prefixes_still_extracted() -> None:
+    """Real Vienna/ÖBB line prefixes still round-trip correctly."""
+    cases = [
+        ("40A: Umleitung", ["40A"], "Umleitung"),
+        ("U1: Verspätung", ["U1"], "Verspätung"),
+        ("S40: Test", ["S40"], "Test"),
+        ("40+41: Betrieb ab Gersthof", ["40", "41"], "Betrieb ab Gersthof"),
+        ("41E/10A: Ersatzbus", ["41E", "10A"], "Ersatzbus"),
+        ("N6/N71: Umleitung", ["N6", "N71"], "Umleitung"),
+        ("27A/28A/29A: Fronleichnamsumzug", ["27A", "28A", "29A"], "Fronleichnamsumzug"),
+        ("40: 40+41: Stacked title", ["40", "41"], "Stacked title"),
+        ("9, 40, 41: Umleitung", ["9", "40", "41"], "Umleitung"),
+    ]
+    for title, expected_lines, expected_body in cases:
+        body, lines = _extract_prefix_lines(title)
+        assert lines == expected_lines, (
+            f"Expected lines {expected_lines}, got {lines} for {title!r}"
+        )
+        assert body == expected_body, (
+            f"Expected body {expected_body!r}, got {body!r} for {title!r}"
+        )
+
+
+def test_rufbus_prefix_extracts_only_strict_line_token() -> None:
+    """``Rufbus N20: …`` keeps N20; ``Rufbus Achtung: …`` is left alone."""
+    body, lines = _extract_prefix_lines("Rufbus N20: Betriebshinweis")
+    assert lines == ["N20"]
+    assert body == "Betriebshinweis"
+
+    # Synthetic edge case: if a Rufbus block ever carries a non-line
+    # token, the strict-token gate must reject the strip rather than
+    # surface a mangled prefix.
+    body, lines = _extract_prefix_lines("Rufbus Achtung: Hinweis")
+    assert lines == [], (
+        f"Non-line Rufbus token leaked through strict gate: lines={lines}"
+    )
+    assert body == "Rufbus Achtung: Hinweis"
+
+
+def test_multiword_prefix_not_stripped() -> None:
+    """``Strecke Heiligenstadt: …`` (space inside the prefix) is left alone.
+
+    The space inside the prefix block already fails the
+    ``[A-Za-z0-9]+`` greedy match — pre-fix this still worked. The
+    test pins the existing behaviour so a future widening of the
+    prefix regex doesn't re-introduce the false positive.
+    """
+    body, lines = _extract_prefix_lines("Strecke Heiligenstadt: ab 10:00")
+    assert lines == []
+    assert body == "Strecke Heiligenstadt: ab 10:00"
+
+
+def test_colon_without_whitespace_not_stripped() -> None:
+    """``U1:Sperre`` (no whitespace after colon) is left alone.
+
+    The strict ``:\\s+`` requirement closes the time-prefix false
+    positive (``17:30 …``). The trade-off is that a hypothetical WL
+    title without a space after the colon (``U1:Sperre``) is no
+    longer recognised as having a line prefix. Every cached WL/ÖBB
+    title in the production cache carries ``: `` with a space, so
+    this is lossless in practice and the test pins the new contract.
+    """
+    body, lines = _extract_prefix_lines("U1:Sperre wegen Fahrzeug")
+    # Without whitespace after the colon, no prefix strip happens.
+    assert lines == [], (
+        f"Colon-without-space was treated as line prefix: lines={lines}"
+    )
+    assert body == "U1:Sperre wegen Fahrzeug"
+
+
+def test_empty_title_passes_through() -> None:
+    body, lines = _extract_prefix_lines("")
+    assert lines == []
+    assert body == ""
+
+
+def test_no_prefix_at_all_passes_through() -> None:
+    body, lines = _extract_prefix_lines("Betrieb ab Gersthof")
+    assert lines == []
+    assert body == "Betrieb ab Gersthof"


### PR DESCRIPTION
## Summary

Round 2 audit found two latent bugs in `src/providers/wl_lines.py:_extract_prefix_lines` (the helper used by `_post_filter_wl` to canonicalise WL title prefixes) plus one stale test-hygiene issue.

### Bug 1 — `_extract_prefix_lines` mis-parses two classes of generic prefixes

The regex was deliberately permissive (`[A-Za-z0-9]+`) so it could absorb operator letter prefixes (`REX7`, `41E`, `10A`, `N20`). That permissiveness let two pathological inputs through:

| Pre-fix input | Pre-fix parse | Mangled title (via `_post_filter_wl`) |
| --- | --- | --- |
| `17:30 Uhr Verspätung` | `lines=["17"], body="30 Uhr Verspätung"` | `17: 30 Uhr Verspätung` |
| `Achtung: Sperre` | `lines=["ACHTUNG"], body="Sperre"` | `ACHTUNG: Sperre` |
| `Information: Test` | `lines=["INFORMATION"], …` | `INFORMATION: Test` |
| `Hinweis: Umleitung` | `lines=["HINWEIS"], …` | `HINWEIS: Umleitung` |
| `Linie: 40 Sperre` | `lines=["LINIE"], body="40 Sperre"` | `LINIE: 40 Sperre` |

The fix adds two complementary guards:

1. **`:(?:\s+|$)` instead of `:\s*`** — colon must be followed by whitespace OR end-of-string. `17:30 …` (colon followed by a digit) no longer matches. `5:` / `5: ` (the empty-body shape that `_ensure_line_prefix` relies on for the rendered-prefix-only case) still works via the `$` branch.
2. **Strict `_STRICT_LINE_TOKEN_RE` gate** — every parsed token must match `^[A-Z]{0,4}\d{1,3}[A-Z]?$` (at least one digit, ≤4 carrier letters, optional trailing variant letter). Words without a digit (`ACHTUNG`, `INFORMATION`, `HINWEIS`, `LINIE`) are rejected; the prefix-loop abandons the strip and the original title body survives untouched. Real-world line codes (`U1`, `S40`, `41E`, `10A`, `N20`, `REX7`, `RJX12`) all pass.

Both bugs were **latent** — every live WL/ÖBB title in the production cache starts with a real line code. The guards close the attack surface against future upstream format changes (or hand-edited cache entries).

### Bug 2 — `test_tiling_limits.py` wrote to repo-root `data/`

`tests/places/test_tiling_limits.py:test_load_tiles_from_file_limits_entries` wrote a synthetic `data/test_tiles_limit.json` into the repo root and relied on a `try/finally` `unlink` for cleanup. The cleanup is fragile (signal termination, write-time exception before the `try` block). Same class of issue as the wrapper-test pollution fixed in PR #1607. Switched to `tmp_path` — pytest cleans up automatically.

## Test plan

- [x] `ruff check src/ scripts/ tests/` — All checks passed
- [x] `mypy --strict src/` — Success: no issues found in 46 source files
- [x] `bandit -ll -r src/ scripts/` — 0 issues across all severity tiers
- [x] `pytest tests/` — 8042 passed, 2 skipped (+8 new tests since PR #1607)
- [x] All 35 existing `test_multi_line_prefix_merge.py` cases stay green
- [x] `git status` clean after a full pytest run

https://claude.ai/code/session_01AL926vUh8tim89iYQnx7CN

---
_Generated by [Claude Code](https://claude.ai/code/session_01AL926vUh8tim89iYQnx7CN)_