### PR TITLE
fix(security): scrub Trojan-Source bytes in two committed-state JSON writers + add closing-rule walker

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,5 +1,78 @@
 # Sentinel's Journal
 
+## 2026-05-23 - Trojan-Source Scrub Audit Walker (Writer-Site Closing Rule)
+
+**Vulnerability:** Two committed-state JSON writer sinks still emitted
+the canonical CVE-2021-42574 Trojan-Source / BiDi-mark / zero-width /
+8-bit C1 attack-byte union as raw UTF-8 bytes despite the 2026-05-14
+Round 13 / 14 closing-checklist sweep:
+
+1. `scripts/extract_oebb_geonetz_stops.py:main` (line ~300) writes
+   `data/oebb_geonetz_stops.json` via
+   `json.dumps(payload, ensure_ascii=False, indent=2,
+   allow_nan=False)` with NO `scrub_trojan_source_primitives` call on
+   the payload. The payload's `stops[].name`, `stops[].address`,
+   `stops[].ifopt_id`, `stops[].bsts_id`, and `stops[].eva_nr`
+   fields flow verbatim from the upstream ÖBB GeoNetz dump
+   (`data.oebb.at` ÖBB-Infrastruktur AG endpoint) — a compromised
+   CDN / DNS hijack / MITM on the GeoNetz fetch carrying U+202E
+   (RIGHT-TO-LEFT OVERRIDE) in any of those fields lands the BiDi
+   reversal trigger directly in the committed sidecar (`E2 80 AE`
+   UTF-8 bytes). Same file's parser-site siblings (size-cap +
+   non-finite literal) were closed in PR #1629 but the writer-side
+   Trojan-Source scrub was missed.
+
+2. `scripts/apply_station_overrides.py:apply_overrides` (line ~324)
+   writes `data/stations.json` after applying the curated overrides
+   list via `json.dumps(stations_payload, indent=2,
+   ensure_ascii=False, allow_nan=False)` with NO
+   `scrub_trojan_source_primitives` call. Two attack vectors land
+   bytes here: (a) a previously-poisoned `data/stations.json`
+   (planted via a bypass of the canonical writer, surviving from a
+   corrupted previous cron run, or written by an early-deployment
+   build pre-dating Round 12-14) survives the read-then-write cycle;
+   (b) the `_op_restore` handler inserts the override's `entry`
+   template verbatim via `dict(entry_template)`, so a hostile PR
+   landing a tampered `data/stations_overrides.json` carrying
+   U+202E in an `entry` `name` field plants the byte directly into
+   the committed `data/stations.json`. Both files reach `main` via
+   the weekly `update-stations.yml` cron pipeline.
+
+**Learning:** The 2026-05-23 closing rule for the parser-site axes
+(`Future canonical-loader rounds should ship the walker alongside the
+per-site fix so every parser-site axis (RecursionError + size-cap +
+non-finite-literal + Trojan-Source scrub) is programmatically
+enforced from the start`) is now realised for the **Trojan-Source
+scrub** axis via `tests/test_sentinel_trojan_source_audit_walker.py`.
+The walker scans every `*.py` under `src/` and `scripts/` for any
+`json.dump(...)` / `json.dumps(...)` call that explicitly pins
+`ensure_ascii=False` as a keyword argument and asserts the smallest
+enclosing function (or module body for module-level writers) contains
+at least one `scrub_trojan_source_primitives(...)` call. Three
+documented sibling-defence sites live in the `ALLOWLIST`:
+`src/places/hafas_client.py:_serialise_payload` (HAFAS wire-format
+bytes are MAC-signed and sent to a third-party endpoint, not
+committed); `src/feed/reporting.py:write_feed_health_json` (per-field
+`_CONTROL_CHARS_RE.sub("", ...)` strips the byte-equivalent canonical
+union pre-serialisation); `src/feed/logging_safe.py:SafeJSONFormatter`
+(two lines — `sanitize_log_message(dumped, strip_control_chars=False)`
+always strips the byte-equivalent canonical union
+post-serialisation). When invoked against the pre-fix codebase the
+walker correctly flagged `scripts/apply_station_overrides.py:324` and
+`scripts/extract_oebb_geonetz_stops.py:300`; post-fix it reports zero
+findings. Any future contributor who adds a fresh
+`json.dump(..., ensure_ascii=False, ...)` /
+`json.dumps(..., ensure_ascii=False, ...)` callsite without a
+sibling `scrub_trojan_source_primitives` call (or a documented
+allowlist entry) fails the walker at PR-review time regardless of
+whether the journal named the file. With this round all four
+canonical fix-family axes (RecursionError + size-cap +
+non-finite-literal + Trojan-Source scrub) are now programmatically
+enforced; the journal-named closing rule from the 2026-05-23
+non-finite-literal round is complete. Future fix families should
+inherit this template: ship the walker alongside the per-site fix
+from PR #1, never as a follow-up round.
+
 ## 2026-05-23 - Non-Finite Literal Audit Walker (Parser-Site Closing Rule)
 
 **Vulnerability:** The 2026-05-14 / 2026-05-15 rounds (PR #1485 /

--- a/scripts/apply_station_overrides.py
+++ b/scripts/apply_station_overrides.py
@@ -44,6 +44,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from src.feed.logging_safe import setup_script_logging  # noqa: E402
 from src.utils.files import atomic_write, loads_finite, read_capped_text  # noqa: E402
+from src.utils.serialize import scrub_trojan_source_primitives  # noqa: E402
 from src.utils.stations import MAX_STATIONS_FILE_BYTES  # noqa: E402
 
 # Cap matches the overrides file's expected upper bound; 1 MiB is generous
@@ -310,6 +311,37 @@ def apply_overrides(
             applied += 1
 
     # Persist
+    # Security (Trojan-Source / BiDi-Mark Drift, ingestion-boundary
+    # defence): strip the canonical CVE-2021-42574 attack-byte union
+    # (BiDi formatting controls, BiDi isolates, zero-width primitives +
+    # LRM/RLM/ALM, Unicode line / paragraph separators, the BOM / ZWNBSP,
+    # and the 8-bit C1 terminal-escape primitives) from every reachable
+    # string in the stations payload BEFORE ``json.dumps``. Two attack
+    # vectors are closed here: (a) a previously-poisoned
+    # ``data/stations.json`` carrying historic BiDi marks (planted via
+    # a bypass of the canonical writer, surviving from a corrupted
+    # previous cron run, or written by an early-deployment build
+    # pre-dating the Round 12-14 closing rounds) would otherwise be
+    # re-emitted verbatim via this re-write; (b) the ``_op_restore``
+    # handler inserts the override's ``entry`` template verbatim via
+    # ``dict(entry_template)``, so a hostile PR landing a tampered
+    # ``data/stations_overrides.json`` carrying U+202E in an
+    # ``entry`` ``name`` field would otherwise plant the byte directly
+    # into the committed ``data/stations.json``. ``ensure_ascii=False``
+    # is preserved at the writer below so legitimate German station
+    # names (umlauts ä/ö/ü/Ä/Ö/Ü + sharp s ß) stay compact in the
+    # commit diff. Mirrors the canonical writer-side pin established
+    # in Round 13 at ``src/places/merge.py:write_stations`` and extended
+    # in Round 14 to the eight named script-level writers
+    # (``tests/test_sentinel_script_station_writers_trojan_source.py``);
+    # the closing-rule walker is
+    # ``tests/test_sentinel_trojan_source_audit_walker.py``.
+    scrubbed_payload = scrub_trojan_source_primitives(stations_payload)
+    serialisable = (
+        scrubbed_payload
+        if isinstance(scrubbed_payload, dict | list)
+        else stations_payload
+    )
     # Security (writer-side non-finite literal defence, symmetric to the
     # ``loads_finite`` reader pin above). ``allow_nan=False`` surfaces any
     # ``float('nan')`` / ``float('inf')`` that bypassed the reader-side
@@ -321,7 +353,7 @@ def apply_overrides(
     # the canonical writer-side pins in ``src/places/merge.py:write_stations``
     # and ``scripts/update_all_stations.py:_write_stations`` (2026-05-14
     # PR #1485 / #1487 / #1488 / #1491).
-    text = json.dumps(stations_payload, indent=2, ensure_ascii=False, allow_nan=False)
+    text = json.dumps(serialisable, indent=2, ensure_ascii=False, allow_nan=False)
     with atomic_write(stations_path, mode="w", encoding="utf-8", permissions=0o644) as handle:
         handle.write(text)
         handle.write("\n")

--- a/scripts/extract_oebb_geonetz_stops.py
+++ b/scripts/extract_oebb_geonetz_stops.py
@@ -50,9 +50,11 @@ if str(_ROOT) not in sys.path:
 try:  # pragma: no cover - convenience for module execution
     from src.feed.logging_safe import setup_script_logging
     from src.utils.files import atomic_write, loads_finite, read_capped_bytes
+    from src.utils.serialize import scrub_trojan_source_primitives
 except ModuleNotFoundError:  # pragma: no cover - fallback when installed as package
     from feed.logging_safe import setup_script_logging  # type: ignore[no-redef]
     from utils.files import atomic_write, loads_finite, read_capped_bytes  # type: ignore[no-redef]
+    from utils.serialize import scrub_trojan_source_primitives  # type: ignore[no-redef]
 
 # Cap mirrors ``MAX_JSON_FILE_BYTES`` in scripts/update_station_directory.py.
 # The raw GeoNetz dump is ~23 MiB; 50 MiB leaves ~2x headroom for a future
@@ -275,6 +277,28 @@ def main(argv: list[str] | None = None) -> int:
 
     payload = extract(args.raw, args.source_url)
     args.output.parent.mkdir(parents=True, exist_ok=True)
+    # Security (Trojan-Source / BiDi-Mark Drift, ingestion-boundary
+    # defence): strip the canonical CVE-2021-42574 attack-byte union
+    # (BiDi formatting controls, BiDi isolates, zero-width primitives +
+    # LRM/RLM/ALM, Unicode line / paragraph separators, the BOM / ZWNBSP,
+    # and the 8-bit C1 terminal-escape primitives) from every reachable
+    # string in the GeoNetz payload BEFORE ``json.dumps``. The payload's
+    # ``stops[].name`` / ``stops[].address`` / ``stops[].ifopt_id`` /
+    # ``stops[].bsts_id`` / ``stops[].eva_nr`` fields are taken verbatim
+    # from the upstream GeoNetz dump — a compromised CDN / DNS hijack /
+    # MITM on the ÖBB-Infrastruktur fetch carrying U+202E in any of
+    # those fields would otherwise land the bytes in the committed
+    # ``data/oebb_geonetz_stops.json`` sidecar. ``ensure_ascii=False``
+    # is preserved at the writer below so legitimate German station
+    # names (umlauts ä/ö/ü/Ä/Ö/Ü + sharp s ß) stay compact in the
+    # commit diff. Mirrors the canonical writer-side pin established
+    # in Round 13 at ``src/places/merge.py:write_stations`` and
+    # extended in Round 14 to the eight named script-level writers
+    # (``tests/test_sentinel_script_station_writers_trojan_source.py``);
+    # the closing-rule walker is
+    # ``tests/test_sentinel_trojan_source_audit_walker.py``.
+    scrubbed = scrub_trojan_source_primitives(payload)
+    serialisable = scrubbed if isinstance(scrubbed, dict) else payload
     # ``atomic_write`` (tempfile + ``os.replace``) so a crash / SIGINT
     # mid-dump cannot leave a half-written JSON snapshot in the
     # repository — ``data/oebb-geonetz-stops.json`` is committed to
@@ -297,7 +321,7 @@ def main(argv: list[str] | None = None) -> int:
     # ``data/oebb_geonetz_stops.json`` sidecar.
     with atomic_write(args.output, mode="w", encoding="utf-8") as handle:
         handle.write(
-            json.dumps(payload, ensure_ascii=False, indent=2, allow_nan=False) + "\n"
+            json.dumps(serialisable, ensure_ascii=False, indent=2, allow_nan=False) + "\n"
         )
     size_kib = args.output.stat().st_size / 1024
     logger.info(

--- a/tests/test_sentinel_geonetz_overrides_writer_trojan_source.py
+++ b/tests/test_sentinel_geonetz_overrides_writer_trojan_source.py
@@ -1,0 +1,481 @@
+"""Sentinel PoC: Trojan-Source / BiDi-Mark leakage at the **two remaining**
+``ensure_ascii=False`` JSON writer sites that the 2026-05-23 GeoNetz +
+i18n closing round flagged as the open Trojan-Source axis.
+
+Round 13 (PR #1438) closed the canonical library writer
+``src/places/merge.py:write_stations`` via the
+``scrub_trojan_source_primitives`` helper. Round 14 (the eight-sink
+sibling closure in ``test_sentinel_script_station_writers_trojan_source.py``)
+extended the scrubber to every named script-level
+``ensure_ascii=False`` station-directory writer. The 2026-05-23 round
+shipped the size-cap walker
+(``tests/test_sentinel_size_cap_audit_walker.py``) AND the non-finite
+walker (``tests/test_sentinel_non_finite_literal_audit_walker.py``),
+explicitly naming the Trojan-Source axis as the remaining open
+closing-rule item::
+
+    Future canonical-loader rounds should ship the walker alongside
+    the per-site fix so every parser-site axis (RecursionError +
+    size-cap + non-finite-literal + Trojan-Source scrub) is
+    programmatically enforced from the start. With this round all
+    three of the parser-site canonical axes [...] are now
+    programmatically enforced; the Trojan-Source scrub axis remains
+    the open closing-rule item for a future round.
+
+Two sibling ``ensure_ascii=False`` writer sinks survived past Round 14
+unscrubbed:
+
+1. **``scripts/extract_oebb_geonetz_stops.py:main`` (line ~300)** —
+   writes the compact ÖBB GeoNetz projection to
+   ``data/oebb_geonetz_stops.json`` via
+   ``json.dumps(payload, ensure_ascii=False, indent=2, allow_nan=False)``
+   with NO scrubber on the payload. The payload's ``stops[].name`` /
+   ``stops[].address`` / ``stops[].ifopt_id`` / ``stops[].bsts_id`` /
+   ``stops[].eva_nr`` fields are taken verbatim from the upstream
+   GeoNetz dump (``data.oebb.at`` ÖBB-Infrastruktur AG endpoint). A
+   compromised CDN / DNS hijack / MITM on the ÖBB-Infrastruktur fetch
+   carrying U+202E in any of those fields lands the bytes in the
+   committed ``data/oebb_geonetz_stops.json`` sidecar — the journal
+   entry for the 2026-05-23 GeoNetz round already pinned this same
+   file's parser-site fix (size-cap + non-finite literal), but the
+   writer-side Trojan-Source scrub was missed.
+
+2. **``scripts/apply_station_overrides.py:apply_overrides`` (line ~324)** —
+   writes ``data/stations.json`` after applying the curated overrides
+   list via
+   ``json.dumps(stations_payload, indent=2, ensure_ascii=False, allow_nan=False)``
+   with NO scrubber on the resulting payload. Two attack vectors:
+
+   * The loaded ``stations_payload`` may carry a U+202E from a
+     previously-poisoned ``data/stations.json`` (planted via a
+     bypass of the canonical writer, surviving from a corrupted
+     previous cron run, or written by an early-deployment build
+     pre-dating the Round 12-14 closing rounds) — the override
+     script reads-then-writes the file without retroactive scrub.
+   * The ``_op_restore`` handler at line 172 inserts the
+     ``entry_template`` from the overrides file verbatim via
+     ``dict(entry_template)`` — so a hostile PR landing a tampered
+     ``data/stations_overrides.json`` carrying U+202E in the
+     ``entry`` ``name`` / ``address`` field plants the BiDi mark
+     directly into ``data/stations.json``.
+
+Both files are committed to ``main`` by the weekly
+``update-stations.yml`` cron pipeline (which sequences
+``update_station_directory.py`` → ``apply_station_overrides.py`` →
+``update_all_stations.py``) and rendered via ``cat`` / ``less`` /
+``git log -p`` / ``git show`` / the GitHub web UI / IDE preview —
+every viewer that honours BiDi reversal displays the
+attacker-controlled byte-flip.
+
+Fix shape (identical to Round 13-14)
+=====================================
+
+  * Reuse ``src/utils/serialize.py:scrub_trojan_source_primitives``
+    (added in Round 12) so the canonical attack-byte union stays
+    single-sourced across every operator-facing JSON sidecar writer.
+  * Each writer applies the scrubber to the incoming payload BEFORE
+    ``json.dumps`` — ingestion-boundary defence so the dangerous bytes
+    never reach the serialiser.
+  * ``ensure_ascii=False`` is preserved at every writer so legitimate
+    German content (umlauts ä/ö/ü/Ä/Ö/Ü + sharp s ß + every other safe
+    Unicode code point) stays compact in the weekly commit diff.
+
+The companion ``tests/test_sentinel_trojan_source_audit_walker.py``
+is the closing-rule programmatic walker for this axis: every future
+``json.dump(..., ensure_ascii=False, ...)`` /
+``json.dumps(..., ensure_ascii=False, ...)`` callsite in ``src/`` or
+``scripts/`` must call ``scrub_trojan_source_primitives`` in the same
+function (or be added to the documented allowlist of legitimate
+alternative-defence sites).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+# Canonical Trojan-Source / zero-width / Unicode-line-terminator / C1
+# terminal-escape primitives — byte-exact mirror of the set pinned in
+# ``tests/test_sentinel_script_station_writers_trojan_source.py``
+# (Round 14) and ``tests/test_sentinel_places_stations_trojan_source.py``
+# (Round 13) so any future widening of the canonical floor is enforced
+# uniformly across the committed-sidecar writer family.
+_TROJAN_SOURCE_PRIMITIVES = (
+    # BiDi formatting controls (CVE-2021-42574 first half).
+    "‪",  # LRE Left-To-Right Embedding
+    "‫",  # RLE Right-To-Left Embedding
+    "‬",  # PDF Pop Directional Formatting
+    "‭",  # LRO Left-To-Right Override
+    "‮",  # RLO Right-To-Left Override
+    # BiDi isolates (CVE-2021-42574 second half).
+    "⁦",  # LRI Left-To-Right Isolate
+    "⁧",  # RLI Right-To-Left Isolate
+    "⁨",  # FSI First Strong Isolate
+    "⁩",  # PDI Pop Directional Isolate
+    # Zero-width / left-right marks.
+    "​",  # ZWSP
+    "‌",  # ZWNJ
+    "‍",  # ZWJ
+    "‎",  # LRM
+    "‏",  # RLM
+    "؜",  # ALM
+    # Unicode line / paragraph separators (SIEM splitter primitive).
+    " ",  # LINE SEPARATOR
+    " ",  # PARAGRAPH SEPARATOR
+    # Byte Order Mark / ZWNBSP.
+    "﻿",
+    # C1 terminal escape primitives (8-bit colour/SGR start, OSC, DCS).
+    "\x9b",  # CSI
+    "\x9d",  # OSC
+    "\x90",  # DCS
+)
+
+# Mapping from each primitive to its raw UTF-8 byte sequence.
+# Pre-fix every byte sequence appears in the on-disk file verbatim
+# (ensure_ascii=False emits each as its raw UTF-8 form);
+# post-fix none of them do (the scrubber strips at the ingestion
+# boundary).
+_UTF8_BYTES = {p: p.encode("utf-8") for p in _TROJAN_SOURCE_PRIMITIVES}
+
+# Smoking-gun primitive: U+202E RLO. The 3-byte UTF-8 sequence
+# E2 80 AE drives the actual BiDi reversal that hides the attack
+# in any operator review pass.
+_RLO_UTF8 = b"\xe2\x80\xae"
+
+
+# ============================================================================
+# Sink 1: ``scripts/extract_oebb_geonetz_stops.py`` — committed
+# ``data/oebb_geonetz_stops.json`` via ``json.dumps(payload,
+# ensure_ascii=False, indent=2, allow_nan=False)``
+# ============================================================================
+
+
+def _planted_geonetz_feature_collection(planted_value: str) -> dict[str, Any]:
+    """Build a minimal GeoNetz FeatureCollection carrying *planted_value*
+    in every operator-facing string field that flows into
+    ``data/oebb_geonetz_stops.json``."""
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [16.37, 48.21]},
+                "properties": {
+                    "STP_ID": f"STP{planted_value}001",
+                    "BSTS_ID": f"bsts{planted_value}001",
+                    "STP_NAME": f"Hauptbahnhof{planted_value}moc.live",
+                    "STP_LAT": 48.21,
+                    "STP_LON": 16.37,
+                    "EVA_NR": f"81{planted_value}001",
+                    "IFOPT_ID": f"at:1:{planted_value}:01",
+                    "STP_ROADNAME": f"Bahnhof{planted_value}straße 1",
+                    "STP_FROMDATE": "2024-12-15T00:00:00",
+                    "STP_TODATE": "2025-12-14T23:59:59",
+                },
+            }
+        ],
+    }
+
+
+def _write_raw_geonetz(tmp_path: Path, payload: dict[str, Any]) -> Path:
+    raw_path = tmp_path / "raw_geonetz.json"
+    raw_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    return raw_path
+
+
+def _run_extract_main(tmp_path: Path, raw_path: Path) -> Path:
+    """Invoke ``scripts/extract_oebb_geonetz_stops.main`` end-to-end and
+    return the produced output path."""
+    from scripts.extract_oebb_geonetz_stops import main as extract_main
+
+    output_path = tmp_path / "oebb_geonetz_stops.json"
+    rc = extract_main([
+        "--raw", str(raw_path),
+        "--output", str(output_path),
+        "--source-url", "https://example.invalid/raw.zip",
+    ])
+    assert rc == 0, f"extract main returned non-zero: {rc}"
+    return output_path
+
+
+def test_extract_geonetz_no_rlo_leak(tmp_path: Path) -> None:
+    """A planted ``STP_NAME`` carrying U+202E reaches
+    ``data/oebb_geonetz_stops.json`` pre-fix via the
+    ``json.dumps(payload, ensure_ascii=False, ...)`` writer."""
+    raw_path = _write_raw_geonetz(
+        tmp_path, _planted_geonetz_feature_collection("‮")
+    )
+    output_path = _run_extract_main(tmp_path, raw_path)
+
+    raw_out = output_path.read_bytes()
+    assert _RLO_UTF8 not in raw_out, (
+        "U+202E (RLO) leaked verbatim into data/oebb_geonetz_stops.json "
+        "via the extract main writer — BiDi reversal is now active for "
+        "any cat / less / git log -p / GitHub web UI / IDE viewer of "
+        "the committed sidecar."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_extract_geonetz_strips_every_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    """Every canonical attack-byte primitive must be rejected at the
+    ingestion boundary — a single primitive surviving in raw form
+    re-opens the attack via a future GeoNetz-controlled field."""
+    raw_path = _write_raw_geonetz(
+        tmp_path, _planted_geonetz_feature_collection(primitive)
+    )
+    output_path = _run_extract_main(tmp_path, raw_path)
+
+    raw_out = output_path.read_bytes()
+    expected = _UTF8_BYTES[primitive]
+    assert expected not in raw_out, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked into "
+        f"data/oebb_geonetz_stops.json as raw UTF-8 bytes ({expected!r}) "
+        "via scripts/extract_oebb_geonetz_stops.main."
+    )
+
+
+def test_extract_geonetz_preserves_german_umlauts(tmp_path: Path) -> None:
+    """Legitimate German content (ä/ö/ü/Ä/Ö/Ü/ß) must survive the
+    scrubber so the weekly commit diff stays compact."""
+    feature_collection = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {"type": "Point", "coordinates": [16.37, 48.21]},
+                "properties": {
+                    "STP_ID": "STP001",
+                    "BSTS_ID": "bsts001",
+                    "STP_NAME": "Wien Hütteldorf",
+                    "STP_LAT": 48.21,
+                    "STP_LON": 16.37,
+                    "EVA_NR": "8100001",
+                    "IFOPT_ID": "at:1:1:01",
+                    "STP_ROADNAME": "Floridsdorfer Brücke",
+                    "STP_FROMDATE": "2024-12-15T00:00:00",
+                    "STP_TODATE": "2025-12-14T23:59:59",
+                },
+            }
+        ],
+    }
+    raw_path = _write_raw_geonetz(tmp_path, feature_collection)
+    output_path = _run_extract_main(tmp_path, raw_path)
+
+    text = output_path.read_text(encoding="utf-8")
+    assert "Hütteldorf" in text
+    assert "Floridsdorfer Brücke" in text
+    # Sanity: the bloated \u00XX escape form must NOT appear — that
+    # would mean we accidentally switched to ensure_ascii=True and
+    # ballooned the diff size 4-6x.
+    assert "\\u00fc" not in text
+    assert "\\u00fc" not in text
+
+
+# ============================================================================
+# Sink 2: ``scripts/apply_station_overrides.py`` — committed
+# ``data/stations.json`` via ``json.dumps(stations_payload,
+# indent=2, ensure_ascii=False, allow_nan=False)``
+# ============================================================================
+
+
+def _write_planted_stations(tmp_path: Path, planted_value: str) -> Path:
+    """Write a stations.json file with U+XXXX-carrying string fields
+    on a baseline entry. Simulates a previously-poisoned stations.json
+    that survived an earlier bypass and lands in the override re-write."""
+    payload = {
+        "stations": [
+            {
+                "name": f"Westbahnhof{planted_value}moc.live",
+                "wl_diva": "60201080",
+                "latitude": 48.196,
+                "longitude": 16.337,
+                "aliases": [f"alias{planted_value}evil"],
+            }
+        ]
+    }
+    target = tmp_path / "stations.json"
+    target.write_text(
+        json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+    )
+    return target
+
+
+def _write_overrides(tmp_path: Path) -> Path:
+    """Write a minimal overrides file that targets the planted entry
+    with ``patch_coords`` (a benign no-op when the coords already
+    match). The override file itself is benign — the leak is from
+    the loaded payload carrying historic Trojan-Source bytes."""
+    overrides = {
+        "overrides": [
+            {
+                "op": "patch_coords",
+                "wl_diva": "60201080",
+                "latitude": 48.196,
+                "longitude": 16.337,
+                "reason": "fixture",
+                "expires_when": "fixture",
+            }
+        ]
+    }
+    target = tmp_path / "stations_overrides.json"
+    target.write_text(
+        json.dumps(overrides, ensure_ascii=False), encoding="utf-8"
+    )
+    return target
+
+
+def _run_apply_overrides(tmp_path: Path, planted_value: str) -> Path:
+    """Invoke ``scripts/apply_station_overrides.apply_overrides`` and
+    return the rewritten stations.json path."""
+    from scripts.apply_station_overrides import apply_overrides
+
+    stations_path = _write_planted_stations(tmp_path, planted_value)
+    overrides_path = _write_overrides(tmp_path)
+    rc = apply_overrides(stations_path, overrides_path)
+    assert rc == 0, f"apply_overrides returned non-zero: {rc}"
+    return stations_path
+
+
+def test_apply_overrides_no_rlo_leak(tmp_path: Path) -> None:
+    """A previously-poisoned ``data/stations.json`` entry carrying
+    U+202E in its ``name`` survives the override application pre-fix —
+    the re-write via ``json.dumps(..., ensure_ascii=False)`` emits the
+    BiDi-reversal trigger verbatim."""
+    stations_path = _run_apply_overrides(tmp_path, "‮")
+    raw_out = stations_path.read_bytes()
+    assert _RLO_UTF8 not in raw_out, (
+        "U+202E (RLO) survived apply_overrides — the planted byte in "
+        "the loaded stations.json was re-emitted verbatim into the "
+        "committed file. ``apply_station_overrides.py`` is the missed "
+        "scrubber site between update_station_directory and "
+        "update_all_stations on the weekly cron."
+    )
+
+
+@pytest.mark.parametrize("primitive", _TROJAN_SOURCE_PRIMITIVES)
+def test_apply_overrides_strips_every_primitive(
+    tmp_path: Path, primitive: str
+) -> None:
+    """Every canonical attack-byte primitive must be stripped at the
+    apply-overrides re-write — historic poisoned ``data/stations.json``
+    bytes are NOT a justifiable propagation source."""
+    stations_path = _run_apply_overrides(tmp_path, primitive)
+    raw_out = stations_path.read_bytes()
+    expected = _UTF8_BYTES[primitive]
+    assert expected not in raw_out, (
+        f"Trojan-Source primitive U+{ord(primitive):04X} leaked into "
+        f"data/stations.json as raw UTF-8 bytes ({expected!r}) via "
+        "scripts/apply_station_overrides.apply_overrides."
+    )
+
+
+def test_apply_overrides_preserves_german_umlauts(tmp_path: Path) -> None:
+    """Legitimate German content (ä/ö/ü/Ä/Ö/Ü/ß) must survive the
+    re-write so the weekly commit diff stays compact."""
+    payload = {
+        "stations": [
+            {
+                "name": "Wien Hütteldorf",
+                "wl_diva": "60201080",
+                "latitude": 48.196,
+                "longitude": 16.337,
+                "aliases": ["Hauptbahnhof", "Floridsdorfer Brücke", "Praterstraße"],
+            }
+        ]
+    }
+    stations_path = tmp_path / "stations.json"
+    stations_path.write_text(
+        json.dumps(payload, ensure_ascii=False), encoding="utf-8"
+    )
+    overrides_path = _write_overrides(tmp_path)
+
+    from scripts.apply_station_overrides import apply_overrides
+
+    rc = apply_overrides(stations_path, overrides_path)
+    assert rc == 0
+
+    text = stations_path.read_text(encoding="utf-8")
+    assert "Hütteldorf" in text
+    assert "Floridsdorfer Brücke" in text
+    assert "Praterstraße" in text
+    # Sanity: the bloated \u00XX escape form must NOT appear — that
+    # would mean we accidentally switched to ensure_ascii=True and
+    # ballooned the diff size 4-6x.
+    assert "\\u00fc" not in text
+    assert "\\u00df" not in text
+
+
+# ============================================================================
+# AST static-invariant: the scrub call is in the function bodies
+# ============================================================================
+
+
+def _function_calls_scrub(
+    module_path: Path, function_name: str
+) -> bool:
+    """Return ``True`` iff the function named *function_name* in
+    *module_path* contains a call to ``scrub_trojan_source_primitives``
+    in its body (excluding docstrings).
+
+    Defence-in-depth against a future refactor that drops the
+    scrubber in either fix site: the byte-level PoC tests above
+    pin the runtime behaviour; this static check pins the SHAPE
+    so a future maintainer who replaces the scrub with an
+    out-of-band defence (or removes it entirely) fails the test
+    at PR-review time regardless of whether the runtime defence
+    fortuitously still passes (e.g. via a different sibling
+    helper)."""
+    import ast
+
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != function_name:
+            continue
+        for sub in ast.walk(node):
+            if (
+                isinstance(sub, ast.Call)
+                and isinstance(sub.func, ast.Name)
+                and sub.func.id == "scrub_trojan_source_primitives"
+            ):
+                return True
+    return False
+
+
+def test_extract_main_calls_scrub() -> None:
+    """``scripts/extract_oebb_geonetz_stops.main`` MUST call
+    ``scrub_trojan_source_primitives`` on the payload before the
+    ``json.dumps(..., ensure_ascii=False, ...)`` writer."""
+    path = REPO_ROOT / "scripts" / "extract_oebb_geonetz_stops.py"
+    assert _function_calls_scrub(path, "main"), (
+        "scripts/extract_oebb_geonetz_stops.py:main must call "
+        "scrub_trojan_source_primitives before json.dumps — the only "
+        "ingestion-boundary defence between a poisoned upstream "
+        "GeoNetz dump and the committed data/oebb_geonetz_stops.json "
+        "sidecar."
+    )
+
+
+def test_apply_overrides_calls_scrub() -> None:
+    """``scripts/apply_station_overrides.apply_overrides`` MUST call
+    ``scrub_trojan_source_primitives`` on the stations_payload before
+    the ``json.dumps(..., ensure_ascii=False, ...)`` re-write."""
+    path = REPO_ROOT / "scripts" / "apply_station_overrides.py"
+    assert _function_calls_scrub(path, "apply_overrides"), (
+        "scripts/apply_station_overrides.py:apply_overrides must call "
+        "scrub_trojan_source_primitives before json.dumps — the only "
+        "ingestion-boundary defence between a previously-poisoned "
+        "stations.json (or a tampered overrides entry) and the "
+        "re-committed data/stations.json sidecar."
+    )

--- a/tests/test_sentinel_trojan_source_audit_walker.py
+++ b/tests/test_sentinel_trojan_source_audit_walker.py
@@ -1,0 +1,642 @@
+"""Sentinel auto-discoverable invariant: every JSON writer site in
+``src/`` and ``scripts/`` that pins ``ensure_ascii=False`` must call
+``scrub_trojan_source_primitives`` in the same function — or be added
+to the documented allowlist of legitimate alternative-defence sites.
+
+Why a walker matters
+--------------------
+The 2026-05-23 GeoNetz / i18n size-bomb rounds (PR #1629, PR #1630)
+journaled the closing rule for the canonical-loader fix family::
+
+    Future canonical-loader rounds should ship the walker alongside
+    the per-site fix so every parser-site axis (RecursionError +
+    size-cap + non-finite-literal + Trojan-Source scrub) is
+    programmatically enforced from the start.
+
+The non-finite-literal closing round (2026-05-23, PR #1632) shipped
+``tests/test_sentinel_non_finite_literal_audit_walker.py`` and named
+the open item::
+
+    With this round all three of the parser-site canonical axes
+    (RecursionError + size-cap + non-finite-literal) are now
+    programmatically enforced; the Trojan-Source scrub axis remains
+    the open closing-rule item for a future round.
+
+This file IS the Trojan-Source scrub walker, run as a regression test
+under pytest. Any future contributor who adds a fresh
+``json.dump(..., ensure_ascii=False, ...)`` /
+``json.dumps(..., ensure_ascii=False, ...)`` call to ``src/`` or
+``scripts/`` without a sibling ``scrub_trojan_source_primitives``
+call in the same function will fail this test at PR-review time,
+regardless of whether the journal named the file.
+
+Coverage rule
+-------------
+For every ``json.dump(...)`` / ``json.dumps(...)`` /
+``<json-alias>.dump(...)`` / ``<json-alias>.dumps(...)`` call in
+``src/`` or ``scripts/`` that pins ``ensure_ascii=False`` as an
+explicit keyword argument, the smallest enclosing
+:class:`ast.FunctionDef` / :class:`ast.AsyncFunctionDef` body
+must contain at least one call to
+``scrub_trojan_source_primitives(...)``. Module-level writer calls
+are checked against the module body.
+
+Why ``ensure_ascii=False`` is the trigger
+------------------------------------------
+:func:`json.dump` / :func:`json.dumps` default to ``ensure_ascii=True``,
+which escapes every non-ASCII code point as a literal ``\\uXXXX``
+sequence — and an escaped ``\\u202e`` sequence in the on-disk file
+does NOT trigger BiDi reversal in ``cat`` / ``less`` / the GitHub web
+UI / IDE preview. The Trojan-Source attack surface only opens when
+the writer explicitly chooses ``ensure_ascii=False`` to keep
+legitimate German content (umlauts ä/ö/ü/Ä/Ö/Ü + sharp s ß) compact
+in the diff. The walker mirrors this asymmetry: a writer that opts
+in to compact UTF-8 output MUST also opt in to the canonical
+attack-byte scrub. Default-shaped writers (no kwarg, or
+``ensure_ascii=True``) are not flagged because the escape pass
+neutralises the Trojan-Source primitives at the serialiser.
+
+Allowlist semantics
+-------------------
+The ``ALLOWLIST`` set lists ``(relative_path, lineno)`` tuples where
+``ensure_ascii=False`` is preserved without an in-function
+``scrub_trojan_source_primitives`` call because an EQUIVALENT sibling
+defence is in place. Three documented cases live here today:
+
+* ``src/places/hafas_client.py:_serialise_payload`` — the function
+  builds the HAFAS wire-format request body whose bytes are hashed
+  by the MAC signing protocol. The serialised payload is sent to the
+  upstream HAFAS endpoint, NOT committed to any
+  operator-facing sidecar, and a scrub would change the bytes that
+  flow into ``hashlib.md5`` and break the request signature. The
+  upstream HAFAS server is not an ``cat`` / ``less`` / GitHub web UI
+  viewer — the threat model that motivates the Trojan-Source axis
+  does not apply.
+
+* ``src/feed/reporting.py:build_feed_health_payload`` /
+  ``write_feed_health_json`` — per-field
+  ``_CONTROL_CHARS_RE.sub("", ...)`` calls strip the canonical
+  attack-byte union from every user-controlled string field
+  (``dedupe_key``, ``titles[]``, ``feed_path``) BEFORE the payload
+  reaches ``json.dump``. The remaining fields (provider names /
+  statuses, durations, internal counters) are populated by internal
+  code with type-checked inputs that cannot carry a Trojan-Source
+  primitive. The byte-equivalent regex pinned here is the canonical
+  sibling of ``_TROJAN_SOURCE_PRIMITIVES_RE`` (see the
+  ``_CONTROL_CHARS_RE`` declaration comment in
+  ``src/utils/logging.py``).
+
+* ``src/feed/logging_safe.py:SafeJSONFormatter.format`` — the JSON
+  log formatter passes the serialised output through
+  ``sanitize_log_message(dumped, strip_control_chars=False)``, which
+  ALWAYS strips the canonical attack-byte union via
+  ``_INVISIBLE_DANGEROUS_RE.sub("", sanitized)`` regardless of the
+  ``strip_control_chars`` flag (see the unconditional always-strip
+  comment in ``src/utils/logging.py:sanitize_log_message``). The
+  defence runs post-serialisation rather than pre-serialisation, but
+  the on-disk / on-wire byte set is byte-equivalent to the
+  pre-serialisation scrubber.
+
+Any future writer that legitimately needs to enter the allowlist
+MUST add a justification comment in the SAME PR that adds the entry,
+and the ``test_allowlist_is_minimal_and_documented`` test pins the
+shape so the allowlist cannot silently grow.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAN_TREES = ("src", "scripts")
+
+# Allowlist of ``(relative_path, lineno)`` pairs that the walker
+# tolerates. Each entry pairs a documented sibling defence that
+# replaces the in-function ``scrub_trojan_source_primitives`` call.
+# See the module docstring above for the rationale narrative on each
+# entry. Adding a new entry without an in-PR justification comment
+# violates the documented allowlist contract.
+ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
+    {
+        # HAFAS wire-format request body; bytes are hashed by the MAC
+        # signing protocol and sent to the upstream HAFAS endpoint,
+        # not committed to any operator-facing sidecar.
+        ("src/places/hafas_client.py", 282),
+        # Feed-health JSON sink; per-field ``_CONTROL_CHARS_RE.sub("",
+        # ...)`` calls at lines 726 / 729 / 777 strip the canonical
+        # attack-byte union from every user-controlled string field
+        # before ``json.dump``.
+        ("src/feed/reporting.py", 846),
+        # JSON log formatter; ``sanitize_log_message(dumped,
+        # strip_control_chars=False)`` always strips the canonical
+        # attack-byte union via ``_INVISIBLE_DANGEROUS_RE.sub("",
+        # sanitized)`` post-serialisation.
+        ("src/feed/logging_safe.py", 247),
+        ("src/feed/logging_safe.py", 258),
+    }
+)
+
+
+def _collect_json_module_aliases(tree: ast.AST) -> set[str]:
+    """Return every local name that aliases the :mod:`json` stdlib module.
+
+    Mirrors the alias-resolution logic in
+    ``tests/test_sentinel_json_audit_walker.py`` and
+    ``tests/test_sentinel_non_finite_literal_audit_walker.py``:
+    always includes ``"json"`` as the canonical name and extends with
+    every ``import json as <alias>`` binding. Without this extension
+    the walker silently skips any aliased import and lets a future
+    contributor re-introduce drift undetected.
+    """
+    aliases: set[str] = {"json"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for name in node.names:
+                if name.name == "json":
+                    aliases.add(name.asname or name.name)
+    return aliases
+
+
+def _is_json_writer_call(
+    node: ast.Call, json_aliases: set[str]
+) -> bool:
+    """Identify ``<json-alias>.dump(...)`` and ``<json-alias>.dumps(...)``
+    serialiser calls.
+
+    The walker intentionally scopes to the stdlib ``json`` module
+    aliases — third-party serialisers (``orjson``, ``ujson``,
+    ``rapidjson``) have different ``ensure_ascii`` defaults and
+    different threat-model surfaces; covering them would require a
+    per-library policy. The codebase does not use any third-party
+    JSON serialiser today (see ``requirements.txt``).
+    """
+    func = node.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    if func.attr not in ("dump", "dumps"):
+        return False
+    return isinstance(func.value, ast.Name) and func.value.id in json_aliases
+
+
+def _has_explicit_ensure_ascii_false(node: ast.Call) -> bool:
+    """Return ``True`` iff the call explicitly pins
+    ``ensure_ascii=False`` as a keyword argument.
+
+    ``json.dump`` / ``json.dumps`` default to ``ensure_ascii=True``,
+    which escapes every non-ASCII code point as a literal ``\\uXXXX``
+    sequence — neutralising the Trojan-Source primitives at the
+    serialiser. The walker only flags the explicit
+    ``ensure_ascii=False`` shape because that's the opt-in that
+    re-opens the attack surface.
+
+    A ``**kwargs`` spread is treated as NOT-explicit because static
+    AST analysis cannot determine the dict's keys. Sites that pass
+    the kwarg via dynamic spread are rare in this codebase and would
+    be caught by the per-callsite source-grep pins in
+    ``tests/test_sentinel_script_station_writers_trojan_source.py``.
+    """
+    for kw in node.keywords:
+        if kw.arg != "ensure_ascii":
+            continue
+        # ``ensure_ascii=False`` literal — the opt-in shape.
+        if isinstance(kw.value, ast.Constant) and kw.value.value is False:
+            return True
+    return False
+
+
+def _build_parent_map(tree: ast.AST) -> dict[int, ast.AST]:
+    parents: dict[int, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[id(child)] = parent
+    return parents
+
+
+def _enclosing_function(
+    parents: dict[int, ast.AST], node: ast.AST
+) -> ast.AST | None:
+    """Walk upward to the smallest enclosing function definition.
+
+    Returns the function node (``ast.FunctionDef`` or
+    ``ast.AsyncFunctionDef``) so the caller can scan its body. If the
+    call appears at module level (no enclosing function), returns
+    ``None`` and the caller falls back to the module body.
+    """
+    cur = parents.get(id(node))
+    while cur is not None:
+        if isinstance(cur, ast.FunctionDef | ast.AsyncFunctionDef):
+            return cur
+        cur = parents.get(id(cur))
+    return None
+
+
+def _scope_calls_scrub(scope: ast.AST) -> bool:
+    """Return ``True`` iff *scope* contains at least one
+    ``scrub_trojan_source_primitives(...)`` call.
+
+    The walker accepts both the bare-name form (``scrub_trojan_source_primitives(payload)``)
+    and the attribute form (``serialize.scrub_trojan_source_primitives(payload)``)
+    so an import-style change does not silently break the audit. The
+    canonical callable lives at
+    ``src/utils/serialize.py:scrub_trojan_source_primitives``; every
+    documented call site uses the bare-name form today.
+    """
+    for node in ast.walk(scope):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "scrub_trojan_source_primitives":
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == "scrub_trojan_source_primitives":
+            return True
+    return False
+
+
+def _audit_module(path: Path, tree: ast.AST) -> list[tuple[int, str]]:
+    """Return ``[(lineno, reason), ...]`` for every unprotected JSON
+    writer site in *path*. The caller is responsible for filtering
+    against ``ALLOWLIST``."""
+    findings: list[tuple[int, str]] = []
+    parents = _build_parent_map(tree)
+    json_aliases = _collect_json_module_aliases(tree)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_json_writer_call(
+            node, json_aliases
+        ):
+            continue
+        if not _has_explicit_ensure_ascii_false(node):
+            continue
+        func_node = _enclosing_function(parents, node)
+        scope: ast.AST = func_node if func_node is not None else tree
+        if _scope_calls_scrub(scope):
+            continue
+        scope_name = (
+            func_node.name
+            if isinstance(func_node, ast.FunctionDef | ast.AsyncFunctionDef)
+            else "<module>"
+        )
+        findings.append(
+            (
+                node.lineno,
+                f"json.dump/dumps(..., ensure_ascii=False, ...) in "
+                f"{scope_name!r} without scrub_trojan_source_primitives "
+                f"call in the same scope",
+            )
+        )
+    return findings
+
+
+def _all_python_files() -> list[Path]:
+    files: list[Path] = []
+    for tree_name in SCAN_TREES:
+        tree_root = REPO_ROOT / tree_name
+        if not tree_root.exists():
+            continue
+        files.extend(sorted(tree_root.rglob("*.py")))
+    return files
+
+
+def test_every_ensure_ascii_false_writer_has_scrub() -> None:
+    """The audit-completion invariant for the Trojan-Source axis:
+    zero unprotected ``ensure_ascii=False`` writer sites in ``src/``
+    or ``scripts/``.
+
+    Every ``json.dump(..., ensure_ascii=False, ...)`` /
+    ``json.dumps(..., ensure_ascii=False, ...)`` call MUST be paired
+    with an in-function ``scrub_trojan_source_primitives(...)`` call,
+    OR be listed in :data:`ALLOWLIST` with a documented sibling
+    defence. The canonical scrubber lives at
+    :func:`src.utils.serialize.scrub_trojan_source_primitives`.
+    """
+    all_findings: list[tuple[Path, int, str]] = []
+    for path in _all_python_files():
+        rel = path.relative_to(REPO_ROOT)
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+        for lineno, reason in _audit_module(path, tree):
+            key = (str(rel), lineno)
+            if key in ALLOWLIST:
+                continue
+            all_findings.append((rel, lineno, reason))
+
+    if not all_findings:
+        return
+    rendered = "\n".join(
+        f"  {p}:{lineno}: {reason}"
+        for p, lineno, reason in all_findings
+    )
+    pytest.fail(
+        f"{len(all_findings)} ``ensure_ascii=False`` writer site(s) "
+        f"without the Trojan-Source scrub:\n{rendered}\n\n"
+        "Each site must either call ``scrub_trojan_source_primitives`` "
+        "in the same function (canonical fix shape — see "
+        "``src/places/merge.py:write_stations`` and the eight named "
+        "sinks pinned in "
+        "``tests/test_sentinel_script_station_writers_trojan_source.py``), "
+        "or be added to ``ALLOWLIST`` with a justification comment in "
+        "the same PR. The closing-rule walker realises the 2026-05-23 "
+        "non-finite-literal round's named-open-item for the "
+        "Trojan-Source scrub axis."
+    )
+
+
+# ============================================================================
+# Smoke tests pinning the walker's pattern-recognition contract
+# ============================================================================
+
+
+def test_walker_flags_bare_ensure_ascii_false_dump() -> None:
+    """A bare ``json.dump(payload, fh, ensure_ascii=False)`` is a
+    violation when the enclosing function has no scrub call."""
+    sample = (
+        "import json\n"
+        "def f(payload, fh):\n"
+        "    json.dump(payload, fh, ensure_ascii=False)\n"
+    )
+    tree = ast.parse(sample)
+    parents = _build_parent_map(tree)
+    json_aliases = _collect_json_module_aliases(tree)
+
+    matches: list[ast.Call] = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_json_writer_call(node, json_aliases)
+    ]
+    assert len(matches) == 1
+    assert _has_explicit_ensure_ascii_false(matches[0])
+    func_node = _enclosing_function(parents, matches[0])
+    assert func_node is not None
+    assert not _scope_calls_scrub(func_node), (
+        "Walker must NOT find the scrub call in this synthetic fixture"
+    )
+
+
+def test_walker_accepts_dump_with_scrub_in_function() -> None:
+    """``json.dump(payload, fh, ensure_ascii=False)`` IS accepted when
+    the enclosing function calls ``scrub_trojan_source_primitives``."""
+    sample = (
+        "import json\n"
+        "from src.utils.serialize import scrub_trojan_source_primitives\n"
+        "def f(raw_payload, fh):\n"
+        "    payload = scrub_trojan_source_primitives(raw_payload)\n"
+        "    json.dump(payload, fh, ensure_ascii=False)\n"
+    )
+    tree = ast.parse(sample)
+    parents = _build_parent_map(tree)
+    json_aliases = _collect_json_module_aliases(tree)
+
+    matches: list[ast.Call] = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_json_writer_call(node, json_aliases)
+    ]
+    assert len(matches) == 1
+    assert _has_explicit_ensure_ascii_false(matches[0])
+    func_node = _enclosing_function(parents, matches[0])
+    assert func_node is not None
+    assert _scope_calls_scrub(func_node), (
+        "Walker must find the scrub call in the synthetic fixture's function body"
+    )
+
+
+def test_walker_accepts_default_ensure_ascii() -> None:
+    """A bare ``json.dump(payload, fh)`` (no ``ensure_ascii``) MUST
+    not be flagged — the default ``ensure_ascii=True`` already
+    escapes the canonical attack-byte union."""
+    sample = (
+        "import json\n"
+        "def f(payload, fh):\n"
+        "    json.dump(payload, fh)\n"
+    )
+    tree = ast.parse(sample)
+    json_aliases = _collect_json_module_aliases(tree)
+    matches: list[ast.Call] = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_json_writer_call(node, json_aliases)
+    ]
+    assert len(matches) == 1
+    assert not _has_explicit_ensure_ascii_false(matches[0]), (
+        "Walker must NOT flag the default-shape writer"
+    )
+
+
+def test_walker_accepts_explicit_ensure_ascii_true() -> None:
+    """``json.dump(payload, fh, ensure_ascii=True)`` MUST not be
+    flagged — the escape pass neutralises Trojan-Source primitives."""
+    sample = (
+        "import json\n"
+        "def f(payload, fh):\n"
+        "    json.dump(payload, fh, ensure_ascii=True)\n"
+    )
+    tree = ast.parse(sample)
+    json_aliases = _collect_json_module_aliases(tree)
+    matches: list[ast.Call] = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_json_writer_call(node, json_aliases)
+    ]
+    assert len(matches) == 1
+    assert not _has_explicit_ensure_ascii_false(matches[0]), (
+        "Walker must NOT flag ensure_ascii=True"
+    )
+
+
+def test_walker_flags_dumps_with_ensure_ascii_false() -> None:
+    """``json.dumps(payload, ensure_ascii=False)`` (the in-memory form)
+    is flagged when the enclosing function lacks the scrub call."""
+    sample = (
+        "import json\n"
+        "def f(payload):\n"
+        "    return json.dumps(payload, ensure_ascii=False)\n"
+    )
+    tree = ast.parse(sample)
+    parents = _build_parent_map(tree)
+    json_aliases = _collect_json_module_aliases(tree)
+    matches: list[ast.Call] = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_json_writer_call(node, json_aliases)
+    ]
+    assert len(matches) == 1
+    assert _has_explicit_ensure_ascii_false(matches[0])
+    func_node = _enclosing_function(parents, matches[0])
+    assert func_node is not None
+    assert not _scope_calls_scrub(func_node)
+
+
+def test_walker_recognises_aliased_json_module() -> None:
+    """``import json as _json_lib; _json_lib.dump(...)`` — the
+    aliased-import shape that bypassed the JSON depth-bomb walker
+    pre-Round-9 — must also be picked up by THIS walker so an alias
+    rename does not silently leak the drift."""
+    sample = (
+        "import json as _json_lib\n"
+        "def f(payload, fh):\n"
+        "    _json_lib.dump(payload, fh, ensure_ascii=False)\n"
+    )
+    tree = ast.parse(sample)
+    parents = _build_parent_map(tree)
+    json_aliases = _collect_json_module_aliases(tree)
+    assert "_json_lib" in json_aliases
+    matches: list[ast.Call] = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_json_writer_call(node, json_aliases)
+    ]
+    assert len(matches) == 1, (
+        "Walker must resolve the aliased ``_json_lib.dump(...)`` shape"
+    )
+    assert _has_explicit_ensure_ascii_false(matches[0])
+    func_node = _enclosing_function(parents, matches[0])
+    assert func_node is not None
+    assert not _scope_calls_scrub(func_node)
+
+
+def test_walker_ignores_json_loads_calls() -> None:
+    """Sanity check: ``json.loads`` / ``json.load`` (parser sites)
+    must NOT be flagged. The Trojan-Source axis covers writers only;
+    the parser-side axes (RecursionError + size-cap + non-finite) live
+    in their own walkers."""
+    sample = (
+        "import json\n"
+        "def f(payload):\n"
+        "    raw = json.loads(payload)\n"
+        "    return raw\n"
+    )
+    tree = ast.parse(sample)
+    json_aliases = _collect_json_module_aliases(tree)
+    matches: list[ast.Call] = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_json_writer_call(node, json_aliases)
+    ]
+    assert matches == [], (
+        "Walker must NOT pick up json.loads — parser sites have their "
+        "own walker(s)."
+    )
+
+
+def test_walker_ignores_unrelated_calls() -> None:
+    """Sanity check: unrelated method calls (``.text``, ``.upper()``,
+    third-party ``orjson.dumps``) must not produce false positives."""
+    sample = (
+        "import json\n"
+        "def f(payload, response):\n"
+        "    a = response.text\n"
+        "    b = 'hello'.upper()\n"
+        "    c = response.status_code\n"
+        "    return a, b, c\n"
+    )
+    tree = ast.parse(sample)
+    json_aliases = _collect_json_module_aliases(tree)
+    matches: list[ast.Call] = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_json_writer_call(node, json_aliases)
+    ]
+    assert matches == [], "Walker must NOT produce false positives"
+
+
+def test_walker_accepts_inline_scrub_call() -> None:
+    """An inline scrub call shape — ``json.dump(scrub_trojan_source_primitives(payload),
+    fh, ensure_ascii=False)`` — must also be accepted because the
+    scrub appears inside the function body (the call is part of the
+    AST tree of the function)."""
+    sample = (
+        "import json\n"
+        "from src.utils.serialize import scrub_trojan_source_primitives\n"
+        "def f(payload, fh):\n"
+        "    json.dump(scrub_trojan_source_primitives(payload), fh, ensure_ascii=False)\n"
+    )
+    tree = ast.parse(sample)
+    parents = _build_parent_map(tree)
+    json_aliases = _collect_json_module_aliases(tree)
+    matches: list[ast.Call] = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_json_writer_call(node, json_aliases)
+    ]
+    assert len(matches) == 1
+    func_node = _enclosing_function(parents, matches[0])
+    assert func_node is not None
+    assert _scope_calls_scrub(func_node), (
+        "Walker must accept inline ``scrub_trojan_source_primitives(...)`` "
+        "inside the json.dump call's positional argument"
+    )
+
+
+def test_walker_accepts_attribute_form_scrub_call() -> None:
+    """An attribute-form scrub call — ``serialize.scrub_trojan_source_primitives(payload)``
+    — must also be accepted so an import-style change does not break
+    the audit."""
+    sample = (
+        "import json\n"
+        "from src.utils import serialize\n"
+        "def f(payload, fh):\n"
+        "    scrubbed = serialize.scrub_trojan_source_primitives(payload)\n"
+        "    json.dump(scrubbed, fh, ensure_ascii=False)\n"
+    )
+    tree = ast.parse(sample)
+    parents = _build_parent_map(tree)
+    json_aliases = _collect_json_module_aliases(tree)
+    matches: list[ast.Call] = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and _is_json_writer_call(node, json_aliases)
+    ]
+    assert len(matches) == 1
+    func_node = _enclosing_function(parents, matches[0])
+    assert func_node is not None
+    assert _scope_calls_scrub(func_node)
+
+
+def test_collect_json_module_aliases_includes_canonical_and_aliased() -> None:
+    """Pin the alias-collection contract: the canonical ``json`` name
+    is always present; every ``import json as <name>`` binding adds a
+    new alias; non-json imports do not pollute the set."""
+    sample = (
+        "import json\n"
+        "import json as _json_lib\n"
+        "import json as another_alias\n"
+        "import os\n"
+        "import requests\n"
+    )
+    tree = ast.parse(sample)
+    aliases = _collect_json_module_aliases(tree)
+    assert aliases == {"json", "_json_lib", "another_alias"}
+
+
+def test_allowlist_is_minimal_and_documented() -> None:
+    """The ALLOWLIST is intentionally small — three legitimate
+    sibling-defence sites today. If a future PR needs to add an
+    entry, this test pins the requirement that the addition is
+    intentional (not accidental) by failing if the allowlist drifts
+    beyond the documented size. Update this assertion alongside any
+    legitimate allowlist addition AND the module docstring."""
+    assert len(ALLOWLIST) == 4, (
+        f"ALLOWLIST drifted from the documented size of 4 entries — "
+        f"got {len(ALLOWLIST)}. Any new entry must come with a "
+        "justification comment AND an update to this assertion + the "
+        "module docstring's allowlist semantics section."
+    )
+    # Pin the exact entries so a future PR that swaps one allowlisted
+    # site for another (without updating the docstring) also fails.
+    assert ALLOWLIST == frozenset(
+        {
+            ("src/places/hafas_client.py", 282),
+            ("src/feed/reporting.py", 846),
+            ("src/feed/logging_safe.py", 247),
+            ("src/feed/logging_safe.py", 258),
+        }
+    )


