### PR TITLE
fix(merge): collapse common-prefix bodies instead of verbose '&' join

### DIFF
--- a/scripts/optimize_site_assets.py
+++ b/scripts/optimize_site_assets.py
@@ -318,7 +318,7 @@ def _run(cmd: list[str], *, tolerate: tuple[int, ...] = ()) -> None:
 def _needs_downscale(path: Path, target: tuple[int, int]) -> bool:
     """True if ``path`` is wider than ``target[0]`` (cheap natural-size check)."""
     with Image.open(path) as img:
-        return img.size[0] > target[0]
+        return bool(img.size[0] > target[0])
 
 
 def _optimise_train_png() -> None:

--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -278,6 +278,107 @@ def _natural_keys(text: str) -> list[str | int]:
     return [int(c) if c.isdigit() else c for c in re.split(r'(\d+)', text)]
 
 
+# Helper for collapsing two merged names that share a substantial common
+# word-aligned prefix. Without this collapse, the merge name-combining
+# logic concatenates with ``&`` and produces ugly walls of text when WL
+# ships near-identical Hinweis items that only differ by date or
+# location. Real cache examples (current snapshot):
+#
+#   * ``11A: Veranstaltung am 09.06.2026`` × 4 items with different
+#     dates merged into the 122-char title
+#     ``11A: Veranstaltung am 09.06.2026 & Veranstaltung am 03.06.2026
+#     & Veranstaltung am 11.06.2026 & Veranstaltung am 20.06.2026``
+#   * ``43: Benutzen Sie die Linie 43A - Dornbacher Straße 85`` +
+#     ``43: Benutzen Sie die Linie 43A - Alszeile 93`` merged into
+#     the 96-char title repeating ``Benutzen Sie die Linie 43A`` twice
+#
+# The collapse keeps the shared prefix once and joins the differing
+# suffixes with ``, ``. When ALL suffix parts are calendar dates
+# (``DD.MM.YYYY``), they get sorted chronologically so the user sees
+# events in time order rather than cache-insertion order.
+_DATE_PIECE_RE = re.compile(r"^(\d{1,2})\.(\d{1,2})\.(\d{4})$")
+
+
+def _date_sort_key(part: str) -> tuple[int, int, int] | None:
+    match = _DATE_PIECE_RE.match(part.strip())
+    if not match:
+        return None
+    day, month, year = match.groups()
+    return (int(year), int(month), int(day))
+
+
+def _collapse_common_prefix(
+    ex_name: str,
+    name: str,
+    *,
+    min_prefix: int = 10,
+    max_suffix: int = 60,
+) -> str | None:
+    """Combine two names by sharing a common word-aligned prefix.
+
+    Returns the collapsed name, or ``None`` to indicate the caller
+    should fall back to the existing ``ex_name & name`` join.
+
+    Constraints:
+
+    * Substantial overlap — at least ``min_prefix`` shared characters,
+      ending at a word boundary (space) so we never split mid-word.
+    * Short suffixes — each remainder must be ≤ ``max_suffix`` chars.
+      Joining two long sentences with a comma is harder to read than
+      the explicit ``&`` join the existing logic produces.
+    * No directional arrow — ÖBB chain routes carrying ``↔`` use that
+      character as a chain joiner (``A ↔ B ↔ C``), not a separator,
+      so collapsing them by common prefix would mangle the route.
+    """
+    if not ex_name or not name:
+        return None
+    if "↔" in ex_name or "↔" in name:
+        return None
+
+    n = min(len(ex_name), len(name))
+    common_len = 0
+    for i in range(n):
+        if ex_name[i] != name[i]:
+            break
+        common_len = i + 1
+    if common_len < min_prefix:
+        return None
+    # Backtrack to the last word boundary so the prefix never splits a
+    # word in half (e.g. ``Veranstaltun`` from ``Veranstaltungen`` vs
+    # ``Veranstaltung am``).
+    while common_len > 0 and not ex_name[common_len - 1].isspace():
+        common_len -= 1
+    if common_len < min_prefix:
+        return None
+
+    prefix = ex_name[:common_len]
+    ex_remainder = ex_name[common_len:].strip()
+    name_remainder = name[common_len:].strip()
+    if not ex_remainder or not name_remainder:
+        return None
+    if len(name_remainder) > max_suffix:
+        return None
+
+    # ``ex_remainder`` may already be a comma-separated list if a
+    # previous merge ran through this helper. Split, dedup, append the
+    # new suffix.
+    ex_parts = [p.strip() for p in ex_remainder.split(",") if p.strip()]
+    if name_remainder in ex_parts:
+        # The new suffix is already present (e.g. duplicate Hinweis
+        # republished by WL). Return the existing name unchanged.
+        return ex_name
+
+    all_parts = ex_parts + [name_remainder]
+    # If every part is a calendar date, sort chronologically so the
+    # user sees ``03.06.2026, 09.06.2026, 11.06.2026`` rather than
+    # the cache-insertion order ``09.06.2026, 03.06.2026, 11.06.2026``.
+    sort_keys = [_date_sort_key(p) for p in all_parts]
+    if all(k is not None for k in sort_keys):
+        all_parts = [p for _, p in sorted(zip(sort_keys, all_parts))]
+
+    return f"{prefix.rstrip()} " + ", ".join(all_parts)
+
+
 _TRAILING_DIRECTIONAL_RE = re.compile(r"\s*[<>]+\s*$")
 
 
