### PR TITLE
Baustellen-Provider: nur ÖPNV-relevante Meldungen (Bahnhofsnähe)

### DIFF
--- a/cache/baustellen_d438c3/events.json
+++ b/cache/baustellen_d438c3/events.json
@@ -2,41 +2,45 @@
   {
     "source": "Stadt Wien – Baustellen",
     "category": "Baustelle",
-    "title": "Arbeiten Mariahilfer Straße",
-    "description": "Fahrbahnverengung, Verzögerungen möglich. \nBeginn: 01.10.2025 06:00 Uhr \nGeplant bis: 15.10.2025 22:00 Uhr \nMaßnahme: Fahrbahnverengung \nBezirk: 06",
+    "title": "Umbau Bahnhofsvorplatz Floridsdorf",
+    "description": "Fahrbahnverengung im Bereich der Bahnhofszufahrt. \nBeginn: 01.10.2025 06:00 Uhr \nGeplant bis: 15.10.2025 22:00 Uhr \nMaßnahme: Fahrbahnverengung \nBezirk: 21",
     "link": "https://www.data.gv.at/katalog/en/dataset/baustellen-wien-verkehrsbeeintraechtigungen",
     "guid": "010687013508b2b01bd842bfe41cb7eed190730dd4fb8dc5b85ff354d291f03c",
     "pubDate": "2025-10-01T06:00:00+02:00",
     "starts_at": "2025-10-01T06:00:00+02:00",
     "ends_at": "2025-10-15T22:00:00+02:00",
     "context": {
-      "district": "06",
+      "district": "21",
       "measure": "Fahrbahnverengung"
     },
     "location": {
-      "address": "Mariahilfer Straße, zwischen Kirchengasse und Zieglergasse",
+      "address": "Am Spitz, zwischen Franz-Jonas-Platz und Pius-Parsch-Platz",
       "coordinates": {
-        "lat": 48.1981,
-        "lon": 16.3505
+        "lat": 48.2562499,
+        "lon": 16.4007
       }
     }
   },
   {
     "source": "Stadt Wien – Baustellen",
     "category": "Baustelle",
-    "title": "Leitungsbau Gürtel",
-    "description": "Tempo 30, Einspurigkeit stadteinwärts. \nBeginn: 05.11.2025 00:00 Uhr \nGeplant bis: 20.11.2025 00:00 Uhr \nMaßnahme: Straßenbahn \nBezirk: 09",
+    "title": "Gleisbau Bahnhof Mödling",
+    "description": "Schienenersatzverkehr, Haltestellen verlegt. \nBeginn: 05.11.2025 00:00 Uhr \nGeplant bis: 20.11.2025 00:00 Uhr \nMaßnahme: Straßenbahn \nBezirk: Mödling",
     "link": "https://www.data.gv.at/katalog/en/dataset/baustellen-wien-verkehrsbeeintraechtigungen",
     "guid": "c358f3d664fce16bb30b2d9627c372ddd065a69fb2ef5ba547d1b28abddad3ff",
     "pubDate": "2025-11-05T00:00:00+01:00",
     "starts_at": "2025-11-05T00:00:00+01:00",
     "ends_at": "2025-11-20T00:00:00+01:00",
     "context": {
-      "district": "09",
+      "district": "Mödling",
       "measure": "Straßenbahn"
     },
     "location": {
-      "address": "Währinger Gürtel, zwischen Spitalgasse und Nußdorfer Straße"
+      "address": "Bahnhofsplatz, zwischen Hauptstraße und Bahnstraße",
+      "coordinates": {
+        "lat": 48.085628,
+        "lon": 16.295474
+      }
     }
   }
 ]

--- a/data/samples/baustellen_sample.geojson
+++ b/data/samples/baustellen_sample.geojson
@@ -5,39 +5,39 @@
       "type": "Feature",
       "properties": {
         "OGD_ID": "BS-0001",
-        "BEZEICHNUNG": "Arbeiten Mariahilfer Straße",
-        "STRASSE": "Mariahilfer Straße",
-        "VON": "Kirchengasse",
-        "BIS": "Zieglergasse",
+        "BEZEICHNUNG": "Umbau Bahnhofsvorplatz Floridsdorf",
+        "STRASSE": "Am Spitz",
+        "VON": "Franz-Jonas-Platz",
+        "BIS": "Pius-Parsch-Platz",
         "ANFANGSZEIT": "2025-10-01T06:00:00+02:00",
         "ENDEZEIT": "2025-10-15T22:00:00+02:00",
-        "BEZIRK": "06",
-        "HINWEIS": "Fahrbahnverengung, Verzögerungen möglich.",
+        "BEZIRK": "21",
+        "HINWEIS": "Fahrbahnverengung im Bereich der Bahnhofszufahrt.",
         "VERKEHRSMASSNAHME": "Fahrbahnverengung"
       },
       "geometry": {
         "type": "Point",
-        "coordinates": [16.3505, 48.1981]
+        "coordinates": [16.4007, 48.2562499]
       }
     },
     {
       "type": "Feature",
       "properties": {
         "OGD_ID": "BS-0002",
-        "MASSNAHME": "Leitungsbau Gürtel",
-        "STRASSENNAME": "Währinger Gürtel",
-        "ABSCHNITT_VON": "Spitalgasse",
-        "ABSCHNITT_BIS": "Nußdorfer Straße",
+        "MASSNAHME": "Gleisbau Bahnhof Mödling",
+        "STRASSENNAME": "Bahnhofsplatz",
+        "ABSCHNITT_VON": "Hauptstraße",
+        "ABSCHNITT_BIS": "Bahnstraße",
         "DAUER": "2025-11-05/2025-11-20",
-        "BEZIRK": "09",
-        "BEMERKUNG": "Tempo 30, Einspurigkeit stadteinwärts.",
+        "BEZIRK": "Mödling",
+        "BEMERKUNG": "Schienenersatzverkehr, Haltestellen verlegt.",
         "VERKEHRSART": "Straßenbahn"
       },
       "geometry": {
         "type": "LineString",
         "coordinates": [
-          [16.3532, 48.2191],
-          [16.3564, 48.2246]
+          [16.295474, 48.085628],
+          [16.296100, 48.086000]
         ]
       }
     }