### PR DESCRIPTION
## Summary

Closes the **Trojan-Source scrub** sibling drift in the JSON / writer defence family — the long-promised programmatic walker named in the 2026-05-23 non-finite-literal round's closing rule ("*Future canonical-loader rounds should ship the walker alongside the per-site fix so every parser-site axis (RecursionError + size-cap + non-finite-literal + Trojan-Source scrub) is programmatically enforced from the start*"). With this round all four canonical fix-family axes are now programmatically enforced.

## Vulnerability

Two `ensure_ascii=False` writer sinks still emitted the canonical CVE-2021-42574 attack-byte union (BiDi formatting controls, BiDi isolates, zero-width primitives, line/paragraph separators, BOM, 8-bit C1 terminal-escape primitives) as raw UTF-8 bytes:

1. **`scripts/extract_oebb_geonetz_stops.py:main`** (line ~300) — writes `data/oebb_geonetz_stops.json` via `json.dumps(payload, ensure_ascii=False, indent=2, allow_nan=False)` with **no** scrubber. The payload's `stops[].name` / `.address` / `.ifopt_id` / `.bsts_id` / `.eva_nr` fields flow verbatim from the upstream ÖBB GeoNetz dump (`data.oebb.at`) — a compromised CDN / DNS hijack / MITM on the fetch carrying U+202E lands the BiDi reversal trigger (`E2 80 AE` UTF-8 bytes) directly in the committed sidecar. The same file's parser-site siblings (size-cap + non-finite literal) were closed in #1629; the writer-side Trojan-Source scrub was the missed third leg.

