### PR TITLE
Feed: nach first_seen sortieren + ausmustern (FIFO), Ungültiges sofort raus

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -2808,11 +2808,18 @@ def _drop_old_items(
     now: datetime,
     state: dict[str, dict[str, Any]],
 ) -> tuple[list[FeedItem], set[str]]:
-    """Entferne Items, die zu alt sind oder bereits beendet wurden.
+    """Entferne Items, die nicht mehr gültig oder zu lange im Feed sind.
 
-    Neben ``pubDate``/``starts_at`` wird – falls vorhanden – ``first_seen`` aus dem
-    geladenen State als Altersreferenz verwendet. Das betrifft Items ohne
-    Datumsangaben, die andernfalls ewig im Feed verbleiben würden.
+    Zwei Regeln:
+
+    1. **Ungültig → sofort raus:** ein ``ends_at`` in der Vergangenheit
+       (über die ``ENDS_AT_GRACE_MINUTES`` hinaus) bedeutet, die Störung ist
+       behoben → die Meldung macht sofort Platz.
+    2. **Alter → FIFO nach ``first_seen``:** das Alter zählt ab dem
+       Auftauchen im Feed (``first_seen`` aus dem State), NICHT ab dem
+       Quell-Startdatum. So fällt ein aktiver Langläufer nicht wegen eines
+       alten Startdatums heraus; ein noch nicht im State vermerktes Item ist
+       brandneu und wird hier nie ausgemustert.
     """
 
     out: list[FeedItem] = []
@@ -2830,25 +2837,17 @@ def _drop_old_items(
                 dropped.add(ident)
                 continue
 
-        dt = it.get("pubDate") or it.get("starts_at")
-        age_days: float | None = None
-        if isinstance(dt, datetime):
-            age_days = (now_utc - _to_utc(dt)).total_seconds() / 86400.0
-        elif isinstance(state_entry, dict):
-            raw_first_seen = state_entry.get("first_seen")
-            if raw_first_seen is not None:
-                try:
-                    first_seen_dt = datetime.fromisoformat(str(raw_first_seen))
-                except Exception:
-                    log.warning(
-                        "first_seen Parsefehler: %r – ignoriere für %s",
-                        raw_first_seen,
-                        ident,
-                    )
-                else:
-                    if first_seen_dt.tzinfo is None:
-                        first_seen_dt = first_seen_dt.replace(tzinfo=UTC)
-                    age_days = (now_utc - _to_utc(first_seen_dt)).total_seconds() / 86400.0
+        # Age out by how long the item has been in the feed (first_seen) —
+        # FIFO by appearance ("man kennt die Meldung schon"). The source
+        # start date is deliberately NOT used, so an active long-runner that
+        # only recently surfaced is not retired for an old upstream start;
+        # an item not yet in the state is brand-new and never aged out here.
+        first_seen_dt = _parse_first_seen(state_entry, None)
+        age_days: float | None = (
+            (now_utc - first_seen_dt).total_seconds() / 86400.0
+            if first_seen_dt is not None
+            else None
+        )
 
         if age_days is not None:
             if age_days > feed_config.ABSOLUTE_MAX_AGE_DAYS:
@@ -2924,6 +2923,28 @@ def _lookup_state(
         if legacy != key:
             entry = state.get(legacy)
     return key, entry
+
+
+def _parse_first_seen(
+    entry: dict[str, Any] | None, fallback: datetime | None
+) -> datetime | None:
+    """Return the UTC ``first_seen`` datetime from a state ``entry``.
+
+    Falls back to ``fallback`` when the entry is absent or its ``first_seen``
+    is missing/unparseable.
+    """
+    if not entry:
+        return fallback
+    raw = entry.get("first_seen")
+    if raw is None:
+        return fallback
+    try:
+        parsed = datetime.fromisoformat(str(raw))
+    except (ValueError, TypeError):
+        return fallback
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return _to_utc(parsed)
 
 
 def _summarize_duplicates(items: Sequence[FeedItem]) -> list[DuplicateSummary]:
@@ -3071,18 +3092,22 @@ def _dedupe_items(items: list[FeedItem]) -> list[FeedItem]:
             out.append(it)
     return out
 
-def _sort_key(item: FeedItem) -> tuple[int, float, str]:
-    pd = item.get("pubDate")
-    # Fix TypeError: Ensure guid is always a string, even if explicitly None
-    guid_val = item.get("guid")
-    if guid_val:
-        guid_str = str(guid_val)
-    else:
-        guid_str = _identity_for_item(item)
+def _recency_sort_key(
+    item: FeedItem, state: dict[str, dict[str, Any]], now_utc: datetime
+) -> tuple[float, str]:
+    """FIFO-by-``first_seen`` ordering for the feed: newest-appeared first.
 
