### PR TITLE
fix(en-feed): preserve Unicode route separators (↔ → — • …) through translation

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -882,6 +882,38 @@ _ENTITY_PLACEHOLDER_FORMAT = "XENT{index}X"
 _ENTITY_PLACEHOLDER_RE: re.Pattern[str] = re.compile(r"XENT\d+X")
 
 
+# Unicode glyphs that the Helsinki opus-mt-de-en tokenizer is likely
+# to map to its ``<unk>`` slot — and silently drop on detokenize.
+# Empirically observed in the live feed (2026-05-22): an ÖBB title
+# ``Wien Hauptbahnhof ↔ Wien Floridsdorf ↔ Wien Meidling`` translated
+# to ``Wien Hauptbahnhof Wien Floridsdorf Wien Meidling`` — the
+# bidirectional arrow ``↔`` (U+2194) was stripped. The fix routes
+# these glyphs through the same placeholder-mask path as proper
+# nouns so they survive the round trip.
+#
+# Coverage by Unicode block:
+#   * U+2010..U+2015 — dashes (hyphen, figure dash, en-/em-dash, …)
+#     plus U+2026 (horizontal ellipsis) and U+2022/U+2023 (bullets);
+#   * U+2190..U+21FF — Arrows block;
+#   * U+27F0..U+27FF — Supplemental Arrows-A;
+#   * U+2900..U+297F — Supplemental Arrows-B;
+#   * U+2B00..U+2BFF — Miscellaneous Symbols and Arrows.
+#
+# The class is intentionally narrow: it does NOT cover the Latin-1
+# supplement (where ``ä``/``ö``/``ü`` live and MUST survive into the
+# model). False-positive risk is therefore zero for typical German
+# disruption text.
+_PRESERVED_SYMBOLS_RE: re.Pattern[str] = re.compile(
+    r"["
+    r"‐-―•‣…"
+    r"←-⇿"
+    r"⟰-⟿"
+    r"⤀-⥿"
+    r"⬀-⯿"
+    r"]"
+)
+
+
 # Aliases that look like a noise-prefixed station ("Bahnhof X", "Bf X",
 # "Station X", …) are skipped — those are spelling variants of the
 # canonical name, not user-facing short forms. The match is
