### PR TITLE
Webseite: Baustellen-Polish (kurzes Label + gelber Balken) & Cache-Busting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,17 +92,19 @@ repos:
   # ── Static-site asset drift check ────────────────────────────────
   # docs/assets/site.min.css and docs/assets/site.min.js are derived
   # from their readable sources (site.css / site.js); the dashboard's
-  # docs/site.html references the minified copies. This hook fails if
-  # the committed bundles fall out of sync with the source — the fix
-  # is to re-run ``python scripts/optimize_site_assets.py --skip-images``
-  # and stage the regenerated bundles.
+  # docs/site.html references the minified copies and carries a
+  # content-hash ``?v=`` cache-bust token per reference. This hook fails
+  # if the committed bundles fall out of sync with the source OR the
+  # ``?v=`` tokens in site.html no longer match the bundle hashes — the
+  # fix is to re-run ``python scripts/optimize_site_assets.py
+  # --skip-images`` and stage the regenerated bundles + site.html.
   - repo: local
     hooks:
       - id: site-assets-minified
         name: docs/assets/site.min.* matches source
         entry: python scripts/optimize_site_assets.py --check
         language: system
-        files: ^docs/assets/site\.(css|js|min\.css|min\.js)$
+        files: ^docs/(site\.html|assets/site\.(css|js|min\.css|min\.js))$
         pass_filenames: false
         require_serial: true
 

--- a/docs/site.html
+++ b/docs/site.html
@@ -18,7 +18,7 @@
   <link rel="alternate" type="application/rss+xml" title="Wien ÖPNV Feed" href="feed.xml">
   <link rel="alternate" type="application/rss+xml" title="Vienna Public Transport Feed (English)" href="feed.en.xml" hreflang="en">
   <link rel="icon" type="image/svg+xml" href="assets/site-favicon.svg">
-  <link rel="stylesheet" href="assets/site.min.css">
+  <link rel="stylesheet" href="assets/site.min.css?v=2a8efb25e5f0">
   <!-- The dashboard fetches the statistics CSVs from raw.githubusercontent.com
        once site.min.js has executed; resolving the DNS upfront shaves ~50–200 ms
        off the first CSV request on cold connections. The ``preconnect`` hint
@@ -329,6 +329,6 @@
     </div>
   </footer>
 
-  <script src="assets/site.min.js" defer></script>
+  <script src="assets/site.min.js?v=5dc00241bd12" defer></script>
 </body>
 </html>

--- a/scripts/optimize_site_assets.py
+++ b/scripts/optimize_site_assets.py
@@ -15,6 +15,7 @@ Outputs (always overwritten):
 
 * ``docs/assets/site.min.css``      — minified CSS referenced by ``docs/site.html``
 * ``docs/assets/site.min.js``       — minified JS referenced by ``docs/site.html``
+* ``docs/site.html``                — CSS/JS references get a content-hash ``?v=`` cache-bust token
 * ``docs/assets/train.png``         — re-encoded in place (downscaled + palette)
 * ``docs/assets/footer-bg.jpg``     — re-encoded in place (downscaled + progressive)
 
@@ -32,7 +33,9 @@ markers from the image tools, which are intentionally stripped via
 from __future__ import annotations
 
 import argparse
+import hashlib
 import logging
+import re
 import shutil
 import subprocess  # nosec B404
 import sys
@@ -294,6 +297,82 @@ def _minify_js(check_only: bool = False) -> bool:
     return True
 
 
