### PR TITLE
fix(en-feed): epoch-based translation-cache invalidation for stale renderings

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -901,6 +901,37 @@ def _sanitize_text(s: str) -> str:
 _TRANSLATION_STATE: dict[str, Any] = {"pipeline": None, "load_failed": False}
 _TRANSLATION_MODEL_NAME = "Helsinki-NLP/opus-mt-de-en"
 
+# Translation-cache epoch. EN translations are cached per disruption
+# identity in ``state[ident]["translations"]["en"]`` and persisted
+# across builds. The cache key (see :func:`_identity_for_item`) is
+# stable across cosmetic changes — a Baustellen item keyed on
+# ``title + date-range`` survives a description-only edit — so a
+# translation computed once is served for the lifetime of the item
+# (multi-year for long construction projects).
+#
+# That persistence is a problem whenever the masking / glossary logic
+# IMPROVES: an item translated by an older build keeps its stale
+# rendering forever, because :func:`_cached_translation` only forces a
+# retry when the cached value equals the German source (the
+# "Sticky-German" guard). A cached value that is a *wrong but
+# non-German* translation — e.g. ``Schlachthausgasse`` rendered as
+# "slaughterhouse gas" before the street-suffix masker existed — is
+# served indefinitely.
+#
+# The epoch breaks that lock. Bump this integer whenever a change to
+# :func:`_mask_entities`, the entity patterns, or the domain glossary
+# would alter the EN output for already-cached items. On the next
+# build :func:`_apply_lang_overlay` evicts every translation stamped
+# with an older epoch and recomputes it through the improved
+# pipeline, then re-stamps the current epoch so subsequent builds
+# trust the cache again (no churn).
+#
+# Epoch history:
+#   1 — first epoch. Invalidates every pre-epoch cache entry, picking
+#       up the street-suffix masker (#1624), the metadata-driven
+#       glossary (#1625) and the disruption-core scope tightening.
+_TRANSLATION_CACHE_EPOCH = 1
+
 # Static lookup for German → English time-line prefixes used inside the
 # bracketed ``[…]`` timeframe (see ``format_local_times``). Translating
 # these via the ML model would be wasteful — every disruption shares
@@ -3473,6 +3504,60 @@ def _summary_duplicates_title(summary: str, title_out: str) -> bool:
     return summary.casefold() == title_body_compare.casefold()
 
 