--- a/scripts/update_baustellen_cache.py
+++ b/scripts/update_baustellen_cache.py
@@ -32,6 +32,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from src.feed.logging_safe import setup_script_logging  # noqa: E402
+from src.providers.baustellen import is_transit_relevant  # noqa: E402
 from utils.cache import write_cache  # noqa: E402
 from utils.files import loads_finite, read_capped_json  # noqa: E402
 from utils.http import fetch_content_safe, session_with_retries, validate_http_url  # noqa: E402
@@ -508,6 +509,35 @@ def _build_context(properties: dict[str, Any]) -> dict[str, Any]:
     return context
 
 
+# GeoJSON geometries arrive as Point (``[lon, lat]``), LineString
+# (``[[lon, lat], ...]``), Polygon (``[[[lon, lat], ...]]``) or their
+# Multi* variants. The station-proximity test only needs one
+# representative coordinate, so we descend to the first vertex. The depth
+# is bounded so a maliciously deep nested array from a compromised
+# ``data.wien.gv.at`` upstream cannot drive unbounded recursion.
+_MAX_COORD_DEPTH = 8
+
+
+def _first_lonlat(coordinates: Any, _depth: int = 0) -> tuple[float, float] | None:
+    """Return the first ``(lon, lat)`` pair from a GeoJSON coordinate array."""
+    if _depth > _MAX_COORD_DEPTH:
+        return None
+    if not isinstance(coordinates, list | tuple) or not coordinates:
+        return None
+    first = coordinates[0]
+    if isinstance(first, bool):
+        return None
+    if isinstance(first, int | float):
+        # Leaf level: a coordinate needs at least a lon/lat pair.
+        if len(coordinates) < 2:
+            return None
+        try:
+            return float(coordinates[0]), float(coordinates[1])
+        except (TypeError, ValueError):
+            return None
+    return _first_lonlat(first, _depth + 1)
+
+
 def _build_location(properties: dict[str, Any], geometry: dict[str, Any]) -> dict[str, Any]:
     location: dict[str, Any] = {}
     address_parts: list[str] = []
@@ -523,43 +553,39 @@ def _build_location(properties: dict[str, Any], geometry: dict[str, Any]) -> dic
     if address_parts:
         location["address"] = ", ".join(address_parts)
     if isinstance(geometry, dict):
-        coordinates = geometry.get("coordinates")
-        if isinstance(coordinates, list | tuple) and len(coordinates) >= 2:
-            try:
-                lon, lat = float(coordinates[0]), float(coordinates[1])
-            except (TypeError, ValueError):
-                pass
-            else:
-                # Security (Coordinate finite/range drift, parser-level
-                # floor): mirror the canonical scrub pinned at
-                # ``src/places/hafas_client.py:_extract_first_location``,
-                # ``src/places/client.py:_parse_place`` and
-                # ``src/places/osm_client.py:filter_complete_places``
-                # (Round 1485 / Round 1486). A compromised
-                # ``data.wien.gv.at`` upstream (or MITM / DNS rebind)
-                # planting GeoJSON ``coordinates: [NaN, Infinity]``
-                # otherwise lands the poisoned float in
-                # ``location["coordinates"]`` — which propagates verbatim
-                # through ``write_cache`` into ``cache/baustellen/
-                # events.json`` (committed to ``main`` by
-                # ``update-cycle.yml``).
-                # ``math.isfinite`` is the strict superset of
-                # ``not math.isnan`` — it rejects ``NaN`` AND ``±Inf``
-                # in one check. The WGS84-range guard (-90 <= lat <= 90,
-                # -180 <= lon <= 180) rejects pathological integer-
-                # overflow shapes. Pairs failing either guard are
-                # silently dropped (the rest of the event's address /
-                # metadata is preserved); the writer-side
-                # ``allow_nan=False`` pin in
-                # ``src/utils/cache.py:write_cache`` is the
-                # defence-in-depth second layer.
-                if (
-                    math.isfinite(lat)
-                    and math.isfinite(lon)
-                    and -90.0 <= lat <= 90.0
-                    and -180.0 <= lon <= 180.0
-                ):
-                    location["coordinates"] = {"lat": lat, "lon": lon}
+        point = _first_lonlat(geometry.get("coordinates"))
+        if point is not None:
+            lon, lat = point
+            # Security (Coordinate finite/range drift, parser-level
+            # floor): mirror the canonical scrub pinned at
+            # ``src/places/hafas_client.py:_extract_first_location``,
+            # ``src/places/client.py:_parse_place`` and
+            # ``src/places/osm_client.py:filter_complete_places``
+            # (Round 1485 / Round 1486). A compromised
+            # ``data.wien.gv.at`` upstream (or MITM / DNS rebind)
+            # planting GeoJSON ``coordinates: [NaN, Infinity]``
+            # otherwise lands the poisoned float in
+            # ``location["coordinates"]`` — which propagates verbatim
+            # through ``write_cache`` into ``cache/baustellen/
+            # events.json`` (committed to ``main`` by
+            # ``update-cycle.yml``).
+            # ``math.isfinite`` is the strict superset of
+            # ``not math.isnan`` — it rejects ``NaN`` AND ``±Inf``
+            # in one check. The WGS84-range guard (-90 <= lat <= 90,
+            # -180 <= lon <= 180) rejects pathological integer-
+            # overflow shapes. Pairs failing either guard are
+            # silently dropped (the rest of the event's address /
+            # metadata is preserved); the writer-side
+            # ``allow_nan=False`` pin in
+            # ``src/utils/cache.py:write_cache`` is the
+            # defence-in-depth second layer.
+            if (
+                math.isfinite(lat)
+                and math.isfinite(lon)
+                and -90.0 <= lat <= 90.0
+                and -180.0 <= lon <= 180.0
+            ):
+                location["coordinates"] = {"lat": lat, "lon": lon}
     return location
 
 
