### PR TITLE
test: remove second silent-pass test (timeout_underflow)

### DIFF
--- a/tests/test_build_feed_timeout.py
+++ b/tests/test_build_feed_timeout.py
@@ -27,41 +27,6 @@ def test_collect_items_timeout_zero() -> None:
         assert "Timeout nach 0s" in args[1]
         mock_executor.submit.assert_not_called()
 
-def test_collect_items_timeout_underflow() -> None:
-    # If timeout logic works properly, _call_fetch_with_timeout shouldn't be executed
-    # when timeout reaches exactly 0
-
-    mock_feed_config = MagicMock()
-    mock_feed_config.PROVIDER_TIMEOUT = 1
-    mock_feed_config.PROVIDER_MAX_WORKERS = 1
-    mock_feed_config.get_bool_env.return_value = True
-
-    def mock_fetch(timeout: Any = None) -> list[dict[str, Any]]: return []
-    mock_fetch.__name__ = "dummy_provider"
-    report = MagicMock(spec=RunReport)
-
-    with patch.object(bf, "feed_config", mock_feed_config), \
-         patch.object(bf, "PROVIDERS", [("DUMMY_ENABLE", mock_fetch)]), \
-         patch.object(bf, "DEFAULT_PROVIDERS", ("DUMMY_ENABLE",)):
-
-        # Intercept _run_fetch just as it is created
-        original_submit = bf.ThreadPoolExecutor.submit
-
-        captured_run_fetch = []
-        def mock_submit(self: Any, fn: Any, *args: Any, **kwargs: Any) -> Any:
-            captured_run_fetch.append(fn)
-            return original_submit(self, fn, *args, **kwargs)
-
-        with patch("src.build_feed.ThreadPoolExecutor.submit", new=mock_submit):
-            # We want to skip actually executing it inside the pool,
-            # so we let the pool cancel or time out. Wait, easiest is to let it run
-            # but mock perf_counter just for the thread.
-            pass
-
-        # Since ThreadPoolExecutor uses real threads, mocking perf_counter is hard.
-        # Let's extract the exact _run_fetch manually without running _collect_items!
-
-# Let's just create a test that directly tests the condition.
 def test_run_fetch_timeout_exactly_zero() -> None:
     # We will simulate exactly what _run_fetch does
     import threading


### PR DESCRIPTION
## Summary

Follow-up to #1631 (which fixed three other silent-pass tests). A deeper audit — running pytest with `pytest-randomly --randomly-seed=12345` and a per-function assertion scan — surfaced one more silent-pass test that escaped the first sweep.

### What was wrong

`tests/test_build_feed_timeout.py::test_collect_items_timeout_underflow`:

```python
def test_collect_items_timeout_underflow() -> None:
    # ... lots of mock setup ...
    with patch.object(bf, "feed_config", mock_feed_config), \
         patch.object(bf, "PROVIDERS", [("DUMMY_ENABLE", mock_fetch)]), \
         patch.object(bf, "DEFAULT_PROVIDERS", ("DUMMY_ENABLE",)):

        original_submit = bf.ThreadPoolExecutor.submit
        captured_run_fetch = []
        def mock_submit(self, fn, *args, **kwargs):
            captured_run_fetch.append(fn)
            return original_submit(self, fn, *args, **kwargs)

        with patch("src.build_feed.ThreadPoolExecutor.submit", new=mock_submit):
            # We want to skip actually executing it inside the pool,
            # so we let the pool cancel or time out. Wait, easiest is to let it run
            # but mock perf_counter just for the thread.
            pass

        # Since ThreadPoolExecutor uses real threads, mocking perf_counter is hard.
        # Let's extract the exact _run_fetch manually without running _collect_items!
```

The author wrote the setup, hit a wall mocking thread-pool timing, gave up with `pass`, left a comment ("Let's extract the exact `_run_fetch` manually without running `_collect_items`!") and wrote a replacement function (`test_run_fetch_timeout_exactly_zero`) immediately below. The original `test_collect_items_timeout_underflow` was left behind as a no-op silent-pass — same shape as the `test_otp_false_positive` I removed in #1631.

### What stays

The replacement test `test_run_fetch_timeout_exactly_zero` in the same file is preserved. It exercises the timeout-arithmetic via a local reimplementation of `_build_run_fetch._run_fetch` from `src/build_feed.py`. The pattern is weak (it tests the replica, not the production function), but it does pin some behaviour and is the author's intentional workaround.

## Verification

- `pytest` full suite: **8230 passed, 2 skipped** in 6:11 (drops by exactly 1 from the previous baseline of 8231, matching the removed silent-pass test).
- `ruff` clean on the modified file.

## Test plan

- [x] Full suite green.
- [x] Collection drops by exactly 1 (the silent-pass test).
- [x] Replacement test `test_run_fetch_timeout_exactly_zero` still runs and passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NkKhsJBcnHCiqceCf8XaMS)_