2. **`scripts/apply_station_overrides.py:apply_overrides`** (line ~324) — re-writes `data/stations.json` via `json.dumps(stations_payload, ensure_ascii=False, ...)` with **no** scrubber. Two attack vectors land bytes here: (a) a previously-poisoned `data/stations.json` (planted via a bypass of the canonical writer, surviving from a corrupted previous cron run, or written by an early-deployment build pre-dating Round 12-14) surviving the read-then-write cycle; (b) the `_op_restore` handler inserts the override `entry` template verbatim via `dict(entry_template)` — a hostile PR landing a tampered `data/stations_overrides.json` carrying U+202E in an `entry` `name` field plants the byte directly into the committed `data/stations.json`. Both files reach `main` via the weekly `update-stations.yml` cron pipeline.

## Fix

- **`scripts/extract_oebb_geonetz_stops.py`**: import `scrub_trojan_source_primitives` and apply it to the `payload` before `json.dumps` at the ingestion boundary. `ensure_ascii=False` preserved so legitimate German content (umlauts ä/ö/ü/Ä/Ö/Ü + sharp s ß) stays compact in the commit diff.
- **`scripts/apply_station_overrides.py`**: import `scrub_trojan_source_primitives` and apply it to the `stations_payload` before `json.dumps` at the ingestion boundary. Same `ensure_ascii=False` preservation.

