### PR TITLE
Baustellen: betroffenen Bahnhof anzeigen + Fallback sichtbar machen

### DIFF
--- a/scripts/update_baustellen_cache.py
+++ b/scripts/update_baustellen_cache.py
@@ -676,9 +676,15 @@ def main() -> int:
                 sanitize_log_arg(timeout_raw),
             )
     payload = _fetch_remote(data_url, timeout)
+    used_fallback = False
     if payload is None:
+        used_fallback = True
         payload = _load_fallback(fallback_path)
         if payload is None:
+            LOGGER.error(
+                "Baustellen: Live-Abruf UND Fallback fehlgeschlagen – Cache "
+                "nicht aktualisiert."
+            )
             return 1
     events = _collect_events(payload)
     # Keep only construction sites at/near a rail Bahnhof (Wien station or
@@ -694,6 +700,18 @@ def main() -> int:
             len(events),
         )
     write_cache("baustellen", relevant)
+    if used_fallback:
+        # Exit 2 = "degraded": the cache was written from the bundled
+        # fallback sample, NOT a live fetch. The cron wrapper maps any
+        # non-zero exit to a visible ``::warning`` so this failure mode
+        # stops hiding behind an INFO "Cache aktualisiert" success line.
+        LOGGER.warning(
+            "Baustellen: Live-Abruf fehlgeschlagen – Cache nutzt FALLBACK-"
+            "Demodaten (%d Eintrag/Einträge, kein ÖPNV-Live-Signal). "
+            "WFS-Endpoint prüfen.",
+            len(relevant),
+        )
+        return 2
     LOGGER.info("Baustellen: Cache mit %d Einträgen aktualisiert.", len(relevant))
     return 0
 

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -328,19 +328,39 @@ def read_cache_oebb() -> list[Any]:
     return _post_filter_oebb(list(read_cache("oebb") or []))
 
 