+# ----- HTML cache-busting --------------------------------------------
+#
+# GitHub Pages serves ``site.min.css`` / ``site.min.js`` with a 10-minute
+# ``Cache-Control: max-age`` and the ``<link>`` / ``<script>`` references
+# carry no version token, so a returning visitor keeps the previously
+# cached bundle for up to ten minutes after a deploy — long enough for a
+# shipped change (e.g. a new feed-source classifier) to look "not applied
+# yet" while the fresh HTML around it already updated. Pinning a short
+# content hash as a ``?v=`` query makes each URL change exactly when the
+# bundle bytes change, so browsers refetch immediately. The query keeps
+# the same origin, so the strict ``script-src 'self'`` / ``style-src
+# 'self'`` CSP is unaffected.
+
+
+def _html_target() -> Path:
+    """The dashboard HTML whose asset references carry the ``?v=`` tokens.
+
+    Derived from ``ASSETS_DIR`` (read at call time) so the isolation
+    fixtures that redirect ``ASSETS_DIR`` into a tmp tree also redirect
+    this path — a test that only patched the asset paths never rewrites
+    the real ``docs/site.html``.
+    """
+    return ASSETS_DIR.parent / "site.html"
+
+
+def _asset_version(content: str) -> str:
+    """Cache-bust token: first 12 hex of the SHA-256 of the served bundle
+    bytes. Changes iff the bundle content changes."""
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()[:12]
+
+
+def _pin_asset_version(html: str, ref: str, version: str) -> str:
+    """Rewrite ``<ref>`` / ``<ref>?v=OLD`` to ``<ref>?v=<version>``.
+
+    ``ref`` is the bare relative URL (e.g. ``assets/site.min.js``). A
+    function replacement is used so no character in ``ref`` / ``version``
+    is interpreted as a backreference, and the optional existing ``?v=``
+    token is replaced so repeated runs are byte-idempotent.
+    """
+    pattern = re.compile(re.escape(ref) + r"(?:\?v=[0-9a-f]+)?")
+    return pattern.sub(lambda _m: f"{ref}?v={version}", html)
+
+
+def _sync_html_versions(check_only: bool = False) -> bool:
+    """Pin the cache-bust ``?v=`` tokens on the CSS/JS references in
+    ``site.html``. In check mode return ``False`` on drift.
+
+    A missing ``site.html`` (isolated test tree) is a no-op success — the
+    asset-only fixtures never create one.
+    """
+    html_path = _html_target()
+    if not html_path.exists():
+        return True
+    current = _read_capped_or_die(html_path, "site.html")
+    css_v = _asset_version(_render_min_css())
+    js_v = _asset_version(_render_min_js())
+    expected = _pin_asset_version(current, f"assets/{CSS_OUT.name}", css_v)
+    expected = _pin_asset_version(expected, f"assets/{JS_OUT.name}", js_v)
+    if check_only:
+        ok = current == expected
+        if not ok:
+            LOG.error(
+                "site.html asset versions are out of date — run "
+                "`python scripts/optimize_site_assets.py --skip-images`",
+            )
+        return ok
+    if current != expected:
+        # Same atomic-write rationale as ``_minify_css`` — ``site.html``
+        # is a repository-committed, GitHub-Pages-served file, so a
+        # partial write would land in the public page.
+        with atomic_write(html_path, mode="w", encoding="utf-8") as handle:
+            handle.write(expected)
+        LOG.info("HTML: pinned cache-bust versions (css=%s, js=%s)", css_v, js_v)
+    return True
+
+
 def _have(tool: str) -> bool:
     return shutil.which(tool) is not None
 
@@ -512,10 +591,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.check:
         css_ok = _minify_css(check_only=True)
         js_ok = _minify_js(check_only=True)
-        return 0 if (css_ok and js_ok) else 1
+        html_ok = _sync_html_versions(check_only=True)
+        return 0 if (css_ok and js_ok and html_ok) else 1
 
     _minify_css()
     _minify_js()
+    _sync_html_versions()
 
     if not args.skip_images:
         _optimise_train_png()

--- a/tests/scripts/test_optimize_site_assets.py
+++ b/tests/scripts/test_optimize_site_assets.py
@@ -137,3 +137,93 @@ def test_render_helpers_are_pure(_isolate_assets: Path) -> None:
     assert not opt.JS_OUT.exists()
     assert ".x{color:red}" in css
     assert "var x=1" in js or "var x = 1" in js  # rjsmin keeps the var-decl spacing
