### PR TITLE
ci(seo-guard): rebase before push to survive update-cycle race

### DIFF
--- a/.github/workflows/seo-guard.yml
+++ b/.github/workflows/seo-guard.yml
@@ -79,12 +79,29 @@ jobs:
           fi
           echo "sitemap.xml verification passed (${url_count} URLs)."
 
+      - name: Pull concurrent remote changes
+        # Defense against the cross-workflow push race documented in
+        # update-cycle.yml's commit step: update-cycle.yml writes to
+        # main every few minutes (paths under docs/**), and any of
+        # those writes can land between this workflow's checkout and
+        # this workflow's push, turning the auto-commit-action's push
+        # into a non-fast-forward rejection. Mirrors the established
+        # pattern in update-cycle.yml and manual-full-refresh.yml:
+        # rebase the locally regenerated sitemap onto the current
+        # remote tip first, then push with --force-with-lease so a
+        # last-millisecond push from another writer cleanly aborts
+        # the push (rather than overwriting) and the run is retried
+        # by the next docs/** push that triggers seo-guard.
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        run: git pull --rebase --autostash
+
       - name: Commit sitemap changes
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: 'chore(seo): refresh sitemap.xml [skip ci]'
           file_pattern: 'docs/sitemap.xml'
+          push_options: '--force-with-lease'
 
       - name: Verify feed file (repo) – exactly one self & one alternate
         shell: bash


### PR DESCRIPTION
## Hintergrund

CI-Lauf `#70328069654` von `seo-guard.yml` ist im `Commit sitemap changes`-Schritt mit Non-Fast-Forward gescheitert:

```
From https://github.com/Origamihase/wien-oepnv
   a20d83ac4..00754cfa6  main       -> origin/main
[main 59b2868ba] chore(seo): refresh sitemap.xml [skip ci]
 ! [rejected]            main -> main (non-fast-forward)
error: failed to push some refs
```

## Root Cause

Cross-Workflow Push-Race zwischen `update-cycle.yml` und `seo-guard.yml`:

- **`update-cycle.yml`** committet alle paar Minuten in `main` (zuletzt >20 `chore: update cycle` in den jüngsten 30 Commits) und berührt dabei Pfade unter `docs/**` (z. B. `docs/feed.xml`, `docs/feed-health.md`, `docs/stats/*`).
- **`seo-guard.yml`** triggert auf `push: paths: docs/**` und wird so durch jeden update-cycle-Commit reaktiv ausgelöst.
- Beide haben **disjoint concurrency groups** (`seo-guard-${{ github.ref }}` vs. `external-api-fetch`), können also parallel laufen.
- Zwischen seo-guards Checkout und Push landet gelegentlich ein frischer update-cycle-Commit → Non-Fast-Forward.

## Lösung — das bereits etablierte Pattern spiegeln

`update-cycle.yml:378-407` und `manual-full-refresh.yml` haben dieselbe Race **bereits gelöst**:

```yaml
- name: Pull concurrent remote changes
  run: git pull --rebase --autostash

- name: Commit cycle outputs
  uses: stefanzweifel/git-auto-commit-action@... # v7
  with:
    push_options: '--force-with-lease'
```

`seo-guard.yml` war der einzige verbliebene main-Writer ohne dieses Pattern. Dieser PR fügt es ein:

1. Neuer Schritt `Pull concurrent remote changes` vor `Commit sitemap changes` (mit identischer `if:`-Bedingung).
2. `push_options: '--force-with-lease'` am Auto-Commit.

Worst case = Status quo (Workflow rot, aber `--force-with-lease` schreibt **nie** fremde Commits über). Best case = Lauf bleibt grün.

## Diskussion der nicht-gewählten Alternativen

- **Concurrency-Gruppen vereinen** (seo-guard + update-cycle in dieselbe Group): Würde wegen update-cycles minutely Cadence einen permanenten Backlog erzeugen. Verworfen.
- **Sitemap-Generation in update-cycle ziehen:** Architekturell größerer Eingriff, größere Blast-Radius. Verworfen zugunsten des minimal-invasiven Fixes.
- **`continue-on-error: true` auf den Commit-Schritt:** Maskiert das Problem, statt es zu lösen. Verworfen.

## Test plan

- [x] YAML syntaktisch valide (`yaml.safe_load` lokal).
- [x] Diff geprüft: nur 17 hinzugefügte Zeilen, kein Bestand verändert.
- [x] Pattern identisch zu `update-cycle.yml` und `manual-full-refresh.yml` — keine neue Sicherheits- oder Konsistenz-Annahme.
- [ ] Nächster `docs/**`-Push triggert seo-guard, beweist im erfolgreichen Lauf, dass Pull-Rebase + `--force-with-lease` greift.
- [ ] CI grün (bandit, CodeQL, mypy-strict, tests, C901 complexity).

https://claude.ai/code/session_011QD7QvHgY7Tg6zWgGLR5VH

---
_Generated by [Claude Code](https://claude.ai/code/session_011QD7QvHgY7Tg6zWgGLR5VH)_