### PR TITLE
Three resilience optimisations: conditional GET, breaker registry, HAFAS validation

### DIFF
--- a/scripts/sync_hafas_profile.py
+++ b/scripts/sync_hafas_profile.py
@@ -46,7 +46,7 @@ import sys
 from collections.abc import Sequence
 from logging import DEBUG, INFO, getLogger
 from pathlib import Path
-from typing import Final
+from typing import Final, cast
 
 import requests
 
@@ -307,6 +307,189 @@ def _build_profile_document(extracted: dict[str, str]) -> dict[str, object]:
     }
 
 
+# ---------------------------------------------------------------------------
+# Structural validation
+#
+# The regex extractor in ``_extract_profile`` only enforces character-class
+# and length bounds on the raw match. If a future upstream refactor moves
+# the credential strings around (renames the ``salt`` key, embeds a
+# placeholder string the regex still matches, accidentally lifts an
+# unrelated literal), the extractor would happily produce a syntactically
+# valid but semantically broken profile. Writing that profile to disk
+# pollutes the HAFAS cache for the entire cron-pipeline lifetime — every
+# enrichment falls through to the Google-Places tier, burning the daily
+# Places quota on stations that should have been served by HAFAS.
+#
+# ``_validate_profile_document`` is the writer-side gate. It runs AFTER
+# ``_build_profile_document`` assembles the document and BEFORE
+# ``_write_profile`` commits the bytes. A validation failure raises
+# :class:`HafasProfileValidationError` which ``main`` catches and turns
+# into exit code 1 — no on-disk state is mutated.
+# ---------------------------------------------------------------------------
+
+_PROFILE_MAX_FIELD_LEN: Final[int] = 256
+_PROFILE_MIN_VER_LEN: Final[int] = 3   # e.g. "1.0"
+_PROFILE_MIN_AID_LEN: Final[int] = 8
+_PROFILE_MIN_SALT_LEN: Final[int] = 8  # only applied when salt is non-empty
+
+# ``ver`` is HAFAS's API client version. Every release observed in the
+# upstream profile since 2022 has used the ``MAJOR.MINOR[.PATCH]`` shape
+# (e.g. "1.45", "1.46", "1.46.LIVE"). The regex is intentionally narrow:
+# a freeform-string drift would silently break the HAFAS request envelope.
+_VER_VALIDATION_RE: Final[re.Pattern[str]] = re.compile(
+    r"^[0-9]+\.[0-9]+(?:\.[0-9A-Za-z_-]+)?$"
+)
+
+# ``aid`` is the deployment-scoped Application-ID. ÖBB's current value
+# ("OWDL4fE4ixNiPBBm") is a 16-char base62-ish token; the regex permits
+# the broader alphanumeric+separator set used by other HAFAS deployments
+# but rejects whitespace / control characters / Trojan-Source primitives.
+_AID_VALIDATION_RE: Final[re.Pattern[str]] = re.compile(
+    r"^[A-Za-z0-9._\-+/]{%d,128}$" % _PROFILE_MIN_AID_LEN
+)
+
+# ``salt`` (when present) is the HMAC-MD5 ingredient. HAFAS deployments
+# that use signing carry an opaque alphanumeric+padding token; ÖBB's
+# current upstream omits it entirely.
+_SALT_VALIDATION_RE: Final[re.Pattern[str]] = re.compile(
+    r"^[A-Za-z0-9._\-+/=]{%d,256}$" % _PROFILE_MIN_SALT_LEN
+)
+
+
+class HafasProfileValidationError(ValueError):
+    """Raised when the assembled HAFAS profile fails structural validation.
+
+    A distinct subclass of :class:`ValueError` so callers (the
+    ``main`` entry point and any future tooling) can differentiate
+    write-time validation failures from generic value errors elsewhere
+    in the pipeline.
+    """
+
+
+def _ensure_str(
+    value: object,
+    field: str,
+    *,
+    min_len: int = 0,
+    max_len: int = _PROFILE_MAX_FIELD_LEN,
+) -> str:
+    """Assert *value* is a string within ``[min_len, max_len]`` characters.
+
+    Returns the validated string. Raises
+    :class:`HafasProfileValidationError` with a field-named message on
+    any violation. The value bytes themselves are NEVER logged or
+    embedded in the message — only the field name and the structural
+    reason — because every field in this document is credential-class.
+    """
+    if not isinstance(value, str):
+        raise HafasProfileValidationError(
+            f"HAFAS profile field {field!r} must be a string, got "
+            f"{type(value).__name__}"
+        )
+    length = len(value)
+    if length < min_len:
+        raise HafasProfileValidationError(
+            f"HAFAS profile field {field!r} too short "
+            f"(len={length}, min={min_len})"
+        )
+    if length > max_len:
+        raise HafasProfileValidationError(
+            f"HAFAS profile field {field!r} too long "
+            f"(len={length}, max={max_len})"
+        )
+    return value
+
+
+def _validate_profile_document(profile: object) -> None:
+    """Structurally validate *profile* before it is committed to disk.
+
+    Checks:
+        * Top-level is a ``dict`` carrying the four mandatory keys
+          (``salt`` / ``ver`` / ``auth`` / ``client``).
+        * Every leaf value is a string within the per-field length bounds.
+        * ``ver`` matches the canonical ``MAJOR.MINOR[.PATCH]`` shape.
+        * ``auth.aid`` matches the alphanumeric+separator token shape
+          and meets the minimum length floor.
+        * ``salt`` is either empty (ÖBB's current state) OR matches the
+          alphanumeric+padding token shape with the minimum length floor.
+        * ``client`` carries the four request-envelope keys (``id`` /
+          ``type`` / ``name`` / ``l``) and every value is a non-empty
+          string.
+
+    Raises :class:`HafasProfileValidationError` with a field-named
+    message on any failure. Field values are never embedded in the
+    message; only the field NAME and the structural reason appear.
+    """
+    if not isinstance(profile, dict):
+        raise HafasProfileValidationError(
+            f"HAFAS profile must be a dict, got {type(profile).__name__}"
+        )
+    profile_dict = cast(dict[str, object], profile)
+
+    required_top = {"salt", "ver", "auth", "client"}
+    missing_top = required_top - profile_dict.keys()
+    if missing_top:
+        raise HafasProfileValidationError(
+            f"HAFAS profile missing top-level keys: {sorted(missing_top)}"
+        )
+
+    salt = _ensure_str(profile_dict["salt"], "salt", min_len=0, max_len=256)
+    if salt and not _SALT_VALIDATION_RE.fullmatch(salt):
+        raise HafasProfileValidationError(
+            "HAFAS profile field 'salt' has invalid format "
+            "(expected alphanumeric+padding token)"
+        )
+
+    ver = _ensure_str(
+        profile_dict["ver"], "ver", min_len=_PROFILE_MIN_VER_LEN, max_len=32
+    )
+    if not _VER_VALIDATION_RE.fullmatch(ver):
+        raise HafasProfileValidationError(
+            "HAFAS profile field 'ver' has invalid format "
+            "(expected MAJOR.MINOR[.PATCH])"
+        )
+
+    auth = profile_dict["auth"]
+    if not isinstance(auth, dict):
+        raise HafasProfileValidationError(
+            f"HAFAS profile field 'auth' must be a dict, got "
+            f"{type(auth).__name__}"
+        )
+    auth_dict = cast(dict[str, object], auth)
+    for auth_key in ("type", "aid"):
+        if auth_key not in auth_dict:
+            raise HafasProfileValidationError(
+                f"HAFAS profile field 'auth' missing required key "
+                f"{auth_key!r}"
+            )
+    _ensure_str(auth_dict["type"], "auth.type", min_len=1, max_len=32)
+    aid = _ensure_str(
+        auth_dict["aid"], "auth.aid", min_len=_PROFILE_MIN_AID_LEN, max_len=128
+    )
+    if not _AID_VALIDATION_RE.fullmatch(aid):
+        raise HafasProfileValidationError(
+            "HAFAS profile field 'auth.aid' has invalid format "
+            "(expected alphanumeric+separator token)"
+        )
+
+    client = profile_dict["client"]
+    if not isinstance(client, dict):
+        raise HafasProfileValidationError(
+            f"HAFAS profile field 'client' must be a dict, got "
+            f"{type(client).__name__}"
+        )
+    client_dict = cast(dict[str, object], client)
+    for client_key in ("id", "type", "name", "l"):
+        if client_key not in client_dict:
+            raise HafasProfileValidationError(
+                f"HAFAS profile field 'client' missing required key "
+                f"{client_key!r}"
+            )
+        _ensure_str(
+            client_dict[client_key], f"client.{client_key}", min_len=1
+        )
+
+
 def _write_profile(profile: dict[str, object], output_path: Path) -> None:
     """Persist the profile atomically with 0600 permissions.
 
@@ -357,6 +540,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
 
     profile = _build_profile_document(extracted)
+    try:
+        _validate_profile_document(profile)
+    except HafasProfileValidationError as exc:
+        # Sanitised: ``str(exc)`` contains the field NAME and the
+        # structural reason but never the field VALUE (the validator
+        # never embeds values in its messages). Routing through
+        # ``sanitize_log_arg`` keeps a hostile upstream's payload from
+        # injecting newline / ANSI / Trojan-Source primitives into the
+        # cron log line.
+        LOGGER.error(
+            "HAFAS profile failed structural validation: %s",
+            sanitize_log_arg(str(exc)),
+        )
+        return 1
     try:
         _write_profile(profile, args.output)
     except OSError as exc:

--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -19,6 +19,7 @@ import logging
 import re
 import sys
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from importlib import import_module
 from pathlib import Path
 from typing import Any, cast
@@ -132,6 +133,15 @@ USER_AGENT = (
     "(https://github.com/Origamihase/wien-oepnv)"
 )
 
+# Bandwidth-saver: each WL OGD CSV download stores ``ETag`` and
+# ``Last-Modified`` in a sibling ``<csv>.cache.json`` so the next run
+# can send ``If-None-Match`` / ``If-Modified-Since`` and short-circuit
+# on ``304 Not Modified``. The sidecar is tiny (<1 KiB) so the cap is
+# generous; oversized files are silently treated as missing (which
+# falls back to an unconditional GET, the safe direction).
+MAX_OGD_CACHE_SIDECAR_BYTES = 64 * 1024
+_OGD_CACHE_SIDECAR_SUFFIX = ".cache.json"
+
 log = logging.getLogger("update_wl_stations")
 
 
@@ -183,31 +193,163 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _cache_sidecar_path(target: Path) -> Path:
+    """Return the sidecar path that stores ``ETag`` / ``Last-Modified``.
+
+    Convention: ``<target>.cache.json`` next to the CSV. The sidecar
+    therefore moves/disappears with the file it describes — there is no
+    risk of a stale sidecar describing a target that no longer exists.
+    """
+    return target.with_name(target.name + _OGD_CACHE_SIDECAR_SUFFIX)
+
+
+def _read_cache_validators(target: Path) -> dict[str, str]:
+    """Return ``If-None-Match`` / ``If-Modified-Since`` headers for *target*.
+
+    Returns an empty dict when either the target CSV or its sidecar is
+    missing, when the sidecar is corrupted/oversized, or when neither
+    validator was captured by the previous fetch. The caller falls back
+    to an unconditional GET in those cases — the safe direction.
+    """
+    sidecar = _cache_sidecar_path(target)
+    if not target.exists() or not sidecar.exists():
+        return {}
+    payload = read_capped_json(
+        sidecar,
+        MAX_OGD_CACHE_SIDECAR_BYTES,
+        label="WL OGD cache sidecar",
+        logger=log,
+    )
+    if not isinstance(payload, dict):
+        return {}
+    validators: dict[str, str] = {}
+    etag = payload.get("etag")
+    if isinstance(etag, str) and etag:
+        validators["If-None-Match"] = etag
+    last_modified = payload.get("last_modified")
+    if isinstance(last_modified, str) and last_modified:
+        validators["If-Modified-Since"] = last_modified
+    return validators
+
+
+def _write_cache_validators(target: Path, headers: Mapping[str, str]) -> None:
+    """Persist ``ETag`` / ``Last-Modified`` from *headers* into the sidecar.
+
+    Best-effort: a write failure is logged but never raised so a
+    successful CSV download is not cancelled by a sidecar I/O glitch.
+    When the upstream returned neither validator we skip writing entirely
+    — a sidecar without validators would force a full-body re-download
+    on the next run anyway, so the empty file would be useless.
+    """
+    etag = headers.get("ETag") or headers.get("etag")
+    last_modified = headers.get("Last-Modified") or headers.get("last-modified")
+    if not etag and not last_modified:
+        return
+    payload = {
+        "version": 1,
+        "etag": etag or "",
+        "last_modified": last_modified or "",
+        "fetched_at": datetime.now(UTC).isoformat(timespec="seconds"),
+    }
+    sidecar = _cache_sidecar_path(target)
+    try:
+        sidecar.parent.mkdir(parents=True, exist_ok=True)
+        with atomic_write(
+            sidecar, mode="w", encoding="utf-8", permissions=0o644
+        ) as handle:
+            json.dump(
+                payload,
+                handle,
+                ensure_ascii=True,
+                sort_keys=True,
+                indent=2,
+                allow_nan=False,
+            )
+            handle.write("\n")
+    except OSError as exc:
+        log.warning(
+            "Failed to write WL OGD cache sidecar [path-sha256=%s] (%s)",
+            _path_fingerprint(sidecar),
+            exc,
+        )
+
+
 def _download_ogd_csv(url: str, target: Path) -> bool:
     """Download a Wiener Linien OGD CSV and write it to *target* atomically.
 
