### PR TITLE
style(hafas): rewrite AID/SALT regex builders as f-strings

### DIFF
--- a/scripts/sync_hafas_profile.py
+++ b/scripts/sync_hafas_profile.py
@@ -345,14 +345,14 @@ _VER_VALIDATION_RE: Final[re.Pattern[str]] = re.compile(
 # the broader alphanumeric+separator set used by other HAFAS deployments
 # but rejects whitespace / control characters / Trojan-Source primitives.
 _AID_VALIDATION_RE: Final[re.Pattern[str]] = re.compile(
-    r"^[A-Za-z0-9._\-+/]{%d,128}$" % _PROFILE_MIN_AID_LEN
+    rf"^[A-Za-z0-9._\-+/]{{{_PROFILE_MIN_AID_LEN},128}}$"
 )
 
 # ``salt`` (when present) is the HMAC-MD5 ingredient. HAFAS deployments
 # that use signing carry an opaque alphanumeric+padding token; ÖBB's
 # current upstream omits it entirely.
 _SALT_VALIDATION_RE: Final[re.Pattern[str]] = re.compile(
-    r"^[A-Za-z0-9._\-+/=]{%d,256}$" % _PROFILE_MIN_SALT_LEN
+    rf"^[A-Za-z0-9._\-+/=]{{{_PROFILE_MIN_SALT_LEN},256}}$"
 )
 
 


### PR DESCRIPTION
## Summary

- `scripts/sync_hafas_profile.py` introduced two `re.compile(r"…{%d,N}$" % MIN_LEN)` builders for the new AID/SALT validation regexes (commit `4d55464`, "feat(hafas): structural validation before writing the cached profile").
- The project's Ruff config selects the `UP` rule set, and Ruff's `UP031` (Use format specifiers instead of percent format) flags both lines. `ruff check .` was therefore red on this branch, which means `scripts/run_static_checks.py` (and any contributor running the documented local lint command) would fail until this lands.
- Switch both builders to `rf"…{{{MIN_LEN},N}}$"`. The doubled `{{` / `}}` escape the regex quantifier braces; the inner `{MIN_LEN}` is the f-string substitution. Output is byte-identical to the previous `%d`-formatted pattern.

## Why an audit surfaced this

An earlier audit run claimed Ruff passed cleanly. It didn't — the report dropped the two `UP031` findings. While reconciling that, the actual rule failure became visible on the branch and needed fixing before the static-check gate stays green.

## Test plan

- [x] `ruff check .` — passes (was 2 errors before, 0 after).
- [x] Built both regex forms (the previous `%d` form and the new f-string form) from the live `_PROFILE_MIN_AID_LEN=8` / `_PROFILE_MIN_SALT_LEN=8` constants and asserted `.pattern` equality (`^[A-Za-z0-9._\-+/]{8,128}$` and `^[A-Za-z0-9._\-+/=]{8,256}$`).
- [x] Boundary checks: 8-char accept, 7-char reject, 128-char accept, 129-char reject, whitespace reject, NUL reject, `=` padding accepted only for SALT, 256-char SALT accept, 257-char SALT reject.
- [x] `pytest tests/scripts/test_sync_hafas_profile.py` — 19/19 pass.

https://claude.ai/code/session_01CB3284jUonZW8PvkzpY3DY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CB3284jUonZW8PvkzpY3DY)_