@@ -655,8 +681,20 @@ def main() -> int:
         if payload is None:
             return 1
     events = _collect_events(payload)
-    write_cache("baustellen", events)
-    LOGGER.info("Baustellen: Cache mit %d Einträgen aktualisiert.", len(events))
+    # Keep only construction sites at/near a rail Bahnhof (Wien station or
+    # Pendlerbahnhof). The upstream feed covers every road works in the
+    # city; admitting all of them would bury the ÖPNV signal the feed
+    # exists to carry.
+    relevant = [event for event in events if is_transit_relevant(event.get("location"))]
+    skipped = len(events) - len(relevant)
+    if skipped:
+        LOGGER.info(
+            "Baustellen: %d von %d Meldung(en) ohne ÖPNV-Bezug verworfen.",
+            skipped,
+            len(events),
+        )
+    write_cache("baustellen", relevant)
+    LOGGER.info("Baustellen: Cache mit %d Einträgen aktualisiert.", len(relevant))
     return 0
 
 

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -328,8 +328,39 @@ def read_cache_oebb() -> list[Any]:
     return _post_filter_oebb(list(read_cache("oebb") or []))
 
 
+def _post_filter_baustellen(items: list[Any]) -> list[Any]:
+    """Defence-in-depth: keep only construction sites at/near a rail Bahnhof.
+
+    ``update_baustellen_cache.py`` already applies this relevance gate at
+    ingestion, but the on-disk cache (or the bundled fallback sample) may
+    predate the current policy. Re-applying on read guarantees the feed
+    never carries a back-courtyard road closure the current spec would
+    reject — the same defence-in-depth contract as :func:`_post_filter_oebb`.
+
+    Items carrying neither a title nor a description are treated as
+    stubs/metadata and passed through unchanged.
+    """
+    from .providers.baustellen import is_transit_relevant
+
+    out: list[Any] = []
+    for item in items:
+        if not isinstance(item, dict):
+            out.append(item)
+            continue
+        title = str(item.get("title") or "")
+        description = str(item.get("description") or "")
+        if not title and not description:
+            # Stub / metadata item — leave it alone.
+            out.append(item)
+            continue
+        if not is_transit_relevant(item.get("location")):
+            continue
+        out.append(item)
+    return out
+
+
 def read_cache_baustellen() -> list[Any]:
-    return list(read_cache("baustellen") or [])
+    return _post_filter_baustellen(list(read_cache("baustellen") or []))
 
 
 # Stammstrecke feed events are now derived from the CSV ledger