-    Returns ``True`` on success, ``False`` on any error. Errors are logged
-    but not raised, so callers can fall back to existing local files.
+    Uses HTTP conditional requests (``If-None-Match`` / ``If-Modified-Since``)
+    when a previous fetch persisted validators in the sidecar — a ``304
+    Not Modified`` response keeps the existing local file untouched and
+    returns ``True`` (the file is up to date, which is a success state).
+    A fresh ``200`` response writes the body atomically and refreshes the
+    sidecar with the new validators.
+
+    Returns ``True`` on success (200 written or 304 skipped),
+    ``False`` on any error. Errors are logged but not raised, so callers
+    can fall back to existing local files.
     """
     base_dir = _project_root()
     if str(base_dir) not in sys.path:  # pragma: no cover - defensive
         sys.path.insert(0, str(base_dir))
     try:
-        from src.utils.http import fetch_content_safe, session_with_retries
+        from src.utils.http import request_safe, session_with_retries
     except ImportError:  # pragma: no cover - defensive
         log.warning("HTTP utilities unavailable; cannot download %s", url)
         return False
 
-    log.info("Downloading WL OGD: %s", url)
+    validators = _read_cache_validators(target)
+    headers: dict[str, str] = {"User-Agent": USER_AGENT, **validators}
+    if validators:
+        log.info(
+            "Downloading WL OGD (conditional, validators=%s): %s",
+            ",".join(sorted(validators)),
+            url,
+        )
+    else:
+        log.info("Downloading WL OGD: %s", url)
+
     try:
         with session_with_retries(USER_AGENT) as session:
-            content = fetch_content_safe(
-                session, url, timeout=OGD_DOWNLOAD_TIMEOUT_SECONDS
+            response = request_safe(
+                session,
+                url,
+                method="GET",
+                timeout=OGD_DOWNLOAD_TIMEOUT_SECONDS,
+                headers=headers,
+                raise_for_status=True,
             )
     except Exception as exc:  # pragma: no cover - network-dependent
         log.warning("Failed to download %s (%s); using local file if present", url, exc)
         return False
 
+    if response.status_code == 304:
+        if not target.exists():
+            # Defensive: the server claims our copy is current but we
+            # don't have one. This would only happen if the sidecar and
+            # the CSV were independently moved/deleted between runs. Drop
+            # the stale sidecar so the next invocation does a full GET.
+            log.warning(
+                "WL OGD returned 304 but local target [path-sha256=%s] is "
+                "missing; clearing stale sidecar",
+                _path_fingerprint(target),
+            )
+            sidecar = _cache_sidecar_path(target)
+            try:
+                sidecar.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as exc:
+                log.warning(
+                    "Failed to clear stale WL OGD cache sidecar (%s)", exc
+                )
+            return False
+        log.info(
+            "WL OGD not modified (304); keeping existing [path-sha256=%s]",
+            _path_fingerprint(target),
+        )
+        return True
+
+    content = cast(bytes, response.content)
     if not content:
         log.warning("Empty response from %s; using local file if present", url)
         return False
@@ -220,6 +362,7 @@ def _download_ogd_csv(url: str, target: Path) -> bool:
         _path_fingerprint(target),
         len(content),
     )
+    _write_cache_validators(target, response.headers)
     return True
 
 

--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -337,7 +337,10 @@ def _download_ogd_csv(url: str, target: Path) -> bool:
             try:
                 sidecar.unlink()
             except FileNotFoundError:
-                pass
+                log.debug(
+                    "Stale WL OGD cache sidecar already absent [path-sha256=%s]",
+                    _path_fingerprint(sidecar),
+                )
             except OSError as exc:
                 log.warning(
                     "Failed to clear stale WL OGD cache sidecar (%s)", exc

--- a/src/utils/circuit_breaker.py
+++ b/src/utils/circuit_breaker.py
@@ -41,9 +41,10 @@ from __future__ import annotations
 import logging
 import threading
 import time
+import weakref
 from collections.abc import Callable
 from enum import Enum
-from typing import Any, TypeVar
+from typing import Any, ClassVar, TypeVar
 
 log = logging.getLogger(__name__)
 
@@ -155,7 +156,24 @@ class CircuitBreaker:
         - ``.jules/saboteur.md`` for the design-rationale entry that
           motivated this primitive over the three pre-existing
           ad-hoc resilience implementations.
+
+    Registry:
+        Every instance is auto-registered into :attr:`_instances`, a
+        process-wide :class:`weakref.WeakSet`. :meth:`iter_instances`
+        returns a stable snapshot; test fixtures use it to reset every
+        live breaker between tests without maintaining a hand-edited
+        list. Strong references stay with the owning module (``_BREAKER
+        = CircuitBreaker(...)``), so module-level singletons survive
+        for the process lifetime while ephemeral breakers created
+        inside tests are garbage-collected as soon as the test exits.
     """
