### PR TITLE
fix(security): cap i18n coverage gate bytes + add size-cap walker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,5 +1,49 @@
 # Sentinel's Journal
 
+## 2026-05-23 - i18n Coverage Gate MemoryError DoS + Size-Cap Walker
+
+**Vulnerability:** `scripts/check_i18n_coverage.py:180-181` used
+`HTML_PATH.read_text(encoding="utf-8")` and
+`JS_PATH.read_text(encoding="utf-8")` with NO byte-size cap on the two
+committed dashboard sources (`docs/site.html`, `docs/assets/site.js`).
+The gate is invoked from TWO blocking pipelines: the local pre-commit
+hook (`.pre-commit-config.yaml`) AND the canonical CI gauntlet at
+`scripts/run_static_checks.py` (which is itself invoked by
+`.github/workflows/test.yml`). A planted multi-GiB
+`docs/site.html` / `docs/assets/site.js` (hostile PR replacing the
+tracked source, compromised CI runner / `main` checkout, partial flush
++ power loss mid-edit) buffered via `read_text()` allocated
+O(file_size) bytes and raised `MemoryError`. `MemoryError` is a
+`BaseException` subclass — NOT caught by any handler in the script
+(`main()` has no try/except at all) — so the unhandled exception
+escaped the gate and crashed the full static-checks pipeline. Direct
+sibling drift from the same canonical inventory: the sibling script
+`scripts/optimize_site_assets.py` writes to the EXACT same two files
+via `atomic_write` and already routes its reads through
+`read_capped_text` with a 4-MiB cap (`MAX_CSS_FILE_BYTES`) — the i18n
+coverage gate was the missed sibling.
+
+**Learning:** The 2026-05-23 GeoNetz round's closing rule
+("future canonical-loader rounds should ship the walker alongside the
+per-site fix so every parser-site axis … is programmatically enforced
+from the start") is now realised for the **size-cap** axis via
+`tests/test_sentinel_size_cap_audit_walker.py`. The walker scans every
+`*.py` under `src/` and `scripts/` for bare `<expr>.read_text(...)` /
+`<expr>.read_bytes(...)` calls (banned shapes — they allocate
+O(file_size) bytes before any defence layer can run). When invoked
+against the pre-fix code it correctly flagged
+`scripts/check_i18n_coverage.py:180` and `:181`; the post-fix
+allowlist is empty by design. Any future contributor who adds a bare
+`path.read_text()` / `path.read_bytes()` call to `src/` or `scripts/`
+will fail the walker at PR-review time regardless of whether the
+journal named the file. The post-fix PoC test in
+`tests/test_sentinel_check_i18n_size_bomb_ondisk.py` uses AST-based
+static inspection of the `main()` function body (excluding docstrings)
+to lock the `read_capped_text` route + ban the bare `read_text` /
+`read_bytes` shapes specifically for this script — defence-in-depth
+against the walker drift case where a future PR silently broadens the
+allowlist.
+
 ## 2026-05-23 - GeoNetz Loader MemoryError DoS + Non-Finite Literal Drift
 
 **Vulnerability:** Two siblings of the JSON size-bomb / non-finite literal

--- a/scripts/check_i18n_coverage.py
+++ b/scripts/check_i18n_coverage.py
@@ -42,8 +42,40 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+# Ensure the project root is on ``sys.path`` so the canonical
+# ``read_capped_text`` defence helper resolves regardless of how the
+# script is invoked (``python scripts/check_i18n_coverage.py`` from the
+# pre-commit hook, ``scripts/run_static_checks.py`` subprocess in CI, or
+# direct execution from a developer shell).
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+try:
+    from src.utils.files import read_capped_text
+except ModuleNotFoundError:
+    from utils.files import read_capped_text  # type: ignore[no-redef]
+
 HTML_PATH = REPO_ROOT / "docs" / "site.html"
 JS_PATH = REPO_ROOT / "docs" / "assets" / "site.js"
+
+# Security: per-loader byte cap for the two committed dashboard files
+# (``docs/site.html`` ~20 KiB, ``docs/assets/site.js`` ~50 KiB). Pre-fix
+# both sites used the unsafe ``Path.read_text(encoding="utf-8")`` shape
+# with NO size cap — a planted multi-GiB file (hostile PR replacing the
+# tracked source, compromised CI runner / ``main`` checkout, partial
+# flush + power loss mid-edit) buffered via ``read_text()`` allocates
+# O(file_size) bytes and raises :exc:`MemoryError`. ``MemoryError`` is a
+# :class:`BaseException` subclass that propagates past every ordinary
+# ``except`` handler in the call chain and aborts both the pre-commit
+# ``i18n-coverage`` hook AND the canonical CI gauntlet at
+# ``scripts/run_static_checks.py`` (which invokes this script as a
+# subprocess and fails the whole gate on a non-zero exit / crash). The
+# 4-MiB cap mirrors :data:`scripts.optimize_site_assets.MAX_CSS_FILE_BYTES`
+# (the closest canonical sibling — the optimiser writes the very same
+# two files via :func:`atomic_write` so the two scripts share the same
+# legitimate ceiling). ~80x headroom over today's largest legitimate
+# source (~50 KiB) while still rejecting GiB-sized planted attacks.
+MAX_I18N_FILE_BYTES = 4 * 1024 * 1024
 
 # data-i18n="key" / data-i18n-aria-label="key" / data-i18n-title="key" /
 # data-i18n-content="key" / data-i18n-href="key" — we extract every
@@ -177,8 +209,34 @@ def main() -> int:
         print(f"ERROR: {JS_PATH} not found", file=sys.stderr)
         return 1
 
-    html_content = HTML_PATH.read_text(encoding="utf-8")
-    js_content = JS_PATH.read_text(encoding="utf-8")
+    # Security: ``read_capped_text`` enforces a TOCTOU-safe byte-size cap
+    # (open-then-fstat on the open file descriptor, defensive
+    # ``read(max_bytes + 1)`` budget) so a planted oversized file is
+    # rejected before buffering — closes the ``MemoryError`` propagation
+    # path that would crash the static-checks pipeline. A ``None`` return
+    # signals "missing / oversized / invalid UTF-8"; either shape is a
+    # hard fail of the gate (we cannot validate i18n coverage against a
+    # corrupt input).
+    html_content = read_capped_text(
+        HTML_PATH, MAX_I18N_FILE_BYTES, label="site.html"
+    )
+    if html_content is None:
+        print(
+            f"ERROR: {HTML_PATH} exceeds the "
+            f"{MAX_I18N_FILE_BYTES}-byte cap or is unreadable",
+            file=sys.stderr,
+        )
+        return 1
+    js_content = read_capped_text(
+        JS_PATH, MAX_I18N_FILE_BYTES, label="site.js"
+    )
+    if js_content is None:
+        print(
+            f"ERROR: {JS_PATH} exceeds the "
+            f"{MAX_I18N_FILE_BYTES}-byte cap or is unreadable",
+            file=sys.stderr,
+        )
+        return 1
 
     html_keys = _extract_html_keys(html_content)
     js_entries = _extract_js_keys(js_content)

--- a/tests/test_sentinel_check_i18n_size_bomb_ondisk.py
+++ b/tests/test_sentinel_check_i18n_size_bomb_ondisk.py
@@ -1,0 +1,219 @@
+"""Sentinel PoC: size-bomb defence for the i18n coverage gate's on-disk
+file reads.
+
+Threat model
+------------
+``scripts/check_i18n_coverage.py`` is invoked from two pipelines:
+
+  * The local pre-commit hook (``.pre-commit-config.yaml``), which runs
+    on every commit that touches ``docs/site.html`` or
+    ``docs/assets/site.js``.
+  * The canonical CI gauntlet at ``scripts/run_static_checks.py``, which
+    is itself invoked by ``.github/workflows/test.yml`` AND by the
+    ``Run static checks`` step on every push / PR.
+
+Pre-fix both file reads used the unsafe ``Path.read_text(encoding=
+"utf-8")`` shape with NO byte-size cap. A planted multi-GiB
+``docs/site.html`` or ``docs/assets/site.js`` (hostile PR replacing the
+tracked source, compromised CI runner checkout, partial flush + power
+loss mid-edit) buffered via ``read_text()`` allocates O(file_size) bytes
+and raises :exc:`MemoryError`. ``MemoryError`` is a
+:class:`BaseException` subclass — it is NOT caught by ``except OSError``
+/ ``except ValueError`` / ``except Exception`` and propagates straight
+out of ``main()`` past the pre-commit hook AND the static-checks gate,
+crashing the entire CI pipeline.
+
+The sibling script ``scripts/optimize_site_assets.py`` writes to the
+exact same two files via :func:`atomic_write` and already routes its
+reads through the canonical :func:`read_capped_text` defence helper
+(``MAX_CSS_FILE_BYTES = 4 * 1024 * 1024``) — the i18n coverage gate is
+the sibling-drift site that escaped the canonical inventory in the same
+shape as the 2026-05-23 GeoNetz loader pair (``_load_geonetz_stops`` /
+``extract_oebb_geonetz_stops``).
+
+Post-fix both reads route through :func:`src.utils.files.read_capped_text`
+with the same 4 MiB cap (``MAX_I18N_FILE_BYTES``), and the ``None``
+return on cap violation is converted to a clean non-zero exit with a
+clear operator message.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ============================================================================
+# Precondition: the canonical cap constant exists
+# ============================================================================
+
+
+def test_precondition_i18n_size_cap_constant_exists() -> None:
+    """Pin the canonical cap constant. If a future refactor renames or
+    removes it, every regression test below would silently pass even on
+    unfixed code — so we pin the precondition first."""
+    from scripts import check_i18n_coverage as gate
+
+    assert isinstance(gate.MAX_I18N_FILE_BYTES, int)
+    assert gate.MAX_I18N_FILE_BYTES > 0
+    # Cap must accommodate the largest legitimate committed source. Both
+    # files were ~20-50 KiB at fix time; pinning ``>= 1 MiB`` leaves
+    # generous headroom for legitimate growth while keeping the cap well
+    # below any reasonable runner's cgroup memory limit.
+    assert gate.MAX_I18N_FILE_BYTES >= 1_000_000
+
+
+# ============================================================================
+# PoC: a planted huge ``docs/site.html`` MUST be rejected
+# ============================================================================
+
+
+def test_i18n_gate_rejects_oversized_html(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pre-fix: ``HTML_PATH.read_text(encoding="utf-8")`` allocated
+    O(file_size) bytes and raised ``MemoryError`` past every surrounding
+    handler. Post-fix: ``read_capped_text`` rejects the file at the
+    fstat-on-open size check and the gate returns 1 with a clear
+    operator message — the pre-commit + static-checks pipeline surfaces
+    the planted-huge-file shape instead of crashing."""
+    from scripts import check_i18n_coverage as gate
+
+    # Point the gate at our fixture paths and shrink the cap to a tiny
+    # value so we don't have to materialise a multi-MiB test fixture.
+    fake_html = tmp_path / "site.html"
+    fake_js = tmp_path / "site.js"
+    fake_html.write_bytes(b"x" * 2048)
+    fake_js.write_text(
+        'const I18N_EN = { "k": "v" };',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gate, "HTML_PATH", fake_html)
+    monkeypatch.setattr(gate, "JS_PATH", fake_js)
+    monkeypatch.setattr(gate, "MAX_I18N_FILE_BYTES", 1024, raising=False)
+
+    rc = gate.main()
+    captured = capsys.readouterr()
+
+    # Post-fix contract: clean non-zero exit + a clear message — NOT a
+    # MemoryError crash.
+    assert rc == 1
+    assert "cap" in captured.err.lower() or "unreadable" in captured.err.lower()
+
+
+def test_i18n_gate_rejects_oversized_js(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Sibling shape to the HTML test: an oversized JS file must be
+    rejected with the same clean-exit contract. Pre-fix
+    ``JS_PATH.read_text(encoding="utf-8")`` ran after the HTML read and
+    therefore propagated ``MemoryError`` from the second buffer site
+    even when the HTML was clean."""
+    from scripts import check_i18n_coverage as gate
+
+    fake_html = tmp_path / "site.html"
+    fake_js = tmp_path / "site.js"
+    # Small valid HTML so it passes the first cap check; huge JS so the
+    # second cap check fires.
+    fake_html.write_text(
+        '<div data-i18n="k">x</div>',
+        encoding="utf-8",
+    )
+    fake_js.write_bytes(b"x" * 2048)
+    monkeypatch.setattr(gate, "HTML_PATH", fake_html)
+    monkeypatch.setattr(gate, "JS_PATH", fake_js)
+    monkeypatch.setattr(gate, "MAX_I18N_FILE_BYTES", 1024, raising=False)
+
+    rc = gate.main()
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "cap" in captured.err.lower() or "unreadable" in captured.err.lower()
+
+
+def test_i18n_gate_normal_files_unaffected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Sanity check: the size cap must not affect legitimate
+    well-formed files. Pinned alongside the rejection tests so a future
+    tightening that accidentally rejects valid input fails loudly."""
+    from scripts import check_i18n_coverage as gate
+
+    fake_html = tmp_path / "site.html"
+    fake_js = tmp_path / "site.js"
+    fake_html.write_text(
+        '<div data-i18n="hello">Hallo</div>',
+        encoding="utf-8",
+    )
+    fake_js.write_text(
+        'const I18N_EN = { "hello": "Hello" };',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gate, "HTML_PATH", fake_html)
+    monkeypatch.setattr(gate, "JS_PATH", fake_js)
+    # Keep the production cap — a legitimate file is well under 4 MiB.
+
+    rc = gate.main()
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert "passed" in captured.out
+
+
+# ============================================================================
+# Static-source invariant — catch a future refactor that re-introduces
+# the unbounded ``path.read_text()`` shape
+# ============================================================================
+
+
+def test_main_routes_through_read_capped_text() -> None:
+    """Pin the fix-shape invariant via the source itself. A future
+    refactor that replaces ``read_capped_text`` with a bare
+    ``path.read_text(...)`` would silently regress the MemoryError
+    defence; this test fails loudly on that drift.
+
+    Uses :mod:`ast` to inspect the function body (excluding the
+    docstring) so the test does not collide with any narrative reference
+    to the pre-fix unbounded shape inside a future docstring.
+    """
+    from scripts.check_i18n_coverage import main
+
+    source = inspect.getsource(main)
+    module = ast.parse(source)
+    func_def = module.body[0]
+    assert isinstance(func_def, ast.FunctionDef)
+
+    call_names: set[str] = set()
+    for node in ast.walk(func_def):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                call_names.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                call_names.add(func.attr)
+
+    assert "read_capped_text" in call_names, (
+        "main() must route both file reads through read_capped_text — "
+        "the canonical defence helper enforces the TOCTOU-safe byte-size "
+        "cap and avoids MemoryError propagation."
+    )
+    assert "read_text" not in call_names, (
+        "main() must NOT call .read_text() directly — the unbounded "
+        "shape allocates O(file_size) bytes and propagates MemoryError "
+        "past the pre-commit + static-checks pipelines."
+    )
+    assert "read_bytes" not in call_names, (
+        "main() must NOT call .read_bytes() directly either — the same "
+        "MemoryError shape applies to the raw-bytes read path."
+    )

--- a/tests/test_sentinel_size_cap_audit_walker.py
+++ b/tests/test_sentinel_size_cap_audit_walker.py
@@ -1,0 +1,241 @@
+"""Sentinel auto-discoverable invariant: every file-read site in
+``src/`` and ``scripts/`` must route through the canonical
+size-capped helpers, never through the unbounded ``Path.read_text()``
+/ ``Path.read_bytes()`` shape.
+
+Why a walker matters
+--------------------
+The 2026-05-23 GeoNetz size-bomb round (PR #1629, closed in the journal
+entry that prompted this round) explicitly noted:
+
+    Closing-checklist drift for JSON-loader fix families must
+    explicitly walk EVERY ``json.loads``/``json.load``/``response.json()``
+    call site in ``src/`` and ``scripts/`` — not just the named files
+    in the PR's audit narrative. […] Future canonical-loader rounds
+    should ship the walker alongside the per-site fix so every
+    parser-site axis (RecursionError + size-cap + non-finite-literal
+    + Trojan-Source scrub) is programmatically enforced from the
+    start.
+
+The 2026-05-08 round canonicalised :func:`src.utils.files.read_capped_json`
+/ :func:`read_capped_text` / :func:`read_capped_bytes` and shipped a
+programmatic walker for the **RecursionError** axis at
+``tests/test_sentinel_json_audit_walker.py``. The **size-cap** axis was
+not similarly pinned — so the i18n-coverage gate at
+``scripts/check_i18n_coverage.py`` (closed in this round) and the
+GeoNetz loader pair (closed in the previous round) survived multiple
+sibling-drift cycles undetected.
+
+This file IS the size-cap walker, run as a regression test under
+pytest. Any future contributor who adds a bare ``path.read_text()`` /
+``path.read_bytes()`` call to ``src/`` or ``scripts/`` will fail this
+test at PR-review time, regardless of whether the journal named the
+file.
+
+Coverage rule
+-------------
+For every ``<expr>.read_text(...)`` and ``<expr>.read_bytes(...)`` call
+in ``src/`` or ``scripts/``, the receiver must NOT be a ``Path`` /
+file-system path expression. Routing the read through
+:func:`src.utils.files.read_capped_text` /
+:func:`src.utils.files.read_capped_bytes` (or, where the input is
+controlled by the helper itself, a bounded ``handle.read(max_bytes + 1)``
+call on an already-open file descriptor) is the only sanctioned shape.
+
+In practice the walker bans the two bare-call shapes outright across
+``src/`` and ``scripts/``; the canonical helpers internally use
+``handle.read(max_bytes + 1)`` so they are not flagged. Allowlist
+entries (none today) would be limited to legitimate fixed-size system
+file reads (e.g. ``/proc/self/cmdline``) that are not realistically
+attacker-controlled — none of which exist in this codebase today.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAN_TREES = ("src", "scripts")
+
+# Methods that, when invoked directly on a path-like object, buffer the
+# entire file into memory before any defence layer can run. Both shapes
+# allocate O(file_size) bytes and propagate :exc:`MemoryError` (a
+# :class:`BaseException` subclass) past every ordinary
+# ``except OSError`` / ``except ValueError`` / ``except Exception``
+# handler, crashing the surrounding pipeline.
+BANNED_METHODS = frozenset({"read_text", "read_bytes"})
+
+# Allowlist of (relative_path, lineno) pairs that the walker should
+# tolerate. EMPTY by design — every legitimate file read goes through
+# :func:`read_capped_text` / :func:`read_capped_bytes`, and any future
+# special-case (e.g. a fixed-size system file) MUST be added here with
+# a justification comment in the same PR that introduces the call.
+ALLOWLIST: frozenset[tuple[str, int]] = frozenset()
+
+
+def _is_banned_read_call(node: ast.AST) -> str | None:
+    """Return the banned method name if *node* is a banned read call,
+    otherwise return ``None``. Walks ``<expr>.read_text(...)`` and
+    ``<expr>.read_bytes(...)`` shapes; the receiver is intentionally
+    not constrained to ``Path`` because the threat model applies
+    equally to any path-like object (``pathlib.Path``,
+    :func:`pathlib.PurePath` subclasses, third-party path wrappers)."""
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return None
+    if func.attr in BANNED_METHODS:
+        return func.attr
+    return None
+
+
+def _audit_module(path: Path) -> list[tuple[int, str]]:
+    """Return ``[(lineno, banned_method), ...]`` for every uncovered
+    read-site in *path*."""
+    findings: list[tuple[int, str]] = []
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return findings
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return findings
+
+    for node in ast.walk(tree):
+        banned = _is_banned_read_call(node)
+        if banned is None:
+            continue
+        findings.append((node.lineno, banned))
+    return findings
+
+
+def _all_python_files() -> list[Path]:
+    files: list[Path] = []
+    for tree_name in SCAN_TREES:
+        tree_root = REPO_ROOT / tree_name
+        if not tree_root.exists():
+            continue
+        files.extend(sorted(tree_root.rglob("*.py")))
+    return files
+
+
+def test_every_file_read_uses_capped_helper() -> None:
+    """The audit-completion invariant for the size-cap axis: zero
+    bare ``Path.read_text()`` / ``Path.read_bytes()`` calls in
+    ``src/`` or ``scripts/``."""
+    all_findings: list[tuple[Path, int, str]] = []
+    for path in _all_python_files():
+        rel = path.relative_to(REPO_ROOT)
+        for lineno, banned in _audit_module(path):
+            key = (str(rel), lineno)
+            if key in ALLOWLIST:
+                continue
+            all_findings.append((rel, lineno, banned))
+
+    if not all_findings:
+        return
+    rendered = "\n".join(
+        f"  {p}:{lineno}: bare .{banned}() — route through "
+        f"src.utils.files.read_capped_text / read_capped_bytes "
+        f"or add (path, lineno) to ALLOWLIST with justification."
+        for p, lineno, banned in all_findings
+    )
+    pytest.fail(
+        f"{len(all_findings)} unbounded file-read site(s) in src/ or "
+        f"scripts/:\n{rendered}\n\n"
+        "Each site must route through the canonical size-capped "
+        "helpers so a planted multi-GiB file cannot allocate "
+        "O(file_size) bytes and propagate MemoryError past the "
+        "surrounding handler. See the Sentinel Size-Bomb Drift Round "
+        "(2026-05-23 — i18n coverage gate) audit for the closing "
+        "rule."
+    )
+
+
+# ============================================================================
+# Smoke tests pinning the walker's pattern-recognition contract
+# ============================================================================
+
+
+def test_walker_recognises_read_text() -> None:
+    """``path.read_text(...)`` is a banned shape — pin recognition."""
+    sample = "from pathlib import Path\n" + "p = Path('x')\n" + "p.read_text()\n"
+    tree = ast.parse(sample)
+    findings = [
+        node.lineno
+        for node in ast.walk(tree)
+        if _is_banned_read_call(node) == "read_text"
+    ]
+    assert findings == [3], "Walker must flag bare path.read_text() calls"
+
+
+def test_walker_recognises_read_bytes() -> None:
+    """``path.read_bytes(...)`` is a banned shape — pin recognition."""
+    sample = "from pathlib import Path\n" + "p = Path('x')\n" + "p.read_bytes()\n"
+    tree = ast.parse(sample)
+    findings = [
+        node.lineno
+        for node in ast.walk(tree)
+        if _is_banned_read_call(node) == "read_bytes"
+    ]
+    assert findings == [3], "Walker must flag bare path.read_bytes() calls"
+
+
+def test_walker_ignores_handle_read_with_bound() -> None:
+    """A bounded ``handle.read(n)`` call is the canonical safe shape and
+    must NOT be flagged. The walker pattern-matches on the method name
+    ``read_text`` / ``read_bytes`` specifically; a generic ``.read(n)``
+    is out of scope (callers that route through ``read_capped_text`` use
+    ``handle.read(max_bytes + 1)`` internally)."""
+    sample = (
+        "with open('x', 'rb') as h:\n"
+        "    payload = h.read(1024)\n"
+    )
+    tree = ast.parse(sample)
+    findings = [
+        node.lineno
+        for node in ast.walk(tree)
+        if _is_banned_read_call(node) is not None
+    ]
+    assert findings == [], (
+        "Walker must NOT flag bounded handle.read(n) — that's the "
+        "canonical safe shape used inside read_capped_text itself."
+    )
+
+
+def test_walker_ignores_unrelated_calls() -> None:
+    """Sanity check: unrelated function calls (string methods,
+    arithmetic, attribute access) must not produce false positives."""
+    sample = (
+        "x = 'hello'.upper()\n"
+        "y = some_dict.get('k')\n"
+        "z = open('x').close()\n"
+    )
+    tree = ast.parse(sample)
+    findings = [
+        node.lineno
+        for node in ast.walk(tree)
+        if _is_banned_read_call(node) is not None
+    ]
+    assert findings == [], (
+        "Walker must NOT produce false positives on unrelated "
+        "method calls."
+    )
+
+
+def test_allowlist_is_empty_today() -> None:
+    """The ALLOWLIST is empty by design — every legitimate file read
+    routes through the canonical capped helpers today. If a future PR
+    needs to add an entry, this test pins the requirement that the
+    addition is intentional (not accidental) by failing if the
+    allowlist drifts. Update this assertion alongside any legitimate
+    allowlist addition."""
+    assert ALLOWLIST == frozenset(), (
+        "ALLOWLIST drifted from empty — any new entry must come with "
+        "a justification comment AND an update to this assertion."
+    )


### PR DESCRIPTION
## Summary

Closes the size-cap sibling drift in the JSON / file-read defence family — the next site after the 2026-05-23 GeoNetz loader pair (#1629) — and ships the long-promised programmatic walker for the **size-cap axis** (realising the closing rule from the previous round's journal entry).

## Vulnerability

`scripts/check_i18n_coverage.py:180-181` used unbounded
```python
HTML_PATH.read_text(encoding="utf-8")
JS_PATH.read_text(encoding="utf-8")
```
on the two committed dashboard sources (`docs/site.html`, `docs/assets/site.js`). The gate is invoked from **two blocking pipelines**:

1. The local pre-commit hook (`.pre-commit-config.yaml`) — runs on every commit that touches the dashboard assets.
2. The canonical CI gauntlet at `scripts/run_static_checks.py` — itself invoked by `.github/workflows/test.yml` on every push and PR.

A planted multi-GiB `docs/site.html` / `docs/assets/site.js` (hostile PR replacing the tracked source, compromised CI runner / `main` checkout, partial flush + power loss mid-edit) buffered via `read_text()` allocates O(file_size) bytes and raises `MemoryError`. `MemoryError` is a `BaseException` subclass — NOT caught by any handler in this script (`main()` has no try/except at all) — so the unhandled exception escapes the gate and crashes the full static-checks pipeline.

**Sibling drift**: the sibling script `scripts/optimize_site_assets.py` writes to the EXACT same two files via `atomic_write` and already routes its reads through the canonical `read_capped_text` defence with a 4-MiB cap (`MAX_CSS_FILE_BYTES`). The i18n coverage gate was the missed sibling — a clone of the GeoNetz pattern from PR #1629.

## Fix

- **`scripts/check_i18n_coverage.py`** — imports `read_capped_text` from `src.utils.files` (with the canonical script-import dual-path pattern), defines `MAX_I18N_FILE_BYTES = 4 * 1024 * 1024` mirroring `MAX_CSS_FILE_BYTES`, and routes both reads through the helper. The `None` return (oversized / missing / invalid UTF-8) is converted to a clean non-zero exit with a clear operator message — no more `MemoryError` propagation.

- **`tests/test_sentinel_size_cap_audit_walker.py`** *(new)* — programmatic walker that scans every `*.py` under `src/` and `scripts/` for bare `<expr>.read_text(...)` / `<expr>.read_bytes(...)` calls. Verified to flag the pre-fix shape at `scripts/check_i18n_coverage.py:180` and `:181`; post-fix the allowlist is empty by design. Any future re-introduction of the unbounded shape fails CI at PR-review time regardless of whether the journal named the file — this is the long-promised size-cap-axis sibling of the existing `test_sentinel_json_audit_walker.py` (RecursionError axis).

- **`tests/test_sentinel_check_i18n_size_bomb_ondisk.py`** *(new)* — 5 PoC + AST static-invariant tests covering: cap-constant precondition, oversized HTML rejection, oversized JS rejection, normal-file sanity, AST-based "main() routes through read_capped_text" invariant.

- **`.jules/sentinel.md`** — journal entry documenting the vulnerability and the walker shipped alongside the per-site fix.

## Verification

- All 8244 existing tests pass (`pytest` — 380s, 0 failures).
- All static checks pass (`python scripts/run_static_checks.py` — Ruff, Mypy, Bandit, secret scanner, C901 gate, i18n gate, pip-audit).
- Verified the PoC fails against the pre-fix code (`git stash` then re-run) — 4 PoC tests fail with the expected `MemoryError`-shape diagnostics, and the walker correctly flags both unsafe call sites with line numbers `180` and `181`.
- Verified the fix passes the PoC tests post-fix (11/11 new tests passing, plus the related `test_sentinel_geonetz_size_bomb_ondisk.py` and `test_sentinel_json_audit_walker.py` suites continue to pass).

## Test plan

- [x] `python -m pytest tests/test_sentinel_check_i18n_size_bomb_ondisk.py tests/test_sentinel_size_cap_audit_walker.py -v` — 11 passed
- [x] `python -m pytest -x -q` — 8244 passed, 2 skipped
- [x] `python scripts/run_static_checks.py` — all checks passed
- [x] PoC verified against pre-fix code (stash + replay)
- [x] Walker verified against pre-fix code (caught both `:180` and `:181` correctly)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y37StoaV2GfTXEz41FUfJB)_