--- a/src/providers/baustellen.py
+++ b/src/providers/baustellen.py
@@ -1,0 +1,87 @@
+"""Relevance policy for the Stadt-Wien construction-site provider.
+
+The upstream WFS feed (``ogdwien:BAUSTELLEOGD``) lists *every* road
+construction site in Vienna — the overwhelming majority of which never
+touch public transport. To keep the feed a focused ÖPNV signal we admit
+a construction site only when it sits at (or right next to) a rail
+*Bahnhof*: a Wien station or a Pendlerbahnhof from the curated station
+directory. A lane closure on the forecourt of Wien Floridsdorf is worth
+surfacing; one in a back courtyard 2 km from any station is not.
+
+The decision is purely geographic — it compares the construction site's
+coordinate against the rail-station coordinates already maintained in
+``data/stations.json`` (see :func:`src.utils.stations.nearest_rail_station`).
+There is no free-text matching, so there is no ReDoS surface and no
+ambiguity from street names that merely echo a station name.
+"""
+from __future__ import annotations
+
+import math
+import os
+from typing import Any, Final
+
+from ..utils.stations import nearest_rail_station
+
+__all__ = [
+    "DEFAULT_STATION_RADIUS_M",
+    "is_transit_relevant",
+    "relevant_station",
+]
+
+#: Default proximity (in metres) between a construction site and a rail
+#: Bahnhof for the site to count as ÖPNV-relevant. 150 m mirrors the
+#: project's existing "effectively at the station" threshold
+#: (:data:`src.utils.geo.STATION_DRIFT_TOLERANCE_METERS`): a closure
+#: within 150 m of a Bahnhof plausibly affects access to it, while the
+#: tight radius keeps unrelated road works out of the feed.
+DEFAULT_STATION_RADIUS_M: Final = 150.0
+
+# Operator override bounds. The upper bound stops anyone widening the
+# radius until the filter re-floods the feed it exists to protect; the
+# lower bound keeps the match meaningful (a sub-25 m radius would drop
+# legitimate forecourt closures over GPS jitter alone).
+_MIN_STATION_RADIUS_M: Final = 25.0
+_MAX_STATION_RADIUS_M: Final = 2_000.0
+
+_RADIUS_ENV: Final = "BAUSTELLEN_STATION_RADIUS_M"
+
+
+def _resolve_radius_m() -> float:
+    """Return the proximity radius, honouring the clamped env override."""
+
+    raw = os.getenv(_RADIUS_ENV, "")
+    if not raw.strip():
+        return DEFAULT_STATION_RADIUS_M
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_STATION_RADIUS_M
+    if not math.isfinite(value):
+        return DEFAULT_STATION_RADIUS_M
+    return min(max(value, _MIN_STATION_RADIUS_M), _MAX_STATION_RADIUS_M)
+
+
+def relevant_station(location: Any, *, radius_m: float | None = None) -> str | None:
+    """Return the rail Bahnhof a construction ``location`` is tied to.
+
+    ``location`` is the provider's location mapping, shaped
+    ``{"coordinates": {"lat": ..., "lon": ...}, ...}``. Anything without
+    a usable coordinate pair is treated as not relevant (fail closed) and
+    yields ``None``.
+    """
+
+    if not isinstance(location, dict):
+        return None
+    coordinates = location.get("coordinates")
+    if not isinstance(coordinates, dict):
+        return None
+    radius = _resolve_radius_m() if radius_m is None else radius_m
+    match = nearest_rail_station(coordinates.get("lat"), coordinates.get("lon"), radius)
+    return match[0] if match else None
+
+
+def is_transit_relevant(location: Any, *, radius_m: float | None = None) -> bool:
+    """Return ``True`` iff the construction ``location`` sits within the
+    configured radius of a rail Bahnhof (Wien station or Pendlerbahnhof)."""
+
+    return relevant_station(location, radius_m=radius_m) is not None

--- a/src/utils/stations.py
+++ b/src/utils/stations.py
@@ -17,12 +17,14 @@ from typing import Any, NamedTuple
 from collections.abc import Iterable
 
 from .files import _reject_non_finite_constant, _reject_non_finite_float
