### PR TITLE
first_seen guid-stabil + providerunabhängig

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -2822,8 +2822,14 @@ def _drop_old_items(
         if not isinstance(it, dict):
             continue  # type: ignore[unreachable]
 
-        ident = _identity_for_item(it)
+        ident = _state_key_for_item(it)
         state_entry = state.get(ident) if isinstance(state, dict) else None
+        if state_entry is None and isinstance(state, dict):
+            # Migration: recover first_seen from a legacy identity-keyed
+            # entry written before the switch to guid-stable state keys.
+            legacy = _identity_for_item(it)
+            if legacy != ident:
+                state_entry = state.get(legacy)
 
         ends_at = it.get("ends_at")
         if isinstance(ends_at, datetime):
@@ -2891,6 +2897,21 @@ def _dedupe_key_for_item(
             key,
         )
     return key, True
+
+
+def _state_key_for_item(it: FeedItem) -> str:
+    """Return the persistent ``first_seen`` state key for ``it``.
+
+    Prefers the provider ``guid`` — stable across upstream title/description
+    edits and the read-side title enrichment — so an item's ``first_seen``
+    (and the age-based retirement that relies on it) survives those changes.
+    Falls back to the content identity when no guid is present, so EVERY
+    item, provider-independently, still gets a first_seen entry.
+    """
+    guid = it.get("guid")
+    if guid:
+        return str(guid)
+    return _identity_for_item(it)
 
 
 def _summarize_duplicates(items: Sequence[FeedItem]) -> list[DuplicateSummary]:
@@ -3183,11 +3204,13 @@ class FormattedContent(NamedTuple):
 
 
 def _update_item_state(it: FeedItem, now: datetime, state: dict[str, dict[str, Any]]) -> tuple[str, datetime]:
-    ident = _identity_for_item(it)
+    ident = _state_key_for_item(it)
     st = state.get(ident)
-    # Fallback: check guid as secondary key
-    if not st and it.get("guid") and it["guid"] != ident:
-        st = state.get(str(it["guid"]))
+    if not st:
+        # Migration: recover first_seen from a legacy identity-keyed entry.
+        legacy = _identity_for_item(it)
+        if legacy != ident:
+            st = state.get(legacy)
     is_strictly_new = not st
     if not st:
         st = {"first_seen": _to_utc(now).isoformat()}

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -2822,14 +2822,7 @@ def _drop_old_items(
         if not isinstance(it, dict):
             continue  # type: ignore[unreachable]
 
-        ident = _state_key_for_item(it)
-        state_entry = state.get(ident) if isinstance(state, dict) else None
-        if state_entry is None and isinstance(state, dict):
-            # Migration: recover first_seen from a legacy identity-keyed
-            # entry written before the switch to guid-stable state keys.
-            legacy = _identity_for_item(it)
-            if legacy != ident:
-                state_entry = state.get(legacy)
+        ident, state_entry = _lookup_state(it, state)
 
         ends_at = it.get("ends_at")
         if isinstance(ends_at, datetime):
@@ -2912,6 +2905,25 @@ def _state_key_for_item(it: FeedItem) -> str:
     if guid:
         return str(guid)
     return _identity_for_item(it)
+
+
+def _lookup_state(
+    it: FeedItem, state: dict[str, dict[str, Any]]
+) -> tuple[str, dict[str, Any] | None]:
+    """Return ``(stable_key, entry)`` for ``it``'s first_seen state.
+
+    Prefers the guid-based key (:func:`_state_key_for_item`); on a miss it
+    falls back to a legacy identity-keyed entry so first_seen migrates
+    without a reset. Shared by the writer (:func:`_update_item_state`) and
+    the age check (:func:`_drop_old_items`) so both stay consistent.
+    """
+    key = _state_key_for_item(it)
+    entry = state.get(key)
+    if entry is None:
+        legacy = _identity_for_item(it)
+        if legacy != key:
+            entry = state.get(legacy)
+    return key, entry
 
 
 def _summarize_duplicates(items: Sequence[FeedItem]) -> list[DuplicateSummary]:
@@ -3204,13 +3216,7 @@ class FormattedContent(NamedTuple):
 
 
 def _update_item_state(it: FeedItem, now: datetime, state: dict[str, dict[str, Any]]) -> tuple[str, datetime]:
-    ident = _state_key_for_item(it)
-    st = state.get(ident)
-    if not st:
-        # Migration: recover first_seen from a legacy identity-keyed entry.
-        legacy = _identity_for_item(it)
-        if legacy != ident:
-            st = state.get(legacy)
+    ident, st = _lookup_state(it, state)
     is_strictly_new = not st
     if not st:
         st = {"first_seen": _to_utc(now).isoformat()}

--- a/tests/test_first_seen_fuzzy.py
+++ b/tests/test_first_seen_fuzzy.py
@@ -72,44 +72,30 @@ def test_first_seen_fuzzy_identity(monkeypatch: pytest.MonkeyPatch, tmp_path: Pa
     assert ident in state_after_second
     assert state_after_second[ident]["first_seen"] == first_seen
 
-    # Test the fallback guid lookup for a different identity (simulating a merged item)
-    item_c = {
-        "source": "wl", # wl identity generation doesn't use guid
+    # Guid-stable first_seen: an item with a guid is keyed on that guid, so
+    # its first_seen survives a title change (e.g. the read-side ÖPNV title
+    # enrichment) instead of resetting.
+    item_c1 = {
+        "source": "wl",
         "category": "test",
-        "title": "Neue Störung",
+        "title": "Linie 9 gestört",
         "starts_at": now,
         "ends_at": now,
-        "guid": ident # Set guid to the identity of item_a
+        "guid": "WL-12345",
     }
-
-    # Need to save the old state!
-    # Because _make_rss processes new items and only saves state for them
-    # Wait, the state variable holds the state memory. We just use the same state variable
-    # So state has `ident`.
-
-    # _make_rss uses `ident` but then adds it. We must also tell _make_rss that
-    # item_c was kept in the state by _make_rss. Wait, `state_after_third` loads from disk.
-    # _save_state deletes items not in the recent batch unless `STATE_RETENTION_DAYS`
-    # actually _save_state does a safe merge and doesn't delete!
-
-    # Wait, the problem is that `_make_rss` takes `state` dict, adds `ident_c` to it,
-    # and then `_save_state(state)` saves BOTH ident and ident_c.
-    # Why wasn't ident_c in `state_after_third`?
-    # Because `state_after_third` ONLY contained the original `ident`? Let's look at the error:
-    # assert 'wl...' in {'oebb...': {'first_seen': '...'}}
-    # ONLY 'oebb...' is there. Why did `build_feed._make_rss` not save `wl...`?
-    # Because `_identity_for_item` mutates the item and sets `_calculated_identity`.
-    # Let's see how `item_c` is processed.
-
-    rss = build_feed._make_rss([item_c], now + timedelta(hours=2), state)
+    state = build_feed._load_state()
+    build_feed._make_rss([item_c1], now + timedelta(hours=2), state)
     build_feed._save_state(state)
+    state = build_feed._load_state()
+    assert "WL-12345" in state  # keyed on the guid, not the title identity
+    fs_c = state["WL-12345"]["first_seen"]
 
-    build_feed._load_state()
-
-    # We want to know what ident was added
-    ident_c = build_feed._identity_for_item(item_c)
-    assert ident_c != ident
-
-    # Let's just check the state directly
-    assert ident_c in state
-    assert state[ident_c]["first_seen"] == first_seen
+    # Same guid, changed title → first_seen preserved, no second entry.
+    item_c2 = dict(item_c1, title="9: Linie 9 gestört wegen Bauarbeiten")
+    state = build_feed._load_state()
+    build_feed._make_rss([item_c2], now + timedelta(hours=3), state)
+    build_feed._save_state(state)
+    state = build_feed._load_state()
+    assert "WL-12345" in state
+    assert state["WL-12345"]["first_seen"] == fs_c
+    assert build_feed._identity_for_item(item_c2) not in state


### PR DESCRIPTION
Jede Meldung bekommt jetzt **providerunabhängig** ein stabiles `first_seen`, damit die Alters-Ausmusterung zuverlässig funktioniert.

## Änderung
- Neuer Helper `_state_key_for_item`: bevorzugt die **`guid`** als State-Schlüssel (stabil gegenüber Upstream-Titel-/Text-Änderungen **und** der read-seitigen ÖPNV-Titel-Anreicherung), mit **Identity-Fallback** für Items ohne guid → so erhält wirklich *jede* Meldung ein `first_seen`.
- Konsistent angewandt: Schreiben (`_update_item_state`), Lesen + Lösch-Menge (`_drop_old_items`) — damit Schreib-, Alters- und Lösch-Schlüssel übereinstimmen.
- **Migrations-sicher**: ist (noch) kein guid-Eintrag vorhanden, wird ein bestehender Identity-Eintrag übernommen → **kein** einmaliger first_seen-Reset; Alt-Einträge laufen über die normale Retention aus.

Vorher hing `first_seen` (wie bei WL) an der **titelbasierten** Identity; der vorhandene guid-Fallback in `_update_item_state` griff praktisch nie, weil der State unter der Identity gespeichert wurde. Damit konnte eine Titeländerung (z. B. die neue Bahnhof-/U-Bahn-Präfixierung) das `first_seen` zurücksetzen. Jetzt ist es guid-stabil.

## Hinweis (separat, nicht in dieser PR)
`first_seen` wird beim Ausmustern nur als Fallback genutzt; `_drop_old_items` altert primär nach `pubDate`/`starts_at`, und `ABSOLUTE_MAX_AGE_DAYS` verwirft aktive Langläufer (z. B. U-Bahn-Bau seit 2021, Ende 2029) wegen ihres alten Startdatums. Falls gewünscht, kann „aktiv + zukünftiges ends_at ⇒ nur nach first_seen altern" als Folge-PR umgesetzt werden.

## Test plan
- [x] `test_first_seen_fuzzy` aktualisiert: gleiche guid + geänderter Titel → `first_seen` bleibt erhalten, kein zweiter Eintrag.
- [x] `test_state`, `test_first_seen_cleanup`, `test_drop_old_items_future`, `test_item_age`, `test_ends_at`, `test_dedupe_items` grün.
- [x] allow_nan-Audit, mypy, ruff sauber. Voller Suite-Lauf läuft als Absicherung.

https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu)_