Both fixes mirror the canonical writer-side pattern from Round 13 / 14 (`src/places/merge.py:write_stations` + the eight named script-level sinks pinned in `tests/test_sentinel_script_station_writers_trojan_source.py`).

## Closing-rule walker

`tests/test_sentinel_trojan_source_audit_walker.py` scans every `*.py` under `src/` and `scripts/` for any `json.dump(..., ensure_ascii=False, ...)` / `json.dumps(..., ensure_ascii=False, ...)` call without a sibling `scrub_trojan_source_primitives` call in the same function (or a documented `ALLOWLIST` entry). The walker:
- Resolves aliased imports (`import json as _json_lib`) so an alias rename does not silently leak the drift.
- Tolerates default-shape writers (no `ensure_ascii` kwarg, or `ensure_ascii=True`) — the `\uXXXX` escape pass already neutralises the canonical attack-byte union at the serialiser.
- Accepts both bare-name (`scrub_trojan_source_primitives(...)`) and attribute-form (`serialize.scrub_trojan_source_primitives(...)`) calls.
- Carries a 4-entry `ALLOWLIST` for the legitimate alternative-defence sites: HAFAS wire-format MAC-signed body (not committed), feed-health JSON sink (per-field `_CONTROL_CHARS_RE.sub`), and the two JSON log-formatter lines (post-sanitised via `sanitize_log_message`).