+from .geo import calculate_distance_meters
 
 __all__ = [
     "canonical_name",
     "display_name",
     "is_in_vienna",
     "is_pendler",
+    "nearest_rail_station",
     "station_by_oebb_id",
     "station_info",
     "text_has_vienna_connection",
@@ -533,6 +535,59 @@ def _station_entries() -> tuple[dict[str, Any], ...]:
         if isinstance(entry, dict):
             result.append(entry)
     return tuple(result)
+
+
+@lru_cache(maxsize=1)
+def _rail_station_coordinates() -> tuple[tuple[str, float, float], ...]:
+    """Return ``(name, lat, lon)`` for every rail Betriebsstelle.
+
+    A ``bst_id`` marks an ÖBB / S-Bahn operating point — i.e. a
+    *Bahnhof* (52 of them inside Vienna) or a *Pendlerbahnhof* (109
+    commuter stations). Pure Wiener-Linien tram/bus stops (``wl_diva``
+    only, no ``bst_id``) are deliberately excluded: matching against the
+    ~1800 stops would turn proximity into "near any stop", which in a
+    dense city means "everywhere". Entries without a valid coordinate
+    pair are skipped.
+    """
+
+    rail: list[tuple[str, float, float]] = []
+    for entry in _station_entries():
+        if not entry.get("bst_id"):
+            continue
+        lat = _coerce_lat(entry.get("latitude") or entry.get("lat"))
+        lon = _coerce_lon(entry.get("longitude") or entry.get("lon"))
+        if lat is None or lon is None:
+            continue
+        name = entry.get("name")
+        if isinstance(name, str) and name.strip():
+            rail.append((name.strip(), lat, lon))
+    return tuple(rail)
+
+
+def nearest_rail_station(
+    lat: object, lon: object, radius_m: float
+) -> tuple[str, float] | None:
+    """Return ``(name, distance_m)`` of the closest rail Bahnhof within
+    ``radius_m`` of the coordinate, or ``None`` if none qualifies.
+
+    Inputs are coerced and range-checked via :func:`_coerce_lat` /
+    :func:`_coerce_lon`, so ``None`` / ``NaN`` / out-of-range coordinates
+    yield ``None`` (fail closed). The scan is ``O(n)`` over the cached
+    rail set (~160 entries) with no regex/backtracking surface.
+    """
+
+    qlat = _coerce_lat(lat)
+    qlon = _coerce_lon(lon)
+    if qlat is None or qlon is None:
+        return None
+    if not radius_m > 0:
+        return None
+    best: tuple[str, float] | None = None
+    for name, slat, slon in _rail_station_coordinates():
+        distance = calculate_distance_meters(qlat, qlon, slat, slon)
+        if distance <= radius_m and (best is None or distance < best[1]):
+            best = (name, distance)
+    return best
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_baustellen_relevance.py
+++ b/tests/test_baustellen_relevance.py
@@ -1,0 +1,212 @@
+"""Tests for the Baustellen ÖPNV-relevance filter.
+
+The provider must only surface construction sites at/near a rail Bahnhof
+(Wien station or Pendlerbahnhof); ordinary road works anywhere else in
+the city must be dropped so the feed stays a focused transit signal.
+"""
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from scripts import update_baustellen_cache
+from src.build_feed import _post_filter_baustellen
+from src.providers import baustellen
+from src.providers.baustellen import (
+    DEFAULT_STATION_RADIUS_M,
+    is_transit_relevant,
+    relevant_station,
+)
+from src.utils import stations
+
+# Real directory coordinates (data/stations.json).
+WIEN_HBF = (48.185184, 16.376413)  # bst_id 900100, in_vienna
+MOEDLING = (48.085628, 16.295474)  # bst_id 1377, pendler
+# A point deep in the Donau-Auen floodplain — no rail Bahnhof for km.
+FAR_AWAY = (48.170000, 16.520000)
+
+SAMPLE_PATH = Path(__file__).resolve().parents[1] / "data" / "samples" / "baustellen_sample.geojson"
+
+
+def _loc(lat: float, lon: float) -> dict:
+    return {"address": "Teststraße", "coordinates": {"lat": lat, "lon": lon}}
+
+
+@pytest.fixture
+def single_station(monkeypatch: pytest.MonkeyPatch):
+    """Replace the rail-station set with one synthetic Bahnhof so distance
+    assertions are independent of the real directory."""
+
+    station = (("Test Bahnhof", 48.2000, 16.3700),)
+    monkeypatch.setattr(stations, "_rail_station_coordinates", lambda: station)
+    return station
+
+
+# --- nearest_rail_station: geometry / radius ----------------------------------
+
+
+def test_nearest_rail_station_matches_at_zero_distance(single_station) -> None:
+    match = stations.nearest_rail_station(48.2000, 16.3700, 150.0)
+    assert match is not None
+    assert match[0] == "Test Bahnhof"
+    assert match[1] == pytest.approx(0.0, abs=1.0)
+
+
+def test_nearest_rail_station_within_radius(single_station) -> None:
+    # ~100 m north of the station (0.0009° lat ≈ 100 m).
+    assert stations.nearest_rail_station(48.2009, 16.3700, 150.0) is not None
+
+
+def test_nearest_rail_station_outside_radius(single_station) -> None:
+    # ~300 m north — dropped at 150 m, kept once the radius is widened.
+    assert stations.nearest_rail_station(48.2027, 16.3700, 150.0) is None
+    assert stations.nearest_rail_station(48.2027, 16.3700, 500.0) is not None
+
+
+@pytest.mark.parametrize(
+    "lat, lon",
+    [
+        (None, 16.37),
+        (48.2, None),
+        (float("nan"), 16.37),
+        (48.2, float("inf")),
+        (95.0, 16.37),  # latitude out of European coercion range
+        ("x", 16.37),
+    ],
+)
+def test_nearest_rail_station_fails_closed_on_bad_coords(single_station, lat, lon) -> None:
+    assert stations.nearest_rail_station(lat, lon, 150.0) is None
+
+
+def test_nearest_rail_station_rejects_nonpositive_radius(single_station) -> None:
+    assert stations.nearest_rail_station(48.2000, 16.3700, 0.0) is None
+    assert stations.nearest_rail_station(48.2000, 16.3700, -10.0) is None
+
+
+# --- is_transit_relevant / relevant_station -----------------------------------
+
+
+def test_relevant_station_at_real_bahnhof() -> None:
+    name = relevant_station(_loc(*WIEN_HBF))
+    assert name is not None
+    assert "Hauptbahnhof" in name
+
+
+def test_pendlerbahnhof_is_relevant() -> None:
+    assert is_transit_relevant(_loc(*MOEDLING)) is True
+
+
+def test_far_away_road_works_is_not_relevant() -> None:
+    assert is_transit_relevant(_loc(*FAR_AWAY)) is False
+
+
+@pytest.mark.parametrize(
+    "location",
+    [
+        None,
+        "nope",
+        {},
+        {"address": "Teststraße"},  # no coordinates
+        {"coordinates": "nope"},
+        {"coordinates": {"lat": None, "lon": None}},
+        {"coordinates": {"lat": float("nan"), "lon": 16.37}},
+    ],
+)
+def test_is_transit_relevant_fails_closed(location) -> None:
+    assert is_transit_relevant(location) is False
+
+
+def test_radius_override_widens_match(monkeypatch: pytest.MonkeyPatch, single_station) -> None:
+    far = _loc(48.2027, 16.3700)  # ~300 m from the synthetic station
+    assert is_transit_relevant(far) is False
+    monkeypatch.setenv("BAUSTELLEN_STATION_RADIUS_M", "500")
+    assert is_transit_relevant(far) is True
+
+
+# --- radius resolution / clamping ---------------------------------------------
+
+
+def test_resolve_radius_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BAUSTELLEN_STATION_RADIUS_M", raising=False)
+    assert baustellen._resolve_radius_m() == DEFAULT_STATION_RADIUS_M
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("500", 500.0),
+        ("5", 25.0),  # clamped up to the minimum
+        ("999999", 2000.0),  # clamped down to the maximum
+        ("abc", DEFAULT_STATION_RADIUS_M),
+        ("inf", DEFAULT_STATION_RADIUS_M),
+        ("  ", DEFAULT_STATION_RADIUS_M),
+    ],
+)
+def test_resolve_radius_clamping(monkeypatch: pytest.MonkeyPatch, raw: str, expected: float) -> None:
+    monkeypatch.setenv("BAUSTELLEN_STATION_RADIUS_M", raw)
+    assert baustellen._resolve_radius_m() == expected
+
+
+# --- _post_filter_baustellen --------------------------------------------------
+
+
+def test_post_filter_keeps_relevant_drops_noise_passes_stubs() -> None:
+    relevant = {"title": "Umbau", "description": "x", "location": _loc(*WIEN_HBF)}
+    noise = {"title": "Hinterhof", "description": "x", "location": _loc(*FAR_AWAY)}
+    no_coords = {"title": "Ohne Geo", "description": "x"}
+    stub = {"guid": "meta-only"}
+    sentinel = "passthrough-non-dict"
+
+    result = _post_filter_baustellen([relevant, noise, no_coords, stub, sentinel])
+
+    assert relevant in result
+    assert noise not in result
+    assert no_coords not in result  # no coordinates → fail closed
+    assert stub in result  # title/description-less stub passes through
+    assert sentinel in result  # non-dict passes through
+
+
+# --- _first_lonlat (geometry descent) -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "coordinates, expected",
+    [
+        ([16.4, 48.2], (16.4, 48.2)),  # Point
+        ([[16.4, 48.2], [16.5, 48.3]], (16.4, 48.2)),  # LineString
+        ([[[16.4, 48.2], [16.5, 48.3]]], (16.4, 48.2)),  # Polygon ring
+        ([[[[16.4, 48.2]]]], (16.4, 48.2)),  # MultiPolygon
+    ],
+)
+def test_first_lonlat_descends_geometries(coordinates, expected) -> None:
+    assert update_baustellen_cache._first_lonlat(coordinates) == expected
+
+
+@pytest.mark.parametrize(
+    "coordinates",
+    [
+        None,
+        [],
+        [16.4],  # too short
+        [True, False],  # bools are not coordinates
+        "16.4,48.2",
+        [[[[[[[[[[16.4, 48.2]]]]]]]]]],  # deeper than _MAX_COORD_DEPTH
+    ],
+)
+def test_first_lonlat_rejects_bad_geometries(coordinates) -> None:
+    assert update_baustellen_cache._first_lonlat(coordinates) is None
+
+
+# --- end-to-end on the bundled sample -----------------------------------------
+
+
+def test_sample_payload_is_all_transit_relevant() -> None:
+    payload = json.loads(SAMPLE_PATH.read_text(encoding="utf-8"))
+    events = update_baustellen_cache._collect_events(payload)
+    assert len(events) == 2
+    assert all(is_transit_relevant(event.get("location")) for event in events)
+    # The LineString feature must still yield a usable coordinate.
+    assert events[1]["location"]["coordinates"]["lat"] == pytest.approx(48.085628)

