### PR TITLE
docs(readme): drop #ausfaelle anchor from website badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Feed Build](https://github.com/Origamihase/wien-oepnv/actions/workflows/build-feed.yml/badge.svg?branch=main)](https://github.com/Origamihase/wien-oepnv/actions/workflows/build-feed.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Subscribe to Feed](https://img.shields.io/badge/RSS-Subscribe_to_Feed-orange?style=flat&logo=rss)](https://origamihase.github.io/wien-oepnv/feed.xml)
-[![Website](https://img.shields.io/badge/Website-Wien_ÖPNV-0F1736?style=flat&logo=githubpages&logoColor=white)](https://origamihase.github.io/wien-oepnv/site.html#ausfaelle)
+[![Website](https://img.shields.io/badge/Website-Wien_ÖPNV-0F1736?style=flat&logo=githubpages&logoColor=white)](https://origamihase.github.io/wien-oepnv/site.html)
 
 ---
 


### PR DESCRIPTION
## Summary
- Removes the `#ausfaelle` fragment from the website badge so it points to the site root.
- Previous target: `https://origamihase.github.io/wien-oepnv/site.html#ausfaelle`
- New target: `https://origamihase.github.io/wien-oepnv/site.html`

## Test plan
- [ ] Verify the badge in the rendered README opens the site root (no auto-scroll to *Ausfälle*).


---
_Generated by [Claude Code](https://claude.ai/code/session_01V2BTUs2ZncyaViS6QSiQAf)_