-def _post_filter_baustellen(items: list[Any]) -> list[Any]:
-    """Defence-in-depth: keep only construction sites at/near a rail Bahnhof.
+def _baustellen_title_names_station(title: str, label: str) -> bool:
+    """Return ``True`` if ``title`` already mentions a distinctive token of
+    the station ``label``, so the prefix isn't doubled up (e.g. avoid
+    ``Wien Floridsdorf: Umbau Bahnhofsvorplatz Floridsdorf``). The generic
+    ``Wien`` token (and other ≤4-char tokens) is ignored on purpose."""
+    lowered = title.lower()
+    return any(
+        len(token) > 4 and token in lowered
+        for token in re.split(r"\W+", label.lower())
+    )
 
-    ``update_baustellen_cache.py`` already applies this relevance gate at
-    ingestion, but the on-disk cache (or the bundled fallback sample) may
-    predate the current policy. Re-applying on read guarantees the feed
-    never carries a back-courtyard road closure the current spec would
-    reject — the same defence-in-depth contract as :func:`_post_filter_oebb`.
+
+def _post_filter_baustellen(items: list[Any]) -> list[Any]:
+    """Defence-in-depth relevance gate plus ÖPNV title enrichment.
+
+    ``update_baustellen_cache.py`` already drops construction sites that
+    are not at/near a rail Bahnhof at ingestion, but the on-disk cache (or
+    the bundled fallback sample) may predate the current policy — so the
+    gate is re-applied here, the same defence-in-depth contract as
+    :func:`_post_filter_oebb`.
+
+    For the items that pass, the affected Bahnhof (Wien station or
+    Pendlerbahnhof) is prefixed onto the title so the entry reads as a
+    transit message at a glance — mirroring the line/route prefixes WL and
+    ÖBB carry, and the title re-derivation :func:`_post_filter_oebb`
+    performs. The prefix is skipped when the title already names the
+    station, keeping the headline compact.
 
     Items carrying neither a title nor a description are treated as
     stubs/metadata and passed through unchanged.
     """
-    from .providers.baustellen import is_transit_relevant
+    from .providers.baustellen import relevant_station
+    from .utils.stations import display_name
 
     out: list[Any] = []
     for item in items:
@@ -353,8 +373,13 @@ def _post_filter_baustellen(items: list[Any]) -> list[Any]:
             # Stub / metadata item — leave it alone.
             out.append(item)
             continue
-        if not is_transit_relevant(item.get("location")):
+        station = relevant_station(item.get("location"))
+        if station is None:
             continue
+        label = display_name(station) or station
+        if label and not _baustellen_title_names_station(title, label):
+            item = dict(item)
+            item["title"] = f"{label}: {title}" if title else label
         out.append(item)
     return out
 

--- a/tests/test_baustellen_relevance.py
+++ b/tests/test_baustellen_relevance.py
@@ -160,7 +160,7 @@ def test_resolve_radius_clamping(monkeypatch: pytest.MonkeyPatch, raw: str, expe
 
 
 def test_post_filter_keeps_relevant_drops_noise_passes_stubs() -> None:
-    relevant = {"title": "Umbau", "description": "x", "location": _loc(*WIEN_HBF)}
+    relevant = {"title": "Fahrbahnsanierung", "description": "x", "location": _loc(*WIEN_HBF)}
     noise = {"title": "Hinterhof", "description": "x", "location": _loc(*FAR_AWAY)}
     no_coords = {"title": "Ohne Geo", "description": "x"}
     stub = {"guid": "meta-only"}
@@ -168,11 +168,29 @@ def test_post_filter_keeps_relevant_drops_noise_passes_stubs() -> None:
 
     result = _post_filter_baustellen([relevant, noise, no_coords, stub, sentinel])
 
-    assert relevant in result
-    assert noise not in result
-    assert no_coords not in result  # no coordinates → fail closed
+    titles = [r["title"] for r in result if isinstance(r, dict) and "title" in r]
+    # Relevant item kept and prefixed with the affected Bahnhof.
+    assert any(t.endswith("Fahrbahnsanierung") and "Hauptbahnhof" in t for t in titles)
+    assert "Hinterhof" not in titles  # far from any Bahnhof → dropped
+    assert "Ohne Geo" not in titles  # no coordinates → fail closed
     assert stub in result  # title/description-less stub passes through
     assert sentinel in result  # non-dict passes through
+
+
+def test_post_filter_enriches_title_with_affected_bahnhof() -> None:
+    item = {"title": "Vollsperre Nordbahnstraße", "description": "x", "location": _loc(*WIEN_HBF)}
+    [out] = _post_filter_baustellen([item])
+    assert out["title"].startswith("Wien Hauptbahnhof: ")
+    assert out["title"].endswith("Vollsperre Nordbahnstraße")
+    # Original dict is left untouched (mutation via copy).
+    assert item["title"] == "Vollsperre Nordbahnstraße"
+
+
+def test_post_filter_does_not_double_name_station() -> None:
+    # Title already names the station → no redundant prefix.
+    item = {"title": "Umbau Bahnhof Mödling", "description": "x", "location": _loc(*MOEDLING)}
+    [out] = _post_filter_baustellen([item])
+    assert out["title"] == "Umbau Bahnhof Mödling"
 
 
 # --- _first_lonlat (geometry descent) -----------------------------------------

--- a/tests/test_sentinel_allow_nan_writer_audit_walker.py
+++ b/tests/test_sentinel_allow_nan_writer_audit_walker.py
@@ -93,7 +93,7 @@ Three documented sites live here today:
   motivates the non-finite-literal axis (committed-to-main artefact
   that strict parsers must handle) does not apply.
 
-* ``src/build_feed.py:_identity_for_item`` (lines 2292 and 2301) —
+* ``src/build_feed.py:_identity_for_item`` (lines 2317 and 2326) —
   two ``json.dumps(item, sort_keys=True, default=str)`` calls compute
   the SHA-256 input for the feed-item identity hash. The serialised
   bytes flow into ``hashlib.sha256(raw.encode("utf-8")).hexdigest()``
@@ -142,8 +142,8 @@ ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
         # into ``hashlib.sha256(...).hexdigest()`` on the very next
         # line and are not retained anywhere else. No parser-consumed
         # artefact, so the threat model does not apply.
-        ("src/build_feed.py", 2292),
-        ("src/build_feed.py", 2301),
+        ("src/build_feed.py", 2317),
+        ("src/build_feed.py", 2326),
     }
 )
 
@@ -536,7 +536,7 @@ def test_allowlist_is_minimal_and_documented() -> None:
     assert ALLOWLIST == frozenset(
         {
             ("src/places/hafas_client.py", 282),
-            ("src/build_feed.py", 2292),
-            ("src/build_feed.py", 2301),
+            ("src/build_feed.py", 2317),
+            ("src/build_feed.py", 2326),
         }
     )

--- a/tests/test_update_baustellen_cache.py
+++ b/tests/test_update_baustellen_cache.py
@@ -152,7 +152,11 @@ def test_collect_events_from_sample_payload() -> None:
     assert first["location"]["coordinates"] == {"lat": 48.2562499, "lon": 16.4007}
 
 
-def test_main_uses_fallback_when_remote_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_main_uses_fallback_when_remote_fails(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import logging
+
     calls: list[tuple[str, list[dict[str, Any]]]] = []
 
     def fake_fetch_remote(url: str, timeout: int) -> None:
@@ -164,12 +168,21 @@ def test_main_uses_fallback_when_remote_fails(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(update_baustellen_cache, "_fetch_remote", fake_fetch_remote)
     monkeypatch.setattr(update_baustellen_cache, "write_cache", capture_cache)
     monkeypatch.setenv("BAUSTELLEN_FALLBACK_PATH", str(SAMPLE_PATH))
+    caplog.set_level(logging.WARNING, logger="update_baustellen_cache")
 
     exit_code = update_baustellen_cache.main()
 
-    assert exit_code == 0
+    # Exit 2 = degraded: the cache came from the fallback sample, not a
+    # live fetch. The previous silent ``return 0`` is what let the broken
+    # WFS fetch hide for weeks.
+    assert exit_code == 2
     assert calls and calls[0][0] == "baustellen"
     assert len(calls[0][1]) == 2
+    assert any(
+        "FALLBACK" in record.getMessage()
+        for record in caplog.records
+        if record.name == "update_baustellen_cache"
+    )
 
 
 def test_resolve_fallback_path_default_when_unset() -> None:


### PR DESCRIPTION
Zwei Folgeänderungen zum (gemergten) ÖPNV-Relevanzfilter aus #1637, damit der Provider **ehrlich** und die Meldungen **leicht verständlich** sind.

## 1. Fallback nicht mehr lautlos

`update_baustellen_cache.main()` gab bei fehlgeschlagenem Live-Abruf bisher `INFO "Cache aktualisiert"` + **Exit 0** zurück — der Grund, warum der defekte WFS-Abruf wochenlang unbemerkt blieb. Jetzt:
- **WARNING**: „Live-Abruf fehlgeschlagen – Cache nutzt FALLBACK-Demodaten … kein ÖPNV-Live-Signal. WFS-Endpoint prüfen."
- **Exit-Code 2** (degraded). Der Cron-Wrapper (`update-cycle.yml`) bildet jeden Nicht-Null-Exit auf eine sichtbare `::warning` ab; der Workflow selbst bleibt grün (best-effort).
- Exit 1 bleibt für „Live **und** Fallback fehlgeschlagen" (jetzt mit ERROR-Log).

## 2. Betroffenen Bahnhof im Titel anzeigen

`_post_filter_baustellen` stellt dem Eintragstitel den betroffenen Bahnhof (Wien-Station / Pendlerbahnhof) voran — analog zu den Linien-/Routen-Präfixen bei WL/ÖBB und der Titel-Neuableitung in `_post_filter_oebb`. So ist auf einen Blick klar, welcher ÖPNV-Knoten betroffen ist:

```
"Vollsperre Brünner Straße"  →  "Wien Floridsdorf: Vollsperre Brünner Straße"
```

Das Präfix entfällt, wenn der Titel den Bahnhof bereits nennt (z. B. „Umbau Bahnhof Mödling" bleibt unverändert) — kompakt, kein Doppel. Verwendet `display_name()` (z. B. „Wien Mitte-Landstraße" → „Wien Mitte").

## Wichtiger offener Punkt: Live-Abruf weiterhin defekt

Diese PR formt **Ausgabe + Sichtbarkeit**. Sie behebt **nicht** die eigentliche Ursache, dass aktuell *gar keine* Live-Baustellen ankommen: Der WFS liefert trotz `outputFormat=json` ein `application/xml` (CI-Log: `Invalid Content-Type: application/xml`), das der Abruf — **bewusst und per Test abgesichert** (`test_fetch_remote_rejects_unexpected_content_type`) — ablehnt. Den genauen Grund (OGC-ServiceException vs. GML vs. falsch etikettiertes JSON) kann ich aus der Sandbox nicht ermitteln (Host nicht in der Egress-Allowlist; curl **und** WebFetch → 403). Nötig ist der Antwort-Body aus einem echten Lauf:

```
curl -s -A "Origamihase-wien-oepnv/3.1" \
  "https://data.wien.gv.at/daten/geo?service=WFS&request=GetFeature&version=1.1.0&typeName=ogdwien:BAUSTELLEOGD&srsName=EPSG:4326&outputFormat=json" | head -c 400
```
Sobald der Body bekannt ist, folgt der eigentliche Request-Fix (vermutlich `outputFormat=application/json` oder WFS-Version/typeName) in einer separaten PR — ohne die Content-Type-Pinnung aufzuweichen.

## Test plan
- [x] `tests/test_baustellen_relevance.py`: Titel-Anreicherung (Präfix gesetzt / bei bereits genanntem Bahnhof übersprungen / Original-Dict unverändert).
- [x] `tests/test_update_baustellen_cache.py`: Fallback → Exit 2 + WARNING.
- [x] allow_nan-Writer-Audit-Allowlist auf die verschobenen `_identity_for_item`-Zeilen retargetiert.
- [x] Regression: build_feed (cache/atom/sort/mutation/dedupe/ends_at/item_age), ÖBB-Provider, Sentinel-Writer-Audit — 186 grün.
- [x] mypy-strict + ruff sauber.
- [ ] Live-Abruf aus der Sandbox nicht testbar (Egress-Block).

https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu)_