**Verified**: walker flags the pre-fix shapes at `scripts/extract_oebb_geonetz_stops.py:300` and `scripts/apply_station_overrides.py:324`; post-fix it reports zero findings.

Any future contributor who adds a fresh `ensure_ascii=False` writer site without the scrub call now fails the walker at PR-review time regardless of whether the journal named the file.

## Test plan

- [x] Static checks: `python scripts/run_static_checks.py` → exit 0 (ruff, mypy, bandit, secrets, complexity, i18n, pip-audit all green).
- [x] Full suite: `pytest` → 8315 passed, 2 skipped in 6:26.
- [x] New PoC tests (48): byte-level no-RLO-leak + parametrised strip across 21 canonical primitives + German umlaut preservation + AST static-invariant pinning the scrub call in the function body, for both fix sites.
- [x] New walker tests (13): 1 full-codebase audit + 12 smoke tests pinning the pattern-recognition contract (default-shape acceptance, alias resolution, inline scrub acceptance, allowlist minimality).
- [x] Walker correctly flags pre-fix shapes when stashed; passes post-fix.

https://claude.ai/code/session_01VM2TbpUuKRUxR5g1JGN648

---
_Generated by [Claude Code](https://claude.ai/code/session_01VM2TbpUuKRUxR5g1JGN648)_