### PR TITLE
docs(strict-typing): mark migration doc as historical reference

### DIFF
--- a/docs/strict-typing-migration.md
+++ b/docs/strict-typing-migration.md
@@ -1,5 +1,17 @@
 # Strict-Typing-Migration der Test-Suite
 
+> ℹ️ **Status: Historische Referenz / Migration abgeschlossen.**
+> Die Cluster-Migration **C25–C33** ist abgeschlossen, das mypy-strict-Gate
+> (`.github/workflows/mypy-strict.yml`) läuft mit einer leeren Allowlist
+> (`.mypy-baseline.txt` = 0 Zeilen = 0 strict-mode-Errors über `src/` und
+> `tests/`). Dieses Dokument bleibt als **Konventions- und Patterns-Referenz**
+> für künftige Test-Annotationen erhalten — die in §3 dokumentierten
+> Patterns gelten unverändert. Die **„Anschluss-Roadmap" in §9** listet
+> historische Folgearbeiten; die dort genannten Backlog-Zahlen
+> (`[type-arg]` 22, `[unused-ignore]` 14, `[no-untyped-def]` 173,
+> `[attr-defined]` 99) reflektieren den Stand **vor** Abschluss der
+> Migration und sind nicht aktuell.
+
 Dieses Dokument konsolidiert die Konventionen, Patterns und Werkzeuge,
 die im Zuge der Cluster-Migration **C25–C33** beim strict-typing-konformen
 Annotieren der `tests/`-Suite etabliert wurden, sowie das mit **C34**


### PR DESCRIPTION
## Hintergrund

Im Doku-Audit (Vorgängerturn) hatte ich drei kleine PRs vorgeschlagen:

1. **PR #1 — drei Sachbug-Fixes** (`audit.md` archivieren, `AGENTS.md` `tests`-Subbefehl entfernen, `oebb_provider_logic.md:32` Pfad korrigieren) → **bereits vom Repo-Owner gefixt** zwischen den Turns.
2. **PR #2 — `performance_monitoring_plan.md` neu rahmen** → **bereits gefixt** (Datei hat jetzt einen ⚠️-Status-Block).
3. **PR #3 — Strict-Typing-Docs Status klären** → ein Dokument war noch offen, dieser PR schließt die Lücke.

## Was dieser PR macht

Fügt einen ℹ️-Status-Block am Anfang von [`docs/strict-typing-migration.md`](docs/strict-typing-migration.md) ein. Das Dokument wurde während der aktiven Cluster-Migration C25–C33 geschrieben, ist aber inzwischen Historie:

- `.mypy-baseline.txt` ist **0 Zeilen lang** — d. h. das mypy-strict-Gate läuft mit leerer Allowlist (0 Fehler über `src/` + `tests/`).
- Die in §9 „Anschluss-Roadmap" genannten Backlog-Zahlen (`[type-arg]` 22, `[unused-ignore]` 14, `[no-untyped-def]` 173, `[attr-defined]` 99) reflektieren den Zustand **vor** Abschluss der Migration und waren ohne Status-Block leicht als aktuell zu missverstehen.
- Die Patterns in §3 bleiben weiter relevant als Konventions-Referenz für neue Tests — der Status-Block macht explizit, welche Sektionen lebendig sind und welche historisch.

Stilistisch analog zum bereits existierenden Status-Block in [`docs/strict-typing-attr-defined-investigation.md`](docs/strict-typing-attr-defined-investigation.md) und [`docs/performance_monitoring_plan.md`](docs/performance_monitoring_plan.md).

## Nicht-Ziele

- Keine Inhaltsänderung an den §1–§9-Sektionen.
- Keine Verschiebung ins Archiv — das Dokument bleibt unter `docs/`, weil §3 für neuen Test-Code weiterhin nützlich ist.

## Test plan

- [x] Diff geprüft: nur 12 hinzugefügte Zeilen (Status-Block), keine Änderung am Bestand.
- [x] Verifiziert: `.mypy-baseline.txt` ist tatsächlich 0 Zeilen (`wc -l`).
- [x] Verifiziert: `.github/workflows/mypy-strict.yml` existiert und führt das Allowlist-Gate aus.
- [ ] CI grün (Mypy-Strict, Tests, Bandit, CodeQL, SEO-Guard) — primär markdown-only-Diff, also keine Auswirkungen erwartet.

https://claude.ai/code/session_011QD7QvHgY7Tg6zWgGLR5VH

---
_Generated by [Claude Code](https://claude.ai/code/session_011QD7QvHgY7Tg6zWgGLR5VH)_