### PR TITLE
Baustellen: neue WFS-Layer + ÖPNV-Filter (Bahnhof ODER Text)

### DIFF
--- a/cache/baustellen_d438c3/events.json
+++ b/cache/baustellen_d438c3/events.json
@@ -3,18 +3,17 @@
     "source": "Stadt Wien – Baustellen",
     "category": "Baustelle",
     "title": "Umbau Bahnhofsvorplatz Floridsdorf",
-    "description": "Fahrbahnverengung im Bereich der Bahnhofszufahrt. \nBeginn: 01.10.2025 06:00 Uhr \nGeplant bis: 15.10.2025 22:00 Uhr \nMaßnahme: Fahrbahnverengung \nBezirk: 21",
+    "description": "Sanierung des Bahnhofsvorplatzes; Zufahrt zeitweise eingeschränkt. \nBeginn: 01.10.2025 02:00 Uhr \nGeplant bis: 15.10.2025 02:00 Uhr \nMaßnahme: Fahrbahnsperre \nBezirk: 21",
     "link": "https://www.data.gv.at/katalog/en/dataset/baustellen-wien-verkehrsbeeintraechtigungen",
-    "guid": "010687013508b2b01bd842bfe41cb7eed190730dd4fb8dc5b85ff354d291f03c",
-    "pubDate": "2025-10-01T06:00:00+02:00",
-    "starts_at": "2025-10-01T06:00:00+02:00",
-    "ends_at": "2025-10-15T22:00:00+02:00",
+    "guid": "0977ee2731bbacf0cde22d04110c6c48822d56e997a960329cd73c3000465df7",
+    "pubDate": "2025-10-01T02:00:00+02:00",
+    "starts_at": "2025-10-01T02:00:00+02:00",
+    "ends_at": "2025-10-15T02:00:00+02:00",
     "context": {
       "district": "21",
-      "measure": "Fahrbahnverengung"
+      "measure": "Fahrbahnsperre"
     },
     "location": {
-      "address": "Am Spitz, zwischen Franz-Jonas-Platz und Pius-Parsch-Platz",
       "coordinates": {
         "lat": 48.2562499,
         "lon": 16.4007
@@ -24,22 +23,21 @@
   {
     "source": "Stadt Wien – Baustellen",
     "category": "Baustelle",
-    "title": "Gleisbau Bahnhof Mödling",
-    "description": "Schienenersatzverkehr, Haltestellen verlegt. \nBeginn: 05.11.2025 00:00 Uhr \nGeplant bis: 20.11.2025 00:00 Uhr \nMaßnahme: Straßenbahn \nBezirk: Mödling",
+    "title": "Thaliastraße",
+    "description": "Die Haltestelle der Straßenbahnlinie 2 wird verlegt; während der Arbeiten ist Schienenersatzverkehr eingerichtet. \nBeginn: 05.11.2025 01:00 Uhr \nGeplant bis: 20.11.2025 01:00 Uhr \nMaßnahme: Gleisbau \nBezirk: 16",
     "link": "https://www.data.gv.at/katalog/en/dataset/baustellen-wien-verkehrsbeeintraechtigungen",
-    "guid": "c358f3d664fce16bb30b2d9627c372ddd065a69fb2ef5ba547d1b28abddad3ff",
-    "pubDate": "2025-11-05T00:00:00+01:00",
-    "starts_at": "2025-11-05T00:00:00+01:00",
-    "ends_at": "2025-11-20T00:00:00+01:00",
+    "guid": "f8526b0fe240aa7ab0d3ba9d7ba91a524ed95b743c1fe2152d15cfff3ccd9384",
+    "pubDate": "2025-11-05T01:00:00+01:00",
+    "starts_at": "2025-11-05T01:00:00+01:00",
+    "ends_at": "2025-11-20T01:00:00+01:00",
     "context": {
-      "district": "Mödling",
-      "measure": "Straßenbahn"
+      "district": "16",
+      "measure": "Gleisbau"
     },
     "location": {
-      "address": "Bahnhofsplatz, zwischen Hauptstraße und Bahnstraße",
       "coordinates": {
-        "lat": 48.085628,
-        "lon": 16.295474
+        "lat": 48.2103,
+        "lon": 16.3255
       }
     }
   }

--- a/data/samples/baustellen_sample.geojson
+++ b/data/samples/baustellen_sample.geojson
@@ -3,42 +3,39 @@
   "features": [
     {
       "type": "Feature",
-      "properties": {
-        "OGD_ID": "BS-0001",
-        "BEZEICHNUNG": "Umbau Bahnhofsvorplatz Floridsdorf",
-        "STRASSE": "Am Spitz",
-        "VON": "Franz-Jonas-Platz",
-        "BIS": "Pius-Parsch-Platz",
-        "ANFANGSZEIT": "2025-10-01T06:00:00+02:00",
-        "ENDEZEIT": "2025-10-15T22:00:00+02:00",
-        "BEZIRK": "21",
-        "HINWEIS": "Fahrbahnverengung im Bereich der Bahnhofszufahrt.",
-        "VERKEHRSMASSNAHME": "Fahrbahnverengung"
-      },
+      "id": "BAUSTELLENPKTOGD.1",
       "geometry": {
         "type": "Point",
         "coordinates": [16.4007, 48.2562499]
+      },
+      "properties": {
+        "OBJECTID": 1,
+        "BEZIRK": 21,
+        "BEZEICHNUNG": "Umbau Bahnhofsvorplatz Floridsdorf",
+        "BEHINDERUNGSART": "Fahrbahnsperre",
+        "PRESSETEXT": "Sanierung des Bahnhofsvorplatzes; Zufahrt zeitweise eingeschränkt.",
+        "OBJEKT_BEGINN": "2025-10-01Z",
+        "OBJEKT_ENDE": "2025-10-15Z"
       }
     },
     {
       "type": "Feature",
-      "properties": {
-        "OGD_ID": "BS-0002",
-        "MASSNAHME": "Gleisbau Bahnhof Mödling",
-        "STRASSENNAME": "Bahnhofsplatz",
-        "ABSCHNITT_VON": "Hauptstraße",
-        "ABSCHNITT_BIS": "Bahnstraße",
-        "DAUER": "2025-11-05/2025-11-20",
-        "BEZIRK": "Mödling",
-        "BEMERKUNG": "Schienenersatzverkehr, Haltestellen verlegt.",
-        "VERKEHRSART": "Straßenbahn"
-      },
+      "id": "BAUSTELLENLINOGD.2",
       "geometry": {
         "type": "LineString",
         "coordinates": [
-          [16.295474, 48.085628],
-          [16.296100, 48.086000]
+          [16.3255, 48.2103],
+          [16.3262, 48.2107]
         ]
+      },
+      "properties": {
+        "OBJECTID": 2,
+        "BEZIRK": 16,
+        "BEZEICHNUNG": "Thaliastraße",
+        "BEHINDERUNGSART": "Gleisbau",
+        "PRESSETEXT": "Die Haltestelle der Straßenbahnlinie 2 wird verlegt; während der Arbeiten ist Schienenersatzverkehr eingerichtet.",
+        "OBJEKT_BEGINN": "2025-11-05Z",
+        "OBJEKT_ENDE": "2025-11-20Z"
       }
     }
   ]

--- a/scripts/update_baustellen_cache.py
+++ b/scripts/update_baustellen_cache.py
@@ -81,7 +81,16 @@ def _path_fingerprint(path: Path) -> str:
 
 DEFAULT_DATA_URL = (
     "https://data.wien.gv.at/daten/geo?service=WFS&request=GetFeature&version=1.1.0"
-    "&typeName=ogdwien:BAUSTELLEOGD&srsName=EPSG:4326&outputFormat=json"
+    "&typeName=ogdwien:BAUSTELLENLINOGD&srsName=EPSG:4326&outputFormat=json"
+)
+
+# The Stadt-Wien OGD migration (GeoServer "geoserverneuogd") split the old
+# single ``BAUSTELLEOGD`` layer into two "verkehrswirksame Baustellen"
+# feature types — one for line segments, one for point locations. Both are
+# fetched and merged so neither geometry kind is lost.
+_BAUSTELLEN_TYPENAMES: tuple[str, ...] = (
+    "ogdwien:BAUSTELLENLINOGD",
+    "ogdwien:BAUSTELLENPKTOGD",
 )
 
 # WFS servers disagree on the token that selects GeoJSON output: GeoServer
@@ -154,6 +163,7 @@ TO_KEYS: tuple[str, ...] = (
     "BIS_KM",
 )
 INFO_KEYS: tuple[str, ...] = (
+    "PRESSETEXT",
     "HINWEIS",
     "INFO",
     "BESCHREIBUNG",
@@ -163,6 +173,7 @@ INFO_KEYS: tuple[str, ...] = (
     "ANMERKUNG",
 )
 START_KEYS: tuple[str, ...] = (
+    "OBJEKT_BEGINN",
     "ANFANGSZEIT",
     "BEGINN",
     "BEGINN_DATUM",
@@ -174,6 +185,7 @@ START_KEYS: tuple[str, ...] = (
     "VON_DATUM",
 )
 END_KEYS: tuple[str, ...] = (
+    "OBJEKT_ENDE",
     "ENDEZEIT",
     "ENDE",
     "END_DATUM",
@@ -461,6 +473,24 @@ def _with_output_format(url: str, output_format: str) -> str:
     return f"{url}{sep}outputFormat={encoded}"
 
 
+def _with_typename(url: str, typename: str) -> str:
+    """Return ``url`` with its ``typeName``/``typeNames`` query value set to
+    ``typename`` (appended if absent).
+
+    Only the type-name token is rewritten — scheme/host/path and the other
+    parameters are preserved, so the host pin from :func:`_resolve_data_url`
+    still holds (``_fetch_remote`` re-validates regardless). The ``ogdwien:``
+    workspace colon is kept readable.
+    """
+    encoded = quote(typename, safe=":")
+    if re.search(r"(?i)[?&]typeNames?=", url):
+        return re.sub(
+            r"(?i)([?&]typeNames?=)[^&]*", lambda m: m.group(1) + encoded, url, count=1
+        )
+    sep = "&" if "?" in url else "?"
+    return f"{url}{sep}typeName={encoded}"
+
+
 def _resolve_fallback_path(candidate: str | None) -> Path:
     """Resolve the fallback-path env override against ``REPO_ROOT``.
 
@@ -540,6 +570,12 @@ def _parse_datetime(value: str | float | int | None) -> datetime | None:
     candidate = value.strip()
     if not candidate:
         return None
+    # Stadt-Wien WFS emits date-only values with a bare trailing ``Z``
+    # (e.g. ``2026-03-22Z``). ``dateutil`` rejects that shape, so expand
+    # it to an explicit UTC midnight before parsing.
+    date_only_z = re.fullmatch(r"(\d{4}-\d{2}-\d{2})Z", candidate)
+    if date_only_z:
+        candidate = f"{date_only_z.group(1)}T00:00:00+00:00"
     try:
         parsed = dtparser.parse(candidate)
     except (ValueError, OverflowError):
@@ -585,7 +621,11 @@ def _build_context(properties: dict[str, Any]) -> dict[str, Any]:
     district = properties.get("BEZIRK") or properties.get("BZR")
     if district:
         context["district"] = str(district).strip()
-    measure = properties.get("VERKEHRSMASSNAHME") or properties.get("VERKEHRSART")
+    measure = (
+        properties.get("BEHINDERUNGSART")
+        or properties.get("VERKEHRSMASSNAHME")
+        or properties.get("VERKEHRSART")
+    )
     if measure:
         context["measure"] = str(measure).strip()
     status = properties.get("STATUS")
@@ -739,6 +779,33 @@ def _collect_events(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return events
 
 
+def _fetch_layers(data_url: str, timeout: int) -> list[dict[str, Any]] | None:
+    """Fetch every Baustellen feature type and return the merged events.
+
+    For each type name the GeoJSON ``outputFormat`` is negotiated (the
+    configured token first, then the common server-specific variants),
+    stopping at the first that returns a parseable GeoJSON object. Returns
+    ``None`` only when NO layer could be fetched (the caller then falls
+    back to the bundled sample); a partial success (one of two layers)
+    still returns the events it got.
+    """
+    merged: list[dict[str, Any]] = []
+    any_success = False
+    for typename in _BAUSTELLEN_TYPENAMES:
+        layer_url = _with_typename(data_url, typename)
+        payload = None
+        for output_format in _OUTPUT_FORMAT_CANDIDATES:
+            payload = _fetch_remote(_with_output_format(layer_url, output_format), timeout)
+            if payload is not None:
+                break
+        if payload is None:
+            LOGGER.warning("Baustellen: Layer %s nicht abrufbar.", typename)
+            continue
+        any_success = True
+        merged.extend(_collect_events(payload))
+    return merged if any_success else None
+
+
 def main() -> int:
     configure_logging()
     data_url = _resolve_data_url(os.getenv("BAUSTELLEN_DATA_URL"))
@@ -760,27 +827,15 @@ def main() -> int:
                 "Baustellen: Ungültiger Timeout-Wert %s – verwende Standard",
                 sanitize_log_arg(timeout_raw),
             )
-    # Negotiate the GeoJSON outputFormat: try the configured token first,
-    # then the common server-specific variants, stopping at the first that
-    # returns a parseable GeoJSON object.
-    payload = None
-    for output_format in _OUTPUT_FORMAT_CANDIDATES:
-        payload = _fetch_remote(_with_output_format(data_url, output_format), timeout)
-        if payload is not None:
-            if output_format != _OUTPUT_FORMAT_CANDIDATES[0]:
-                LOGGER.info(
-                    "Baustellen: outputFormat=%s vom Endpoint akzeptiert.",
-                    output_format,
-                )
-            break
+    events = _fetch_layers(data_url, timeout)
     used_fallback = False
-    if payload is None:
+    if events is None:
         used_fallback = True
-        # Every outputFormat variant was refused — capture WHY (the OGC
-        # exception body) before falling back, so the operator log can
-        # pinpoint a renamed typeName / unsupported version.
+        # Every layer was refused — capture WHY (the OGC exception body)
+        # before falling back, so the operator log can pinpoint a renamed
+        # typeName / unsupported version.
         _log_endpoint_diagnostic(
-            _with_output_format(data_url, _OUTPUT_FORMAT_CANDIDATES[0]), timeout
+            _with_typename(data_url, _BAUSTELLEN_TYPENAMES[0]), timeout
         )
         payload = _load_fallback(fallback_path)
         if payload is None:
@@ -789,12 +844,12 @@ def main() -> int:
                 "nicht aktualisiert."
             )
             return 1
-    events = _collect_events(payload)
-    # Keep only construction sites at/near a rail Bahnhof (Wien station or
-    # Pendlerbahnhof). The upstream feed covers every road works in the
-    # city; admitting all of them would bury the ÖPNV signal the feed
-    # exists to carry.
-    relevant = [event for event in events if is_transit_relevant(event.get("location"))]
+        events = _collect_events(payload)
+    # Keep only ÖPNV-relevant sites: at/near a rail Bahnhof OR a text that
+    # mentions public transport (stop / line / bus / tram / metro). The
+    # upstream feed is "verkehrswirksam" but still includes pure car-traffic
+    # works, which would bury the ÖPNV signal the feed exists to carry.
+    relevant = [event for event in events if is_transit_relevant(event)]
     skipped = len(events) - len(relevant)
     if skipped:
         LOGGER.info(

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -343,23 +343,23 @@ def _baustellen_title_names_station(title: str, label: str) -> bool:
 def _post_filter_baustellen(items: list[Any]) -> list[Any]:
     """Defence-in-depth relevance gate plus ÖPNV title enrichment.
 
-    ``update_baustellen_cache.py`` already drops construction sites that
-    are not at/near a rail Bahnhof at ingestion, but the on-disk cache (or
-    the bundled fallback sample) may predate the current policy — so the
-    gate is re-applied here, the same defence-in-depth contract as
-    :func:`_post_filter_oebb`.
+    ``update_baustellen_cache.py`` already drops non-ÖPNV-relevant sites at
+    ingestion, but the on-disk cache (or the bundled fallback sample) may
+    predate the current policy — so the gate is re-applied here, the same
+    defence-in-depth contract as :func:`_post_filter_oebb`.
 
-    For the items that pass, the affected Bahnhof (Wien station or
-    Pendlerbahnhof) is prefixed onto the title so the entry reads as a
-    transit message at a glance — mirroring the line/route prefixes WL and
-    ÖBB carry, and the title re-derivation :func:`_post_filter_oebb`
-    performs. The prefix is skipped when the title already names the
-    station, keeping the headline compact.
+    An item is kept when it is ÖPNV-relevant — at/near a rail Bahnhof OR its
+    text mentions public transport (the "Bahnhofsnähe ODER ÖPNV-Text"
+    policy). When a Bahnhof matches, its name is prefixed onto the title so
+    the entry reads as a transit message at a glance — mirroring the
+    line/route prefixes WL and ÖBB carry, and the title re-derivation
+    :func:`_post_filter_oebb` performs. The prefix is skipped when the title
+    already names the station, keeping the headline compact.
 
     Items carrying neither a title nor a description are treated as
     stubs/metadata and passed through unchanged.
     """
-    from .providers.baustellen import relevant_station
+    from .providers.baustellen import mentions_oepnv, relevant_station
     from .utils.stations import display_name
 
     out: list[Any] = []
@@ -374,12 +374,13 @@ def _post_filter_baustellen(items: list[Any]) -> list[Any]:
             out.append(item)
             continue
         station = relevant_station(item.get("location"))
-        if station is None:
+        if station is None and not mentions_oepnv(f"{title} {description}"):
             continue
-        label = display_name(station) or station
-        if label and not _baustellen_title_names_station(title, label):
-            item = dict(item)
-            item["title"] = f"{label}: {title}" if title else label
+        if station is not None:
+            label = display_name(station) or station
+            if label and not _baustellen_title_names_station(title, label):
+                item = dict(item)
+                item["title"] = f"{label}: {title}" if title else label
         out.append(item)
     return out
 

--- a/src/providers/baustellen.py
+++ b/src/providers/baustellen.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import math
 import os
+import re
 from typing import Any, Final
 
 from ..utils.stations import nearest_rail_station
@@ -25,8 +26,35 @@ from ..utils.stations import nearest_rail_station
 __all__ = [
     "DEFAULT_STATION_RADIUS_M",
     "is_transit_relevant",
+    "mentions_oepnv",
     "relevant_station",
 ]
+
+# Public-transport vocabulary for the text signal. A construction site whose
+# title/description mentions any of these affects ÖPNV even when it is not
+# right next to a rail Bahnhof (e.g. a bus/tram stop being relocated). The
+# alternation is plain literals + bounded character classes — linear, no
+# catastrophic backtracking. Clear compound terms match as substrings;
+# short/ambiguous tokens (bus, bim, linie, U1–U6, tram) require word
+# boundaries so "Busch" or "Baulinie" do not false-trigger.
+_OEPNV_RE: Final = re.compile(
+    r"haltestelle"
+    r"|stra[sß]+enbahn"
+    r"|schienenersatz"
+    r"|verkehrsmittel"
+    r"|buslinie"
+    r"|autobus"
+    r"|u-?bahn"
+    r"|s-?bahn"
+    r"|öpnv"
+    r"|öffentliche[rn]?\s+verkehr"
+    r"|\bbus(?:se)?\b"
+    r"|\bbim\b"
+    r"|\blinien?\b"
+    r"|\bu[1-6]\b"
+    r"|\btram\b",
+    re.IGNORECASE,
+)
 
 #: Default proximity (in metres) between a construction site and a rail
 #: Bahnhof for the site to count as ÖPNV-relevant. 150 m mirrors the
@@ -80,8 +108,26 @@ def relevant_station(location: Any, *, radius_m: float | None = None) -> str | N
     return match[0] if match else None
 
 
-def is_transit_relevant(location: Any, *, radius_m: float | None = None) -> bool:
-    """Return ``True`` iff the construction ``location`` sits within the
-    configured radius of a rail Bahnhof (Wien station or Pendlerbahnhof)."""
+def mentions_oepnv(text: str) -> bool:
+    """Return ``True`` if ``text`` mentions public transport (a stop, line,
+    bus, tram/Bim, U-/S-Bahn, …)."""
 
-    return relevant_station(location, radius_m=radius_m) is not None
+    return bool(_OEPNV_RE.search(text or ""))
+
+
+def is_transit_relevant(item: Any, *, radius_m: float | None = None) -> bool:
+    """Return ``True`` if a construction ``item`` is ÖPNV-relevant.
+
+    Relevance is geographic **or** textual: the site sits within the
+    configured radius of a rail Bahnhof (Wien station or Pendlerbahnhof),
+    OR its title/description names public transport. ``item`` is the
+    provider's event mapping (``location`` + ``title`` + ``description``).
+    Non-dict input is treated as not relevant (fail closed).
+    """
+
+    if not isinstance(item, dict):
+        return False
+    if relevant_station(item.get("location"), radius_m=radius_m) is not None:
+        return True
+    text = f"{item.get('title') or ''} {item.get('description') or ''}"
+    return mentions_oepnv(text)

--- a/tests/test_baustellen_relevance.py
+++ b/tests/test_baustellen_relevance.py
@@ -18,6 +18,7 @@ from src.providers import baustellen
 from src.providers.baustellen import (
     DEFAULT_STATION_RADIUS_M,
     is_transit_relevant,
+    mentions_oepnv,
     relevant_station,
 )
 from src.utils import stations
@@ -99,37 +100,79 @@ def test_relevant_station_at_real_bahnhof() -> None:
     assert "Hauptbahnhof" in name
 
 
-def test_pendlerbahnhof_is_relevant() -> None:
-    assert is_transit_relevant(_loc(*MOEDLING)) is True
+def _item(lat: float, lon: float, *, title: str = "Sanierung", description: str = "Fahrbahn") -> dict[str, Any]:
+    return {"location": _loc(lat, lon), "title": title, "description": description}
 
 
-def test_far_away_road_works_is_not_relevant() -> None:
-    assert is_transit_relevant(_loc(*FAR_AWAY)) is False
+def test_geo_only_item_is_relevant_without_oepnv_text() -> None:
+    # Near a Pendlerbahnhof, no ÖPNV keyword needed.
+    assert is_transit_relevant(_item(*MOEDLING)) is True
+
+
+def test_text_only_item_is_relevant_far_from_rail() -> None:
+    item = _item(*FAR_AWAY, title="Umbau", description="Die Haltestelle wird verlegt")
+    assert is_transit_relevant(item) is True
+
+
+def test_item_neither_geo_nor_oepnv_is_not_relevant() -> None:
+    assert is_transit_relevant(_item(*FAR_AWAY, title="Innenhof", description="Hinterhofarbeiten")) is False
 
 
 @pytest.mark.parametrize(
-    "location",
+    "item",
     [
         None,
         "nope",
         {},
-        {"address": "Teststraße"},  # no coordinates
-        {"coordinates": "nope"},
-        {"coordinates": {"lat": None, "lon": None}},
-        {"coordinates": {"lat": float("nan"), "lon": 16.37}},
+        {"title": "Innenhof", "description": "Hinterhofarbeiten"},  # no location, no ÖPNV text
+        {"location": {"coordinates": {"lat": None, "lon": None}}, "title": "x", "description": "y"},
+        {"location": {"coordinates": {"lat": float("nan"), "lon": 16.37}}, "title": "x", "description": "y"},
     ],
 )
-def test_is_transit_relevant_fails_closed(location: object) -> None:
-    assert is_transit_relevant(location) is False
+def test_is_transit_relevant_fails_closed(item: object) -> None:
+    assert is_transit_relevant(item) is False
 
 
-def test_radius_override_widens_match(
+def test_radius_override_widens_geo_match(
     monkeypatch: pytest.MonkeyPatch, single_station: _RailSet
 ) -> None:
-    far = _loc(48.2027, 16.3700)  # ~300 m from the synthetic station
+    # ~300 m from the synthetic station, no ÖPNV text → relevance is purely radius-driven.
+    far = _item(48.2027, 16.3700, title="Sanierung", description="Fahrbahn")
     assert is_transit_relevant(far) is False
     monkeypatch.setenv("BAUSTELLEN_STATION_RADIUS_M", "500")
     assert is_transit_relevant(far) is True
+
+
+# --- mentions_oepnv -----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Die Haltestelle Haspingerplatz wird aufgelassen",
+        "Umleitung der Straßenbahnlinie 2",
+        "Schienenersatzverkehr eingerichtet",
+        "betrifft die öffentlichen Verkehrsmittel",
+        "Sperre der Buslinie 10A",
+        "Linie 46 verkürzt",
+        "U6 Teilsperre",
+    ],
+)
+def test_mentions_oepnv_true(text: str) -> None:
+    assert mentions_oepnv(text) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "Vollsperre der Fahrbahn wegen Rohrlegung",
+        "Gehsteigsanierung im Innenhof",
+        "Buschenschank am Nussberg",  # 'Busch…' must not trip the \\bbus\\b token
+    ],
+)
+def test_mentions_oepnv_false(text: str) -> None:
+    assert mentions_oepnv(text) is False
 
 
 # --- radius resolution / clamping ---------------------------------------------
@@ -160,19 +203,20 @@ def test_resolve_radius_clamping(monkeypatch: pytest.MonkeyPatch, raw: str, expe
 
 
 def test_post_filter_keeps_relevant_drops_noise_passes_stubs() -> None:
-    relevant = {"title": "Fahrbahnsanierung", "description": "x", "location": _loc(*WIEN_HBF)}
-    noise = {"title": "Hinterhof", "description": "x", "location": _loc(*FAR_AWAY)}
-    no_coords = {"title": "Ohne Geo", "description": "x"}
+    geo = {"title": "Fahrbahnsanierung", "description": "x", "location": _loc(*WIEN_HBF)}
+    text = {"title": "Gleisarbeiten", "description": "Haltestelle verlegt", "location": _loc(*FAR_AWAY)}
+    noise = {"title": "Hinterhof", "description": "Innenhofarbeiten", "location": _loc(*FAR_AWAY)}
     stub = {"guid": "meta-only"}
     sentinel = "passthrough-non-dict"
 
-    result = _post_filter_baustellen([relevant, noise, no_coords, stub, sentinel])
+    result = _post_filter_baustellen([geo, text, noise, stub, sentinel])
 
     titles = [r["title"] for r in result if isinstance(r, dict) and "title" in r]
-    # Relevant item kept and prefixed with the affected Bahnhof.
+    # geo-relevant → kept and prefixed with the affected Bahnhof.
     assert any(t.endswith("Fahrbahnsanierung") and "Hauptbahnhof" in t for t in titles)
-    assert "Hinterhof" not in titles  # far from any Bahnhof → dropped
-    assert "Ohne Geo" not in titles  # no coordinates → fail closed
+    # text-relevant (far from rail, but mentions a stop) → kept, NOT prefixed.
+    assert "Gleisarbeiten" in titles
+    assert "Hinterhof" not in titles  # neither near a Bahnhof nor ÖPNV text → dropped
     assert stub in result  # title/description-less stub passes through
     assert sentinel in result  # non-dict passes through
 
@@ -233,6 +277,8 @@ def test_sample_payload_is_all_transit_relevant() -> None:
     payload = json.loads(SAMPLE_PATH.read_text(encoding="utf-8"))
     events = update_baustellen_cache._collect_events(payload)
     assert len(events) == 2
-    assert all(is_transit_relevant(event.get("location")) for event in events)
-    # The LineString feature must still yield a usable coordinate.
-    assert events[1]["location"]["coordinates"]["lat"] == pytest.approx(48.085628)
+    # Feature 1 is geo-relevant (at a Bahnhof), feature 2 is text-relevant
+    # (mentions a stop, far from rail) — the "Bahnhofsnähe ODER ÖPNV-Text" policy.
+    assert all(is_transit_relevant(event) for event in events)
+    # The LineString feature must still yield a usable representative coordinate.
+    assert events[1]["location"]["coordinates"]["lat"] == pytest.approx(48.2103)

--- a/tests/test_sentinel_allow_nan_writer_audit_walker.py
+++ b/tests/test_sentinel_allow_nan_writer_audit_walker.py
@@ -93,7 +93,7 @@ Three documented sites live here today:
   motivates the non-finite-literal axis (committed-to-main artefact
   that strict parsers must handle) does not apply.
 
-* ``src/build_feed.py:_identity_for_item`` (lines 2317 and 2326) —
+* ``src/build_feed.py:_identity_for_item`` (lines 2318 and 2327) —
   two ``json.dumps(item, sort_keys=True, default=str)`` calls compute
   the SHA-256 input for the feed-item identity hash. The serialised
   bytes flow into ``hashlib.sha256(raw.encode("utf-8")).hexdigest()``
@@ -142,8 +142,8 @@ ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
         # into ``hashlib.sha256(...).hexdigest()`` on the very next
         # line and are not retained anywhere else. No parser-consumed
         # artefact, so the threat model does not apply.
-        ("src/build_feed.py", 2317),
-        ("src/build_feed.py", 2326),
+        ("src/build_feed.py", 2318),
+        ("src/build_feed.py", 2327),
     }
 )
 
@@ -536,7 +536,7 @@ def test_allowlist_is_minimal_and_documented() -> None:
     assert ALLOWLIST == frozenset(
         {
             ("src/places/hafas_client.py", 282),
-            ("src/build_feed.py", 2317),
-            ("src/build_feed.py", 2326),
+            ("src/build_feed.py", 2318),
+            ("src/build_feed.py", 2327),
         }
     )

--- a/tests/test_update_baustellen_cache.py
+++ b/tests/test_update_baustellen_cache.py
@@ -193,7 +193,7 @@ def test_with_output_format_rewrites_only_the_token() -> None:
     )
     assert rewritten.endswith("outputFormat=application/json")
     # Every other parameter is preserved byte-for-byte.
-    assert "typeName=ogdwien:BAUSTELLEOGD" in rewritten
+    assert "typeName=ogdwien:BAUSTELLENLINOGD" in rewritten
     assert "srsName=EPSG:4326" in rewritten
     assert rewritten.startswith("https://data.wien.gv.at/daten/geo?")
 
@@ -204,6 +204,41 @@ def test_with_output_format_appends_when_absent() -> None:
         update_baustellen_cache._with_output_format(base, "geojson")
         == base + "&outputFormat=geojson"
     )
+
+
+def test_with_typename_rewrites_only_the_token() -> None:
+    rewritten = update_baustellen_cache._with_typename(
+        update_baustellen_cache.DEFAULT_DATA_URL, "ogdwien:BAUSTELLENPKTOGD"
+    )
+    assert "typeName=ogdwien:BAUSTELLENPKTOGD" in rewritten
+    assert "BAUSTELLENLINOGD" not in rewritten
+    # Other parameters untouched.
+    assert "outputFormat=json" in rewritten
+    assert "srsName=EPSG:4326" in rewritten
+
+
+def test_fetch_layers_merges_both_typenames(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Both feature types are fetched and their events merged."""
+    seen_typenames: list[str] = []
+
+    def fake_fetch_remote(url: str, timeout: int) -> dict[str, Any]:
+        # Record which layer was requested; return one feature per layer.
+        for typename in update_baustellen_cache._BAUSTELLEN_TYPENAMES:
+            if typename in url:
+                seen_typenames.append(typename)
+        return {"type": "FeatureCollection", "features": []}
+
+    monkeypatch.setattr(update_baustellen_cache, "_fetch_remote", fake_fetch_remote)
+    events = update_baustellen_cache._fetch_layers(
+        update_baustellen_cache.DEFAULT_DATA_URL, timeout=5
+    )
+    assert events == []  # empty FeatureCollections → no events, but not None
+    assert set(seen_typenames) == set(update_baustellen_cache._BAUSTELLEN_TYPENAMES)
+
+
+def test_fetch_layers_returns_none_when_all_layers_fail(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_baustellen_cache, "_fetch_remote", lambda url, timeout: None)
+    assert update_baustellen_cache._fetch_layers("https://data.wien.gv.at/x", timeout=5) is None
 
 
 def test_main_negotiates_output_format(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Macht den Baustellen-Provider mit der **aktuellen** Stadt-Wien-Quelle funktionsfähig. Per Live-Diagnose (#1640) + GetCapabilities bestätigt: `ogdwien:BAUSTELLEOGD` existiert nicht mehr — die Migration auf den neuen GeoServer (`geoserverneuogd`) hat den Datensatz in **zwei** „verkehrswirksame Baustellen"-Layer gesplittet.

## Änderungen

**Beide neuen Layer abrufen + zusammenführen**
- `ogdwien:BAUSTELLENLINOGD` (Linien) + `ogdwien:BAUSTELLENPKTOGD` (Punkte) via `_with_typename` + `_fetch_layers`; outputFormat-Aushandlung bleibt pro Layer.

**Feld-Schema auf die echte Quelle gemappt** (aus einem realen Feature)
- `PRESSETEXT` → Beschreibung, `OBJEKT_BEGINN`/`OBJEKT_ENDE` → Daten, `BEHINDERUNGSART` → Maßnahme.
- Das Datumsformat `2026-03-22Z` (Datum + `Z`, ohne Zeit) wird jetzt geparst (dateutil lehnte es zuvor ab).
- Koordinaten-Reihenfolge an einem echten Feature als **lon/lat** verifiziert (kein Achsentausch).

**Relevanz = „Bahnhofsnähe ODER ÖPNV-Text"** (deine Wahl)
- Behalte ein Item, wenn es ≤150 m an einer Schienenstation liegt **oder** sein Text ÖPNV nennt (Haltestelle, Linie, (Auto)Bus, Bim/Straßenbahn, U-/S-Bahn, öffentlich, Schienenersatz). Die Quelle ist bereits auf verkehrswirksame Baustellen kuratiert (viele betreffen Bus-/Tram-Haltestellen abseits von Bahnhöfen) — der reine Bahnhofs-Filter hätte diese verworfen (z. B. das Sample: Haltestellen-Verlegung, 890 m von der nächsten Schienenstation → jetzt via Text behalten).
- `is_transit_relevant` nimmt jetzt das Item; `_post_filter_baustellen` wendet dieselbe ODER-Logik an und behält das Bahnhofs-Präfix im Titel, wenn die Geo-Bedingung greift.

**Sample auf das echte Schema umgestellt**
- Ein geo-relevanter Punkt (Floridsdorf), eine text-relevante Linie (Thaliastraße/Haltestelle) — mit Daten in der Vergangenheit, damit das Fallback nie Demodaten in den Live-Feed schreibt.

## Sicherheit / Robustheit
- `_with_typename`/`_with_output_format` schreiben nur das jeweilige Query-Token um (byte-erhaltend); Host-Pinning bleibt, `_fetch_remote` re-validiert. Der ÖPNV-Regex ist linear (kein ReDoS), Wortgrenzen für kurze Tokens (`bus`, `bim`, `u1`–`u6`, `tram`).

## Test plan
- [x] Relevanz: geo-only, text-only, beides/keins, fail-closed; `mentions_oepnv` (inkl. „Busch…" darf `\bbus\b` nicht auslösen); Radius-Clamping.
- [x] Parser: `Z`-Datum, neue Felder; `_with_typename`/`_with_output_format`; `_fetch_layers` (merge beider Layer / None wenn alle scheitern).
- [x] Sample end-to-end: Feature 1 geo-relevant (Floridsdorf), Feature 2 text-relevant; Koordinaten lon/lat.
- [x] Regression: build_feed (cache/atom/sort/dedupe/item_age/ends_at), Provider, Sentinels (allow_nan-Allowlist retargetiert, Path-Log) — grün.
- [x] ruff + bandit + mypy (keine neuen Fehler) sauber.
- [ ] Live-WFS aus der Sandbox nicht abrufbar (Egress) — Logik per Mock/Sample getestet; nächster `update-cycle`/`manual-full-refresh`-Lauf liefert die echten Live-Daten.

https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu)_