### PR TITLE
Baustellen: Full-Refresh absichern + WFS-Ablehnung diagnostizieren

### DIFF
--- a/.github/workflows/manual-full-refresh.yml
+++ b/.github/workflows/manual-full-refresh.yml
@@ -111,7 +111,14 @@ jobs:
         uses: ./.github/actions/install-deps
 
       # ----- 1) Caches der Quellsysteme aktualisieren -----
+      # ``continue-on-error``: der Baustellen-Updater gibt Exit 2 zurück,
+      # wenn der Live-WFS-Abruf scheitert und das Fallback-Sample
+      # geschrieben wird (siehe ``update_baustellen_cache.main``). Eine
+      # einzelne degradierte Quelle darf den manuellen Full-Refresh NICHT
+      # abbrechen (sonst kein Feed-Rebuild) — die Warnung bleibt im Log
+      # sichtbar, der Step wird als "tolerierter Fehler" markiert.
       - name: Refresh Baustellen cache
+        continue-on-error: true
         run: python scripts/update_baustellen_cache.py
 
       - name: Refresh Wiener Linien cache

--- a/scripts/update_baustellen_cache.py
+++ b/scripts/update_baustellen_cache.py
@@ -100,6 +100,12 @@ _OUTPUT_FORMAT_CANDIDATES: tuple[str, ...] = (
     "geojson",
     "GEOJSON",
 )
+
+# Upper bound for the read-only diagnostic snippet logged when the WFS
+# refuses every outputFormat. An OGC ``ServiceExceptionReport`` naming the
+# offending parameter fits comfortably in 2 KiB; the cap keeps a hostile /
+# oversized upstream body from being buffered into the log.
+_DIAGNOSTIC_MAX_BYTES = 2048
 DEFAULT_INFO_URL = (
     "https://www.data.gv.at/katalog/en/dataset/baustellen-wien-verkehrsbeeintraechtigungen"
 )
@@ -284,6 +290,49 @@ def _fetch_remote(url: str, timeout: int) -> dict[str, Any] | None:
         LOGGER.warning("Baustellen: Ungültiges JSON vom Endpoint (%s)", exc)
         return None
     return payload
+
+
+def _log_endpoint_diagnostic(url: str, timeout: int) -> None:
+    """Best-effort: log a short, sanitised snippet of a refusing WFS
+    response so an operator can see *why* the endpoint rejects the request
+    (typically an OGC ``ServiceExceptionReport`` naming the bad
+    ``typeName`` / version).
+
+    Strictly read-only and bounded — it reads at most
+    ``_DIAGNOSTIC_MAX_BYTES``, follows no redirects, and the bytes are only
+    sanitised and logged, never parsed as data or returned. The data path
+    keeps refusing non-JSON content types unchanged; this is pure
+    observability. Every error is swallowed so a diagnostic hiccup can
+    never break the cron flow.
+    """
+    if not validate_http_url(url):
+        return
+    try:
+        with session_with_retries(USER_AGENT, raise_on_status=False) as session:
+            with session.get(
+                url,
+                timeout=timeout,
+                stream=True,
+                allow_redirects=False,
+                headers={"Accept": "application/json"},
+            ) as response:
+                status = response.status_code
+                content_type = response.headers.get("Content-Type", "?")
+                chunk = next(response.iter_content(_DIAGNOSTIC_MAX_BYTES), b"")
+    except (RequestException, OSError, ValueError) as exc:
+        LOGGER.info(
+            "Baustellen: Endpoint-Diagnose nicht möglich (%s)",
+            sanitize_log_arg(str(exc)),
+        )
+        return
+    snippet = chunk.decode("utf-8", errors="replace").strip()
+    if snippet:
+        LOGGER.warning(
+            "Baustellen: Endpoint-Diagnose – HTTP %s, Content-Type %s, Auszug: %s",
+            status,
+            sanitize_log_arg(content_type),
+            sanitize_log_arg(snippet),
+        )
 
 
 def _load_fallback(path: Path) -> dict[str, Any] | None:
@@ -727,6 +776,12 @@ def main() -> int:
     used_fallback = False
     if payload is None:
         used_fallback = True
+        # Every outputFormat variant was refused — capture WHY (the OGC
+        # exception body) before falling back, so the operator log can
+        # pinpoint a renamed typeName / unsupported version.
+        _log_endpoint_diagnostic(
+            _with_output_format(data_url, _OUTPUT_FORMAT_CANDIDATES[0]), timeout
+        )
         payload = _load_fallback(fallback_path)
         if payload is None:
             LOGGER.error(

--- a/tests/test_update_baustellen_cache.py
+++ b/tests/test_update_baustellen_cache.py
@@ -167,6 +167,8 @@ def test_main_uses_fallback_when_remote_fails(
 
     monkeypatch.setattr(update_baustellen_cache, "_fetch_remote", fake_fetch_remote)
     monkeypatch.setattr(update_baustellen_cache, "write_cache", capture_cache)
+    # Stub the network diagnostic so the fallback path stays offline.
+    monkeypatch.setattr(update_baustellen_cache, "_log_endpoint_diagnostic", lambda *a, **k: None)
     monkeypatch.setenv("BAUSTELLEN_FALLBACK_PATH", str(SAMPLE_PATH))
     caplog.set_level(logging.WARNING, logger="update_baustellen_cache")
 
@@ -229,6 +231,61 @@ def test_main_negotiates_output_format(monkeypatch: pytest.MonkeyPatch) -> None:
     assert cached and cached[0][0] == "baustellen"
 
 
+def test_log_endpoint_diagnostic_logs_sanitised_snippet(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """When the WFS refuses every format, the diagnostic surfaces a snippet
+    of the refusing body (e.g. an OGC ServiceException) so the cause is
+    visible in the operator log."""
+    import logging
+
+    import responses
+
+    _patch_http_layer_bypass(monkeypatch)
+
+    @responses.activate
+    def run() -> None:
+        responses.get(
+            update_baustellen_cache.DEFAULT_DATA_URL,
+            body=(
+                '<?xml version="1.0"?><ServiceExceptionReport>'
+                '<ServiceException code="InvalidParameterValue" locator="typeName">'
+                "Unknown layer ogdwien:BAUSTELLEOGD</ServiceException>"
+                "</ServiceExceptionReport>"
+            ),
+            status=200,
+            content_type="application/xml",
+        )
+        caplog.set_level(logging.INFO, logger="update_baustellen_cache")
+        update_baustellen_cache._log_endpoint_diagnostic(
+            update_baustellen_cache.DEFAULT_DATA_URL, timeout=5
+        )
+        messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "update_baustellen_cache"
+        ]
+        assert any(
+            "Endpoint-Diagnose" in message and "ServiceException" in message
+            for message in messages
+        )
+
+    run()
+
+
+def test_log_endpoint_diagnostic_swallows_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A diagnostic hiccup must never raise — it is strictly best-effort."""
+
+    def boom(*args: Any, **kwargs: Any) -> Any:
+        raise OSError("network down")
+
+    monkeypatch.setattr(update_baustellen_cache, "session_with_retries", boom)
+    # Must return cleanly rather than propagate.
+    update_baustellen_cache._log_endpoint_diagnostic(
+        update_baustellen_cache.DEFAULT_DATA_URL, timeout=5
+    )
+
+
 def test_resolve_fallback_path_default_when_unset() -> None:
     assert update_baustellen_cache._resolve_fallback_path(None) == update_baustellen_cache.DEFAULT_FALLBACK_PATH
     assert update_baustellen_cache._resolve_fallback_path("") == update_baustellen_cache.DEFAULT_FALLBACK_PATH
@@ -286,6 +343,7 @@ def test_baustellen_timeout_env_is_clamped(
 
     monkeypatch.setattr(update_baustellen_cache, "_fetch_remote", fake_fetch_remote)
     monkeypatch.setattr(update_baustellen_cache, "write_cache", lambda *args, **kwargs: None)
+    monkeypatch.setattr(update_baustellen_cache, "_log_endpoint_diagnostic", lambda *a, **k: None)
     monkeypatch.setenv("BAUSTELLEN_FALLBACK_PATH", str(SAMPLE_PATH))
     monkeypatch.setenv("BAUSTELLEN_TIMEOUT", raw)
 


### PR DESCRIPTION
## Was das Live-Log (manual-full-refresh, Run 70482378500) zeigt

Alle **vier** outputFormat-Varianten werden mit `application/xml` beantwortet:
```
outputFormat=json            → Invalid Content-Type: application/xml
outputFormat=application/json → Invalid Content-Type: application/xml
outputFormat=geojson         → Invalid Content-Type: application/xml
outputFormat=GEOJSON         → Invalid Content-Type: application/xml
→ FALLBACK-Demodaten, exit 2  (Step rot → Full-Refresh abgebrochen)
```
→ Die Ursache ist **nicht** das Format, sondern die Anfrage selbst (vermutlich `typeName`/Version → OGC-`ServiceExceptionReport`). Die Aushandlung aus #1639 ist damit ausgeschlossen.

## Zwei Konsequenzen (diese PR)

**1. `continue-on-error` auf den Baustellen-Step** (`manual-full-refresh.yml`)
Da der Updater seit #1638 bei Fallback **Exit 2** liefert, brach der manuelle Full-Refresh sonst ab, bevor der Feed neu gebaut wird. Eine einzelne degradierte Quelle darf das nicht — die Warnung bleibt im Log sichtbar, der Rest des Refresh läuft durch. *(Das war die von dir freigegebene Änderung.)*

**2. Sichere Endpoint-Diagnose** (`_log_endpoint_diagnostic`)
Wenn alle Formate abgelehnt werden, wird ein **streng read-only** Auszug der Antwort geloggt, damit der nächste Lauf den OGC-Exception-Body zeigt (= den genauen Grund):
- `validate_http_url` vorab, `allow_redirects=False`, max **2 KiB** gelesen, gehärtete Session (IP-Pinning)
- Auszug + Content-Type via `sanitize_log_arg` (kein Log-Injection)
- Body wird **nie** als Daten geparst/zurückgegeben → die Content-Type-Pinnung des Datenpfads bleibt unangetastet
- jeder Fehler wird geschluckt → kann den Cron nie brechen

Sandbox-Beleg (Host blockiert): `Endpoint-Diagnose – HTTP 403, Content-Type text/plain, Auszug: Host not in allowlist` — sauber geloggt, kein Crash.

## So geht's weiter
Nach dem Merge **manual-full-refresh erneut starten** → der „Endpoint-Diagnose"-Log zeigt den `ServiceException`-Text (z. B. „Unknown layer ogdwien:BAUSTELLEOGD" oder „version not supported"). Damit liefere ich den **präzisen** Request-Fix (Layer-Name/Version) nach — kein Raten mehr.

## Test plan
- [x] `test_log_endpoint_diagnostic_logs_sanitised_snippet` (ServiceException-Auszug im Log) + `…_swallows_errors` (best-effort, kein Raise).
- [x] Fallback-Tests stubben die Diagnose (offline); Negotiation-/Timeout-Tests unverändert grün.
- [x] Regression: Path-Log-Sanitisation, URL-Host-Pinning, HTTPS-Drift, http_security, request_safe, Relevanz — 181 grün.
- [x] ruff + bandit sauber; mypy: keine neuen Fehler durch diese Änderung (vorbestehender `redundant-cast` unberührt).
- [ ] Live-WFS-Body aus der Sandbox nicht abrufbar (Egress-Block) — daher die Diagnose im Workflow-Log.

https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu)_