-    if isinstance(pd, datetime):
-        return (0, -_to_utc(pd).timestamp(), guid_str)
-    return (1, 0.0, guid_str)
+    Sorts by the persisted (guid-stable) ``first_seen`` descending. An item
+    not yet in the state counts as just-appeared (``now``) so genuinely new
+    disruptions lead. No-longer-valid items are already removed upstream by
+    :func:`_drop_old_items`, so the visible Top-N are the newest still-valid
+    disruptions; older ones fall off the bottom as fresher ones arrive.
+    """
+    _, entry = _lookup_state(item, state)
+    first_seen = _parse_first_seen(entry, now_utc) or now_utc
+    guid_val = item.get("guid")
+    guid_str = str(guid_val) if guid_val else _identity_for_item(item)
+    return (-first_seen.timestamp(), guid_str)
 
 
 def _build_canonical_link(candidate: Any, ident: str) -> str:
@@ -4154,8 +4179,9 @@ def main() -> int:
             log.warning("Keine Items gesammelt.")
             items = []
         else:
-            log.debug("Sortiere %d Items nach Priorität.", len(items))
-        items.sort(key=_sort_key)
+            log.debug("Sortiere %d Items nach Priorität (first_seen, neueste zuerst).", len(items))
+        now_utc = _to_utc(now)
+        items.sort(key=lambda it: _recency_sort_key(it, state, now_utc))
 
         new_items_count = _count_new_items(items, state)
 

--- a/tests/test_build_feed_cache.py
+++ b/tests/test_build_feed_cache.py
@@ -234,12 +234,19 @@ def test_cache_iso_items_sorted_and_emit_pubdate(monkeypatch: pytest.MonkeyPatch
             assert isinstance(value, datetime)
             assert value.tzinfo is not None
 
-    state: dict[str, dict[str, Any]] = {}
+    # first_seen now drives ordering: "new-guid" appeared later than
+    # "older-guid", so it sorts first. ("Veraltete" is dropped by its past
+    # ends_at regardless of state.)
+    state: dict[str, dict[str, Any]] = {
+        "new-guid": {"first_seen": "2024-01-02T08:00:00+00:00"},
+        "older-guid": {"first_seen": "2024-01-01T08:00:00+00:00"},
+    }
     filtered, _ = build_feed._drop_old_items(cache_items, now, state)
     assert {it["guid"] for it in filtered} == {"new-guid", "older-guid"}
 
     deduped = build_feed._dedupe_items(filtered)
-    deduped.sort(key=build_feed._sort_key)
+    now_utc = build_feed._to_utc(now)
+    deduped.sort(key=lambda it: build_feed._recency_sort_key(it, state, now_utc))
 
     assert [it["guid"] for it in deduped] == ["new-guid", "older-guid"]
 

--- a/tests/test_build_feed_sort.py
+++ b/tests/test_build_feed_sort.py
@@ -4,6 +4,7 @@ import pytest
 import types
 from pathlib import Path
 from datetime import datetime, UTC
+from typing import Any
 
 def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
     module_name = "src.build_feed"
@@ -42,7 +43,7 @@ def test_sort_key_handles_none_guid(monkeypatch: pytest.MonkeyPatch, tmp_path: P
 
     build_feed = _import_build_feed(monkeypatch)
     now_utc = datetime.now(UTC)
-    state: dict = {}
+    state: dict[str, dict[str, Any]] = {}
 
     # Create an item with explicitly None guid
     item_none_guid = {
@@ -84,7 +85,7 @@ def test_deterministic_sorting_fallback(monkeypatch: pytest.MonkeyPatch, tmp_pat
     build_feed = _import_build_feed(monkeypatch)
 
     now = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
-    state: dict = {}
+    state: dict[str, dict[str, Any]] = {}
     # No state → identical first_seen (now); no guids → identity tiebreak.
     items = [
         {"title": "Item C", "pubDate": now},

--- a/tests/test_build_feed_sort.py
+++ b/tests/test_build_feed_sort.py
@@ -29,7 +29,8 @@ def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
 
 def test_sort_key_handles_none_guid(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """
-    Verify that _sort_key handles cases where 'guid' is explicitly None in the item dict.
+    Verify that _recency_sort_key handles cases where 'guid' is explicitly
+    None / missing / a string in the item dict (tiebreak part is index 1).
     """
 
     monkeypatch.setenv("OUT_PATH", "docs/feed.xml")
@@ -40,6 +41,8 @@ def test_sort_key_handles_none_guid(monkeypatch: pytest.MonkeyPatch, tmp_path: P
     (tmp_path / "log").mkdir()
 
     build_feed = _import_build_feed(monkeypatch)
+    now_utc = datetime.now(UTC)
+    state: dict = {}
 
     # Create an item with explicitly None guid
     item_none_guid = {
@@ -62,34 +65,34 @@ def test_sort_key_handles_none_guid(monkeypatch: pytest.MonkeyPatch, tmp_path: P
     }
 
     # This should not raise TypeError
-    key1 = build_feed._sort_key(item_none_guid)
-    key2 = build_feed._sort_key(item_missing_guid)
-    key3 = build_feed._sort_key(item_str_guid)
+    key1 = build_feed._recency_sort_key(item_none_guid, state, now_utc)
+    key2 = build_feed._recency_sort_key(item_missing_guid, state, now_utc)
+    key3 = build_feed._recency_sort_key(item_str_guid, state, now_utc)
 
-    # Verify that the guid part of the key is a string
-    assert isinstance(key1[2], str)
-    assert len(key1[2]) > 0
+    # Verify that the tiebreak (guid) part of the key is a string
+    assert isinstance(key1[1], str)
+    assert len(key1[1]) > 0
 
-    assert isinstance(key2[2], str)
-    assert len(key2[2]) > 0
+    assert isinstance(key2[1], str)
+    assert len(key2[1]) > 0
 
-    assert isinstance(key3[2], str)
-    assert key3[2] == "some-guid"
+    assert isinstance(key3[1], str)
+    assert key3[1] == "some-guid"
 
 def test_deterministic_sorting_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 
     build_feed = _import_build_feed(monkeypatch)
 
     now = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
-    # Identical pubDates, but no guids
+    state: dict = {}
+    # No state → identical first_seen (now); no guids → identity tiebreak.
     items = [
         {"title": "Item C", "pubDate": now},
         {"title": "Item A", "pubDate": now},
         {"title": "Item B", "pubDate": now},
     ]
 
-    # Generate keys using _sort_key
-    sorted_items = sorted(items, key=build_feed._sort_key)
+    sorted_items = sorted(items, key=lambda it: build_feed._recency_sort_key(it, state, now))
 
     # Ensure they don't error out, and order is deterministic.
     # The _sort_key will generate strings via _identity_for_item

--- a/tests/test_drop_old_items_future.py
+++ b/tests/test_drop_old_items_future.py
@@ -34,18 +34,19 @@ def test_future_ends_at_skips_max_age(monkeypatch: pytest.MonkeyPatch) -> None:
         {"MAX_ITEM_AGE_DAYS": "365", "ABSOLUTE_MAX_AGE_DAYS": "540"},
     )
     now = datetime.now(UTC)
-    future = {
-        "title": "future",
-        "pubDate": now - timedelta(days=400),
-        "ends_at": now + timedelta(days=1),
+    # Aging is by first_seen (feed presence), so it is driven by state.
+    future = {"title": "future", "guid": "G-future", "ends_at": now + timedelta(days=1)}
+    no_end = {"title": "no_end", "guid": "G-no-end"}
+    too_old = {"title": "too_old", "guid": "G-too-old", "ends_at": now + timedelta(days=1)}
+    state = {
+        # 400 d in the feed: past MAX (365) but a future ends_at skips the MAX drop.
+        "G-future": {"first_seen": (now - timedelta(days=400)).isoformat()},
+        # 400 d in the feed, no ends_at → dropped by MAX.
+        "G-no-end": {"first_seen": (now - timedelta(days=400)).isoformat()},
+        # 541 d in the feed → ABSOLUTE drop regardless of ends_at.
+        "G-too-old": {"first_seen": (now - timedelta(days=541)).isoformat()},
     }
-    no_end = {"title": "no_end", "pubDate": now - timedelta(days=400)}
-    too_old = {
-        "title": "too_old",
-        "pubDate": now - timedelta(days=541),
-        "ends_at": now + timedelta(days=1),
-    }
-    res, _ = build_feed._drop_old_items([future, no_end, too_old], now, {})
+    res, _ = build_feed._drop_old_items([future, no_end, too_old], now, state)
     assert res == [future]
 
 

--- a/tests/test_item_age.py
+++ b/tests/test_item_age.py
@@ -38,8 +38,13 @@ def test_main_filters_items_older_than_max(
     )
 
     now = datetime.now(UTC)
-    recent = {"title": "recent", "pubDate": now - timedelta(days=2) + timedelta(minutes=1)}
-    old = {"title": "old", "pubDate": now - timedelta(days=2) - timedelta(minutes=1)}
+    # Aging is now by first_seen (feed presence), not the source date.
+    recent = {"title": "recent", "guid": "G-recent"}
+    old = {"title": "old", "guid": "G-old"}
+    fake_state = {
+        "G-recent": {"first_seen": (now - timedelta(days=1)).isoformat()},
+        "G-old": {"first_seen": (now - timedelta(days=2, minutes=1)).isoformat()},
+    }
 
     def fake_collect(report: Any = None) -> list[dict[str, Any]]:
         return [recent, old]
@@ -61,6 +66,8 @@ def test_main_filters_items_older_than_max(
 
     monkeypatch.setattr(build_feed, "_collect_items", fake_collect)
     monkeypatch.setattr(build_feed, "_make_rss", fake_make_rss)
+    monkeypatch.setattr(build_feed, "_load_state", lambda: dict(fake_state))
+    monkeypatch.setattr(build_feed, "_save_state", lambda *a, **k: None)
     monkeypatch.chdir(tmp_path)
     setattr(build_feed, "OUT_PATH", "docs/feed.xml")
 
@@ -79,13 +86,12 @@ def test_main_filters_items_older_than_absolute(
     )
 
     now = datetime.now(UTC)
-    within = {
-        "title": "within_abs",
-        "starts_at": now - timedelta(days=2) + timedelta(minutes=1),
-    }
-    too_old = {
-        "title": "too_old",
-        "starts_at": now - timedelta(days=2) - timedelta(minutes=1),
+    # ABSOLUTE_MAX_AGE_DAYS applies to first_seen regardless of ends_at.
+    within = {"title": "within_abs", "guid": "G-within"}
+    too_old = {"title": "too_old", "guid": "G-too-old"}
+    fake_state = {
+        "G-within": {"first_seen": (now - timedelta(days=2) + timedelta(minutes=1)).isoformat()},
+        "G-too-old": {"first_seen": (now - timedelta(days=2) - timedelta(minutes=1)).isoformat()},
     }
 
     def fake_collect(report: Any = None) -> list[dict[str, Any]]:
@@ -108,6 +114,8 @@ def test_main_filters_items_older_than_absolute(
 
     monkeypatch.setattr(build_feed, "_collect_items", fake_collect)
     monkeypatch.setattr(build_feed, "_make_rss", fake_make_rss)
+    monkeypatch.setattr(build_feed, "_load_state", lambda: dict(fake_state))
+    monkeypatch.setattr(build_feed, "_save_state", lambda *a, **k: None)
     monkeypatch.chdir(tmp_path)
     setattr(build_feed, "OUT_PATH", "docs/feed.xml")
 


### PR DESCRIPTION
Macht den auf `MAX_ITEMS` (10) gekappten Feed so, dass wirklich das Relevanteste sichtbar ist — nach dem von dir gewählten Modell **FIFO nach `first_seen`, Ungültiges sofort raus**.

## Änderungen
1. **Sortierung = `first_seen` absteigend** (neue `_recency_sort_key`): zuletzt aufgetauchte Meldungen oben; ältere rutschen nach unten und fallen aus den 10 Plätzen, sobald frischere kommen. Ersetzt den bisherigen pubDate-Sort, unter dem eine Baustelle mit **zukünftigem Startdatum** (pubDate = `OBJEKT_BEGINN`) über akuten Live-Störungen stand. Brandneue (noch nicht im State) zählen als „gerade aufgetaucht&#34; → oben.
2. **Ausmustern nach `first_seen`** statt Quell-Startdatum (`_drop_old_items`): gezählt wird die **Feed-Verweildauer** („man kennt die Meldung schon&#34;). Ein aktiver Langläufer (z. B. U-Bahn-Bau seit 2021, Ende 2029) fällt nicht mehr wegen des alten Startdatums heraus. Ein noch nicht im State vermerktes Item ist brandneu und wird hier nie ausgemustert.
3. **Ungültig → sofort raus:** `ends_at` in der Vergangenheit (über die Grace-Minuten hinaus) wirft die Meldung sofort weg → Platz für eine gültige (erste Regel, unverändert).

Gemeinsamer Helfer `_parse_first_seen` für Sort + Alterscheck.

## Test plan
- [x] `_recency_sort_key` (Tiebreak-Index, deterministische Reihenfolge via Identity), `_drop_old_items` (first_seen-Alter, future-ends_at überspringt MAX, ABSOLUTE greift trotzdem, brandneu bleibt), `test_first_seen_used_when_no_dates`.
- [x] `test_item_age` auf state-getriebenes first_seen-Aging umgestellt.
- [x] `test_cache_iso_items_sorted_and_emit_pubdate` auf `_recency_sort_key` + first_seen-State umgestellt.
- [x] mypy + ruff + C901-Komplexitäts-Gate sauber.
- [x] Voller Suite-Lauf lokal grün (8407 passed, 2 skipped); CI-/Restfehler fange ich ab.

https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu)_