--- a/tests/test_baustellen_relevance.py
+++ b/tests/test_baustellen_relevance.py
@@ -7,7 +7,6 @@ the city must be dropped so the feed stays a focused transit signal.
 from __future__ import annotations
 
 import json
-import math
 from pathlib import Path
 
 import pytest

--- a/tests/test_baustellen_relevance.py
+++ b/tests/test_baustellen_relevance.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -29,13 +30,15 @@ FAR_AWAY = (48.170000, 16.520000)
 
 SAMPLE_PATH = Path(__file__).resolve().parents[1] / "data" / "samples" / "baustellen_sample.geojson"
 
+_RailSet = tuple[tuple[str, float, float], ...]
 
-def _loc(lat: float, lon: float) -> dict:
+
+def _loc(lat: float, lon: float) -> dict[str, Any]:
     return {"address": "Teststraße", "coordinates": {"lat": lat, "lon": lon}}
 
 
 @pytest.fixture
-def single_station(monkeypatch: pytest.MonkeyPatch):
+def single_station(monkeypatch: pytest.MonkeyPatch) -> _RailSet:
     """Replace the rail-station set with one synthetic Bahnhof so distance
     assertions are independent of the real directory."""
 
@@ -47,19 +50,19 @@ def single_station(monkeypatch: pytest.MonkeyPatch):
 # --- nearest_rail_station: geometry / radius ----------------------------------
 
 