+
+    # Process-wide registry of live breakers. Weakly referenced so that
+    # ephemeral breakers (e.g. created inside a test function) are
+    # garbage-collected without leaking — module-level singletons keep
+    # themselves alive via the importing module's own reference.
+    _instances: ClassVar[weakref.WeakSet[CircuitBreaker]] = weakref.WeakSet()
+    _registry_lock: ClassVar[threading.Lock] = threading.Lock()
 
     def __init__(
         self,
@@ -178,6 +196,24 @@ class CircuitBreaker:
         self._consecutive_failures = 0
         self._opened_at: float | None = None
         self._lock = threading.RLock()
+
+        # Register AFTER the instance is fully constructed so a partial
+        # state cannot leak into a concurrent ``iter_instances`` snapshot.
+        with CircuitBreaker._registry_lock:
+            CircuitBreaker._instances.add(self)
+
+    @classmethod
+    def iter_instances(cls) -> list[CircuitBreaker]:
+        """Return a snapshot list of every live :class:`CircuitBreaker`.
+
+        Snapshots are returned (instead of an iterator over the live
+        :class:`~weakref.WeakSet`) so callers can safely reset, inspect
+        or count without tripping on concurrent garbage collection.
+        Useful for test fixtures that need to reset every project-owned
+        breaker without hard-coding a per-module import list.
+        """
+        with cls._registry_lock:
+            return list(cls._instances)
 
     @property
     def state(self) -> CircuitState:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,44 +273,66 @@ def isolate_stats_writes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Ite
 # fails any later test that exercises the same call site with a
 # ``CircuitBreakerOpen`` masquerading as the upstream's real failure.
 #
-# The autouse fixture below resets every project-owned CircuitBreaker
-# back to CLOSED + zero failures before each test runs. Adding a new
-# breaker is a single ``_iter_known_breakers`` line — no test boilerplate
-# required.
+# The autouse fixture below resets every CircuitBreaker registered in
+# :attr:`CircuitBreaker._instances` back to CLOSED + zero failures
+# before each test runs. Adding a new breaker is now zero boilerplate:
+# the :class:`CircuitBreaker` ``__init__`` auto-registers every
+# instance into the process-wide :class:`weakref.WeakSet` so newly
+# instantiated breakers (HAFAS, Stammstrecke, future providers) are
+# picked up automatically without touching this fixture.
 # ---------------------------------------------------------------------------
 
 
-def _iter_known_breakers() -> Iterator[object]:
-    """Yield every module-level CircuitBreaker the project owns.
+def _eagerly_import_breaker_modules() -> None:
+    """Import every module known to own a :class:`CircuitBreaker` singleton.
 
-    Imports are inside the function so a partial test environment (e.g.
-    a places-free worktree) never aborts collection. Each entry is
-    yielded as ``object`` because the actual type is an implementation
-    detail of the producing module.
+    The registry is populated lazily by ``CircuitBreaker.__init__``, so a
+    breaker only appears in :meth:`iter_instances` after its owning
+    module is imported. Tests that exercise (e.g.) HAFAS but happen to
+    run before the first test that imports the OSM client would
+    otherwise see a partial registry. Eager-importing the known
+    breaker-owning modules here ties registration to session start, not
+    to first use, so the autouse reset fixture covers every project
+    breaker on the very first test.
+
+    Imports are wrapped individually so a partial test environment
+    (e.g. a places-free worktree) does not abort collection.
     """
-    from src.places import osm_client as _osm_module
+    import importlib
 
-    yield _osm_module._BREAKER
+    for module_name in (
+        "src.places.osm_client",
+        "src.places.hafas_client",
+    ):
+        try:
+            importlib.import_module(module_name)
+        except ImportError:  # pragma: no cover - tolerated by design
+            pass
+
+
+_eagerly_import_breaker_modules()
 
 
 @pytest.fixture(autouse=True)
 def reset_circuit_breakers() -> Iterator[None]:
     """Force every known CircuitBreaker back to CLOSED before each test.
 
-    Without this guard, a test that opens the breaker (intentionally or
-    by side-effect of a chaos run) would silently fail every later test
-    that touches the same call site, masking real upstream regressions
-    and creating order-dependent test failures.
+    Iterates :meth:`CircuitBreaker.iter_instances` (the process-wide
+    weak registry populated by ``CircuitBreaker.__init__``) so newly
+    added breakers are picked up automatically — no per-module
+    bookkeeping required. Without this guard, a test that opens the
+    breaker (intentionally or by side-effect of a chaos run) would
+    silently fail every later test that touches the same call site,
+    masking real upstream regressions and creating order-dependent
+    test failures.
     """
-    for breaker in _iter_known_breakers():
-        reset = getattr(breaker, "reset", None)
-        if callable(reset):
-            reset()
+    from src.utils.circuit_breaker import CircuitBreaker
+
+    for breaker in CircuitBreaker.iter_instances():
+        breaker.reset()
     yield
-    for breaker in _iter_known_breakers():
-        reset = getattr(breaker, "reset", None)
-        if callable(reset):
-            reset()
+    for breaker in CircuitBreaker.iter_instances():
+        breaker.reset()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_sync_hafas_profile.py
+++ b/tests/scripts/test_sync_hafas_profile.py
@@ -1,0 +1,268 @@
+"""Tests for :mod:`scripts.sync_hafas_profile`.
+
+The script is the writer-side guard against upstream HAFAS profile
+drift. These tests pin two contracts:
+
+1. ``_validate_profile_document`` rejects every structurally-invalid
+   profile shape the regex extractor could conceivably produce against
+   a future upstream refactor (renamed key, embedded placeholder string,
+   accidentally-matched unrelated literal).
+2. ``main`` short-circuits with exit code 1 BEFORE
+   :func:`_write_profile` touches the disk when validation fails — so
+   a corrupt profile never reaches the on-disk cache.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from scripts import sync_hafas_profile as script
+
+
+def _valid_extracted() -> dict[str, str]:
+    """Return the minimal extracted-profile dict that builds a valid document.
+
+    Values mirror the current ÖBB upstream observed in
+    ``data/hafas_profile.json`` so the success path runs through the
+    same validator gates the cron job would hit.
+    """
+    return {"ver": "1.45", "aid": "OWDL4fE4ixNiPBBm"}
+
+
+def _valid_profile() -> dict[str, Any]:
+    """Return the assembled profile that mirrors ``data/hafas_profile.json``."""
+    return script._build_profile_document(_valid_extracted())
+
+
+# ---------------------------------------------------------------------------
+# Validator — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_validate_accepts_canonical_profile() -> None:
+    """The current ÖBB upstream profile shape must pass validation
+    unchanged. Regression-pins that the validator's allow-list is wide
+    enough to not break the actual production payload."""
+    script._validate_profile_document(_valid_profile())
+
+
+def test_validate_accepts_profile_with_salt() -> None:
+    """When upstream restores HMAC signing, the ``salt`` field will be
+    a non-empty alphanumeric token. The validator must accept it."""
+    profile = _valid_profile()
+    profile["salt"] = "abcdef0123456789"
+    script._validate_profile_document(profile)
+
+
+def test_validate_accepts_versioned_patch_release() -> None:
+    """Future HAFAS releases may bump from ``1.45`` to ``1.46.LIVE``."""
+    profile = _valid_profile()
+    profile["ver"] = "1.46.LIVE"
+    script._validate_profile_document(profile)
+
+
+# ---------------------------------------------------------------------------
+# Validator — structural failures
+# ---------------------------------------------------------------------------
+
+
+def test_validate_rejects_non_dict_profile() -> None:
+    with pytest.raises(script.HafasProfileValidationError, match="must be a dict"):
+        script._validate_profile_document(["not", "a", "dict"])
+
+
+def test_validate_rejects_missing_top_level_key() -> None:
+    profile = _valid_profile()
+    profile.pop("ver")
+    with pytest.raises(
+        script.HafasProfileValidationError, match="missing top-level keys"
+    ):
+        script._validate_profile_document(profile)
+
+
+def test_validate_rejects_non_string_salt() -> None:
+    profile = _valid_profile()
+    profile["salt"] = 12345
+    with pytest.raises(
+        script.HafasProfileValidationError, match="'salt' must be a string"
+    ):
+        script._validate_profile_document(profile)
+
+
+def test_validate_rejects_oversized_field() -> None:
+    profile = _valid_profile()
+    profile["salt"] = "A" * (script._PROFILE_MAX_FIELD_LEN + 1)
+    with pytest.raises(
+        script.HafasProfileValidationError, match="'salt' too long"
+    ):
+        script._validate_profile_document(profile)
+
+
+def test_validate_rejects_short_ver() -> None:
+    profile = _valid_profile()
+    profile["ver"] = "x"
+    with pytest.raises(
+        script.HafasProfileValidationError, match="'ver' too short"
+    ):
+        script._validate_profile_document(profile)
+
+
+def test_validate_rejects_malformed_ver() -> None:
+    """``ver`` must match ``MAJOR.MINOR[.PATCH]`` — a freeform string
+    extracted from an upstream comment would otherwise corrupt the
+    HAFAS request envelope."""
+    profile = _valid_profile()
+    profile["ver"] = "TODO"
+    with pytest.raises(
+        script.HafasProfileValidationError, match="'ver' has invalid format"
+    ):
+        script._validate_profile_document(profile)
+
+
+def test_validate_rejects_non_dict_auth() -> None:
+    profile = _valid_profile()
+    profile["auth"] = "AID"
+    with pytest.raises(
+        script.HafasProfileValidationError, match="'auth' must be a dict"
+    ):
+        script._validate_profile_document(profile)
+
+
+def test_validate_rejects_missing_auth_aid() -> None:
+    profile = _valid_profile()
+    profile["auth"] = {"type": "AID"}
+    with pytest.raises(
+        script.HafasProfileValidationError,
+        match="'auth' missing required key 'aid'",
+    ):
+        script._validate_profile_document(profile)
+
+
+def test_validate_rejects_short_auth_aid() -> None:
+    profile = _valid_profile()
+    profile["auth"] = {"type": "AID", "aid": "short"}
+    with pytest.raises(
+        script.HafasProfileValidationError, match="'auth.aid' too short"
+    ):
+        script._validate_profile_document(profile)
+
+
+def test_validate_rejects_aid_with_whitespace() -> None:
+    """A regex-extracted ``aid`` containing whitespace points at a
+    drifted upstream — the canonical token is solid alphanumeric."""
+    profile = _valid_profile()
+    profile["auth"] = {"type": "AID", "aid": "OWDL4fE4 ixNiPBBm"}
+    with pytest.raises(
+        script.HafasProfileValidationError,
+        match="'auth.aid' has invalid format",
+    ):
+        script._validate_profile_document(profile)
+
+
+def test_validate_rejects_non_dict_client() -> None:
+    profile = _valid_profile()
+    profile["client"] = "webapp"
+    with pytest.raises(
+        script.HafasProfileValidationError, match="'client' must be a dict"
+    ):
+        script._validate_profile_document(profile)
+
+
+def test_validate_rejects_missing_client_key() -> None:
+    profile = _valid_profile()
+    profile["client"] = {"id": "OEBB", "type": "WEB", "name": "webapp"}
+    with pytest.raises(
+        script.HafasProfileValidationError,
+        match="'client' missing required key 'l'",
+    ):
+        script._validate_profile_document(profile)
+
+
+def test_validate_rejects_empty_client_value() -> None:
+    profile = _valid_profile()
+    profile["client"] = {"id": "OEBB", "type": "WEB", "name": "", "l": "vs_webapp"}
+    with pytest.raises(
+        script.HafasProfileValidationError, match="'client.name' too short"
+    ):
+        script._validate_profile_document(profile)
+
+
+def test_validate_rejects_short_non_empty_salt() -> None:
+    """A non-empty salt that's only a couple of bytes long is almost
+    certainly an extraction artefact (e.g. matched the wrong literal).
+    The validator's minimum-length floor catches it."""
+    profile = _valid_profile()
+    profile["salt"] = "abc"
+    with pytest.raises(
+        script.HafasProfileValidationError, match="'salt' has invalid format"
+    ):
+        script._validate_profile_document(profile)
+
+
+# ---------------------------------------------------------------------------
+# main() integration — corrupt profile never touches disk
+# ---------------------------------------------------------------------------
+
+
+def test_main_returns_1_on_validation_failure_without_writing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The crucial cron-pipeline contract: when the upstream extractor
+    returns a syntactically valid but semantically broken triple, ``main``
+    must exit with code 1 BEFORE :func:`_write_profile` touches the
+    on-disk JSON. Otherwise the next cron tick caches the corrupt
+    profile, every HAFAS enrichment fails, and the fallthrough drains
+    the Google Places quota."""
+    output = tmp_path / "hafas_profile.json"
+
+    # ``ver="TODO"`` passes the extractor's loose regex but is rejected by
+    # ``_validate_profile_document`` — the validator gate fires before
+    # the writer is called.
+    with patch.object(
+        script, "_fetch_combined_source", return_value="<js source>"
+    ), patch.object(
+        script, "_extract_profile", return_value={"ver": "TODO", "aid": "shortaid"}
+    ):
+        caplog.set_level(logging.ERROR, logger=script.LOGGER.name)
+        exit_code = script.main(["--output", str(output)])
+
+    assert exit_code == 1
+    assert not output.exists(), (
+        "The writer must not run when validation rejects the profile; "
+        "an unbuffered partial write would still cache a broken profile."
+    )
+    assert any(
+        "structural validation" in record.getMessage()
+        for record in caplog.records
+    ), "Operators need a clear log line naming the validation failure."
+
+
+def test_main_succeeds_when_extracted_triple_is_canonical(
+    tmp_path: Path,
+) -> None:
+    """End-to-end smoke for the happy path: a canonical extracted triple
+    rounds through validation and reaches :func:`_write_profile`."""
+    output = tmp_path / "hafas_profile.json"
+
+    with patch.object(
+        script, "_fetch_combined_source", return_value="<js source>"
+    ), patch.object(script, "_extract_profile", return_value=_valid_extracted()):
+        exit_code = script.main(["--output", str(output)])
+
+    assert exit_code == 0
+    assert output.exists()
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["ver"] == "1.45"
+    assert payload["auth"] == {"type": "AID", "aid": "OWDL4fE4ixNiPBBm"}
+    assert payload["client"] == {
+        "id": "OEBB",
+        "type": "WEB",
+        "name": "webapp",
+        "l": "vs_webapp",
+    }

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -7,6 +7,7 @@ Each test maps to one chaos scenario in ``.jules/saboteur.md``.
 from __future__ import annotations
 
 import threading
+import weakref
 from collections.abc import Iterator
 from typing import Any
 
@@ -393,3 +394,62 @@ def test_chaos_flapping_upstream_doesnt_cause_breaker_thrashing() -> None:
     # Counter never accumulated above 2 because each success cleared it
     assert_state(breaker, CircuitState.CLOSED)
     assert breaker.consecutive_failures == 0
+
+
+# ---------- Registry ----------
+
+
+def test_new_breaker_is_auto_registered() -> None:
+    """Every fresh CircuitBreaker must show up in ``iter_instances``
+    immediately — the autouse ``reset_circuit_breakers`` fixture in
+    ``conftest.py`` relies on this to find newly-added module breakers
+    without explicit per-module bookkeeping."""
+    breaker = CircuitBreaker("registry-probe")
+    snapshot = CircuitBreaker.iter_instances()
+    assert breaker in snapshot, (
+        "Newly-constructed breakers must be auto-registered into "
+        "CircuitBreaker._instances so the test fixture covers them."
+    )
+
+
+def test_iter_instances_returns_snapshot_list() -> None:
+    """``iter_instances`` must return a list snapshot (not the live
+    ``WeakSet``) so callers can safely mutate / iterate without
+    tripping on concurrent garbage collection."""
+    snapshot = CircuitBreaker.iter_instances()
+    assert isinstance(snapshot, list)
+
+
+def test_garbage_collected_breaker_drops_from_registry() -> None:
+    """Ephemeral breakers (created inside a test, no module-level
+    reference) must be evictable from the registry. The ``WeakSet``
+    backs this: once the local reference is gone and GC runs, the
+    registry entry vanishes — preventing memory leakage across long
+    test sessions."""
+    import gc
+
+    breaker = CircuitBreaker("ephemeral-gc-probe")
+    ref = weakref.ref(breaker)
+    assert ref() is not None
+    del breaker
+    gc.collect()
+    # If a strong reference accidentally survived (e.g. a stray module
+    # global), this would still hold the breaker alive. The fact that
+    # WeakSet drops the entry is what we're protecting.
+    assert ref() is None, (
+        "Ephemeral breaker should be GC-eligible — strong refs from "
+        "the registry would defeat the WeakSet contract."
+    )
+
+
+def test_registered_breakers_include_module_singletons() -> None:
+    """The OSM and HAFAS module-level breakers must be reachable via
+    ``iter_instances`` once their owning modules have been imported.
+    Regression-pins the test-isolation guarantee that newly added
+    project breakers are reset automatically."""
+    from src.places import hafas_client as _hafas
+    from src.places import osm_client as _osm
+
+    snapshot = CircuitBreaker.iter_instances()
+    assert _osm._BREAKER in snapshot
+    assert _hafas._BREAKER in snapshot

--- a/tests/test_update_wl_stations_merge.py
+++ b/tests/test_update_wl_stations_merge.py
@@ -12,16 +12,37 @@ import pytest
 from scripts import update_wl_stations
 
 
-def test_download_ogd_csv_returns_false_on_network_failure(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """When the WL OGD endpoint is unreachable the helper degrades gracefully.
+class _DummyResponse:
+    """Minimal stand-in for :class:`requests.Response` used by the helper.
 
-    Sandboxed environments may not have network access; the download must
-    return ``False`` (without raising) so that the existing local CSV
-    files keep the pipeline functional.
+    Only exposes the surface ``_download_ogd_csv`` actually reads:
+    ``status_code``, ``content`` and ``headers``. Headers default to an
+    empty dict so tests that don't care about validators stay terse.
     """
-    target = tmp_path / "wienerlinien-ogd-haltestellen.csv"
+
+    def __init__(
+        self,
+        status_code: int = 200,
+        content: bytes = b"",
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.content = content
+        self.headers = dict(headers or {})
+
+
+def _install_fake_http(
+    monkeypatch: pytest.MonkeyPatch,
+    request_callable: object,
+) -> list[dict[str, object]]:
+    """Patch ``session_with_retries`` and ``request_safe`` to deterministic doubles.
+
+    Returns a mutable list that captures one entry per ``request_safe``
+    invocation, recording the URL and the request kwargs. Tests inspect
+    this to assert that conditional headers were (or weren't) sent.
+    """
+
+    captured: list[dict[str, object]] = []
 
     def fake_session_with_retries(_user_agent):  # type: ignore[no-untyped-def]
         class _DummySession:
@@ -33,12 +54,33 @@ def test_download_ogd_csv_returns_false_on_network_failure(
 
         return _DummySession()
 
-    def fake_fetch(_session, _url, *, timeout):  # type: ignore[no-untyped-def]
-        raise OSError("simulated network failure")
+    def fake_request_safe(_session, url, **kwargs):  # type: ignore[no-untyped-def]
+        captured.append({"url": url, "kwargs": kwargs})
+        if callable(request_callable):
+            return request_callable(url, kwargs)
+        return request_callable
 
     import src.utils.http as http_utils
     monkeypatch.setattr(http_utils, "session_with_retries", fake_session_with_retries)
-    monkeypatch.setattr(http_utils, "fetch_content_safe", fake_fetch)
+    monkeypatch.setattr(http_utils, "request_safe", fake_request_safe)
+    return captured
+
+
+def test_download_ogd_csv_returns_false_on_network_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the WL OGD endpoint is unreachable the helper degrades gracefully.
+
+    Sandboxed environments may not have network access; the download must
+    return ``False`` (without raising) so that the existing local CSV
+    files keep the pipeline functional.
+    """
+    target = tmp_path / "wienerlinien-ogd-haltestellen.csv"
+
+    def boom(_url, _kwargs):  # type: ignore[no-untyped-def]
+        raise OSError("simulated network failure")
+
+    _install_fake_http(monkeypatch, boom)
 
     ok = update_wl_stations._download_ogd_csv(
         "https://example.invalid/wl.csv", target
@@ -53,28 +95,165 @@ def test_download_ogd_csv_writes_target_on_success(
     target = tmp_path / "wienerlinien-ogd-haltestellen.csv"
     payload = b'"HALTESTELLEN_ID";"NAME";"DIVA"\n"1001";"Karlsplatz";"60201076"\n'
 
-    def fake_session_with_retries(_user_agent):  # type: ignore[no-untyped-def]
-        class _DummySession:
-            def __enter__(self):  # type: ignore[no-untyped-def]
-                return self
-
-            def __exit__(self, *_args):  # type: ignore[no-untyped-def]
-                return False
-
-        return _DummySession()
-
-    def fake_fetch(_session, _url, *, timeout):  # type: ignore[no-untyped-def]
-        return payload
-
-    import src.utils.http as http_utils
-    monkeypatch.setattr(http_utils, "session_with_retries", fake_session_with_retries)
-    monkeypatch.setattr(http_utils, "fetch_content_safe", fake_fetch)
+    response = _DummyResponse(
+        status_code=200,
+        content=payload,
+        headers={"ETag": '"abc123"', "Last-Modified": "Wed, 01 Jan 2025 00:00:00 GMT"},
+    )
+    captured = _install_fake_http(monkeypatch, response)
 
     ok = update_wl_stations._download_ogd_csv(
         "https://example.test/wl.csv", target
     )
     assert ok is True
     assert target.read_bytes() == payload
+    # First call: no validators on disk, so no conditional headers
+    kwargs = cast(dict[str, object], captured[0]["kwargs"])
+    first_headers = cast(dict[str, str], kwargs["headers"])
+    assert "If-None-Match" not in first_headers
+    assert "If-Modified-Since" not in first_headers
+    # Sidecar is created with the returned validators
+    sidecar = update_wl_stations._cache_sidecar_path(target)
+    assert sidecar.exists()
+    sidecar_payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert sidecar_payload["etag"] == '"abc123"'
+    assert sidecar_payload["last_modified"] == "Wed, 01 Jan 2025 00:00:00 GMT"
+
+
+def test_download_ogd_csv_sends_conditional_headers_when_sidecar_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second invocation must send ``If-None-Match`` / ``If-Modified-Since``
+    derived from the sidecar persisted by the previous run."""
+    target = tmp_path / "wienerlinien-ogd-haltestellen.csv"
+    target.write_bytes(b'"HALTESTELLEN_ID";"NAME"\n')
+    sidecar = update_wl_stations._cache_sidecar_path(target)
+    sidecar.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "etag": '"abc123"',
+                "last_modified": "Wed, 01 Jan 2025 00:00:00 GMT",
+                "fetched_at": "2026-05-22T16:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    response = _DummyResponse(status_code=304)
+    captured = _install_fake_http(monkeypatch, response)
+
+    ok = update_wl_stations._download_ogd_csv(
+        "https://example.test/wl.csv", target
+    )
+
+    assert ok is True
+    kwargs = cast(dict[str, object], captured[0]["kwargs"])
+    headers = cast(dict[str, str], kwargs["headers"])
+    assert headers["If-None-Match"] == '"abc123"'
+    assert headers["If-Modified-Since"] == "Wed, 01 Jan 2025 00:00:00 GMT"
+    # 304 leaves the existing target untouched (bytes-identical)
+    assert target.read_bytes() == b'"HALTESTELLEN_ID";"NAME"\n'
+    # Sidecar is preserved as-is on 304
+    sidecar_payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert sidecar_payload["etag"] == '"abc123"'
+
+
+def test_download_ogd_csv_304_with_missing_target_clears_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the sidecar lies about the local copy (file missing) the helper
+    must drop the stale sidecar and report failure so the next run does a
+    full GET."""
+    target = tmp_path / "wienerlinien-ogd-haltestellen.csv"
+    sidecar = update_wl_stations._cache_sidecar_path(target)
+    # Create a sidecar but NOT the target. Because the helper checks for
+    # target existence before considering the sidecar valid, no
+    # conditional headers are sent — but the server may still respond
+    # 304 (e.g. via an upstream cache). Simulate that hostile-shape edge
+    # case so the recovery path is exercised.
+    sidecar.write_text(
+        json.dumps({"version": 1, "etag": '"x"', "last_modified": ""}),
+        encoding="utf-8",
+    )
+
+    response = _DummyResponse(status_code=304)
+    _install_fake_http(monkeypatch, response)
+
+    ok = update_wl_stations._download_ogd_csv(
+        "https://example.test/wl.csv", target
+    )
+
+    assert ok is False
+    assert not target.exists()
+    assert not sidecar.exists(), "Stale sidecar must be cleared on 304-without-target"
+
+
+def test_download_ogd_csv_refreshes_sidecar_on_200(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 200 response with new validators must overwrite the existing sidecar."""
+    target = tmp_path / "wienerlinien-ogd-haltestellen.csv"
+    target.write_bytes(b"stale-payload\n")
+    sidecar = update_wl_stations._cache_sidecar_path(target)
+    sidecar.write_text(
+        json.dumps({"version": 1, "etag": '"old"', "last_modified": ""}),
+        encoding="utf-8",
+    )
+
+    fresh_payload = b'"DIVA";"PlatformText"\n"60201076";"Karlsplatz"\n'
+    response = _DummyResponse(
+        status_code=200,
+        content=fresh_payload,
+        headers={
+            "ETag": '"new-etag"',
+            "Last-Modified": "Thu, 02 Jan 2025 00:00:00 GMT",
+        },
+    )
+    _install_fake_http(monkeypatch, response)
+
+    ok = update_wl_stations._download_ogd_csv(
+        "https://example.test/wl.csv", target
+    )
+
+    assert ok is True
+    assert target.read_bytes() == fresh_payload
+    sidecar_payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert sidecar_payload["etag"] == '"new-etag"'
+    assert sidecar_payload["last_modified"] == "Thu, 02 Jan 2025 00:00:00 GMT"
+
+
+def test_download_ogd_csv_skips_sidecar_when_no_validators_returned(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 200 with neither ETag nor Last-Modified must NOT create an empty
+    sidecar (it would force a full GET next time anyway)."""
+    target = tmp_path / "wienerlinien-ogd-haltestellen.csv"
+
+    response = _DummyResponse(
+        status_code=200, content=b"row\n", headers={}
+    )
+    _install_fake_http(monkeypatch, response)
+
+    ok = update_wl_stations._download_ogd_csv(
+        "https://example.test/wl.csv", target
+    )
+    assert ok is True
+    assert target.read_bytes() == b"row\n"
+    assert not update_wl_stations._cache_sidecar_path(target).exists()
+
+
+def test_read_cache_validators_ignores_corrupt_sidecar(
+    tmp_path: Path,
+) -> None:
+    """A corrupted JSON sidecar must be treated as missing (return ``{}``)
+    so the next fetch falls back to an unconditional GET."""
+    target = tmp_path / "wienerlinien-ogd-haltestellen.csv"
+    target.write_bytes(b"")
+    sidecar = update_wl_stations._cache_sidecar_path(target)
+    sidecar.write_text("{not valid json", encoding="utf-8")
+
+    assert update_wl_stations._read_cache_validators(target) == {}
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

Three independent optimisations for network efficiency, test isolation, and pipeline resilience — one logical commit each.

- **`feat(wl): conditional GET for OGD CSV downloads`** — `scripts/update_wl_stations.py` now persists `ETag` / `Last-Modified` in a sidecar (`<csv>.cache.json`) so subsequent runs send `If-None-Match` / `If-Modified-Since` and short-circuit on `304 Not Modified` instead of re-streaming the full CSV. Defensive recovery for missing/corrupted sidecars; the helper falls back to an unconditional GET on any sidecar-side anomaly.

- **`refactor(tests): auto-register CircuitBreakers into a weak registry`** — `CircuitBreaker.__init__` now auto-registers every instance into a process-wide `weakref.WeakSet`; `tests/conftest.py` iterates the registry instead of a hand-edited list. New module-level breakers (HAFAS, Stammstrecke, future providers) are picked up automatically — no per-module test bookkeeping. A session-start eager-import step ensures the singletons land in the registry before the first test runs.

- **`feat(hafas): structural validation before writing the cached profile`** — `scripts/sync_hafas_profile.py` gates `_write_profile` behind `_validate_profile_document`, which asserts structure, per-field types, length bounds and format regexes for `ver` / `auth.aid` / `salt`. A drifted upstream now exits with code 1 BEFORE `data/hafas_profile.json` is touched — corrupt profiles never reach the cache, so the Google-Places quota stays unsmoked.

## Test plan

- [x] `pytest tests/` — 8121 passed, 2 skipped (+26 new tests across the three changes)
- [x] `mypy src` — clean (46 files, zero errors)
- [x] `ruff check` — clean (zero findings on every touched file)
- [x] New unit tests cover every rejection branch of the HAFAS validator, every conditional-GET state transition (200 / 304 / 304-with-missing-target / corrupted-sidecar / no-validators-returned) and the registry's snapshot / weak-eviction / singleton-discovery contract.

https://claude.ai/code/session_014yq33wxFj9k2ps8av135Rh

---
_Generated by [Claude Code](https://claude.ai/code/session_014yq33wxFj9k2ps8av135Rh)_