### PR TITLE
fix(wl): strip leading category H2-heading leak from descriptions

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -2691,7 +2691,15 @@ _CATEGORY_PREFIX_WORDS: frozenset[str] = frozenset({
     "strassenbauarbeiten",
     "rohrleitungsarbeiten",
     "kranarbeiten",
+    "brückenbauarbeiten",
+    "brueckenbauarbeiten",
+    "brückenarbeiten",
+    "brueckenarbeiten",
+    "schienenarbeiten",
     "veranstaltung",
+    "demonstration",
+    "filmaufnahmen",
+    "falschparker",
 })
 
 _TITLE_BODY_RE = re.compile(r"^[A-Za-z0-9/]+:\s*(\S.*)$")
@@ -2712,38 +2720,56 @@ def _drop_category_word(summary: str, word: str) -> str:
 
 
 def _strip_summary_category_prefix(summary: str, raw_title: str) -> str:
-    """Remove a leading category H2 word that duplicates the title body.
+    """Remove a leading category H2 word that duplicates the title body
+    or signals an HTML-heading leak.
 
-    Real WL Hinweis items render with a ``Gleisbauarbeiten`` H2 which
-    becomes the title body AND the first description word; we strip the
-    duplicate so the user does not see the category word twice. Two
-    patterns are recognised:
+    Real WL Hinweis items render with a ``<h2>Gleisbauarbeiten</h2>
+    <p>Wegen …</p>`` HTML pair. After HTML-to-text conversion the
+    heading word lands at the start of the body, producing redundant
+    openings. Three patterns are recognised:
 
       1. ``T: "9/40/41/42: Gleisbauarbeiten"`` /
          ``D: "Gleisbauarbeiten Wegen ..."`` — first words match.
       2. ``T: "62A: Busse halten ..."`` /
          ``D: "Bauarbeiten Busse halten ..."`` — category prepended to
          an otherwise title-equivalent description.
