### PR TITLE
chore(consistency): atomic_write for the four remaining repo-committed sinks

### DIFF
--- a/scripts/extract_oebb_geonetz_stops.py
+++ b/scripts/extract_oebb_geonetz_stops.py
@@ -48,10 +48,10 @@ if str(_ROOT) not in sys.path:
 
 try:  # pragma: no cover - convenience for module execution
     from src.feed.logging_safe import setup_script_logging
-    from src.utils.files import read_capped_bytes
+    from src.utils.files import atomic_write, read_capped_bytes
 except ModuleNotFoundError:  # pragma: no cover - fallback when installed as package
     from feed.logging_safe import setup_script_logging  # type: ignore[no-redef]
-    from utils.files import read_capped_bytes  # type: ignore[no-redef]
+    from utils.files import atomic_write, read_capped_bytes  # type: ignore[no-redef]
 
 # Cap mirrors ``MAX_JSON_FILE_BYTES`` in scripts/update_station_directory.py.
 # The raw GeoNetz dump is ~23 MiB; 50 MiB leaves ~2x headroom for a future
@@ -248,10 +248,16 @@ def main(argv: list[str] | None = None) -> int:
 
     payload = extract(args.raw, args.source_url)
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(
-        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
-        encoding="utf-8",
-    )
+    # ``atomic_write`` (tempfile + ``os.replace``) so a crash / SIGINT
+    # mid-dump cannot leave a half-written JSON snapshot in the
+    # repository — ``data/oebb-geonetz-stops.json`` is committed to
+    # ``main`` by the operator's station-refresh prep and consumed by
+    # ``scripts/update_station_directory.py:_enrich_with_geonetz`` on
+    # the next cron tick. Mirrors the canonical writer pattern used by
+    # the sibling ``data/stations.json`` / ``data/quarantine.json`` /
+    # ``cache/<provider>/events.json`` sinks.
+    with atomic_write(args.output, mode="w", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
     size_kib = args.output.stat().st_size / 1024
     logger.info(
         "Wrote %d stops (%.0f KiB) to %s — fahrplanperiode %s..%s",

--- a/scripts/optimize_site_assets.py
+++ b/scripts/optimize_site_assets.py
@@ -69,7 +69,7 @@ if str(REPO_ROOT) not in sys.path:
 # hostile log content (e.g. an attacker-controlled URL in a subprocess error)
 # can't bypass scrubbing on the way to stderr.
 from src.feed.logging_safe import setup_script_logging  # noqa: E402
-from src.utils.files import read_capped_text  # noqa: E402
+from src.utils.files import atomic_write, read_capped_text  # noqa: E402
 
 # Pillow 10 renamed the resampling enum; expose a stable alias so the
 # downscale step works on both modern (``Image.Resampling.LANCZOS``)
@@ -249,7 +249,16 @@ def _minify_css(check_only: bool = False) -> bool:
                 "`python scripts/optimize_site_assets.py --skip-images`",
             )
         return ok
-    CSS_OUT.write_text(expected, encoding="utf-8")
+    # ``atomic_write`` (tempfile + ``os.replace``) so a crash / SIGINT
+    # mid-write cannot leave a partial ``site.min.css`` in the working
+    # tree — the file is committed to ``main`` by the SEO guard
+    # workflow, so a corrupt half-write would land in the public asset
+    # served by GitHub Pages. Mirrors the canonical writer pattern
+    # established for every other repository-committed sink
+    # (``data/stations.json``, ``data/quarantine.json``,
+    # ``cache/<provider>/events.json``, …).
+    with atomic_write(CSS_OUT, mode="w", encoding="utf-8") as handle:
+        handle.write(expected)
     LOG.info(
         "CSS: %d -> %d bytes (%.1f%% smaller)",
         CSS_SRC.stat().st_size,
@@ -271,7 +280,11 @@ def _minify_js(check_only: bool = False) -> bool:
                 "`python scripts/optimize_site_assets.py --skip-images`",
             )
         return ok
-    JS_OUT.write_text(expected, encoding="utf-8")
+    # Same atomic-write rationale as ``_minify_css`` above — see that
+    # function's comment block for the SEO-guard commit path that
+    # makes a partial write user-visible on GitHub Pages.
+    with atomic_write(JS_OUT, mode="w", encoding="utf-8") as handle:
+        handle.write(expected)
     LOG.info(
         "JS:  %d -> %d bytes (%.1f%% smaller)",
         JS_SRC.stat().st_size,

--- a/src/cli.py
+++ b/src/cli.py
@@ -12,9 +12,11 @@ from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from . import build_feed as build_feed_module
+    from .utils.files import atomic_write
     from .utils.stations_validation import validate_stations
 else:
     from . import build_feed as build_feed_module
+    from .utils.files import atomic_write
     from .utils.stations_validation import validate_stations
 
 __all__ = ["build_feed_module"]
@@ -350,7 +352,16 @@ def _handle_stations_validate(args: argparse.Namespace) -> int:
     if args.output:
         output_path: Path = args.output
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        output_path.write_text(markdown, encoding="utf-8")
+        # ``atomic_write`` (tempfile + ``os.replace``) so a SIGINT
+        # mid-write cannot leave a half-rendered Markdown report at
+        # the caller's path. Operators routinely pipe this command's
+        # output into a build pipeline (the validation report is the
+        # next-step input for a release decision); a partial write
+        # would surface as a silent truncation downstream. Mirrors
+        # the canonical writer pattern established for every other
+        # operator-facing sink in the repository.
+        with atomic_write(output_path, mode="w", encoding="utf-8") as handle:
+            handle.write(markdown)
         print(f"Report written to {output_path}")
 
     if args.fail_on_issues and report.has_issues:


### PR DESCRIPTION
## Summary

A pattern-hunt for `.write_text(...)` outside the project's canonical `atomic_write` helper surfaced four call sites that write content which is either committed to `main` by the cron pipeline or consumed by a downstream cron step. All four are converted to `atomic_write` so a crash / SIGINT mid-write cannot leave a half-written artefact in the working tree.

No behaviour change on the happy path — the write ends with `os.replace` so the destination is atomically swapped.

| Site | Writes | Risk on partial write |
| --- | --- | --- |
| `scripts/optimize_site_assets.py:_minify_css` | `docs/assets/site.min.css` | Corrupt CSS on GitHub Pages (committed by `seo-guard.yml`) |
| `scripts/optimize_site_assets.py:_minify_js` | `docs/assets/site.min.js` | Corrupt JS on GitHub Pages |
| `scripts/extract_oebb_geonetz_stops.py:main` | `data/oebb-geonetz-stops.json` | Loader crash or silent entry drop in next weekly station refresh |
| `src/cli.py:_cmd_stations_validate` | Operator-supplied Markdown report path | Silent truncation in downstream release-decision pipelines |

Mirrors the canonical writer pattern already used by every other repository-committed sink (`data/stations.json`, `data/quarantine.json`, `data/places_quota.json`, `cache/<provider>/events.json`, `data/first_seen.json`, `data/stations_last_run.json`).

`scripts/scaffold_provider_plugin.py` is intentionally NOT converted — one-shot dev scaffolder that writes a new file from a template; recoverable by re-running and never invoked from CI.

## Audit note: diminishing returns

This is the 5th round of audits. Rounds 1-2 found 5 real bugs (3 critical, 2 minor); rounds 3-4 found 0 new bugs and yielded defensive improvements (workflow timeouts, property tests). This round surfaced one consistency gap. The codebase is in genuinely good shape now — further audit work would mostly be quality-of-life improvements rather than bug fixes.

## Test plan

- [x] `ruff check src/ scripts/ tests/` — All checks passed
- [x] `mypy --strict src/` — Success: no issues found in 46 source files
- [x] `pytest tests/` — 8051 passed, 2 skipped
- [x] `git status` clean after the test run
- [x] `mypy --strict src/cli.py` (the only `src/` change) — clean

https://claude.ai/code/session_01AL926vUh8tim89iYQnx7CN

---
_Generated by [Claude Code](https://claude.ai/code/session_01AL926vUh8tim89iYQnx7CN)_