### PR TITLE
docs(readme): add website badge linking to live site

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Feed Build](https://github.com/Origamihase/wien-oepnv/actions/workflows/build-feed.yml/badge.svg?branch=main)](https://github.com/Origamihase/wien-oepnv/actions/workflows/build-feed.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Subscribe to Feed](https://img.shields.io/badge/RSS-Subscribe_to_Feed-orange?style=flat&logo=rss)](https://origamihase.github.io/wien-oepnv/feed.xml)
+[![Website](https://img.shields.io/badge/Website-Wien_ÖPNV-0F1736?style=flat&logo=githubpages&logoColor=white)](https://origamihase.github.io/wien-oepnv/site.html#ausfaelle)
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a new Status Badge for the project website (`site.html#ausfaelle`).
- Uses the website's brand dark blue (`#0F1736`) and the GitHub Pages logo for visual consistency with the existing badges.

## Preview
`[[Website](`https://img.shields.io/badge/Website-Wien_ÖPNV-0F1736?style=flat&logo=githubpages&logoColor=white)](https://origamihase.github.io/wien-oepnv/site.html#ausfaelle)``

## Test plan
- [ ] Verify the rendered badge displays in the dark navy color matching the website.
- [ ] Click the badge and confirm it opens `https://origamihase.github.io/wien-oepnv/site.html#ausfaelle` (jumps to the *Ausfälle* section).


---
_Generated by [Claude Code](https://claude.ai/code/session_01V2BTUs2ZncyaViS6QSiQAf)_