+
+
+# --- HTML cache-busting -----------------------------------------------
+
+
+def _write_html(path: Path) -> None:
+    path.write_text(
+        '<!doctype html><html><head>'
+        '<link rel="stylesheet" href="assets/site.min.css">'
+        '</head><body>'
+        '<script src="assets/site.min.js" defer></script>'
+        '</body></html>',
+        encoding="utf-8",
+    )
+
+
+def test_html_cache_bust_pins_content_hash(_isolate_assets: Path) -> None:
+    _write(opt.CSS_SRC, ".x{color:red}\n")
+    _write(opt.JS_SRC, "var x = 1;\n")
+    html_path = _isolate_assets.parent / "site.html"
+    _write_html(html_path)
+
+    assert opt.main(["--skip-images"]) == 0
+
+    html = html_path.read_text(encoding="utf-8")
+    css_v = opt._asset_version(opt._render_min_css())
+    js_v = opt._asset_version(opt._render_min_js())
+    assert f'href="assets/site.min.css?v={css_v}"' in html
+    assert f'src="assets/site.min.js?v={js_v}"' in html
+    # Freshly pinned HTML satisfies --check.
+    assert opt.main(["--check"]) == 0
+
+
+def test_html_cache_bust_is_idempotent(_isolate_assets: Path) -> None:
+    _write(opt.CSS_SRC, ".x{color:red}\n")
+    _write(opt.JS_SRC, "var x = 1;\n")
+    html_path = _isolate_assets.parent / "site.html"
+    _write_html(html_path)
+    assert opt.main(["--skip-images"]) == 0
+    first = html_path.read_text(encoding="utf-8")
+    # A second run against the unchanged bundle is byte-identical.
+    assert opt.main(["--skip-images"]) == 0
+    assert html_path.read_text(encoding="utf-8") == first
+
+
+def test_html_cache_bust_token_follows_content(_isolate_assets: Path) -> None:
+    _write(opt.CSS_SRC, ".x{color:red}\n")
+    _write(opt.JS_SRC, "var x = 1;\n")
+    html_path = _isolate_assets.parent / "site.html"
+    _write_html(html_path)
+    assert opt.main(["--skip-images"]) == 0
+    before = opt._asset_version(opt._render_min_css())
+
+    # Change the CSS source → the pinned ?v= token must change with it.
+    _write(opt.CSS_SRC, ".x{color:blue}\n")
+    assert opt.main(["--skip-images"]) == 0
+    after = opt._asset_version(opt._render_min_css())
+    assert before != after
+    assert f"?v={after}" in html_path.read_text(encoding="utf-8")
+
+
+def test_html_cache_bust_check_detects_stale_version(
+    _isolate_assets: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    _write(opt.CSS_SRC, ".x{color:red}\n")
+    _write(opt.JS_SRC, "var x = 1;\n")
+    html_path = _isolate_assets.parent / "site.html"
+    _write_html(html_path)
+    assert opt.main(["--skip-images"]) == 0
+
+    # Corrupt only the pinned CSS token; the bundles stay in sync, so this
+    # isolates the HTML drift path from the CSS/JS bundle checks.
+    stale = html_path.read_text(encoding="utf-8").replace(
+        opt._asset_version(opt._render_min_css()), "deadbeefdead"
+    )
+    html_path.write_text(stale, encoding="utf-8")
+
+    caplog.set_level("ERROR", logger=opt.LOG.name)
+    assert opt.main(["--check"]) == 1
+    assert any("site.html" in r.getMessage() for r in caplog.records)
+
+
+def test_sync_html_versions_missing_html_is_noop(_isolate_assets: Path) -> None:
+    _write(opt.CSS_SRC, ".x{color:red}\n")
+    _write(opt.JS_SRC, "var x = 1;\n")
+    # No site.html in the tmp tree → the cache-bust step is a silent
+    # success and never touches the real docs/site.html.
+    assert not (_isolate_assets.parent / "site.html").exists()
+    assert opt._sync_html_versions(check_only=True) is True
+    assert opt.main(["--skip-images"]) == 0


### PR DESCRIPTION
Zwei zusammenhängende Verbesserungen rund um die Baustellen-Quelle im Dashboard. Beide liegen auf demselben Branch (`claude/elegant-faraday-fbySb`); die zweite demonstriert die erste live (Asset-Änderung → neuer `?v=`-Hash).

---

## 1) Content-Hash Cache-Busting für `site.min.css`/`js`

### Problem
Nach Merge von #1645 trugen bestehende Baustellen-Meldungen weiterhin **ANDERE** statt **Baustellen**. Ursache war **nicht** Code/Feed (beide korrekt – der minifizierte `detectSource` liefert für `data.gv.at/...baustellen` korrekt `"baustellen"`), sondern **stale Browser-Cache**: GitHub Pages liefert `site.min.js`/`css` mit ~10 Min `Cache-Control: max-age`, und die Referenzen trugen keinen Versions-Token. Ein wiederkehrender Besucher sah frische `site.html` + **altes gecachtes JS** → alte Klassifizierung.

### Lösung
`optimize_site_assets.py` hängt an jede CSS/JS-Referenz in `site.html` ein `?v=<sha256[:12]>` der **ausgelieferten Bundle-Bytes**:
```html
<link rel="stylesheet" href="assets/site.min.css?v=41a7f7c4deaf">
<script src="assets/site.min.js?v=cdc95ac2ba26" defer></script>
```
- Token ändert sich **genau dann**, wenn sich der Bundle-Inhalt ändert → sofortiges Neuladen, kein 10-Min-Fenster.
- Same-Origin-Query → **CSP-konform** (`script-src 'self'` / `style-src 'self'` unverändert).
- `--check` verifiziert die Tokens; Erzeugung ist **byte-idempotent**. Pre-commit-Trigger deckt jetzt auch `docs/site.html` ab.

## 2) Quellen-Statistik: kurzes „Baustellen" + gelber Balken

### Problem
In **Verteilung je Quelle** kam die neue Quelle als **„Stadt Wien – Baustellen"** mit **grauem** Balken. Grund: die Balkenfarbe wird per `data-key` (= roher `provider`-String) gesetzt; für diese Quelle gab es keine Regel → grauer Default `#6b7d99`.

### Lösung
- **Display-only-Remap** in `site.js` (`providerLabel`): `/Baustellen/` → kurzes **„Baustellen"**. Der Jahresledger und die Feed-Pipeline (Glossar/Entity-Masking) behalten den beschreibenden String **„Stadt Wien – Baustellen"** – **keine Datenänderung**. Gilt auch für die KPI „Häufigste Quelle".
- **CSS**: neue Regel `…[data-key="Baustellen"] .bar-row__fill { fill: var(--c-baustellen) }` → **gelb** (`#f2b600` hell / `#f7c948` dunkel), identisch zum bestehenden Baustellen-Badge im Feed.

## Test plan
- [x] `--skip-images` pinnt Tokens & re-pinnt bei Asset-Änderung (css/js-Hash wechselte); `--check` rc=0; idempotent.
- [x] `providerLabel` sanity (node): `"Stadt Wien – Baustellen"→"Baustellen"`, andere unverändert; Remap + CSS-Regel überstehen Minifizierung.
- [x] 89 relevante Tests grün (Optimizer inkl. 5 neuer HTML-Cache-Bust-Tests, i18n-Gate, Translation-Coverage, Size-Bomb-Sentinels).
- [x] mypy --strict / ruff / bandit sauber.
- [ ] Hinweis: visuelle Browser-Verifikation im Sandbox nicht möglich (Statistik lädt CSVs von raw.githubusercontent.com) – verifiziert per Code-Inspektion: remappter `data-key="Baustellen"` matcht exakt die neue CSS-Regel.

https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46r2bMKJtjeiDRqBFTaRu)_