-def test_nearest_rail_station_matches_at_zero_distance(single_station) -> None:
+def test_nearest_rail_station_matches_at_zero_distance(single_station: _RailSet) -> None:
     match = stations.nearest_rail_station(48.2000, 16.3700, 150.0)
     assert match is not None
     assert match[0] == "Test Bahnhof"
     assert match[1] == pytest.approx(0.0, abs=1.0)
 
 
-def test_nearest_rail_station_within_radius(single_station) -> None:
+def test_nearest_rail_station_within_radius(single_station: _RailSet) -> None:
     # ~100 m north of the station (0.0009° lat ≈ 100 m).
     assert stations.nearest_rail_station(48.2009, 16.3700, 150.0) is not None
 
 
-def test_nearest_rail_station_outside_radius(single_station) -> None:
+def test_nearest_rail_station_outside_radius(single_station: _RailSet) -> None:
     # ~300 m north — dropped at 150 m, kept once the radius is widened.
     assert stations.nearest_rail_station(48.2027, 16.3700, 150.0) is None
     assert stations.nearest_rail_station(48.2027, 16.3700, 500.0) is not None
@@ -76,11 +79,13 @@ def test_nearest_rail_station_outside_radius(single_station) -> None:
         ("x", 16.37),
     ],
 )
-def test_nearest_rail_station_fails_closed_on_bad_coords(single_station, lat, lon) -> None:
+def test_nearest_rail_station_fails_closed_on_bad_coords(
+    single_station: _RailSet, lat: object, lon: object
+) -> None:
     assert stations.nearest_rail_station(lat, lon, 150.0) is None
 
 
-def test_nearest_rail_station_rejects_nonpositive_radius(single_station) -> None:
+def test_nearest_rail_station_rejects_nonpositive_radius(single_station: _RailSet) -> None:
     assert stations.nearest_rail_station(48.2000, 16.3700, 0.0) is None
     assert stations.nearest_rail_station(48.2000, 16.3700, -10.0) is None
 
@@ -114,11 +119,13 @@ def test_far_away_road_works_is_not_relevant() -> None:
         {"coordinates": {"lat": float("nan"), "lon": 16.37}},
     ],
 )
-def test_is_transit_relevant_fails_closed(location) -> None:
+def test_is_transit_relevant_fails_closed(location: object) -> None:
     assert is_transit_relevant(location) is False
 
 
-def test_radius_override_widens_match(monkeypatch: pytest.MonkeyPatch, single_station) -> None:
+def test_radius_override_widens_match(
+    monkeypatch: pytest.MonkeyPatch, single_station: _RailSet
+) -> None:
     far = _loc(48.2027, 16.3700)  # ~300 m from the synthetic station
     assert is_transit_relevant(far) is False
     monkeypatch.setenv("BAUSTELLEN_STATION_RADIUS_M", "500")
@@ -180,7 +187,9 @@ def test_post_filter_keeps_relevant_drops_noise_passes_stubs() -> None:
         ([[[[16.4, 48.2]]]], (16.4, 48.2)),  # MultiPolygon
     ],
 )
-def test_first_lonlat_descends_geometries(coordinates, expected) -> None:
+def test_first_lonlat_descends_geometries(
+    coordinates: object, expected: tuple[float, float]
+) -> None:
     assert update_baustellen_cache._first_lonlat(coordinates) == expected
 
 
@@ -195,7 +204,7 @@ def test_first_lonlat_descends_geometries(coordinates, expected) -> None:
         [[[[[[[[[[16.4, 48.2]]]]]]]]]],  # deeper than _MAX_COORD_DEPTH
     ],
 )
-def test_first_lonlat_rejects_bad_geometries(coordinates) -> None:
+def test_first_lonlat_rejects_bad_geometries(coordinates: object) -> None:
     assert update_baustellen_cache._first_lonlat(coordinates) is None
 
 

--- a/tests/test_sentinel_allow_nan_writer_audit_walker.py
+++ b/tests/test_sentinel_allow_nan_writer_audit_walker.py
@@ -93,7 +93,7 @@ Three documented sites live here today:
   motivates the non-finite-literal axis (committed-to-main artefact
   that strict parsers must handle) does not apply.
 
-* ``src/build_feed.py:_identity_for_item`` (lines 2261 and 2270) —
+* ``src/build_feed.py:_identity_for_item`` (lines 2292 and 2301) —
   two ``json.dumps(item, sort_keys=True, default=str)`` calls compute
   the SHA-256 input for the feed-item identity hash. The serialised
   bytes flow into ``hashlib.sha256(raw.encode("utf-8")).hexdigest()``
@@ -142,8 +142,8 @@ ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
         # into ``hashlib.sha256(...).hexdigest()`` on the very next
         # line and are not retained anywhere else. No parser-consumed
         # artefact, so the threat model does not apply.
-        ("src/build_feed.py", 2261),
-        ("src/build_feed.py", 2270),
+        ("src/build_feed.py", 2292),
+        ("src/build_feed.py", 2301),
     }
 )
 
@@ -536,7 +536,7 @@ def test_allowlist_is_minimal_and_documented() -> None:
     assert ALLOWLIST == frozenset(
         {
             ("src/places/hafas_client.py", 282),
-            ("src/build_feed.py", 2261),
-            ("src/build_feed.py", 2270),
+            ("src/build_feed.py", 2292),
+            ("src/build_feed.py", 2301),
         }
     )

