### PR TITLE
fix(ci): two-attempt actions/checkout (workaround for upstream #2351)

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -42,7 +42,17 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # Workaround for actions/checkout#2351 (sporadic includeIf credential
+      # race on v6 → "could not read Username, terminal prompts disabled").
+      # Two attempts; remove once v6.0.3+ is pinned.
+      - name: Check out repository (attempt 1/2)
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        continue-on-error: true
+
+      - name: Check out repository (attempt 2/2 — runs only if attempt 1 hit checkout#2351)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6

--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -54,7 +54,19 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # Workaround for actions/checkout#2351 (sporadic includeIf credential
+      # race on v6 → "could not read Username, terminal prompts disabled").
+      # Two attempts; remove once v6.0.3+ is pinned.
+      - name: Check out repository (attempt 1/2)
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+        continue-on-error: true
+
+      - name: Check out repository (attempt 2/2 — runs only if attempt 1 hit checkout#2351)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,16 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-    - name: Checkout repository
+    # Workaround for actions/checkout#2351 (sporadic includeIf credential
+    # race on v6 → "could not read Username, terminal prompts disabled").
+    # Two attempts; remove once v6.0.3+ is pinned.
+    - name: Check out repository (attempt 1/2)
+      id: checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      continue-on-error: true
+
+    - name: Check out repository (attempt 2/2 — runs only if attempt 1 hit checkout#2351)
+      if: steps.checkout.outcome == 'failure'
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.

--- a/.github/workflows/complexity-gate.yml
+++ b/.github/workflows/complexity-gate.yml
@@ -34,7 +34,16 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Check out repository
+      # Workaround for actions/checkout#2351 (sporadic includeIf credential
+      # race on v6 → "could not read Username, terminal prompts disabled").
+      # Two attempts; remove once v6.0.3+ is pinned.
+      - name: Check out repository (attempt 1/2)
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        continue-on-error: true
+
+      - name: Check out repository (attempt 2/2 — runs only if attempt 1 hit checkout#2351)
+        if: steps.checkout.outcome == 'failure'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python

--- a/.github/workflows/manual-full-refresh.yml
+++ b/.github/workflows/manual-full-refresh.yml
@@ -52,7 +52,18 @@ jobs:
       VOR_VERSION: ${{ secrets.VOR_VERSION }}
 
     steps:
-      - name: Check out repository
+      # Workaround for actions/checkout#2351 (sporadic includeIf credential
+      # race on v6 → "could not read Username, terminal prompts disabled").
+      # Two attempts; remove once v6.0.3+ is pinned.
+      - name: Check out repository (attempt 1/2)
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+        continue-on-error: true
+
+      - name: Check out repository (attempt 2/2 — runs only if attempt 1 hit checkout#2351)
+        if: steps.checkout.outcome == 'failure'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0

--- a/.github/workflows/mypy-strict.yml
+++ b/.github/workflows/mypy-strict.yml
@@ -29,7 +29,16 @@ jobs:
       PYTHONPATH: src
 
     steps:
-      - name: Check out repository
+      # Workaround for actions/checkout#2351 (sporadic includeIf credential
+      # race on v6 → "could not read Username, terminal prompts disabled").
+      # Two attempts; remove once v6.0.3+ is pinned.
+      - name: Check out repository (attempt 1/2)
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        continue-on-error: true
+
+      - name: Check out repository (attempt 2/2 — runs only if attempt 1 hit checkout#2351)
+        if: steps.checkout.outcome == 'failure'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python

--- a/.github/workflows/seo-guard.yml
+++ b/.github/workflows/seo-guard.yml
@@ -36,7 +36,18 @@ jobs:
       SITE_BASE: https://origamihase.github.io/wien-oepnv
       DESC: Konsolidierter RSS-Feed für Störungen und Baustellenmeldungen im Wiener ÖPNV (WL/ÖBB/VOR), inkl. Doku & Open-Data-Workflows.
     steps:
-      - name: Checkout
+      # Workaround for actions/checkout#2351 (sporadic includeIf credential
+      # race on v6 → "could not read Username, terminal prompts disabled").
+      # Two attempts; remove once v6.0.3+ is pinned.
+      - name: Check out repository (attempt 1/2)
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+        continue-on-error: true
+
+      - name: Check out repository (attempt 2/2 — runs only if attempt 1 hit checkout#2351)
+        if: steps.checkout.outcome == 'failure'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0

--- a/.github/workflows/test-vor-api.yml
+++ b/.github/workflows/test-vor-api.yml
@@ -28,7 +28,16 @@ jobs:
       VOR_BASE_URL: ${{ secrets.VOR_BASE_URL }}
 
     steps:
-      - name: Check out repository
+      # Workaround for actions/checkout#2351 (sporadic includeIf credential
+      # race on v6 → "could not read Username, terminal prompts disabled").
+      # Two attempts; remove once v6.0.3+ is pinned.
+      - name: Check out repository (attempt 1/2)
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        continue-on-error: true
+
+      - name: Check out repository (attempt 2/2 — runs only if attempt 1 hit checkout#2351)
+        if: steps.checkout.outcome == 'failure'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Validate required secrets

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,16 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
     steps:
-      - name: Check out repository
+      # Workaround for actions/checkout#2351 (sporadic includeIf credential
+      # race on v6 → "could not read Username, terminal prompts disabled").
+      # Two attempts; remove once v6.0.3+ is pinned.
+      - name: Check out repository (attempt 1/2)
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        continue-on-error: true
+
+      - name: Check out repository (attempt 2/2 — runs only if attempt 1 hit checkout#2351)
+        if: steps.checkout.outcome == 'failure'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python

--- a/.github/workflows/update-cycle.yml
+++ b/.github/workflows/update-cycle.yml
@@ -85,12 +85,23 @@ jobs:
       VOR_VERSION: ${{ secrets.VOR_VERSION }}
 
     steps:
-      - name: Check out repository
+      # Workaround for actions/checkout#2351 (sporadic includeIf credential
+      # race on v6 → "could not read Username, terminal prompts disabled").
+      # Two attempts; remove once v6.0.3+ is pinned.
+      - name: Check out repository (attempt 1/2)
+        id: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           # Need full history so ``git pull --rebase --autostash`` can
           # cleanly stitch our commit onto whatever the parallel
           # ``update-stations.yml`` (Sundays) pushed during this run.
+          fetch-depth: 0
+        continue-on-error: true
+
+      - name: Check out repository (attempt 2/2 — runs only if attempt 1 hit checkout#2351)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
           fetch-depth: 0
 
       - name: Set up Python

--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -63,7 +63,18 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src
     steps:
-      - name: Check out repository
+      # Workaround for actions/checkout#2351 (sporadic includeIf credential
+      # race on v6 → "could not read Username, terminal prompts disabled").
+      # Two attempts; remove once v6.0.3+ is pinned.
+      - name: Check out repository (attempt 1/2)
+        id: checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+        continue-on-error: true
+
+      - name: Check out repository (attempt 2/2 — runs only if attempt 1 hit checkout#2351)
+        if: steps.checkout.outcome == 'failure'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Beschreibung der Änderung

`actions/checkout@v6.0.2` (`de0fac2`) versagt sporadisch beim initialen `git fetch` mit:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

Ursache: das neue `includeIf`-basierte Credentials-Setup von v6 wird gelegentlich nicht auf den ersten Fetch auf gehosteten Runnern angewandt (Upstream-Issue `actions/checkout#2351`, offen). Das eingebaute 3-Versuche-Retry der Action greift in derselben VM denselben kaputten Zustand und versagt jedes Mal identisch nach ~150 ms — vor jedem TLS-Roundtrip. Der einzige Ausweg ist eine frische `actions/checkout`-Invocation, die neue Credential-UUIDs erzeugt und das gesamte Setup neu fährt.

Konkret beobachtet am 23.05.2026: cycle-Run 12:00 UTC scheiterte mit obiger Fehlermeldung über drei Retries (12 s + 18 s Backoff), Re-Run 15 min später auf einer anderen VM lief sauber durch. Konfigurationsdiff zwischen beiden Runs: nur die UUIDs. Klar Backend-/Race-Symptom, nicht Konfigurationsfehler.

Pattern in allen 11 Workflows:

```yaml
- name: Check out repository (attempt 1/2)
  id: checkout
  uses: actions/checkout@de0fac2…  # v6
  with: …
  continue-on-error: true

- name: Check out repository (attempt 2/2 — runs only if attempt 1 hit checkout#2351)
  if: steps.checkout.outcome == 'failure'
  uses: actions/checkout@de0fac2…  # v6
  with: …
```

Eigenschaften:

- **Selbstheilend** — kein manuelles Re-Run, passt zum autonomen Cycle.
- **`persist-credentials` bleibt intakt** — `update-cycle.yml` braucht die für `git pull --rebase --autostash` + `stefanzweifel/git-auto-commit-action` am Workflow-Ende; beide laufen unverändert.
- **Null neue Drittparty-Action-Oberfläche** — derselbe SHA wie zuvor, zweimal aufgerufen.
- **Null Kosten auf Happy Path** — Attempt 2 wird übersprungen, kein Wall-Clock-Overhead.
- **Eindeutiges Rückbau-Signal** — drei-Zeilen-Kommentar oberhalb jedes Blocks zeigt auf `actions/checkout#2351` und nennt die Removal-Bedingung (`v6.0.3+ gepinnt`).

## Ticket-Referenz

Upstream: `actions/checkout#2351`. Kein lokales Issue.

## Bewusst ausgeklammert

- **Kein Rollback auf v5**: explizit gegen Maintainer-Workaround-Empfehlung in `#2393` entschieden — der Single-Point-of-Failure ist ein bekannter v6-Bug, kein v6-Designfehler; v6 bringt FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 + Node 24 das Repo bereits aktiv nutzt.
- **Keine Composite Action `.github/actions/robust-checkout/`**: Henne-Ei — die Action-Datei lebt im Repo, das wir gerade auschecken wollen. Inline-Duplikation ist die einzig saubere Variante für einen Checkout-Wrap.
- **Keine `nick-fields/retry@v3`-Variante**: wrappt nur `run:`-Shellkommandos, nicht `uses:`-Steps.
- **Kein Fallback `git clone` mit URL-eingebettetem Token**: würde `persist-credentials` für die Push-Schritte am Workflow-Ende manuell nachbauen müssen (`http.extraheader` mit base64-Token in Shell-Variable) — zusätzliche Token-Exposure-Oberfläche ohne Gegenwert.

## Review-Checkliste

Für reine CI-Workflow-Änderung ohne Source-Code-/Pipeline-Touch sind die meisten Punkte nicht zutreffend. Relevant:

### Sicherheit
- [x] Kein neuer HTTP-Aufruf, kein neuer Host, keine `# nosec`-Markierung.
- [x] Keine neue Token-Exposure: derselbe `actions/checkout`-SHA wird genutzt, Token-Handling unverändert.

### Statische Analyse
- [x] Alle 11 Workflow-YAMLs parsen mit `yaml.safe_load` (lokal verifiziert).
- [x] Strukturvalidierung pro Workflow: genau zwei `actions/checkout`-Steps, identischer SHA, identische `with:`-Werte, Attempt 1 hat `id: checkout` + `continue-on-error: true`, Attempt 2 hat `if: steps.checkout.outcome == 'failure'`.
- [x] Keine `needs:`-Graph-Brüche.
- [x] Keine trailing whitespace, keine fehlenden final newlines.

### Komplexität / Resilienz / Dokumentation
- N/A — kein Python-Code geändert.

## Test Plan

Da das Pattern nur auf `failure` der ersten Attempts feuert, ist die direkte Verifikation begrenzt. Was machbar ist:

- [x] YAML-Syntax-Validität (lokal verifiziert).
- [x] Strukturvalidierung pro Workflow (lokal verifiziert).
- [ ] Happy-Path-Check: nächster IFTTT-Cycle-Tick (~30 min nach Merge) muss durchlaufen wie vorher; Attempt 2 darf laut Logs nicht ausgeführt werden.
- [ ] Failure-Path-Check: beim nächsten sporadischen `#2351`-Treffer (basierend auf der gestrigen Frequenz: ≤ Tage) muss der cycle-Job grün durchlaufen, Attempt 2 in den Logs sichtbar als "Check out repository (attempt 2/2 …)".
- [ ] Mittelfristig: Failure-Rate nach Merge gegen Pre-Merge-Baseline. Wenn `#2351` wieder zuschlägt und Attempt 2 ihn nicht heilt, ist die Hypothese widerlegt und es braucht Plan B (z. B. Fallback-Clone-Variante).

---
_Generated by [Claude Code](https://claude.ai/code/session_018e7x6EhSi6PbnKpCFo1bJd)_