### PR TITLE
Baustellen: WFS-outputFormat aushandeln (Live-Abruf reparieren)

### DIFF
--- a/scripts/update_baustellen_cache.py
+++ b/scripts/update_baustellen_cache.py
@@ -8,13 +8,14 @@ import json
 import logging
 import math
 import os
+import re
 import sys
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 from collections.abc import Iterable, Sequence
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from dateutil import parser as dtparser
 from requests.exceptions import RequestException
@@ -81,6 +82,23 @@ def _path_fingerprint(path: Path) -> str:
 DEFAULT_DATA_URL = (
     "https://data.wien.gv.at/daten/geo?service=WFS&request=GetFeature&version=1.1.0"
     "&typeName=ogdwien:BAUSTELLEOGD&srsName=EPSG:4326&outputFormat=json"
+)
+
+# WFS servers disagree on the token that selects GeoJSON output: GeoServer
+# accepts ``json`` / ``application/json``, MapServer wants ``geojson`` /
+# ``GEOJSON``. When the configured token is not honoured the endpoint
+# answers with a GML / XML ServiceException (Content-Type
+# ``application/xml``) — which the strict ``_fetch_remote`` content-type
+# pin then (correctly) rejects, leaving the cron stuck on the bundled
+# fallback. Negotiating across the known tokens lets the fetch self-heal
+# across an upstream server/config change WITHOUT relaxing that pin: each
+# attempt still has to return a JSON content-type and parse as a GeoJSON
+# object, so a WAF/error page never slips through.
+_OUTPUT_FORMAT_CANDIDATES: tuple[str, ...] = (
+    "json",
+    "application/json",
+    "geojson",
+    "GEOJSON",
 )
 DEFAULT_INFO_URL = (
     "https://www.data.gv.at/katalog/en/dataset/baustellen-wien-verkehrsbeeintraechtigungen"
@@ -374,6 +392,24 @@ def _resolve_data_url(candidate: str | None) -> str:
         )
         return DEFAULT_DATA_URL
     return validated
+
+
+def _with_output_format(url: str, output_format: str) -> str:
+    """Return ``url`` with its ``outputFormat`` query value set to
+    ``output_format`` (appended if absent).
+
+    Only the ``outputFormat`` token is rewritten — every other byte of the
+    URL (scheme, host, ``typeName``/``srsName`` colons, …) is left
+    untouched, so the host pin already applied by :func:`_resolve_data_url`
+    still holds and ``_fetch_remote`` re-validates the result anyway. The
+    value is percent-encoded (``/`` kept readable, as WFS endpoints expect
+    for ``application/json``).
+    """
+    encoded = quote(output_format, safe="/")
+    if re.search(r"(?i)[?&]outputFormat=", url):
+        return re.sub(r"(?i)([?&]outputFormat=)[^&]*", lambda m: m.group(1) + encoded, url, count=1)
+    sep = "&" if "?" in url else "?"
+    return f"{url}{sep}outputFormat={encoded}"
 
 
 def _resolve_fallback_path(candidate: str | None) -> Path:
@@ -675,7 +711,19 @@ def main() -> int:
                 "Baustellen: Ungültiger Timeout-Wert %s – verwende Standard",
                 sanitize_log_arg(timeout_raw),
             )
-    payload = _fetch_remote(data_url, timeout)
+    # Negotiate the GeoJSON outputFormat: try the configured token first,
+    # then the common server-specific variants, stopping at the first that
+    # returns a parseable GeoJSON object.
+    payload = None
+    for output_format in _OUTPUT_FORMAT_CANDIDATES:
+        payload = _fetch_remote(_with_output_format(data_url, output_format), timeout)
+        if payload is not None:
+            if output_format != _OUTPUT_FORMAT_CANDIDATES[0]:
+                LOGGER.info(
+                    "Baustellen: outputFormat=%s vom Endpoint akzeptiert.",
+                    output_format,
+                )
+            break
     used_fallback = False
     if payload is None:
         used_fallback = True

--- a/tests/test_update_baustellen_cache.py
+++ b/tests/test_update_baustellen_cache.py
@@ -185,6 +185,50 @@ def test_main_uses_fallback_when_remote_fails(
     )
 
 
