### PR TITLE
docs: align Pages landing with VOR-Stammstrecke scope, list 8th .jules journal

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -699,6 +699,7 @@ Zukunft enger werden, sind die niedrig-hängenden Hebel:
 - **`request_safe` joint refactor** → `.jules/omega.md`
 - **Chaos audit + RecursionError fix** → `.jules/saboteur.md`
 - **DX / docs / cartography** → `.jules/scribe.md` (this document's companion)
+- **Governance gates & hooks** → `.jules/automator.md`
 
 The `.jules/` journals are the project's institutional memory. When
 adding a new defence, optimisation, or refactor, append an entry there

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Der gesamte Code steht als Open Source zur Verfügung, sodass du jederzeit nachv
 
 ## Warum der Wien ÖPNV Feed?
 
-- **Zentrale Verkehrsinformationen**: Vereinheitlichte Meldungen der Wiener Linien (WL), der ÖBB und des Verkehrsverbund Ost-Region (VOR) inklusive neuer Baustellen-Datenquellen.
+- **Zentrale Verkehrsinformationen**: Vereinheitlichte Meldungen der Wiener Linien (WL) und der ÖBB, ergänzt um offizielle OGD-Baustellendaten der Stadt Wien sowie einen VOR/VAO-basierten S-Bahn-Stammstrecken-Monitor (Verspätungen & Ausfälle; seit 2026-05-11 ist VOR ausschließlich für diesen Monitor in Verwendung, siehe Tabelle weiter unten).
 - **Suchmaschinenfreundlich**: Optimierte Seitentitel, strukturierte Daten und interne Verlinkungen helfen, dass Entwickler:innen, Journalist:innen und Mobilitätsplaner:innen das Projekt schnell finden.
 - **Fokus auf Reproduzierbarkeit**: Vom Cache-Update über den Feed-Build bis hin zu Tests und Audits – jeder Schritt ist dokumentiert und automatisierbar.
 - **Flexible Nutzung**: Konsumiere den RSS-Feed, greife direkt auf JSON-Caches zu oder verwende die Python-Helfer aus `src/`, um deine Anwendung mit Echtzeitdaten zu versorgen.


### PR DESCRIPTION
## Hintergrund

Vertieftes Doku-Audit der letzten Iteration fand zwei objektive Faktura-Drifts (nach mehrfacher Verifikation, mehrere voreilige „Befunde" wurden vorher verworfen):

1. **`docs/index.md:18`** — die Bullet-Liste „Warum der Wien ÖPNV Feed?" beschrieb VOR als gleichrangigen Disruption-Provider neben WL und ÖBB. Das widerspricht der Datenquellen-Tabelle in derselben Datei (Zeile 97: „VOR seit 2026-05-11 **ausschließlich** für den Stammstrecken-Monitor genutzt") sowie der gesamten Repo-Linie nach der 2026-05-11-Konsolidierung.

2. **`docs/architecture.md` §8** — die Cross-Reference-Liste der `.jules/`-Journale enthielt nur sieben Einträge, obwohl acht Journale unter `.jules/` existieren und `automator.md` (Z. 2-6) sich selbst als „**Eighth and final companion log** … documenting governance-as-code (gates, hooks, templates)" beschreibt.

## Änderungen

**`docs/index.md`** — Bullet auf die in `README.md:16` etablierte Formulierung umgestellt: WL + ÖBB als Verkehrsmeldungs-Provider, OGD-Baustellen separat, VOR-Stammstrecken-Monitor als eigene Säule mit explizitem 2026-05-11-Scope-Hinweis und Vorwärts-Verweis auf die Datenquellen-Tabelle.

**`docs/architecture.md` §8** — `automator.md`-Eintrag ans Ende der `.jules/`-Liste angefügt (passend zur Selbstbeschreibung als „eighth and final"). Stilistisch konsistent zu den existierenden Bullets (kurzes Topic-Label + Pfeil).

## Was dieser PR *nicht* berührt

- Keine Code-Pfade — reine Doku-Faktura.
- Keine Stil-Politur (Sprachen-Mix in architecture.md, fehlender `docs/reference/INDEX.md`, dünne SECURITY.md). Carry-over im Audit-Backlog.
- Keine inhaltliche Umschreibung der §§1–7 von architecture.md.

## Verifikation

- `git diff` zeigt **+2 / -1 Zeilen** über 2 Dateien, keine Markdown-Strukturschäden.
- `docs/index.md:18`-Neufassung deckungsgleich im Wortlaut zur bereits sanktionierten `README.md:16`-Phrasierung.
- `.jules/automator.md` als Linkziel existiert (`ls .jules/`).
- Alle anderen 7 `.jules/`-Journal-Pfade in §8 vorher gegen-geprüft.

## Test plan

- [x] Diff visuell inspiziert — minimal-invasiv, kein Bestand verändert
- [x] Linkziel `.jules/automator.md` existiert
- [x] Phrasierung in `docs/index.md` mit `README.md` abgeglichen
- [x] Keine Markdown-Fence-/Tabellen-Defekte (nur einzelne Bullet-Zeilen geändert)
- [ ] CI grün (rein Markdown, keine Code-Pfade — keine Code-Gates erwartet)

https://claude.ai/code/session_011QD7QvHgY7Tg6zWgGLR5VH

---
_Generated by [Claude Code](https://claude.ai/code/session_011QD7QvHgY7Tg6zWgGLR5VH)_