--- a/tests/test_update_baustellen_cache.py
+++ b/tests/test_update_baustellen_cache.py
@@ -146,9 +146,10 @@ def test_collect_events_from_sample_payload() -> None:
     assert len(events) == 2
     first = events[0]
     assert first["category"] == "Baustelle"
-    assert first["context"]["district"] == "06"
+    assert first["context"]["district"] == "21"
     assert first["starts_at"].startswith("2025-10-01")
     assert "location" in first
+    assert first["location"]["coordinates"] == {"lat": 48.2562499, "lon": 16.4007}
 
 
 def test_main_uses_fallback_when_remote_fails(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Hintergrund

Der Stadt-Wien-WFS-Feed (`ogdwien:BAUSTELLEOGD`) listet **jede** Baustelle der Stadt — auch solche ohne jeden ÖPNV-Bezug (Gehsteigarbeiten, Hinterhöfe, Leitungsbau abseits von Linien). Bisher gab es **keinerlei** Relevanzfilter: bei funktionierendem Abruf würde der Feed mit Straßenbaustellen geflutet.

Ziel: Der Provider soll den Feed **nicht zuspammen**, sondern nur mit *besonders interessanten* ÖPNV-Meldungen anreichern — z. B. wenn ein Bahnhof in Wien oder ein Pendlerbahnhof umgebaut wird.

## Ansatz

Anker ist das vorhandene **Stationsverzeichnis** (`data/stations.json`). Die 161 Einträge mit `bst_id` sind genau die Schienen-Betriebsstellen — **52 Wien-Bahnhöfe** (`in_vienna`) + **109 Pendlerbahnhöfe** (`pendler`). Reine Wiener-Linien-Halte (`wl_diva`, ~1800 Stück) werden bewusst ausgeschlossen, sonst würde „in der Nähe einer Station" in einer dichten Stadt „überall" bedeuten.

Eine Baustelle gilt als ÖPNV-relevant, wenn ihre Koordinate innerhalb eines (konfigurierbaren) Radius — **Default 150 m** — zu einem dieser Bahnhöfe liegt. Rein geografisch, also keine Freitext-Heuristik (kein ReDoS-Risiko, keine Mehrdeutigkeit durch Straßennamen).

## Änderungen

- **`src/utils/stations.py`** — `nearest_rail_station(lat, lon, radius_m)` über den gecachten `bst_id`-Bahnhofssatz; nutzt den kanonischen Haversine-Helfer (`src/utils/geo.py`) und schlägt bei ungültigen Koordinaten *fail-closed* fehl.
- **`src/providers/baustellen.py`** (neu) — geografische Relevanz-Policy mit geklemmtem Env-Override `BAUSTELLEN_STATION_RADIUS_M` (25 m–2000 m).
- **`scripts/update_baustellen_cache.py`** — Relevanz-Gate bei der Ingestion in `main()`; `_first_lonlat` extrahiert eine repräsentative Koordinate aus Point/LineString/Polygon-Geometrien (mit gebundener Rekursionstiefe gegen verschachtelte Payloads).
- **`src/build_feed.py`** — `_post_filter_baustellen` wendet das Gate beim Lesen erneut an (Defense-in-Depth, analog zu `_post_filter_oebb`), damit veraltete Caches / das Fallback-Sample nichts Irrelevantes einschleusen.
- **`data/samples/baustellen_sample.geojson`** — zwei Bahnhofs-verankerte Demo-Features (Floridsdorf als Point, Mödling als LineString).

## Hinweis: Abruf weiterhin defekt (separat)

Dieser PR formt, **was** angezeigt wird, sobald Daten fließen. Der eigentliche Grund, warum aktuell **gar nichts** erscheint, ist davon unberührt: Der WFS-Endpoint liefert trotz `outputFormat=json` ein `application/xml` (CI-Log bestätigt: `Invalid Content-Type: application/xml`), wodurch der Abruf scheitert und still aufs (abgelaufene) Sample zurückfällt. Der genaue Grund (OGC-Fehlerreport vs. GML vs. falsch etikettiertes JSON) braucht noch den Antwort-Body aus einem CI-Lauf — bewusst nicht in diesem PR.

## Test plan

- [x] `tests/test_baustellen_relevance.py` (neu): Bahnhofsnähe (Treffer/keine Treffer), Pendlerbahnhof, Fail-closed bei fehlenden/ungültigen Koordinaten, Radius-Override + Clamping, `_post_filter_baustellen` (behält relevant, verwirft Rauschen, lässt Stubs/Non-Dicts durch), `_first_lonlat` über alle Geometrietypen + Tiefenbombe, End-to-End auf dem Sample.
- [x] Bestehende `tests/test_update_baustellen_cache.py` angepasst (neues Sample) — grün.
- [x] Regression: `test_geo`, `test_build_feed_cache/atom`, `test_drop_old_items_future`, `test_provider_*`, `test_*_stations`, ÖBB-Provider — 123 grün.
- [x] mypy-strict (`src/`) sauber; C901-Komplexitäts-Gate ohne neue Verstöße.
- [ ] Live-Abruf konnte aus der Sandbox nicht getestet werden (Host nicht in der Allowlist).

https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu)_