+def _evict_stale_translations(
+    ident: str, state: dict[str, dict[str, Any]] | None
+) -> None:
+    """Drop cached EN translations that predate the current
+    :data:`_TRANSLATION_CACHE_EPOCH`.
+
+    Called at the top of :func:`_apply_lang_overlay` before any cache
+    lookup. When the persisted epoch is older than the current one the
+    item was translated by a build with weaker masking / glossary
+    logic; the whole ``en`` sub-dict is removed so every field is
+    recomputed through the improved pipeline. The epoch is re-stamped
+    only AFTER a successful retranslation (see
+    :func:`_stamp_translation_epoch`) so a transient pipeline failure
+    cannot lock in a half-empty cache at the current epoch.
+    """
+    if state is None or not ident:
+        return
+    entry = state.get(ident)
+    if not isinstance(entry, dict):
+        return
+    translations = entry.get("translations")
+    if not isinstance(translations, dict):
+        return
+    epoch_raw = translations.get("epoch", 0)
+    epoch = epoch_raw if isinstance(epoch_raw, int) else 0
+    if epoch < _TRANSLATION_CACHE_EPOCH:
+        if "en" in translations:
+            log.info(
+                "Evicting stale EN translation for %s (epoch %s < %s).",
+                sanitize_log_arg(ident),
+                epoch,
+                _TRANSLATION_CACHE_EPOCH,
+            )
+        translations.pop("en", None)
+
+
+def _stamp_translation_epoch(
+    ident: str, state: dict[str, dict[str, Any]] | None
+) -> None:
+    """Record that ``ident``'s cached translations were produced under
+    the current :data:`_TRANSLATION_CACHE_EPOCH`.
+
+    Called only after every field translated successfully, so a future
+    build trusts the cache instead of evicting it again (no churn even
+    for items whose translation legitimately drops a placeholder).
+    """
+    if state is None or not ident:
+        return
+    entry = state.setdefault(ident, {})
+    translations = entry.setdefault("translations", {})
+    if isinstance(translations, dict):
+        translations["epoch"] = _TRANSLATION_CACHE_EPOCH
+
+
 def _apply_lang_overlay(
     base: FormattedContent,
     summary_de: str,
@@ -3509,9 +3594,21 @@ def _apply_lang_overlay(
     inside the translation cascade. Default ``None`` keeps the
     function callable from the existing tests that do not need to
     exercise the metadata path.
+
+    Cache freshness: cached translations are tagged with the
+    :data:`_TRANSLATION_CACHE_EPOCH` they were produced under. Stale
+    entries (older epoch) are evicted up-front so a masking / glossary
+    improvement is picked up on the next build instead of serving the
+    old rendering for the lifetime of the item.
     """
     if lang != "en":
         return base
+
+    # Pick up masking / glossary improvements: discard cached
+    # translations produced under an older epoch so the lookups below
+    # recompute them. Re-stamped at the end only when every field
+    # translated successfully.
+    _evict_stale_translations(ident, state)
 
     title_raw, title_ok = _cached_translation(
         base.title_out, "title", ident, state,
@@ -3536,6 +3633,10 @@ def _apply_lang_overlay(
             summary_ok,
         )
         return base
+
+    # Every field translated under the current epoch — stamp it so the
+    # next build trusts the cache instead of evicting and recomputing.
+    _stamp_translation_epoch(ident, state)
 
     title_en = _sanitize_text(title_raw)
     summary_en = _sanitize_text(summary_raw)

--- a/tests/test_sentinel_allow_nan_writer_audit_walker.py
+++ b/tests/test_sentinel_allow_nan_writer_audit_walker.py
@@ -93,7 +93,7 @@ Three documented sites live here today:
   motivates the non-finite-literal axis (committed-to-main artefact
   that strict parsers must handle) does not apply.
 
-* ``src/build_feed.py:_identity_for_item`` (lines 2328 and 2337) —
+* ``src/build_feed.py:_identity_for_item`` (lines 2359 and 2368) —
   two ``json.dumps(item, sort_keys=True, default=str)`` calls compute
   the SHA-256 input for the feed-item identity hash. The serialised
   bytes flow into ``hashlib.sha256(raw.encode("utf-8")).hexdigest()``
@@ -142,8 +142,8 @@ ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
         # into ``hashlib.sha256(...).hexdigest()`` on the very next
         # line and are not retained anywhere else. No parser-consumed
         # artefact, so the threat model does not apply.
-        ("src/build_feed.py", 2328),
-        ("src/build_feed.py", 2337),
+        ("src/build_feed.py", 2359),
+        ("src/build_feed.py", 2368),
     }
 )
 
@@ -536,7 +536,7 @@ def test_allowlist_is_minimal_and_documented() -> None:
     assert ALLOWLIST == frozenset(
         {
             ("src/places/hafas_client.py", 282),
-            ("src/build_feed.py", 2328),
-            ("src/build_feed.py", 2337),
+            ("src/build_feed.py", 2359),
+            ("src/build_feed.py", 2368),
         }
     )

--- a/tests/test_translation_coverage.py
+++ b/tests/test_translation_coverage.py
@@ -553,3 +553,149 @@ def test_metadata_glossary_no_cross_operator_contamination(
     # leaking into a road-construction item).
     assert "kurzführung" in desc_en
     assert "short-running service" not in desc_en
+
+
+# --- Translation-cache epoch invalidation -----------------------------
+#
+# EN translations are cached per disruption identity and persisted
+# across builds. The cache key (title + date-range for Baustellen
+# items) survives a description-only edit, so a translation computed
+# once is served for the lifetime of the item. When the masking /
+# glossary logic improves, the ``_TRANSLATION_CACHE_EPOCH`` guard
+# evicts the stale rendering and recomputes it through the improved
+# pipeline.
+
+
+def _fc(title_out: str) -> "build_feed.FormattedContent":
+    """Minimal FormattedContent whose only meaningful field for the
+    overlay is ``title_out`` (the German title to translate)."""
+    return build_feed.FormattedContent(
+        guid="g",
+        link="",
+        title_cdata=title_out,
+        desc_text_truncated="",
+        desc_cdata="",
+        raw_desc="",
+        title_out=title_out,
+        desc_html="",
+    )
+
+
+def test_stale_epoch_evicts_and_retranslates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for the live ``Schlachthausgasse`` → "slaughterhouse
+    gas" leak. A translation cached by a build with weaker masking
+    (no street-suffix protection) keeps its broken rendering because
+    the cache key (title + dates) survives a description-only edit.
+    The epoch guard must evict the stale entry and recompute with the
+    current masker, which protects the street name verbatim."""
+    # Current pipeline behaviour: preserves the XENT/XGLO placeholders
+    # the masker injects; only rewrites a couple of connectors.
+    def fake(text: str, **kwargs: Any) -> list[dict[str, str]]:
+        out = text.replace("Fahrbahn", "Roadway").replace(" bis ", " to ")
+        return [{"translation_text": out}]
+
+    monkeypatch.setattr(build_feed, "_get_translation_pipeline", lambda: fake)
+
+    ident = "stadt wien – baustellen|baustelle|L=|D=2026-03-09|T=Fahrbahn|F=abc"
+    de_title = "Fahrbahn Hauptstraße von Apostelgasse bis Schlachthausgasse"
+    state: dict[str, dict[str, Any]] = {
+        ident: {
+            "first_seen": "2026-03-09T00:00:00+00:00",
+            "translations": {
+                # Stale rendering from a pre-street-masking build; note
+                # the ABSENT epoch key → treated as epoch 0 → stale.
+                "en": {
+                    "title": "Roadway Hauptstraße from Apostelgasse to slaughterhouse gas",
+                },
+            },
+        },
+    }
+    out = build_feed._apply_lang_overlay(
+        _fc(de_title), "", "", ident, "en", state,
+        source="Stadt Wien – Baustellen", category="Baustelle",
+    )
+    # Stale broken rendering is gone; the street name survives verbatim.
+    assert "slaughterhouse gas" not in out.title_out
+    assert "Schlachthausgasse" in out.title_out
+    # Cache refreshed and stamped with the current epoch.
+    assert (
+        state[ident]["translations"]["epoch"]
+        == build_feed._TRANSLATION_CACHE_EPOCH
+    )
+    assert "slaughterhouse" not in state[ident]["translations"]["en"]["title"]
+
+
+def test_current_epoch_cache_is_trusted_without_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A translation tagged with the current epoch is served from the
+    cache verbatim — the pipeline is never invoked (proven by a fake
+    that raises if called)."""
+    def boom(text: str, **kwargs: Any) -> list[dict[str, str]]:
+        raise AssertionError("pipeline must not be called for fresh cache")
+
+    monkeypatch.setattr(build_feed, "_get_translation_pipeline", lambda: boom)
+    ident = "fresh-cache-1"
+    state: dict[str, dict[str, Any]] = {
+        ident: {
+            "translations": {
+                "en": {"title": "Cached English title"},
+                "epoch": build_feed._TRANSLATION_CACHE_EPOCH,
+            },
+        },
+    }
+    out = build_feed._apply_lang_overlay(
+        _fc("Deutscher Titel"), "", "", ident, "en", state,
+    )
+    assert out.title_out == "Cached English title"
+    # Epoch unchanged (still current).
+    assert (
+        state[ident]["translations"]["epoch"]
+        == build_feed._TRANSLATION_CACHE_EPOCH
+    )
+
+
+def test_fresh_translation_stamps_current_epoch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A first-time translation stamps the current epoch so the next
+    build trusts the cache instead of recomputing."""
+    def fake(text: str, **kwargs: Any) -> list[dict[str, str]]:
+        return [{"translation_text": text}]
+
+    monkeypatch.setattr(build_feed, "_get_translation_pipeline", lambda: fake)
+    ident = "fresh-stamp-1"
+    state: dict[str, dict[str, Any]] = {}
+    build_feed._apply_lang_overlay(
+        _fc("U6: Betriebsstörung"), "Eine Meldung.", "", ident, "en", state,
+        source="Wiener Linien", category="Störung",
+    )
+    assert (
+        state[ident]["translations"]["epoch"]
+        == build_feed._TRANSLATION_CACHE_EPOCH
+    )
+
+
+def test_epoch_not_stamped_when_pipeline_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient pipeline failure must NOT advance the epoch — the
+    item stays flagged stale so the next (healthy) build retries
+    instead of locking in a half-empty cache at the current epoch."""
+    monkeypatch.setattr(build_feed, "_get_translation_pipeline", lambda: None)
+    ident = "fail-epoch-1"
+    state: dict[str, dict[str, Any]] = {
+        ident: {"translations": {"en": {"title": "stale"}}},  # epoch 0
+    }
+    out = build_feed._apply_lang_overlay(
+        _fc("U6: Betriebsstörung"), "Meldung", "", ident, "en", state,
+    )
+    # Pipeline down → atomic German fallback (base returned unchanged).
+    assert out.title_out == "U6: Betriebsstörung"
+    # Epoch NOT advanced — the entry remains eligible for a retry.
+    assert (
+        state[ident]["translations"].get("epoch", 0)
+        < build_feed._TRANSLATION_CACHE_EPOCH
+    )

--- a/tests/test_translation_coverage.py
+++ b/tests/test_translation_coverage.py
@@ -566,7 +566,7 @@ def test_metadata_glossary_no_cross_operator_contamination(
 # pipeline.
 
 
-def _fc(title_out: str) -> "build_feed.FormattedContent":
+def _fc(title_out: str) -> build_feed.FormattedContent:
     """Minimal FormattedContent whose only meaningful field for the
     overlay is ``title_out`` (the German title to translate)."""
     return build_feed.FormattedContent(


### PR DESCRIPTION
## Symptom (live feed)

```xml
<title>Roadway Hauptstraße from Emmerich-Teuber-Platz and Juchgasse and Apostelgasse to slaughterhouse gas</title>
```

**"slaughterhouse gas"** ist die Wiener Station/Straße **Schlachthausgasse** (U3), wörtlich zerlegt: `Schlachthaus` → "slaughterhouse", `gasse` → "gas". Der Eigenname hätte verbatim erhalten bleiben müssen — und das tut er beim **aktuellen Code auch** (der Street-Suffix-Masker aus #1624 schützt ihn). Die Live-Meldung trägt eine **veraltete** Übersetzung.

## Root Cause: stale Übersetzungs-Cache, der nie invalidiert wird

EN-Übersetzungen werden pro Disruption-Identität in `state[ident]["translations"]["en"]` gecached und über Builds hinweg persistiert. Zwei Mechanismen zusammen erzeugen den Bug:

1. **Cache-Key ≠ Content-Hash.** `_identity_for_item` keyt Baustellen-Items auf `Titel + Datumsbereich`, nicht auf den Content-Hash. Eine **Beschreibungs-Änderung** erzeugt einen neuen Feed-`<guid>` (und setzt `first_seen` zurück auf 24.05.), während die Übersetzungs-Identität stabil bleibt → eine im **März** gecachte Übersetzung (vor dem Street-Masking-Fix #1624) taucht in einem scheinbar „neuen" Item von heute auf. Das erklärt den Widerspruch `first_seen=24.05.` vs. `starts_at=09.03.`.

2. **Keine Retry-Logik für falsche Übersetzungen.** `_cached_translation` erzwingt einen Retry nur, wenn der Cache-Wert dem deutschen Original entspricht (die „Sticky-German"-Heuristik). Ein **falscher-aber-nicht-deutscher** Cache-Wert wie „slaughterhouse gas" wird für die Lebensdauer des Items serviert — bei langen Bauprojekten mehrjährig (`ends_at=2027`).

## Fix: Übersetzungs-Cache-Epoch

Cached Übersetzungen werden mit `_TRANSLATION_CACHE_EPOCH` getaggt. Die Konstante wird hochgezählt, sobald sich Masking-/Glossar-Logik so ändert, dass bereits gecachte Renderings betroffen wären.

`_apply_lang_overlay`:
- **vorne**: `_evict_stale_translations` verwirft die `en`-Einträge, deren Epoch älter ist → die Lookups darunter rechnen mit der verbesserten Pipeline neu
- **hinten**: `_stamp_translation_epoch` stempelt die aktuelle Epoch — **nur** wenn alle Felder erfolgreich übersetzt wurden

Daraus folgen die zwei wichtigen Eigenschaften:
- Ein transienter Pipeline-Ausfall stempelt **nicht** (kein halb-leerer Cache wird auf die aktuelle Epoch eingefroren — nächster Build versucht erneut)
- Ein gesundes Item wird **nicht zweimal** neu übersetzt (kein Churn) — nach dem einmaligen Recompute ist die Epoch aktuell und der Cache wird wieder vertraut

Epoch startet bei **1** und invalidiert damit jeden Vor-Epoch-Cache-Eintrag einmalig — der Street-Suffix-Masker (#1624), das Metadaten-Glossar (#1625) und die Disruption-Core-Scope-Straffung erreichen so auch bereits gecachte Items beim nächsten Build.

**DE-Pfad unberührt**: die Eviction sitzt hinter `if lang != "en": return base`, läuft also nur bei EN-Builds.

## End-to-end Verifikation

```
ident   = stadt wien – baustellen|baustelle|L=|D=|T=Fahrbahn Hauptstraße ...

BEFORE (stale cache, kein epoch):
  title = Roadway Hauptstraße from Apostelgasse and Juchgasse to slaughterhouse gas

AFTER (epoch eviction + retranslate):
  title = Roadway Hauptstraße from Apostelgasse and Juchgasse to Schlachthausgasse
  epoch = 1
```

## Betriebshinweis

Der **erste** Build mit Epoch 1 übersetzt den gesamten Backlog einmalig neu (alle Vor-Epoch-Caches → evict → recompute). Bei ~100–200 Items ein einmaliger Aufwand von wenigen Minuten (torch + HF-Cache sind in den Workflows warm). Danach vertrauen alle Folge-Builds dem Cache.

## Tests
- [x] +4 in `test_translation_coverage.py`:
  - `test_stale_epoch_evicts_and_retranslates` — Regression auf das Schlachthausgasse-Rendering
  - `test_current_epoch_cache_is_trusted_without_pipeline` — Pipeline wird bei frischem Cache nie aufgerufen
  - `test_fresh_translation_stamps_current_epoch` — Epoch-Stempelung nach Erfolg
  - `test_epoch_not_stamped_when_pipeline_fails` — kein Stempel bei transientem Ausfall (Retry bleibt möglich)
- [x] `tests/test_translation_coverage.py` — 14 passed
- [x] `tests/test_{feed_translation,feed_entity_masking,entity_masking_properties,translation_coverage}.py` — 91 passed
- [x] `ruff check src/build_feed.py` — clean
- [x] `mypy --no-pretty src/build_feed.py` — 0 Errors in build_feed.py
- [x] `python scripts/check_complexity.py` — 0 neue C901-Verstöße
- [x] End-to-End-Reproduktion: Schlachthausgasse bleibt erhalten, stale Rendering evicted, Epoch gestempelt
- [ ] **Live-Verifizierung** nach Merge: nächster `update-cycle.yml`-Run mit Epoch 1 ersetzt die „slaughterhouse gas"-Meldung durch „Schlachthausgasse"

https://claude.ai/code/session_01YNjxtfNC9cowFQpTAQo1jk

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNjxtfNC9cowFQpTAQo1jk)_