+def test_with_output_format_rewrites_only_the_token() -> None:
+    rewritten = update_baustellen_cache._with_output_format(
+        update_baustellen_cache.DEFAULT_DATA_URL, "application/json"
+    )
+    assert rewritten.endswith("outputFormat=application/json")
+    # Every other parameter is preserved byte-for-byte.
+    assert "typeName=ogdwien:BAUSTELLEOGD" in rewritten
+    assert "srsName=EPSG:4326" in rewritten
+    assert rewritten.startswith("https://data.wien.gv.at/daten/geo?")
+
+
+def test_with_output_format_appends_when_absent() -> None:
+    base = "https://data.wien.gv.at/daten/geo?service=WFS"
+    assert (
+        update_baustellen_cache._with_output_format(base, "geojson")
+        == base + "&outputFormat=geojson"
+    )
+
+
+def test_main_negotiates_output_format(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The configured ``json`` token returns nothing (the production
+    failure mode); the negotiation must fall through to the next variant
+    and use it as a live success — NOT the degraded fallback."""
+    seen: list[str] = []
+    payload = {"type": "FeatureCollection", "features": []}
+
+    def fake_fetch_remote(url: str, timeout: int) -> dict[str, Any] | None:
+        seen.append(url)
+        return payload if "outputFormat=application/json" in url else None
+
+    cached: list[tuple[str, list[dict[str, Any]]]] = []
+    monkeypatch.setattr(update_baustellen_cache, "_fetch_remote", fake_fetch_remote)
+    monkeypatch.setattr(
+        update_baustellen_cache, "write_cache", lambda p, items: cached.append((p, items))
+    )
+
+    exit_code = update_baustellen_cache.main()
+
+    assert exit_code == 0  # live success via the negotiated format, not fallback
+    assert seen[0].endswith("outputFormat=json")  # configured token tried first
+    assert any("outputFormat=application/json" in url for url in seen)
+    assert cached and cached[0][0] == "baustellen"
+
+
 def test_resolve_fallback_path_default_when_unset() -> None:
     assert update_baustellen_cache._resolve_fallback_path(None) == update_baustellen_cache.DEFAULT_FALLBACK_PATH
     assert update_baustellen_cache._resolve_fallback_path("") == update_baustellen_cache.DEFAULT_FALLBACK_PATH
@@ -247,7 +291,10 @@ def test_baustellen_timeout_env_is_clamped(
 
     update_baustellen_cache.main()
 
-    assert captured == [expected]
+    # main() now negotiates the outputFormat, so _fetch_remote is called
+    # once per candidate; every call must receive the clamped timeout.
+    assert captured
+    assert all(value == expected for value in captured)
 
 
 def test_resolve_fallback_path_blocks_symlink_escape(tmp_path: Path) -> None:


### PR DESCRIPTION
Letzter offener Punkt aus #1637/#1638: Es kommt **keine Live-Baustelle** im Feed an, weil der Stadt-Wien-WFS auf `outputFormat=json` mit `application/xml` (OGC-ServiceException) antwortet — was die (per Test abgesicherte) Content-Type-Pinnung korrekt ablehnt. Der Cron hängt deshalb dauerhaft im Fallback.

## Lösung: outputFormat aushandeln statt Sicherheits-Pin aufweichen

WFS-Server sind sich beim GeoJSON-Token uneinig (GeoServer: `json`/`application/json`, MapServer: `geojson`/`GEOJSON`). `main()` probiert jetzt das konfigurierte Token zuerst und dann die gängigen Varianten, und nimmt das erste, das ein **parsebares GeoJSON-Objekt** liefert:

```
json  →  application/json  →  geojson  →  GEOJSON
```

- **Sicherheit unangetastet:** Jeder Versuch durchläuft dieselbe Content-Type-Pinnung **und** die JSON-Struktur-Validierung (`_load_json_from_content`). Eine WAF-/Fehlerseite kommt weiterhin nicht durch. Der per Test fixierte Invariant (`test_fetch_remote_rejects_unexpected_content_type`) bleibt gültig — `_fetch_remote` ist unverändert.
- **Nur das Token wird umgeschrieben** (`_with_output_format`, byte-erhaltend per Regex); die host-gepinnte Basis-URL bleibt unverändert, `_fetch_remote` re-validiert ohnehin.
- **Kein Erfolg → sichtbarer Fallback** (WARNING + Exit 2 aus #1638).

## Ehrliche Einordnung

Aus der Sandbox **nicht live verifizierbar** (Egress blockt `data.wien.gv.at`, `x-deny-reason: host_not_allowed`; curl **und** WebFetch → 403). Die **Logik** ist per Mock getestet (json scheitert → `application/json` greift → Live-Erfolg statt Fallback). Falls der nächste Cron-Lauf weiterhin die Degraded-Warnung loggt, liegt die Ursache **nicht** am outputFormat, sondern am Layer-Namen (`ogdwien:BAUSTELLEOGD`) oder der WFS-Version — das ließe sich dann nur mit dem Response-Body / Netzzugriff klären.

## Test plan
- [x] `test_with_output_format_*`: Token wird byte-erhaltend umgeschrieben / angehängt; `typeName`/`srsName` bleiben erhalten.
- [x] `test_main_negotiates_output_format`: `json` liefert nichts → `application/json` greift → Exit 0 (Live), nicht Fallback.
- [x] `test_baustellen_timeout_env_is_clamped` angepasst (Timeout pro Versuch geklemmt).
- [x] Regression: URL-Host-Pinning, HTTPS-Drift-Sentinel, Path-Log-Sanitisation, http_security, Relevanz-Suite — 174 grün; ruff + bandit + mypy (Testdatei) sauber.
- [ ] Live-WFS-Abruf aus der Sandbox nicht testbar (Egress-Block).

https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu)_