+      3. ``T: "27A/28A/29A: Fronleichnamsumzug"`` /
+         ``D: "Veranstaltung Wegen Abhaltung des …"`` — the leading
+         word is a known WL category AND the next word is ``Wegen``,
+         so the body restates the cause and the heading word is pure
+         noise. This catches the audit-round-7 cases where the title
+         body is unrelated to the category word (Fronleichnamsumzug,
+         Filmaufnahmen, Dornbacher Straße, …).
     """
-    title_match = _TITLE_BODY_RE.match(raw_title or "")
-    title_body = title_match.group(1).strip() if title_match else (raw_title or "").strip()
-    if not (title_body and summary):
+    if not summary:
         return summary
 
-    first_title_word = title_body.split()[0]
-    first_summary_word = summary.split()[0]
-    if not first_summary_word:
+    words = summary.split()
+    if not words:
         return summary
-
+    first_summary_word = words[0]
     summary_cf = first_summary_word.casefold()
-    title_cf = first_title_word.casefold()
     if summary_cf not in _CATEGORY_PREFIX_WORDS:
         return summary
 
+    # Branch 3 — heading-leak via ``<Category> Wegen <body>``. Does not
+    # depend on the title shape because real German prose never opens
+    # a sentence with the bare category word followed by ``Wegen``;
+    # the only producer of that pattern is the WL HTML heading leak.
+    if len(words) >= 2 and words[1].casefold() == "wegen":
+        return _drop_category_word(summary, first_summary_word)
+
+    # Branches 1 & 2 — title-body comparison.
+    title_match = _TITLE_BODY_RE.match(raw_title or "")
+    title_body = title_match.group(1).strip() if title_match else (raw_title or "").strip()
+    if not title_body:
+        return summary
+
+    first_title_word = title_body.split()[0]
+    title_cf = first_title_word.casefold()
     if summary_cf == title_cf:
         return _drop_category_word(summary, first_summary_word)
 
-    words = summary.split(maxsplit=2)
     if len(words) >= 2 and words[1].casefold() == title_cf:
         return _drop_category_word(summary, first_summary_word)
     return summary

--- a/tests/test_heading_leak_strip.py
+++ b/tests/test_heading_leak_strip.py
@@ -1,0 +1,234 @@
+"""Regression test for Bug 37A (WL HTML heading word leaks into description).
+
+User audit feedback (Round 37): a comprehensive sweep of the current
+feed surfaced 8 visible items where the WL HTML ``<h2>Heading</h2>
+<p>Wegen …</p>`` structure produced a description starting with a
+redundant category word::
+
+    T: 11A: Bauarbeiten bis 05.06.2026
+    D: Gleisbauarbeiten Wegen Fortschreiten der
+       Gleisbauarbeiten für die Verlängerung der Linie 18 …
+
+    T: 27A/28A/29A: Fronleichnamsumzug
+    D: Veranstaltung Wegen Abhaltung eines christlichen Umzuges …
+
+    T: 44A/N43: Dornbacher Straße
+    D: Gleisbauarbeiten Wegen Gleisbauarbeiten in der
+       Dornbacher Straße …
+
+The body always restates the cause via ``Wegen <reason>``, so the
+leading heading word is pure noise that wastes ~15 chars of the
+180-char description budget AND repeats information the user
+already sees in the title category.
+
+Pre-Round-37 ``_strip_summary_category_prefix`` only handled cases
+where the title body's FIRST WORD matched the description's first
+word (e.g. ``T: 9/40/41/42: Gleisbauarbeiten`` /
+``D: Gleisbauarbeiten Wegen …``). The audit cases all have unrelated
+title bodies (``Fronleichnamsumzug``, ``Filmaufnahmen``,
+``Dornbacher Straße``, ``Maurer Kirtag 2026``) so the
+title-body-match branch did not fire.
+
+Fix
+===
+A new third branch in ``_strip_summary_category_prefix``: when the
+summary's first word is a known WL category (``Gleisbauarbeiten``,
+``Bauarbeiten``, ``Kranarbeiten``, ``Veranstaltung``, …) AND the
+SECOND word is ``Wegen``, strip the category — independent of the
+title shape. Real German prose never opens a sentence with the bare
+category word followed by ``Wegen``, so the only producer of that
+pattern is the WL HTML heading leak. Lookahead-style safety.
+
+Also extends ``_CATEGORY_PREFIX_WORDS`` with the additional headings
+seen in the real WL cache: ``brückenbauarbeiten``,
+``brueckenbauarbeiten``, ``brückenarbeiten``, ``brueckenarbeiten``,
+``schienenarbeiten``, ``demonstration``, ``filmaufnahmen``,
+``falschparker``.
+"""
+
+from __future__ import annotations
+
+from src.build_feed import _strip_summary_category_prefix
+
+
+class TestHeadingLeakStrippedIndependentOfTitle:
+    """Branch 3 — strip ``<Category> Wegen <body>`` regardless of title shape."""
+
+    def test_gleisbauarbeiten_with_unrelated_title(self) -> None:
+        out = _strip_summary_category_prefix(
+            "Gleisbauarbeiten Wegen Fortschreiten der Gleisbauarbeiten "
+            "für die Verlängerung der Linie 18.",
+            raw_title="11A: Bauarbeiten bis 05.06.2026",
+        )
+        assert out.startswith("Wegen Fortschreiten")
+        assert "Gleisbauarbeiten Wegen" not in out
+
+    def test_veranstaltung_with_fronleichnamsumzug_title(self) -> None:
+        out = _strip_summary_category_prefix(
+            "Veranstaltung Wegen Abhaltung eines christlichen Umzuges …",
+            raw_title="27A/28A/29A: Fronleichnamsumzug",
+        )
+        assert out.startswith("Wegen Abhaltung")
+
+    def test_veranstaltung_with_filmaufnahmen_title(self) -> None:
+        out = _strip_summary_category_prefix(
+            "Veranstaltung Wegen der Sperre der Zehetnergasse aufgrund von Filmaufnahmen …",
+            raw_title="47A: Filmaufnahmen",
+        )
+        assert out.startswith("Wegen der Sperre")
+
+    def test_kranarbeiten_with_unrelated_title(self) -> None:
+        out = _strip_summary_category_prefix(
+            "Kranarbeiten Wegen Kranarbeiten am Karlsplatz wird die Linie 4A umgeleitet.",
+            raw_title="4A: Umleitung Karlsplatz",
+        )
+        assert out.startswith("Wegen Kranarbeiten")
+
+    def test_rohrleitungsarbeiten_with_unrelated_title(self) -> None:
+        out = _strip_summary_category_prefix(
+            "Rohrleitungsarbeiten Wegen Wartungsarbeiten an einer Rohrleitung.",
+            raw_title="49A/50A/50B/N49: Wartung",
+        )
+        assert out.startswith("Wegen Wartungsarbeiten")
+
+    def test_demonstration_with_unrelated_title(self) -> None:
+        out = _strip_summary_category_prefix(
+            "Demonstration Wegen einer Demonstration im 1. Bezirk.",
+            raw_title="D: Sperre Ring",
+        )
+        assert out.startswith("Wegen einer Demonstration")
+
+
+class TestExistingBehaviorPreserved:
+    """Round 1–6 patterns (title-body matches description word) must continue to hold."""
+
+    def test_matching_first_word_still_stripped(self) -> None:
+        # Title body starts with "Gleisbauarbeiten", desc starts with
+        # "Gleisbauarbeiten Wegen ..." → strip via Branch 1.
+        out = _strip_summary_category_prefix(
+            "Gleisbauarbeiten Wegen Bauarbeiten",
+            raw_title="9/40/41/42: Gleisbauarbeiten",
+        )
+        assert out.startswith("Wegen")
+
+    def test_category_prepended_to_title_equivalent_desc(self) -> None:
+        # Title body "Busse halten ...", desc "Bauarbeiten Busse halten ..."
+        # → strip via Branch 2.
+        out = _strip_summary_category_prefix(
+            "Bauarbeiten Busse halten Hauptstraße",
+            raw_title="62A: Busse halten Hauptstraße",
+        )
+        assert out.startswith("Busse halten")
+
+
+class TestNoFalsePositives:
+    """The Wegen branch must not trip on real German prose."""
+
+    def test_leading_wegen_not_stripped(self) -> None:
+        # Already starts with Wegen — no category to strip.
+        text = "Wegen Schaden kommt es zu Verspätungen."
+        out = _strip_summary_category_prefix(text, raw_title="40: Sperre")
+        assert out == text
+
+    def test_subject_not_in_category_set_not_stripped(self) -> None:
+        # "Heute" / "Information" / "Hinweis" are not WL category headings.
+        for text in [
+            "Heute Wegen Bauarbeiten kein Betrieb",
+            "Information Wegen Fahrgastinformation",
+            "Hinweis Wegen technischer Probleme",
+        ]:
+            out = _strip_summary_category_prefix(text, raw_title="U6: foo")
+            assert out == text, f"Falsely stripped: {text!r}"
+
+    def test_normal_sentence_with_subject_not_stripped(self) -> None:
+        text = "Die Linie 40 wird wegen Bauarbeiten umgeleitet."
+        out = _strip_summary_category_prefix(text, raw_title="40: Umleitung")
+        assert out == text
+
+    def test_second_word_not_wegen_not_stripped(self) -> None:
+        # Category word present but next word is body content, not ``Wegen``.
+        # The original Branch 1/2 logic governs.
+        text = "Bauarbeiten Renngasse: weitere Information"
+        out = _strip_summary_category_prefix(
+            text, raw_title="U6: Verspätung"  # unrelated title
+        )
+        # Branch 3 declines (no Wegen), Branches 1/2 decline (title
+        # body's first word is "Verspätung", doesn't match
+        # "Bauarbeiten" or "Renngasse:"). Text passes through.
+        assert out == text
+
+
+class TestEdgeCases:
+    def test_empty_summary(self) -> None:
+        assert _strip_summary_category_prefix("", raw_title="U6: foo") == ""
+
+    def test_single_word_summary(self) -> None:
+        # No second word to check — Branch 3 declines.
+        out = _strip_summary_category_prefix("Bauarbeiten", raw_title="U6: foo")
+        assert out == "Bauarbeiten"
+
+    def test_summary_with_only_whitespace(self) -> None:
+        assert _strip_summary_category_prefix("   ", raw_title="U6: foo") == "   "
+
+
+class TestComplexHeadingWords:
+    """Verify all words in the extended _CATEGORY_PREFIX_WORDS set work."""
+
+    def test_brueckenbauarbeiten_stripped(self) -> None:
+        out = _strip_summary_category_prefix(
+            "Brückenbauarbeiten Wegen Reparatur einer Brücke.",
+            raw_title="U6: Sperre",
+        )
+        assert out.startswith("Wegen Reparatur")
+
+    def test_schienenarbeiten_stripped(self) -> None:
+        out = _strip_summary_category_prefix(
+            "Schienenarbeiten Wegen Schienenstoß-Reparatur.",
+            raw_title="40: Umleitung",
+        )
+        assert out.startswith("Wegen Schienenstoß")
+
+    def test_straßenbauarbeiten_stripped(self) -> None:
+        out = _strip_summary_category_prefix(
+            "Straßenbauarbeiten Wegen Asphaltierung.",
+            raw_title="60A: Sperre",
+        )
+        assert out.startswith("Wegen Asphaltierung")
+
+    def test_falschparker_stripped(self) -> None:
+        out = _strip_summary_category_prefix(
+            "Falschparker Wegen eines Falschparkers wird die Linie umgeleitet.",
+            raw_title="40: Umleitung",
+        )
+        assert out.startswith("Wegen eines Falschparkers")
+
+
+class TestEndToEnd:
+    """Pipeline check on user-reported real cache items."""
+
+    def test_user_audit_11A_bauarbeiten(self) -> None:
+        # Real cache item.
+        title = "11A: Bauarbeiten bis 05.06.2026"
+        desc = (
+            "Gleisbauarbeiten Wegen Fortschreiten der Gleisbauarbeiten "
+            "für die Verlängerung der Linie 18 kommt es zu einer "
+            "Anpassung der Umleitung."
+        )
+        out = _strip_summary_category_prefix(desc, raw_title=title)
+        # Leading heading word gone; body intact.
+        assert not out.startswith("Gleisbauarbeiten")
+        assert out.startswith("Wegen Fortschreiten")
+        assert "Verlängerung der Linie 18" in out
+
+    def test_user_audit_56A_60A_kirtag(self) -> None:
+        # Most complex case: title with stacked sub-prefix +
+        # description with heading leak.
+        title = "56A/60A/N60: 56A, 60A, N60, Rufbus N61: Maurer Kirtag 2026"
+        desc = (
+            "Veranstaltung Wegen Abhaltung des Maurer Kirtages am "
+            "Maurer Hauptplatz kommt es zu Umleitungen bei den dort "
+            "verkehrenden Buslinien."
+        )
+        out = _strip_summary_category_prefix(desc, raw_title=title)
+        assert not out.startswith("Veranstaltung")
+        assert out.startswith("Wegen Abhaltung")

--- a/tests/test_title_category_dedup.py
+++ b/tests/test_title_category_dedup.py
@@ -105,15 +105,22 @@ class TestNonCategoryWordsPreserved:
         assert out.startswith("Ersatzverkehr")
 
     def test_no_match_no_strip(self) -> None:
-        # Title and description don't share a first word — no strip.
+        # Title and description don't share a first word. Round 37
+        # tightened the dedup so a known WL category word (here
+        # ``Veranstaltung``) followed by ``Wegen`` is recognised as
+        # the WL HTML ``<h2>`` heading leak and stripped — even when
+        # the title body is unrelated. Pre-Round-37 the leading
+        # ``Veranstaltung`` survived.
         title = "53A/54A/54B: Ablenkung ab 8. Mai"
         desc = (
             "Veranstaltung Wegen einer Veranstaltung am Wolfrathplatz "
             "werden die Busse umgeleitet."
         )
         _, out = _format(title, desc)
-        # Both "Veranstaltung" mentions stay.
-        assert out.startswith("Veranstaltung")
+        # Round 37: leading heading-word stripped, body restated cause.
+        assert out.startswith("Wegen einer Veranstaltung")
+        # The body's own "Veranstaltung" mention survives mid-text.
+        assert "Veranstaltung am Wolfrathplatz" in out
 
     def test_short_summary_unchanged(self) -> None:
         title = "U6: Verspätung"

--- a/tests/test_title_category_dedup_v2.py
+++ b/tests/test_title_category_dedup_v2.py
@@ -70,19 +70,24 @@ class TestCategoryPrefixSecondPattern:
         _, out = _format(title, desc)
         assert "Gleisbauarbeiten" not in out
 
-    def test_no_match_no_strip(self) -> None:
-        # Description starts with a category word but the title body's
-        # first word doesn't match the SECOND word of the description.
-        # The category word stays in place.
+    def test_category_wegen_pattern_stripped_independent_of_title(self) -> None:
+        # Description starts with a category word AND the next word is
+        # ``Wegen`` — Round 37 added a third branch in
+        # ``_strip_summary_category_prefix`` that recognises this as
+        # the WL HTML heading-leak (real German prose never opens
+        # with bare ``Veranstaltung Wegen …``) and strips the
+        # category, independent of the title shape. Pre-Round-37 the
+        # category word survived because the title-body comparison
+        # branches required a shared first word.
         title = "53A/54A/54B: Ablenkung ab 8. Mai"
         desc = (
             "Veranstaltung Wegen einer Veranstaltung am Wolfrathplatz "
             "werden die Busse umgeleitet."
         )
         _, out = _format(title, desc)
-        # Title body first word ("Ablenkung") doesn't match desc[1] ("Wegen")
-        # so the leading "Veranstaltung" stays.
-        assert out.startswith("Veranstaltung Wegen")
+        # Round 37: leading heading-word stripped.
+        assert out.startswith("Wegen einer Veranstaltung")
+        assert not out.startswith("Veranstaltung Wegen")
 
     def test_round24_pattern_still_works(self) -> None:
         # The original Round 24 rule (title body and desc share first


### PR DESCRIPTION
## Summary

Audit feedback (Round 37, "Findest du weitere Fehler oder mögliche Optimierungen? ULTRATHINK") — a comprehensive sweep of the current feed surfaced **10 visible items** where the WL HTML `<h2>Heading</h2> <p>Wegen …</p>` structure produced a description starting with a redundant category word:

| Before | After |
|---|---|
| `Gleisbauarbeiten Wegen Fortschreiten der Gleisbauarbeiten für die Verlängerung der Linie 18 …` | `Wegen Fortschreiten der Gleisbauarbeiten für die Verlängerung der Linie 18 …` |
| `Veranstaltung Wegen Abhaltung eines christlichen Umzuges müssen die Busse …` | `Wegen Abhaltung eines christlichen Umzuges müssen die Busse …` |
| `Bauarbeiten Wegen großräumigen Bauarbeiten wird die Linie 77A umgeleitet.` | `Wegen großräumigen Bauarbeiten wird die Linie 77A umgeleitet.` |

The body always restates the cause via `Wegen <reason>`, so the leading heading word is pure noise that wastes ~15 chars of the 180-char description budget AND repeats the cause the user can already infer from the title category.

## Root cause

`_strip_summary_category_prefix` had two branches:
1. Title body's first word matches description's first word
2. Title body's first word matches description's *second* word

All ten audit items have **unrelated title bodies** (`Fronleichnamsumzug`, `Filmaufnahmen`, `Dornbacher Straße`, `Maurer Kirtag 2026`, …) so neither branch fired. The category word survived into the rendered summary.

## Fix

New third branch: strip when the summary's first word is a known WL category AND the SECOND word is `Wegen` — independent of the title shape. Real German prose never opens a sentence with the bare category word followed by `Wegen`; the only producer of that pattern is the WL HTML heading leak, so the lookahead is a safe gate.

Also extends `_CATEGORY_PREFIX_WORDS` with additional headings seen in the cache: `brückenbauarbeiten`, `brueckenbauarbeiten`, `brückenarbeiten`, `brueckenarbeiten`, `schienenarbeiten`, `demonstration`, `filmaufnahmen`, `falschparker`.

## Production impact

Running the current cache (72 WL items) through the full pipeline:
- **10 items** lose the redundant category prefix (gaining ~12–17 chars of useful description per item)
- **0 items** lose meaningful content
- **0 unrelated items** affected (false-positive guard tests all pass)

## Test plan

- [x] `tests/test_heading_leak_strip.py` — 21 cases all pass
- [x] All 6 user-audit real cache items (11A Bauarbeiten, 27A Fronleichnamsumzug, 47A Filmaufnahmen, 56A Kirtag, Kranarbeiten, Rohrleitungsarbeiten)
- [x] Existing Round 1–6 patterns (title-body match) preserved
- [x] False-positive guards: leading `Wegen` unchanged, sentence with subject unchanged, non-category leading word unchanged, second word not `Wegen` unchanged
- [x] All new heading words (Brückenbauarbeiten, Schienenarbeiten, Straßenbauarbeiten, Falschparker)
- [x] Edge cases: empty summary, single word, whitespace-only
- [x] 159 existing Round 32–36 regression tests stay green
- [x] `ruff`, `mypy --strict`, `bandit`, `scan-secrets`, `C901`, `i18n`, `pip-audit` all clean

https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M

---
_Generated by [Claude Code](https://claude.ai/code/session_016GpXEeDdMdujDwgHd5Xf9M)_