@@ -1025,12 +1057,20 @@ def _brand_entity_pattern() -> re.Pattern[str]:
 def _mask_entities(text: str) -> tuple[str, dict[str, str]]:
     """Replace known entities in ``text`` with stable placeholders.
 
-    The masker applies three passes (brands → stations → line tokens)
-    so the longest-matching span wins regardless of which source
-    discovered it. Each unique surface form gets exactly one
-    placeholder so a sentence mentioning the same station twice
-    survives one round-trip through the translation model with
-    identical tokens.
+    The masker applies four passes (brands → stations → line tokens
+    → preserved Unicode symbols) so the longest-matching span wins
+    regardless of which source discovered it. Each unique surface
+    form gets exactly one placeholder so a sentence mentioning the
+    same station twice — or the same ``↔`` arrow twice — survives
+    one round-trip through the translation model with identical
+    tokens.
+
+    The fourth pass covers Unicode glyphs that the Marian
+    SentencePiece tokenizer routinely drops as ``<unk>`` (arrows,
+    bullets, em-/en-dashes, …). Without it, a route-style title like
+    ``Wien Hauptbahnhof ↔ Wien Floridsdorf`` loses the ``↔``
+    separator during translation and the EN feed shows the station
+    names smashed together.
 
     Returns a tuple ``(masked_text, mapping)`` where ``mapping`` maps
     each placeholder back to the original entity text. Callers feed
@@ -1058,6 +1098,7 @@ def _mask_entities(text: str) -> tuple[str, dict[str, str]]:
     if station_pattern is not None:
         working = station_pattern.sub(_replace, working)
     working = _LINE_ENTITY_RE.sub(_replace, working)
+    working = _PRESERVED_SYMBOLS_RE.sub(_replace, working)
     return working, mapping
 
 

--- a/tests/test_feed_entity_masking.py
+++ b/tests/test_feed_entity_masking.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from src import build_feed
 
 
@@ -63,6 +65,83 @@ def test_mask_entities_protects_wien_x_aliases() -> None:
     assert "Wien Rennweg" not in masked
     assert "Wien Mitte" in mapping.values()
     assert "Wien Rennweg" in mapping.values()
+
+
+def test_mask_entities_protects_unicode_route_separators() -> None:
+    """Regression: Unicode glyphs that Marian's SentencePiece tokenizer
+    treats as ``<unk>`` must be masked so they survive the round trip.
+
+    User report (live feed.en.xml, 2026-05-22):
+
+      DE: ``Wien Hauptbahnhof ↔ Wien Floridsdorf ↔ Wien Meidling``
+      EN: ``Wien Hauptbahnhof Wien Floridsdorf Wien Meidling``  ← arrows stripped
+
+    Without masking, the translator silently drops every preserved
+    glyph (arrows, bullets, em-/en-dashes, …) and the EN feed shows
+    the station names smashed together. The new fourth pass in
+    :func:`_mask_entities` routes those glyphs through the same
+    placeholder machinery as proper nouns.
+    """
+    text = "Wien Hauptbahnhof ↔ Wien Floridsdorf ↔ Wien Meidling"
+    masked, mapping = build_feed._mask_entities(text)
+    # The arrow must NOT appear in the masked text — if it did, the
+    # translator would receive it raw and drop it.
+    assert "↔" not in masked, (
+        f"↔ leaked into the masked text — Marian would drop it as <unk>. "
+        f"masked={masked!r}"
+    )
+    # The arrow IS in the mapping (so unmask can restore it).
+    assert "↔" in mapping.values()
+    # Repeated arrows share a single placeholder so the token count is
+    # stable across mention frequency.
+    arrow_placeholders = [k for k, v in mapping.items() if v == "↔"]
+    assert len(arrow_placeholders) == 1
+    # Round-trip restores the original glyphs verbatim.
+    assert build_feed._unmask_entities(masked, mapping) == text
+
+
+@pytest.mark.parametrize(
+    "glyph",
+    [
+        "↔",   # U+2194 LEFT RIGHT ARROW (the user-reported case)
+        "→",   # U+2192 RIGHTWARDS ARROW
+        "←",   # U+2190 LEFTWARDS ARROW
+        "⇄",   # U+21C4 RIGHTWARDS ARROW OVER LEFTWARDS ARROW
+        "⇒",   # U+21D2 RIGHTWARDS DOUBLE ARROW
+        "⇔",   # U+21D4 LEFT RIGHT DOUBLE ARROW
+        "—",   # U+2014 EM DASH
+        "–",   # U+2013 EN DASH
+        "•",   # U+2022 BULLET
+        "…",   # U+2026 HORIZONTAL ELLIPSIS
+    ],
+)
+def test_mask_entities_protects_every_glyph_class(glyph: str) -> None:
+    """Every preserved-symbol class registered in
+    :data:`build_feed._PRESERVED_SYMBOLS_RE` must round-trip cleanly.
+    """
+    text = f"A {glyph} B"
+    masked, mapping = build_feed._mask_entities(text)
+    assert glyph not in masked, f"{glyph!r} reached the translator raw"
+    assert glyph in mapping.values()
+    assert build_feed._unmask_entities(masked, mapping) == text
+
+
+def test_mask_entities_preserves_umlauts_and_letters() -> None:
+    """Sanity guard: the preserved-symbols pass must NOT touch German
+    umlauts (``ä``, ``ö``, ``ü``, ``ß``) — those MUST reach the model
+    so the surrounding sentence can be translated. False positives in
+    this class would break every German disruption text.
+    """
+    text = "Straße — Östlich Verzögerung für Reisende: Ärger über Übergänge."
+    masked, mapping = build_feed._mask_entities(text)
+    # Each umlaut survives the mask pass verbatim.
+    for letter in ("ä", "ö", "ü", "ß", "Ä", "Ö", "Ü"):
+        assert letter in masked, (
+            f"umlaut {letter!r} was wrongly masked — masked={masked!r}"
+        )
+    # The em-dash IS protected (the user's reported failure mode).
+    assert "—" not in masked
+    assert "—" in mapping.values()
 
 
 def test_mask_entities_longest_match_wins() -> None:


### PR DESCRIPTION
## Summary

User-Report (Live feed.en.xml, 2026-05-22 11:00):

```xml
DE: <title>Wien Hauptbahnhof ↔ Wien Floridsdorf ↔ Wien Meidling</title>
EN: <title>Wien Hauptbahnhof Wien Floridsdorf Wien Meidling</title>
                              ↑ Pfeile sind weg
```

Das bidirektionale-Pfeile-Glyph `↔` (U+2194) wird beim Übersetzen verschluckt — Marian/SentencePiece behandelt unbekannte Unicode-Symbole als `<unk>` und der Detokenizer lässt sie im Output einfach weg. Mein Entity-Masker schützte bisher nur Eigennamen; Unicode-Symbole gingen ungeschützt durch den Tokenizer.

ÖBB und WL nutzen solche Glyphs regelmäßig als Route-Separator in Titeln (`A ↔ B ↔ C`, `A → B`), daher tritt der Bug systematisch auf — nicht nur bei dem einen gemeldeten Item.

## Fix

Neue Konstante `_PRESERVED_SYMBOLS_RE` als Character-Klasse für die kleinen Unicode-Blocks die Marian routinemäßig droppt:

| Block | Beispiele |
|---|---|
| U+2010..U+2015 | Dashes: `‐`, `–`, `—`, `―` |
| U+2022, U+2023 | Bullets: `•`, `‣` |
| U+2026 | Horizontal ellipsis: `…` |
| U+2190..U+21FF | Arrows block: `←`, `→`, `↔`, `⇄`, `⇒`, `⇔`, … |
| U+27F0..U+27FF | Supplemental Arrows-A |
| U+2900..U+297F | Supplemental Arrows-B |
| U+2B00..U+2BFF | Miscellaneous Symbols and Arrows |

**Bewusst eng gefasst**: die Klasse deckt NICHT den Latin-1-Supplement-Block, wo `ä`/`ö`/`ü`/`ß` leben. Diese MÜSSEN das Modell erreichen, damit der umliegende Satz übersetzt wird. False-Positive-Risiko ist null für typischen deutschen Disruption-Text.

## Pipeline-Integration

`_mask_entities()` bekommt einen vierten Pass (symbols last, damit single-char matches keine längeren Stationsspannen schatten):

```
Pass 1: brands       (Wiener Linien, ÖBB, ...)
Pass 2: stations     (Wien Hauptbahnhof, Wien Mitte, ...)
Pass 3: line tokens  (U6, 5A, S40, ...)
Pass 4: NEW: symbols (↔, →, —, •, ...)
```

Wiederholte Glyphs teilen einen einzigen Placeholder via `surface_to_placeholder`-Dedup, also Titel mit drei `↔` hat eine Mapping-Entry, nicht drei.

## End-to-end Verifikation

Simulation mit fake Marian der alle Pfeile dropt:
```
Input:  Wien Hauptbahnhof ↔ Wien Floridsdorf ↔ Wien Meidling
Output: Wien Hauptbahnhof ↔ Wien Floridsdorf ↔ Wien Meidling  ✓
```

Round-trip intakt — sogar wenn die Pipeline jeden preserved Glyph aus dem maskierten Text dropt, restore`unmask_entities` sie.

## Tests

- `test_mask_entities_protects_unicode_route_separators` — Pin der exakten User-Reported Titel
- `test_mask_entities_protects_every_glyph_class` — Parametrisiert über 10 Glyph-Klassen (arrows, dashes, bullet, ellipsis, double arrows)
- `test_mask_entities_preserves_umlauts_and_letters` — Sanity-Guard: alle deutschen Umlaute (`ä`, `ö`, `ü`, `ß`, `Ä`, `Ö`, `Ü`) überleben den Symbol-Pass; em-dash wird preserved

## Test plan
- [x] `python -m pytest tests/test_feed_entity_masking.py` — 27 passed (inkl. 3 neue)
- [x] `python -m pytest tests/test_feed_entity_masking.py tests/test_feed_translation.py tests/test_translation_coverage.py` — 42 passed
- [x] Full sweep: 8063 passed (+ 1 pre-existing local-env flake unverändert)
- [x] Static checks: 0 neue C901/mypy/ruff Findings
- [x] End-to-end simulation: Round-trip mit Pfeil-droppender fake pipeline
- [ ] **Live-Verifizierung**: Nach Merge & dem nächsten update-cycle.yml Run sollte das `Wien Hauptbahnhof ↔ Wien Floridsdorf ↔ Wien Meidling`-Item im EN-Feed die Pfeile behalten

https://claude.ai/code/session_01YNjxtfNC9cowFQpTAQo1jk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNjxtfNC9cowFQpTAQo1jk)_