@@ -511,7 +612,24 @@ def deduplicate_fuzzy(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
                             # Simple check:
                             parts = [p.strip() for p in ex_name.split("&")]
                             if name not in parts:
-                                new_name = f"{ex_name} & {name}"
+                                # Try a smarter collapse first — when
+                                # ``ex_name`` and ``name`` share a
+                                # substantial word-aligned prefix
+                                # (e.g. ``Veranstaltung am 09.06.2026``
+                                # + ``Veranstaltung am 03.06.2026``),
+                                # keep the prefix once and join the
+                                # differing suffixes with ``, ``
+                                # instead of ` & `. Falls through to
+                                # the legacy ``&``-join if the
+                                # collapse declines (short prefix,
+                                # long suffix, ÖBB ``↔`` chain).
+                                collapsed = _collapse_common_prefix(
+                                    ex_name, name
+                                )
+                                if collapsed is not None:
+                                    new_name = collapsed
+                                else:
+                                    new_name = f"{ex_name} & {name}"
 
                     # Reconstruct Title
                     # Sort lines naturally (alphanumeric)?

--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -395,6 +395,19 @@ def _trim_trailing_directional(text: str) -> str:
     return _TRAILING_DIRECTIONAL_RE.sub("", text).rstrip()
 
 
+def _join_merged_names(ex_name: str, name: str) -> str:
+    """Combine two non-identical bodies — prefer prefix collapse, else ``&``.
+
+    Extracted from :func:`deduplicate_fuzzy` to keep its McCabe count at
+    the baselined 21. Tries :func:`_collapse_common_prefix` first
+    (produces the user-friendly ``Veranstaltung am DATE1, DATE2`` form
+    when both bodies share a substantial word-aligned prefix), and
+    falls back to the legacy ``ex_name & name`` join when the collapse
+    declines (short overlap, long suffix, ÖBB ``↔`` chain).
+    """
+    return _collapse_common_prefix(ex_name, name) or f"{ex_name} & {name}"
+
+
 def _calculate_line_overlap(lines1: set[str], lines2: set[str]) -> float:
     if not lines1 or not lines2:
         return 0.0
@@ -623,13 +636,7 @@ def deduplicate_fuzzy(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
                                 # the legacy ``&``-join if the
                                 # collapse declines (short prefix,
                                 # long suffix, ÖBB ``↔`` chain).
-                                collapsed = _collapse_common_prefix(
-                                    ex_name, name
-                                )
-                                if collapsed is not None:
-                                    new_name = collapsed
-                                else:
-                                    new_name = f"{ex_name} & {name}"
+                                new_name = _join_merged_names(ex_name, name)
 
                     # Reconstruct Title
                     # Sort lines naturally (alphanumeric)?

--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -374,7 +374,7 @@ def _collapse_common_prefix(
     # the cache-insertion order ``09.06.2026, 03.06.2026, 11.06.2026``.
     sort_keys = [_date_sort_key(p) for p in all_parts]
     if all(k is not None for k in sort_keys):
-        all_parts = [p for _, p in sorted(zip(sort_keys, all_parts))]
+        all_parts = [p for _, p in sorted(zip(sort_keys, all_parts, strict=True))]
 
     return f"{prefix.rstrip()} " + ", ".join(all_parts)
 

--- a/tests/test_feed_merge.py
+++ b/tests/test_feed_merge.py
@@ -158,10 +158,19 @@ def test_fuzzy_merge_name_combining() -> None:
             "guid": "g2"
         }
     ]
-    # Tokens "Event", "Special" overlap.
+    # Tokens "Event", "Special" overlap. Round 36's
+    # ``_collapse_common_prefix`` keeps the shared
+    # ``Event Special `` prefix once and joins the differing
+    # suffixes with ``, ``. Pre-Round-36 the merge produced
+    # ``Event Special Run & Event Special Walk`` (legacy
+    # ``&``-join).
     merged = deduplicate_fuzzy(items)
     assert len(merged) == 1
-    assert "Event Special Run & Event Special Walk" in merged[0]["title"] or "Event Special Walk & Event Special Run" in merged[0]["title"]
+    title = merged[0]["title"]
+    assert (
+        "Event Special Run, Walk" in title
+        or "Event Special Walk, Run" in title
+    ), f"Unexpected merged title: {title!r}"
 
 def test_fuzzy_merge_recursive() -> None:
     # A merges with B, result merges with C?

--- a/tests/test_merge_common_prefix_collapse.py
+++ b/tests/test_merge_common_prefix_collapse.py
@@ -1,0 +1,244 @@
+"""Regression test for Bug 36A (verbose ``&``-joined merged titles).
+
+User audit feedback: the feed surfaced two visibly-broken titles
+created by ``deduplicate_fuzzy``'s legacy ``ex_name & name`` join::
+
+    11A: Veranstaltung am 09.06.2026 & Veranstaltung am 03.06.2026
+       & Veranstaltung am 11.06.2026 & Veranstaltung am 20.06.2026
+
+    43: Benutzen Sie die Linie 43A - Dornbacher Straße 85
+       & Benutzen Sie die Linie 43A - Alszeile 93
+
+Both are real WL Hinweis items republished by WL once per affected
+date/location. The legacy join repeated the entire body verbatim,
+producing 96–122-character walls of text.
+
+Fix
+===
+``src/feed/merge.py:_collapse_common_prefix`` detects substantial
+shared word-aligned prefixes between ``ex_name`` and ``name`` and
+keeps the prefix once while joining the differing suffixes with
+``, ``. When ALL suffixes are calendar dates (``DD.MM.YYYY``) they
+are sorted chronologically so the user sees events in time order
+rather than cache-insertion order.
+
+Guards
+------
+* ``min_prefix=10`` — short overlaps (``Sperre`` between two unrelated
+  bodies) don't trigger.
+* ``max_suffix=60`` — long sentence suffixes fall back to the
+  explicit ``&`` join (which is more readable for full sentences
+  than a stray comma).
+* ``↔`` skip — ÖBB chain routes (``A ↔ B ↔ C``) use ``↔`` as a
+  chain joiner, not a separator, so the collapse must not touch
+  them.
+"""
+
+from __future__ import annotations
+
+from src.feed.merge import _collapse_common_prefix
+
+
+class TestCommonPrefixCollapseUserCases:
+    def test_four_veranstaltung_dates_chained_collapse(self) -> None:
+        # Simulate the chained 4-way merge that ``deduplicate_fuzzy``
+        # performs item-by-item on the user-visible 11A case.
+        state = "Veranstaltung am 09.06.2026"
+        for new in (
+            "Veranstaltung am 03.06.2026",
+            "Veranstaltung am 11.06.2026",
+            "Veranstaltung am 20.06.2026",
+        ):
+            collapsed = _collapse_common_prefix(state, new)
+            assert collapsed is not None, (
+                f"Collapse declined on {state!r} + {new!r}"
+            )
+            state = collapsed
+        # Dates are sorted chronologically.
+        assert state == (
+            "Veranstaltung am 03.06.2026, 09.06.2026, "
+            "11.06.2026, 20.06.2026"
+        )
+
+    def test_43_benutzen_sie_locations_collapse(self) -> None:
+        # The 43-line case: same "Benutzen Sie die Linie 43A - "
+        # prefix, different location suffixes.
+        result = _collapse_common_prefix(
+            "Benutzen Sie die Linie 43A - Dornbacher Straße 85",
+            "Benutzen Sie die Linie 43A - Alszeile 93",
+        )
+        # Non-date suffixes preserve cache-insertion order.
+        assert result == (
+            "Benutzen Sie die Linie 43A - Dornbacher Straße 85, "
+            "Alszeile 93"
+        )
+
+    def test_dedup_when_new_suffix_already_present(self) -> None:
+        # A republished item carrying the same date that the existing
+        # list already includes must not duplicate.
+        result = _collapse_common_prefix(
+            "Veranstaltung am 03.06.2026, 09.06.2026",
+            "Veranstaltung am 03.06.2026",
+        )
+        assert result == "Veranstaltung am 03.06.2026, 09.06.2026"
+
+
+class TestCommonPrefixCollapseGuards:
+    def test_short_common_prefix_declines(self) -> None:
+        # ``Sperre `` is only 7 chars — below the 10-char minimum.
+        result = _collapse_common_prefix("Sperre Foo", "Sperre Bar")
+        assert result is None
+
+    def test_no_common_prefix_declines(self) -> None:
+        result = _collapse_common_prefix("Falschparker", "Sperre Foo")
+        assert result is None
+
+    def test_oebb_chain_route_skipped(self) -> None:
+        # ÖBB routes use ``↔`` as a chain joiner — never collapse.
+        result = _collapse_common_prefix(
+            "Wien Hbf ↔ Wien Mitte",
+            "Wien Mitte ↔ Flughafen Wien",
+        )
+        assert result is None
+
+    def test_long_suffix_declines(self) -> None:
+        # A 70-char suffix exceeds the 60-char cap.
+        prefix = "Gleisbauarbeiten "
+        long_suffix = "x" * 70
+        result = _collapse_common_prefix(
+            prefix + "kurz",
+            prefix + long_suffix,
+        )
+        assert result is None
+
+    def test_word_boundary_required(self) -> None:
+        # ``Veranstaltun`` is mid-word; must not be a valid prefix
+        # for ``Veranstaltung`` vs ``Veranstaltungen``.
+        result = _collapse_common_prefix(
+            "Veranstaltungen Test",  # different word continuation
+            "Veranstaltung der Linie",
+        )
+        # Common chars are ``Veranstaltung`` (13) but no space after;
+        # backtrack to last word boundary finds nothing → decline.
+        assert result is None
+
+    def test_empty_inputs_decline(self) -> None:
+        assert _collapse_common_prefix("", "Foo bar baz") is None
+        assert _collapse_common_prefix("Foo bar baz", "") is None
+        assert _collapse_common_prefix("", "") is None
+
+
+class TestCommonPrefixCollapseDateSorting:
+    def test_dates_sorted_chronologically(self) -> None:
+        # Out-of-order dates collapse into ascending order.
+        result = _collapse_common_prefix(
+            "Veranstaltung am 31.12.2026",
+            "Veranstaltung am 01.01.2026",
+        )
+        assert result == "Veranstaltung am 01.01.2026, 31.12.2026"
+
+    def test_dates_across_years_sorted(self) -> None:
+        result = _collapse_common_prefix(
+            "Veranstaltung am 15.05.2026",
+            "Veranstaltung am 10.01.2025",
+        )
+        assert result == "Veranstaltung am 10.01.2025, 15.05.2026"
+
+    def test_non_date_suffixes_keep_insertion_order(self) -> None:
+        # When suffixes aren't dates, preserve cache-insertion order
+        # (the older item already in ex_name comes first).
+        result = _collapse_common_prefix(
+            "Sperre Hauptstraße bei Foo",
+            "Sperre Hauptstraße bei Bar",
+        )
+        # Prefix ``Sperre Hauptstraße bei `` is 23 chars, passes min.
+        assert result == "Sperre Hauptstraße bei Foo, Bar"
+
+    def test_mixed_date_and_text_falls_back_to_insertion_order(self) -> None:
+        # If even one part isn't a recognisable date, don't reorder
+        # any of them — the user's mental model of "list order" is
+        # only safe to override when the data is uniformly dates.
+        result = _collapse_common_prefix(
+            "Veranstaltung am 09.06.2026",
+            "Veranstaltung am ungeklärtem Datum",
+        )
+        # The "ungeklärtem Datum" is too long for the suffix cap? No
+        # — only 18 chars. Below 60. Should collapse with insertion
+        # order preserved.
+        assert result == (
+            "Veranstaltung am 09.06.2026, ungeklärtem Datum"
+        )
+
+
+class TestEndToEndDeduplicateFuzzy:
+    """The collapse must work through the full ``deduplicate_fuzzy`` pipeline."""
+
+    def test_user_reported_11a_veranstaltung_pipeline(self) -> None:
+        from datetime import datetime, timezone
+
+        from src.feed.merge import deduplicate_fuzzy
+
+        def _make(date_str: str, guid: str) -> dict:
+            return {
+                "source": "Wiener Linien",
+                "category": "Hinweis",
+                "title": f"11A: Veranstaltung am {date_str}",
+                "description": (
+                    "Wegen einer Veranstaltung im Ernst-Happel-Stadion "
+                    "kommt es zu folgenden Verkehrsmaßnahmen."
+                ),
+                "link": "",
+                "guid": guid,
+                "starts_at": "2026-05-21T00:00:00+02:00",
+                "ends_at": "2026-06-21T01:00:00+02:00",
+                "pubDate": "2026-05-21T00:00:00+02:00",
+            }
+
+        items = [
+            _make("09.06.2026", "a"),
+            _make("03.06.2026", "b"),
+            _make("11.06.2026", "c"),
+            _make("20.06.2026", "d"),
+        ]
+        merged = deduplicate_fuzzy(items)
+        # All four collapse to one item.
+        assert len(merged) == 1
+        # Title shows sorted dates without ``&`` repetition.
+        title = merged[0]["title"]
+        assert "&" not in title, f"Legacy & join survived: {title!r}"
+        assert "Veranstaltung am" in title
+        # All four dates present, sorted.
+        assert title.index("03.06.2026") < title.index("09.06.2026")
+        assert title.index("09.06.2026") < title.index("11.06.2026")
+        assert title.index("11.06.2026") < title.index("20.06.2026")
+
+    def test_unrelated_items_dont_merge(self) -> None:
+        # The collapse only runs on items that ``deduplicate_fuzzy``
+        # already decided to merge — the helper itself can't cause
+        # unrelated items to merge.
+        from src.feed.merge import deduplicate_fuzzy
+
+        items = [
+            {
+                "source": "Wiener Linien", "category": "Hinweis",
+                "title": "11A: Veranstaltung am 09.06.2026",
+                "description": "Body A",
+                "link": "", "guid": "a",
+                "starts_at": "2026-05-21T00:00:00+02:00",
+                "ends_at": "2026-06-10T01:00:00+02:00",
+                "pubDate": "2026-05-21T00:00:00+02:00",
+            },
+            {
+                "source": "Wiener Linien", "category": "Hinweis",
+                "title": "U6: Verspätung",
+                "description": "Body completely unrelated",
+                "link": "", "guid": "b",
+                "starts_at": "2026-05-21T00:00:00+02:00",
+                "ends_at": "2026-06-10T01:00:00+02:00",
+                "pubDate": "2026-05-21T00:00:00+02:00",
+            },
+        ]
+        merged = deduplicate_fuzzy(items)
+        assert len(merged) == 2, (
+            "Unrelated items merged spuriously"
+        )

--- a/tests/test_merge_common_prefix_collapse.py
+++ b/tests/test_merge_common_prefix_collapse.py
@@ -36,6 +36,8 @@ Guards
 
 from __future__ import annotations
 
+from typing import Any
+
 from src.feed.merge import _collapse_common_prefix
 
 
@@ -178,7 +180,7 @@ class TestEndToEndDeduplicateFuzzy:
 
         from src.feed.merge import deduplicate_fuzzy
 
-        def _make(date_str: str, guid: str) -> dict:
+        def _make(date_str: str, guid: str) -> dict[str, Any]:
             return {
                 "source": "Wiener Linien",
                 "category": "Hinweis",

--- a/tests/test_merge_common_prefix_collapse.py
+++ b/tests/test_merge_common_prefix_collapse.py
@@ -176,8 +176,6 @@ class TestEndToEndDeduplicateFuzzy:
     """The collapse must work through the full ``deduplicate_fuzzy`` pipeline."""
 
     def test_user_reported_11a_veranstaltung_pipeline(self) -> None:
-        from datetime import datetime, timezone
-
         from src.feed.merge import deduplicate_fuzzy
 
         def _make(date_str: str, guid: str) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Audit feedback ("Findest du weitere Fehler? ULTRATHINK") — two real cache items surface as visibly-broken titles created by `deduplicate_fuzzy`'s legacy `ex_name & name` join:

| Before | After |
|---|---|
| `11A: Veranstaltung am 09.06.2026 & Veranstaltung am 03.06.2026 & Veranstaltung am 11.06.2026 & Veranstaltung am 20.06.2026` (122 chars) | `11A: Veranstaltung am 03.06.2026, 09.06.2026, 11.06.2026, 20.06.2026` (68 chars, sorted) |
| `43: Benutzen Sie die Linie 43A - Dornbacher Straße 85 & Benutzen Sie die Linie 43A - Alszeile 93` (96 chars) | `43: Benutzen Sie die Linie 43A - Dornbacher Straße 85, Alszeile 93` (66 chars) |

Both items are real WL Hinweis republications (one per affected date/location). The legacy `&` join repeated the entire body verbatim.

## Fix

New helper `_collapse_common_prefix` in `src/feed/merge.py`:
- Detects substantial shared word-aligned prefixes between `ex_name` and `name`
- Keeps the prefix once and joins differing suffixes with `, `
- When ALL suffixes are calendar dates (`DD.MM.YYYY`), sorts chronologically so users see events in time order rather than cache-insertion order

**Guards:**
- `min_prefix=10` — short overlaps don't trigger
- `max_suffix=60` — long sentences fall back to `&` join (more readable than stray comma)
- `↔` skip — ÖBB chain routes (`A ↔ B ↔ C`) use `↔` as a chain joiner, not a separator

## Production impact

Running the current cache (72 WL + 17 ÖBB + 2 baustellen items) through the full pipeline:
- Both broken titles cleaned up as shown above
- All other merged titles unchanged (no `&` remains anywhere in the feed)
- Only `S 50: St. Pölten ↔ Wien Westbahnhof ↔ Wien Hütteldorf ↔ Tullnerbach-Pressbaum` (90 chars) remains in the >80-char band — a legitimate ÖBB chain route correctly skipped by the `↔` guard

## Test plan

- [x] `tests/test_merge_common_prefix_collapse.py` — 15 cases all pass
- [x] User's exact 11A 4-way chained collapse with date sort verified
- [x] User's exact 43 location collapse (insertion order preserved)
- [x] Republished item dedup (no double-listing)
- [x] Guards: short prefix, no prefix, ÖBB ↔ skip, long suffix, word-boundary requirement, empty inputs
- [x] Date sorting across days/months/years
- [x] Mixed date+text falls back to insertion order
- [x] End-to-end `deduplicate_fuzzy` pipeline
- [x] Unrelated items don't merge spuriously
- [x] 128 existing Round 32-35 regression tests stay green
- [x] `ruff`, `mypy --strict`, `bandit`, `scan-secrets`, `C901`, `i18n`, `pip-audit` all clean

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_