### PR TITLE
feat(stations): WL OGD coord loader fix + WL→HAFAS→OSM coordinate consensus

### DIFF
--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -549,6 +549,22 @@ def _load_gtfs_locations(path: Path) -> dict[str, LocationInfo]:
     return locations
 
 
+_WL_DIVA_KEY_PREFIX = "diva:"
+
+
+def _wl_diva_key(diva: str) -> str:
+    """Return the namespaced location-index key for a WL DIVA identifier.
+
+    ``_normalize_location_keys`` strips ``:`` (and casefolds), so a DIVA
+    key can never collide with a name-derived key — letting callers that
+    hold a station's ``wl_diva`` resolve coordinates by the authoritative
+    identifier instead of the lossy ``Wien <name> (WL)`` <-> ``<name>``
+    name match.
+    """
+
+    return f"{_WL_DIVA_KEY_PREFIX}{diva}"
+
+
 def _load_wienerlinien_locations(path: Path) -> dict[str, LocationInfo]:
     locations: dict[str, LocationInfo] = {}
     if not path.exists():
@@ -571,12 +587,25 @@ def _load_wienerlinien_locations(path: Path) -> dict[str, LocationInfo]:
     try:
         reader = csv.DictReader(io.StringIO(content), delimiter=";")
         for row in reader:
-            name = row.get("NAME")
+            # The Wiener Linien OGD CSV schema migrated (PR #1442): the
+            # legacy data.wien.gv.at proxy export keyed on NAME /
+            # WGS84_LAT / WGS84_LON; the canonical wienerlinien.at
+            # OGD-Echtzeit export that replaced it renames those to
+            # StopText / Latitude / Longitude and exposes the DIVA. Read
+            # the new names first and fall back to the legacy ones so the
+            # loader survives either upstream shape (mirrors the fuzzy-key
+            # resilience in scripts/update_wl_stations.py).
+            name = row.get("StopText") or row.get("NAME")
             if name:
                 name = _harmonize_station_name(name)
-            lat = _coerce_float_value(row.get("WGS84_LAT"))
-            lon = _coerce_float_value(row.get("WGS84_LON"))
-            if not name or lat is None or lon is None:
+            lat = _coerce_float_value(row.get("Latitude") or row.get("WGS84_LAT"))
+            lon = _coerce_float_value(row.get("Longitude") or row.get("WGS84_LON"))
+            if lat is None or lon is None:
+                continue
+            diva = (row.get("DIVA") or "").strip()
+            if diva:
+                _store_location(locations, _wl_diva_key(diva), lat, lon, source="wl")
+            if not name:
                 continue
             for key in _normalize_location_keys(name):
                 if not key:
@@ -1167,8 +1196,8 @@ def _enrich_manual_stations(
     Resolution order — same fail-cheap-first rationale as ``_enrich_with_osm``
     / ``_enrich_with_hafas`` / ``_enrich_with_google_places``:
 
-      1. **Local index** (``location_index`` = GTFS + VOR coords, free,
-         in-memory). Already built earlier in ``main()`` for the ÖBB
+      1. **Local index** (``location_index`` = GTFS + WL + VOR coords,
+         free, in-memory). Already built earlier in ``main()`` for the ÖBB
          flag-annotation pass; we just re-use it.
       2. **HAFAS LocMatch** (ÖBB Scotty, free, no monthly quota; the same
          tier that ``_enrich_with_hafas`` taps for ÖBB stations). Handles
@@ -1201,12 +1230,18 @@ def _enrich_manual_stations(
             continue
         name = name_raw.strip()
 
-        # 1. Local index (GTFS + VOR coords already loaded by _build_location_index)
+        # 1. Local index. Try the authoritative WL DIVA first (exact key,
+        #    immune to the "Wien <name> (WL)" vs "<name>" mismatch), then
+        #    fall back to the normalized name keys.
         info: LocationInfo | None = None
-        for key in _normalize_location_keys(name):
-            info = location_index.get(key)
-            if info:
-                break
+        wl_diva = entry.get("wl_diva")
+        if isinstance(wl_diva, str) and wl_diva.strip():
+            info = location_index.get(_wl_diva_key(wl_diva.strip()))
+        if info is None:
+            for key in _normalize_location_keys(name):
+                info = location_index.get(key)
+                if info:
+                    break
         if info is not None:
             entry["latitude"] = info.latitude
             entry["longitude"] = info.longitude
@@ -2547,7 +2582,7 @@ def main() -> None:
     # Enrich the manual block (manual_distant_at / manual_foreign_city —
     # the Ostregion Liniennetz stations from PR #1557) that bypassed the
     # ÖBB filter and therefore the ÖBB-side enrichment chain. Re-uses
-    # the location_index built earlier (free GTFS/VOR lookup) and falls
+    # the location_index built earlier (free GTFS/WL/VOR lookup) and falls
     # back to the unmetered HAFAS LocMatch tier — exactly the same
     # cheap-first strategy the ÖBB pipeline already runs.
     #

--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -91,12 +91,66 @@ def _load_scrub_trojan_source_primitives() -> Callable[..., Any]:
     return cast(Callable[..., Any], module.scrub_trojan_source_primitives)
 
 
+def _load_get_bool_env() -> Callable[..., bool]:
+    base_dir = _project_root()
+    if str(base_dir) not in sys.path:
+        sys.path.insert(0, str(base_dir))
+    module = import_module("src.utils.env")
+    return cast(Callable[..., bool], module.get_bool_env)
+
+
+def _load_sanitize_log_arg() -> Callable[..., Any]:
+    base_dir = _project_root()
+    if str(base_dir) not in sys.path:
+        sys.path.insert(0, str(base_dir))
+    module = import_module("src.utils.logging")
+    return cast(Callable[..., Any], module.sanitize_log_arg)
+
+
+def _load_resolve_at_coordinate() -> Callable[..., Any]:
+    base_dir = _project_root()
+    if str(base_dir) not in sys.path:
+        sys.path.insert(0, str(base_dir))
+    module = import_module("src.places.coordinate_consensus")
+    return cast(Callable[..., Any], module.resolve_at_coordinate)
+
+
+def _load_enrich_station_with_hafas() -> Callable[..., Any]:
+    """Lazy HAFAS import — pulls ``requests`` and the HAFAS profile loader,
+    so it is only resolved when the reconciliation pass actually runs.
+    """
+
+    base_dir = _project_root()
+    if str(base_dir) not in sys.path:
+        sys.path.insert(0, str(base_dir))
+    module = import_module("src.places.hafas_client")
+    return cast(Callable[..., Any], module.enrich_station_with_hafas)
+
+
+def _load_osm_place_fetchers() -> tuple[Callable[..., Any], Callable[..., Any]]:
+    """Lazy OSM import — pulls the Overpass client; resolved only when a
+    WL/HAFAS disagreement needs an arbiter.
+    """
+
+    base_dir = _project_root()
+    if str(base_dir) not in sys.path:
+        sys.path.insert(0, str(base_dir))
+    module = import_module("src.places.osm_client")
+    return (
+        cast(Callable[..., Any], module.fetch_osm_places),
+        cast(Callable[..., Any], module.filter_complete_places),
+    )
+
+
 BASE_DIR = _project_root()
 is_in_vienna = _load_is_in_vienna()
 atomic_write = _load_atomic_write()
 read_capped_json = _load_read_capped_json()
 read_capped_text = _load_read_capped_text()
 scrub_trojan_source_primitives = _load_scrub_trojan_source_primitives()
+get_bool_env = _load_get_bool_env()
+sanitize_log_arg = _load_sanitize_log_arg()
+resolve_at_coordinate = _load_resolve_at_coordinate()
 
 # Security cap against wide-but-flat JSON size-bomb attacks. Mirrors the
 # canonical ``MAX_*_FILE_BYTES`` contract from ``src/utils/cache.py`` /
@@ -1264,9 +1318,230 @@ def _lookup_candidates(index: Mapping[str, dict[str, object]], key: object | Non
     return index.get(text)
 
 
+def _wl_coord_index(
+    wl_entries: Iterable[Mapping[str, object]],
+) -> dict[str, tuple[float, float]]:
+    """Map ``wl_diva`` → authoritative WL ``(lat, lon)`` from the payloads.
+
+    The first DIVA wins (payloads are already de-duplicated upstream).
+    Non-finite / out-of-range coordinates are dropped so the consensus
+    resolver never receives an invalid WL anchor.
+    """
+
+    index: dict[str, tuple[float, float]] = {}
+    for payload in wl_entries:
+        diva = str(payload.get("wl_diva") or "").strip()
+        if not diva or diva in index:
+            continue
+        lat = payload.get("latitude")
+        lon = payload.get("longitude")
+        if (
+            isinstance(lat, int | float)
+            and isinstance(lon, int | float)
+            and -90.0 <= lat <= 90.0
+            and -180.0 <= lon <= 180.0
+        ):
+            index[diva] = (float(lat), float(lon))
+    return index
+
+
+def _coord_from_hafas_hit(hit: object) -> tuple[float, float] | None:
+    if not isinstance(hit, Mapping):
+        return None
+    lat = hit.get("lat")
+    lon = hit.get("lon")
+    if isinstance(lat, int | float) and isinstance(lon, int | float):
+        return (float(lat), float(lon))
+    return None
+
+
+def _build_hafas_lookup() -> Callable[[str], tuple[float, float] | None]:
+    """Return a name → ``(lat, lon)`` HAFAS lookup backed by ÖBB Scotty.
+
+    Results are cached per name and every failure degrades to ``None`` so a
+    HAFAS outage can never shift a coordinate or crash the WL merge.
+    """
+
+    enrich = _load_enrich_station_with_hafas()
+    cache: dict[str, tuple[float, float] | None] = {}
+
+    def lookup(name: str) -> tuple[float, float] | None:
+        if name in cache:
+            return cache[name]
+        try:
+            hit = enrich(name)
+        except Exception:  # nosec B902 - HAFAS must never crash the merge
+            log.warning(
+                "HAFAS lookup raised during coordinate reconciliation for %s",
+                sanitize_log_arg(name),
+            )
+            hit = None
+        coord = _coord_from_hafas_hit(hit)
+        cache[name] = coord
+        return coord
+
+    return lookup
+
+
+def _build_osm_index_loader() -> Callable[[], Mapping[str, tuple[float, float]]]:
+    """Return a lazy loader of a normalised-name → ``(lat, lon)`` OSM index.
+
+    The Overpass round-trip happens on first call only; the reconciliation
+    pass invokes it solely when a WL/HAFAS disagreement actually needs an
+    arbiter, so an all-agree run never touches the network. Failures
+    degrade to an empty index (every disagreement then stays unresolved
+    and keeps WL).
+    """
+
+    def loader() -> Mapping[str, tuple[float, float]]:
+        try:
+            fetch_osm_places, filter_complete_places = _load_osm_place_fetchers()
+            places = filter_complete_places(fetch_osm_places())
+        except Exception as exc:  # nosec B902 - OSM must never crash the merge
+            log.warning(
+                "OSM fetch for coordinate arbitration failed: %s",
+                sanitize_log_arg(type(exc).__name__),
+            )
+            return {}
+        index: dict[str, tuple[float, float]] = {}
+        for place in places:
+            key = _normalize_key(getattr(place, "name", None))
+            lat = getattr(place, "latitude", None)
+            lon = getattr(place, "longitude", None)
+            if (
+                key
+                and key not in index
+                and isinstance(lat, int | float)
+                and isinstance(lon, int | float)
+            ):
+                index[key] = (float(lat), float(lon))
+        return index
+
+    return loader
+
+
+def _apply_coordinate_decision(entry: dict[str, object], decision: Any) -> None:
+    """Write a :class:`CoordinateDecision` onto a merged station entry.
+
+    Coordinates are rounded to 6 decimals to match the WL aggregation
+    precision and keep the committed ``stations.json`` diff stable, and the
+    decision's provider tokens are folded into the ``source`` field.
+    """
+
+    entry["latitude"] = round(float(decision.latitude), 6)
+    entry["longitude"] = round(float(decision.longitude), 6)
+    entry["source"] = _merge_sources(entry.get("source"), *decision.sources)
+
+
+def _reconcile_at_overlap(
+    entries: list[dict[str, object]],
+    wl_coord_by_diva: Mapping[str, tuple[float, float]],
+    *,
+    hafas_lookup: Callable[[str], tuple[float, float] | None],
+    osm_index_loader: Callable[[], Mapping[str, tuple[float, float]]] | None = None,
+    agree_tolerance_m: float = 150.0,
+    osm_sanity_radius_m: float = 500.0,
+) -> None:
+    """Apply the ``WL → HAFAS → OSM`` coordinate priority to overlap entries.
+
+    Only entries carrying BOTH a ``wl_diva`` with a known WL coordinate and
+    a HAFAS identity (``hafas_extId`` / ``eva_nr``) are reconciled — the
+    multimodal hubs where a Wiener-Linien stop and an ÖBB station were
+    unified. WL is authoritative; HAFAS is cross-checked; OSM (fetched
+    lazily, only when a disagreement exists) arbitrates by endorsing the
+    candidate closer to it. A missing HAFAS result is a deliberate no-op:
+    a transient outage must never shift a coordinate. An unresolvable
+    conflict keeps WL (highest priority) and is logged for review — Google
+    is the gap-fill of last resort for coordinate-less stations, not an
+    arbiter between two Austrian sources.
+    """
+
+    pending_osm: list[
+        tuple[dict[str, object], tuple[float, float], tuple[float, float]]
+    ] = []
+    agreed = 0
+    skipped_no_hafas = 0
+
+    for entry in entries:
+        diva = str(entry.get("wl_diva") or "").strip()
+        if not diva:
+            continue
+        wl = wl_coord_by_diva.get(diva)
+        if wl is None:
+            continue
+        if not (entry.get("hafas_extId") or entry.get("eva_nr")):
+            # WL-only stop: no second Austrian source to reconcile against.
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        hafas = hafas_lookup(name.strip())
+        if hafas is None:
+            skipped_no_hafas += 1
+            continue
+        decision = resolve_at_coordinate(
+            wl=wl, hafas=hafas, agree_tolerance_m=agree_tolerance_m
+        )
+        if decision.decision == "wl_hafas_agree":
+            _apply_coordinate_decision(entry, decision)
+            agreed += 1
+        else:
+            # WL and HAFAS disagree → defer until OSM (the arbiter) is loaded.
+            pending_osm.append((entry, wl, hafas))
+
+    osm_index: Mapping[str, tuple[float, float]] = {}
+    if pending_osm and osm_index_loader is not None:
+        osm_index = osm_index_loader()
+
+    picked_wl = picked_hafas = unresolved = 0
+    for entry, wl, hafas in pending_osm:
+        name = str(entry.get("name") or "")
+        osm = osm_index.get(_normalize_key(name))
+        decision = resolve_at_coordinate(
+            wl=wl,
+            hafas=hafas,
+            osm=osm,
+            agree_tolerance_m=agree_tolerance_m,
+            osm_sanity_radius_m=osm_sanity_radius_m,
+        )
+        _apply_coordinate_decision(entry, decision)
+        if decision.decision == "osm_picked_hafas":
+            picked_hafas += 1
+            log.warning(
+                "WL/HAFAS coordinate conflict for %s: OSM endorsed HAFAS",
+                sanitize_log_arg(name),
+            )
+        elif decision.decision == "osm_picked_wl":
+            picked_wl += 1
+            log.warning(
+                "WL/HAFAS coordinate conflict for %s: OSM endorsed WL",
+                sanitize_log_arg(name),
+            )
+        else:
+            unresolved += 1
+            log.warning(
+                "WL/HAFAS coordinate conflict for %s unresolved (OSM "
+                "unavailable or implausible); kept WL",
+                sanitize_log_arg(name),
+            )
+
+    if agreed or pending_osm or skipped_no_hafas:
+        log.info(
+            "AT coordinate reconciliation: %d agreed, %d OSM->WL, %d OSM->HAFAS, "
+            "%d unresolved, %d not cross-checkable",
+            agreed,
+            picked_wl,
+            picked_hafas,
+            unresolved,
+            skipped_no_hafas,
+        )
+
+
 def merge_into_stations(
     stations_path: Path,
     wl_entries: list[dict[str, Any]],
+    *,
+    reconcile: Callable[[list[dict[str, object]]], None] | None = None,
 ) -> None:
     # Security: ``read_capped_json`` enforces both the depth-bomb catch
     # tuple and the byte-size cap (see MAX_JSON_FILE_BYTES). The
@@ -1381,6 +1656,14 @@ def merge_into_stations(
 
     filtered.extend(unmatched)
 
+    # Coordinate consensus (WL → HAFAS → OSM → Google): runs on the fully
+    # merged list so overlap entries already carry both ``wl_diva`` and the
+    # ÖBB-side HAFAS identity. Optional so direct callers / unit tests keep
+    # the historical no-reconcile behaviour; ``main()`` injects the real,
+    # network-backed pass behind the ``WIEN_OEPNV_AT_RECONCILE`` gate.
+    if reconcile is not None:
+        reconcile(filtered)
+
     # Security (Trojan-Source / BiDi-Mark Drift Round 14, ingestion-boundary
     # defence): strip the canonical CVE-2021-42574 attack-byte union from
     # the merged stations BEFORE ``json.dump``. A planted Wien OGD CSV
@@ -1447,7 +1730,33 @@ def main(argv: Sequence[str] | None = None) -> int:
     wl_entries = build_wl_entries(haltestellen, haltepunkte, vor_mapping)
     log.info("Prepared %d WL station entries", len(wl_entries))
 
-    merge_into_stations(args.stations, wl_entries)
+    # Austrian-source coordinate consensus (WL → HAFAS → OSM → Google).
+    # Env-disabled via ``WIEN_OEPNV_AT_RECONCILE=0`` — mirrors the
+    # ``WIEN_OEPNV_OSM_ENRICH`` gate so the orchestrator wrapper test can
+    # skip the ~40 real HAFAS round-trips (and a possible Overpass call)
+    # that would otherwise tip it over its pytest timeout. Production cron
+    # runs leave the env unset so reconciliation remains active.
+    reconcile: Callable[[list[dict[str, object]]], None] | None = None
+    if get_bool_env("WIEN_OEPNV_AT_RECONCILE", True):
+        wl_coord_by_diva = _wl_coord_index(wl_entries)
+        hafas_lookup = _build_hafas_lookup()
+        osm_index_loader = _build_osm_index_loader()
+
+        def _run_reconcile(merged: list[dict[str, object]]) -> None:
+            _reconcile_at_overlap(
+                merged,
+                wl_coord_by_diva,
+                hafas_lookup=hafas_lookup,
+                osm_index_loader=osm_index_loader,
+            )
+
+        reconcile = _run_reconcile
+    else:
+        log.info(
+            "Skipping AT coordinate reconciliation (WIEN_OEPNV_AT_RECONCILE=0)"
+        )
+
+    merge_into_stations(args.stations, wl_entries, reconcile=reconcile)
     return 0
 
 

--- a/src/places/__init__.py
+++ b/src/places/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 __all__ = [
     "client",
+    "coordinate_consensus",
     "merge",
     "normalize",
     "osm_client",

--- a/src/places/coordinate_consensus.py
+++ b/src/places/coordinate_consensus.py
@@ -1,0 +1,143 @@
+"""Coordinate consensus for the Austrian-source station directory.
+
+Implements the ``WL -> HAFAS -> OSM -> Google`` priority chain used by the
+weekly station-directory refresh (``scripts/update_wl_stations.py``).
+
+Wiener Linien is the authoritative source for a Vienna stop coordinate;
+HAFAS (ÖBB) is the second Austrian source. When both are present and
+agree (distance ``<=`` tolerance) the WL coordinate is kept. When they
+disagree, OpenStreetMap arbitrates by endorsing whichever of the two
+lies closer to it. OSM is consulted only as a tie-breaker — never as a
+primary source — and Google Places stays the gap-fill of last resort for
+a station that has *no* coordinate at all (handled elsewhere in the
+pipeline), never an arbiter between two Austrian sources.
+
+The module is deliberately pure (no I/O, no network): callers inject the
+already-resolved WL / HAFAS / OSM coordinates so the policy is trivially
+unit-testable and deterministic across cron runs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+from ..utils.geo import calculate_distance_meters
+
+#: ``WL`` and ``HAFAS`` are treated as the same location when no further
+#: apart than this. Matches ``STATION_DRIFT_TOLERANCE_METERS`` (150 m): the
+#: multimodal hubs in the WL∩HAFAS overlap legitimately span >100 m between
+#: the tram/bus stop centroid and the rail station point, so a tighter
+#: bound would flag every large station as a conflict.
+DEFAULT_AGREE_TOLERANCE_M: Final = 150.0
+
+#: OSM may only break a WL/HAFAS tie when it sits within this radius of at
+#: least one candidate. Beyond it the OSM hit is implausible (wrong match /
+#: stale node) and the conflict is left unresolved rather than trusting a
+#: far-away arbiter.
+DEFAULT_OSM_SANITY_RADIUS_M: Final = 500.0
+
+Coordinate = tuple[float, float]
+
+
+@dataclass(frozen=True)
+class CoordinateDecision:
+    """Outcome of :func:`resolve_at_coordinate`.
+
+    ``decision`` is a stable machine token for logging / tests:
+    ``wl_hafas_agree``, ``osm_picked_wl``, ``osm_picked_hafas``,
+    ``unresolved_kept_wl`` or ``wl_only``. ``sources`` lists the provider
+    tokens that contributed to the decision so the caller can merge them
+    into the entry's ``source`` field.
+    """
+
+    latitude: float
+    longitude: float
+    chosen_source: str
+    decision: str
+    sources: tuple[str, ...]
+
+
+def _valid(coord: Coordinate | None) -> Coordinate | None:
+    """Return ``coord`` as floats iff it is a finite, in-range WGS-84 pair.
+
+    ``None``, ``NaN``, ``inf`` and out-of-range values all collapse to
+    ``None`` so the resolver can treat an unusable source as absent rather
+    than raising from the distance helper.
+    """
+
+    if coord is None:
+        return None
+    lat, lon = coord
+    # NaN fails every comparison, so the range checks also reject NaN/inf.
+    if not (-90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0):
+        return None
+    return (float(lat), float(lon))
+
+
+def resolve_at_coordinate(
+    *,
+    wl: Coordinate,
+    hafas: Coordinate | None,
+    osm: Coordinate | None = None,
+    agree_tolerance_m: float = DEFAULT_AGREE_TOLERANCE_M,
+    osm_sanity_radius_m: float = DEFAULT_OSM_SANITY_RADIUS_M,
+) -> CoordinateDecision:
+    """Resolve a station coordinate per the WL→HAFAS→OSM→Google priority.
+
+    Args:
+        wl: The authoritative Wiener-Linien coordinate. Required and must
+            be a valid WGS-84 pair.
+        hafas: The HAFAS (ÖBB) coordinate, or ``None`` when the station is
+            not cross-checkable against HAFAS.
+        osm: The OpenStreetMap coordinate used to arbitrate a WL/HAFAS
+            disagreement, or ``None`` when unavailable.
+        agree_tolerance_m: WL/HAFAS agreement threshold in metres.
+        osm_sanity_radius_m: Maximum distance OSM may sit from a candidate
+            and still be trusted as the arbiter.
+
+    Returns:
+        A :class:`CoordinateDecision` naming the winning coordinate, source
+        and a machine-readable ``decision`` token.
+
+    Raises:
+        ValueError: If ``wl`` is not a valid WGS-84 coordinate.
+    """
+
+    wl_valid = _valid(wl)
+    if wl_valid is None:
+        raise ValueError("resolve_at_coordinate requires a valid WL coordinate")
+    wl_lat, wl_lon = wl_valid
+
+    hafas_valid = _valid(hafas)
+    if hafas_valid is None:
+        # No second Austrian source to cross-check against — WL stands.
+        return CoordinateDecision(wl_lat, wl_lon, "wl", "wl_only", ("wl",))
+    haf_lat, haf_lon = hafas_valid
+
+    if calculate_distance_meters(wl_lat, wl_lon, haf_lat, haf_lon) <= agree_tolerance_m:
+        return CoordinateDecision(
+            wl_lat, wl_lon, "wl", "wl_hafas_agree", ("wl", "hafas")
+        )
+
+    # WL and HAFAS disagree → let OSM decide which one is correct.
+    osm_valid = _valid(osm)
+    if osm_valid is not None:
+        osm_lat, osm_lon = osm_valid
+        dist_wl = calculate_distance_meters(osm_lat, osm_lon, wl_lat, wl_lon)
+        dist_haf = calculate_distance_meters(osm_lat, osm_lon, haf_lat, haf_lon)
+        if min(dist_wl, dist_haf) <= osm_sanity_radius_m:
+            if dist_haf < dist_wl:
+                return CoordinateDecision(
+                    haf_lat, haf_lon, "hafas", "osm_picked_hafas",
+                    ("wl", "hafas", "osm"),
+                )
+            return CoordinateDecision(
+                wl_lat, wl_lon, "wl", "osm_picked_wl", ("wl", "hafas", "osm")
+            )
+
+    # OSM missing or implausibly far from both → keep the highest-priority
+    # source (WL) and let the caller flag the unresolved conflict.
+    return CoordinateDecision(
+        wl_lat, wl_lon, "wl", "unresolved_kept_wl", ("wl", "hafas")
+    )

--- a/tests/test_at_coordinate_consensus.py
+++ b/tests/test_at_coordinate_consensus.py
@@ -1,0 +1,280 @@
+"""Tests for the Austrian-source coordinate consensus (WL → HAFAS → OSM).
+
+Covers the pure policy resolver (:mod:`src.places.coordinate_consensus`)
+and the overlap reconciliation pass wired into
+:mod:`scripts.update_wl_stations`. Both are exercised without network: the
+resolver is pure, and the reconciliation pass takes injected HAFAS / OSM
+lookups.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from scripts import update_wl_stations
+from src.places.coordinate_consensus import (
+    CoordinateDecision,
+    resolve_at_coordinate,
+)
+
+# A WL anchor in central Vienna plus offsets with known great-circle gaps
+# (≈111 m per 0.001° of latitude):
+_WL = (48.2000, 16.3700)
+_HAFAS_NEAR = (48.2009, 16.3700)  # ~100 m from _WL  → agreement
+_HAFAS_FAR = (48.2030, 16.3700)  # ~334 m from _WL  → disagreement
+_OSM_BY_HAFAS = (48.2028, 16.3700)  # ~22 m from _HAFAS_FAR, ~311 m from _WL
+_OSM_BY_WL = (48.2002, 16.3700)  # ~22 m from _WL, ~311 m from _HAFAS_FAR
+_OSM_FAR = (48.2100, 16.3700)  # >500 m from both candidates
+
+
+# --------------------------------------------------------------------------
+# resolve_at_coordinate — the pure policy.
+# --------------------------------------------------------------------------
+
+
+def test_wl_and_hafas_agree_keeps_wl() -> None:
+    decision = resolve_at_coordinate(wl=_WL, hafas=_HAFAS_NEAR)
+    assert decision.decision == "wl_hafas_agree"
+    assert decision.chosen_source == "wl"
+    assert (decision.latitude, decision.longitude) == _WL
+    assert decision.sources == ("wl", "hafas")
+
+
+def test_missing_hafas_is_wl_only() -> None:
+    decision = resolve_at_coordinate(wl=_WL, hafas=None)
+    assert decision.decision == "wl_only"
+    assert (decision.latitude, decision.longitude) == _WL
+    assert decision.sources == ("wl",)
+
+
+def test_disagreement_osm_endorses_hafas() -> None:
+    decision = resolve_at_coordinate(wl=_WL, hafas=_HAFAS_FAR, osm=_OSM_BY_HAFAS)
+    assert decision.decision == "osm_picked_hafas"
+    assert decision.chosen_source == "hafas"
+    assert (decision.latitude, decision.longitude) == _HAFAS_FAR
+    assert decision.sources == ("wl", "hafas", "osm")
+
+
+def test_disagreement_osm_endorses_wl() -> None:
+    decision = resolve_at_coordinate(wl=_WL, hafas=_HAFAS_FAR, osm=_OSM_BY_WL)
+    assert decision.decision == "osm_picked_wl"
+    assert (decision.latitude, decision.longitude) == _WL
+    assert decision.sources == ("wl", "hafas", "osm")
+
+
+def test_disagreement_without_osm_keeps_wl() -> None:
+    decision = resolve_at_coordinate(wl=_WL, hafas=_HAFAS_FAR, osm=None)
+    assert decision.decision == "unresolved_kept_wl"
+    assert (decision.latitude, decision.longitude) == _WL
+    assert decision.sources == ("wl", "hafas")
+
+
+def test_disagreement_osm_far_from_both_is_unresolved() -> None:
+    decision = resolve_at_coordinate(wl=_WL, hafas=_HAFAS_FAR, osm=_OSM_FAR)
+    assert decision.decision == "unresolved_kept_wl"
+    assert (decision.latitude, decision.longitude) == _WL
+
+
+def test_tolerance_boundary_is_inclusive() -> None:
+    from src.utils.geo import calculate_distance_meters
+
+    gap = calculate_distance_meters(_WL[0], _WL[1], _HAFAS_FAR[0], _HAFAS_FAR[1])
+    # Exactly at the gap the inclusive ``<=`` must count as agreement …
+    at_boundary = resolve_at_coordinate(
+        wl=_WL, hafas=_HAFAS_FAR, agree_tolerance_m=gap
+    )
+    assert at_boundary.decision == "wl_hafas_agree"
+    # … and a hair below it flips to a disagreement.
+    below = resolve_at_coordinate(
+        wl=_WL, hafas=_HAFAS_FAR, agree_tolerance_m=gap - 0.01
+    )
+    assert below.decision != "wl_hafas_agree"
+
+
+def test_invalid_wl_raises() -> None:
+    with pytest.raises(ValueError):
+        resolve_at_coordinate(wl=(91.0, 16.37), hafas=_HAFAS_NEAR)
+
+
+def test_non_finite_hafas_treated_as_absent() -> None:
+    decision = resolve_at_coordinate(wl=_WL, hafas=(float("nan"), 16.37))
+    assert decision.decision == "wl_only"
+
+
+# --------------------------------------------------------------------------
+# _reconcile_at_overlap — the wired pass over merged entries.
+# --------------------------------------------------------------------------
+
+
+class _FakeHafas:
+    """Records every queried name and replies from a fixed table."""
+
+    def __init__(self, table: Mapping[str, tuple[float, float] | None]) -> None:
+        self._table = table
+        self.queried: list[str] = []
+
+    def __call__(self, name: str) -> tuple[float, float] | None:
+        self.queried.append(name)
+        return self._table.get(name)
+
+
+class _FakeOsm:
+    """Lazy OSM index loader that counts how many times it is invoked."""
+
+    def __init__(self, index: Mapping[str, tuple[float, float]]) -> None:
+        self._index = index
+        self.calls = 0
+
+    def __call__(self) -> Mapping[str, tuple[float, float]]:
+        self.calls += 1
+        return self._index
+
+
+def _entry(**kwargs: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "name": "Wien Test",
+        "latitude": 48.2500,
+        "longitude": 16.4000,
+        "source": "oebb,oebb_geonetz",
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_overlap_agreement_promotes_wl_coordinate() -> None:
+    entry = _entry(
+        name="Wien Hbf", wl_diva="60200096", hafas_extId="1290401", source="oebb,wl"
+    )
+    hafas = _FakeHafas({"Wien Hbf": _HAFAS_NEAR})
+    osm = _FakeOsm({})
+
+    update_wl_stations._reconcile_at_overlap(
+        [entry],
+        {"60200096": _WL},
+        hafas_lookup=hafas,
+        osm_index_loader=osm,
+    )
+
+    assert (entry["latitude"], entry["longitude"]) == _WL
+    assert "hafas" in str(entry["source"]).split(",")
+    assert osm.calls == 0  # agreement never needs the arbiter
+
+
+def test_overlap_disagreement_osm_picks_hafas() -> None:
+    entry = _entry(
+        name="Wien Floridsdorf", wl_diva="60200999", eva_nr="8100test", source="oebb,wl"
+    )
+    hafas = _FakeHafas({"Wien Floridsdorf": _HAFAS_FAR})
+    osm = _FakeOsm({update_wl_stations._normalize_key("Wien Floridsdorf"): _OSM_BY_HAFAS})
+
+    update_wl_stations._reconcile_at_overlap(
+        [entry],
+        {"60200999": _WL},
+        hafas_lookup=hafas,
+        osm_index_loader=osm,
+    )
+
+    assert (entry["latitude"], entry["longitude"]) == _HAFAS_FAR
+    assert set(str(entry["source"]).split(",")) >= {"hafas", "osm", "wl"}
+    assert osm.calls == 1
+
+
+def test_missing_hafas_leaves_coordinate_untouched() -> None:
+    entry = _entry(
+        name="Wien Mitte", wl_diva="60200111", hafas_extId="x", source="oebb,wl"
+    )
+    before = (entry["latitude"], entry["longitude"], entry["source"])
+    hafas = _FakeHafas({"Wien Mitte": None})  # transient outage / not in HAFAS
+    osm = _FakeOsm({})
+
+    update_wl_stations._reconcile_at_overlap(
+        [entry],
+        {"60200111": _WL},
+        hafas_lookup=hafas,
+        osm_index_loader=osm,
+    )
+
+    assert (entry["latitude"], entry["longitude"], entry["source"]) == before
+    assert osm.calls == 0
+
+
+def test_non_overlap_entry_is_never_queried() -> None:
+    # wl_diva present but no HAFAS identity → not part of the overlap.
+    entry = _entry(name="Stephansplatz", wl_diva="60200222", source="wl")
+    before = (entry["latitude"], entry["longitude"])
+    hafas = _FakeHafas({"Stephansplatz": _HAFAS_FAR})
+    osm = _FakeOsm({})
+
+    update_wl_stations._reconcile_at_overlap(
+        [entry],
+        {"60200222": _WL},
+        hafas_lookup=hafas,
+        osm_index_loader=osm,
+    )
+
+    assert (entry["latitude"], entry["longitude"]) == before
+    assert hafas.queried == []
+    assert osm.calls == 0
+
+
+def test_osm_loader_invoked_once_for_multiple_conflicts() -> None:
+    entries = [
+        _entry(name="Wien A", wl_diva="1", hafas_extId="a", source="oebb,wl"),
+        _entry(name="Wien B", wl_diva="2", hafas_extId="b", source="oebb,wl"),
+    ]
+    hafas = _FakeHafas({"Wien A": _HAFAS_FAR, "Wien B": _HAFAS_FAR})
+    osm = _FakeOsm(
+        {
+            update_wl_stations._normalize_key("Wien A"): _OSM_BY_WL,
+            update_wl_stations._normalize_key("Wien B"): _OSM_BY_HAFAS,
+        }
+    )
+
+    update_wl_stations._reconcile_at_overlap(
+        entries,
+        {"1": _WL, "2": _WL},
+        hafas_lookup=hafas,
+        osm_index_loader=osm,
+    )
+
+    assert osm.calls == 1
+    assert (entries[0]["latitude"], entries[0]["longitude"]) == _WL
+    assert (entries[1]["latitude"], entries[1]["longitude"]) == _HAFAS_FAR
+
+
+def test_wl_coord_index_skips_invalid_and_dedupes() -> None:
+    index = update_wl_stations._wl_coord_index(
+        [
+            {"wl_diva": "1", "latitude": 48.2, "longitude": 16.37},
+            {"wl_diva": "1", "latitude": 48.9, "longitude": 16.0},  # dup → ignored
+            {"wl_diva": "2", "latitude": 999.0, "longitude": 16.0},  # invalid
+            {"wl_diva": "", "latitude": 48.2, "longitude": 16.0},  # no diva
+        ]
+    )
+    assert index == {"1": (48.2, 16.37)}
+
+
+def test_reconcile_skips_entry_without_known_wl_coordinate() -> None:
+    entry = _entry(name="Wien Ghost", wl_diva="absent", hafas_extId="z")
+    before = (entry["latitude"], entry["longitude"])
+    hafas = _FakeHafas({"Wien Ghost": _HAFAS_NEAR})
+    osm = _FakeOsm({})
+
+    update_wl_stations._reconcile_at_overlap(
+        [entry],
+        {},  # no WL coordinate for this diva
+        hafas_lookup=hafas,
+        osm_index_loader=osm,
+    )
+
+    assert (entry["latitude"], entry["longitude"]) == before
+    assert hafas.queried == []
+
+
+def test_coordinate_decision_is_frozen() -> None:
+    decision = CoordinateDecision(48.2, 16.37, "wl", "wl_only", ("wl",))
+    with pytest.raises(FrozenInstanceError):
+        decision.latitude = 0.0  # type: ignore[misc]

--- a/tests/test_update_all_stations_wrapper.py
+++ b/tests/test_update_all_stations_wrapper.py
@@ -274,6 +274,13 @@ def test_wrapper_atomic_on_success(tmp_path: Path) -> None:
     # The manual-enrichment helper is exercised in isolation by
     # ``tests/test_update_station_directory_manual_enrichment.py``.
     env["WIEN_OEPNV_MANUAL_ENRICH"] = "0"
+    # Also disable the WL↔HAFAS coordinate reconciliation (added with the
+    # Austrian-source consensus): for the ~40 multimodal overlap hubs it
+    # fires real HAFAS round-trips (and a possible Overpass call), the same
+    # network cost that ``WIEN_OEPNV_OSM_ENRICH=0`` exists to keep out of
+    # this timing-sensitive wrapper test. The pass is exercised in
+    # isolation by ``tests/test_at_coordinate_consensus.py``.
+    env["WIEN_OEPNV_AT_RECONCILE"] = "0"
 
     target_stations, wrapper_args = _wrapper_args_for(tmp_path)
 

--- a/tests/test_update_station_directory_manual_enrichment.py
+++ b/tests/test_update_station_directory_manual_enrichment.py
@@ -164,3 +164,46 @@ def test_skips_entry_with_blank_name(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert usd._enrich_manual_stations([entry], {}) == 0
     assert "latitude" not in entry
+
+
+def test_local_index_resolves_via_wl_diva_before_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A WL station whose display name (``Wien Herrengasse (WL)``) cannot
+    match the bare WL stop name resolves via its authoritative ``wl_diva``
+    key — never touching the metered HAFAS/Google tiers."""
+    entry = _manual("Wien Herrengasse (WL)", wl_diva="60200506")
+    # Only the DIVA key carries the coordinate; the normalized name keys
+    # ("wien herrengasse", ...) are deliberately ABSENT from the index.
+    location_index = {usd._wl_diva_key("60200506"): _location(48.2095, 16.3658, source="wl")}
+
+    def _explode_if_called(_name: str) -> object:
+        raise AssertionError("HAFAS must not be called when the WL DIVA resolves")
+
+    monkeypatch.setattr(usd, "enrich_station_with_hafas", _explode_if_called)
+    enriched = usd._enrich_manual_stations([entry], location_index)
+
+    assert enriched == 1
+    assert entry["latitude"] == 48.2095
+    assert entry["longitude"] == 16.3658
+    # Source merge: 'manual' (existing) + 'wl' (DIVA-index source), comma-sorted.
+    assert entry["source"] == "manual,wl"
+
+
+def test_falls_back_to_name_when_wl_diva_not_indexed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``wl_diva`` that is absent from the index must not short-circuit
+    resolution — the normalized name keys remain the fallback."""
+    entry = _manual("Wolkersdorf", wl_diva="99999999")  # DIVA not in index
+    location_index = {"wolkersdorf": _location(48.3784, 16.5127, source="wl")}
+
+    def _explode_if_called(_name: str) -> object:
+        raise AssertionError("HAFAS must not be called when the name index hits")
+
+    monkeypatch.setattr(usd, "enrich_station_with_hafas", _explode_if_called)
+    enriched = usd._enrich_manual_stations([entry], location_index)
+
+    assert enriched == 1
+    assert entry["latitude"] == 48.3784
+    assert entry["longitude"] == 16.5127

--- a/tests/test_update_station_directory_wl_loader.py
+++ b/tests/test_update_station_directory_wl_loader.py
@@ -1,0 +1,92 @@
+"""Coverage for ``_load_wienerlinien_locations`` (the WL OGD coordinate tier).
+
+Regression context: the loader read the pre-migration ``NAME`` /
+``WGS84_LAT`` / ``WGS84_LON`` columns, but the canonical wienerlinien.at
+OGD-Echtzeit CSV that replaced the legacy data.wien.gv.at proxy renamed
+those to ``StopText`` / ``Latitude`` / ``Longitude`` and exposes the
+``DIVA``. The mismatch made the loader silently load ZERO of ~5123 rows,
+so WL stations that should have resolved from the free on-disk snapshot
+fell through to the metered Google Places tier.
+
+These tests pin: the current schema loads (name keys + the authoritative
+DIVA key), the legacy schema still loads via fallback, and the pinned
+repository snapshot yields coordinates (the direct regression guard).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import update_station_directory as usd
+
+
+def test_loads_current_ogd_schema(tmp_path: Path) -> None:
+    """The post-migration ``StopText`` / ``Latitude`` / ``Longitude`` /
+    ``DIVA`` schema must load — both name keys and the DIVA key."""
+    csv_path = tmp_path / "haltepunkte.csv"
+    csv_path.write_text(
+        "StopID;DIVA;StopText;Municipality;MunicipalityID;Longitude;Latitude\n"
+        "2001;60200506;Herrengasse;Wien;49000001;16.3658;48.2095\n"
+        "2002;60200506;Herrengasse;Wien;49000001;16.3660;48.2096\n"
+        "3001;60201430;Volkstheater;Wien;49000001;16.3580;48.2051\n",
+        encoding="utf-8",
+    )
+
+    locations = usd._load_wienerlinien_locations(csv_path)
+
+    assert locations, "loader must not be empty for the current OGD schema"
+    # DIVA key resolves to the first platform coordinate (representative
+    # point for the stop — _store_location keeps the first write).
+    diva_info = locations[usd._wl_diva_key("60200506")]
+    assert diva_info.latitude == pytest.approx(48.2095)
+    assert diva_info.longitude == pytest.approx(16.3658)
+    assert "wl" in diva_info.sources
+    # Name keys keep working alongside the DIVA key.
+    assert "herrengasse" in locations
+    assert "volkstheater" in locations
+
+
+def test_legacy_schema_still_loads(tmp_path: Path) -> None:
+    """The pre-migration ``NAME`` / ``WGS84_LAT`` / ``WGS84_LON`` columns
+    must still resolve via the legacy fallback."""
+    csv_path = tmp_path / "legacy.csv"
+    csv_path.write_text(
+        "NAME;WGS84_LAT;WGS84_LON\n"
+        "Stephansplatz;48.2081;16.3716\n",
+        encoding="utf-8",
+    )
+
+    locations = usd._load_wienerlinien_locations(csv_path)
+
+    assert "stephansplatz" in locations
+    info = locations["stephansplatz"]
+    assert info.latitude == pytest.approx(48.2081)
+    assert info.longitude == pytest.approx(16.3716)
+
+
+def test_rows_without_coordinates_are_skipped(tmp_path: Path) -> None:
+    """A row missing usable coordinates contributes nothing (no crash)."""
+    csv_path = tmp_path / "partial.csv"
+    csv_path.write_text(
+        "StopID;DIVA;StopText;Longitude;Latitude\n"
+        "1;60200001;NoCoords;;\n"
+        "2;60200002;HasCoords;16.40;48.20\n",
+        encoding="utf-8",
+    )
+
+    locations = usd._load_wienerlinien_locations(csv_path)
+
+    assert usd._wl_diva_key("60200001") not in locations
+    assert usd._wl_diva_key("60200002") in locations
+
+
+def test_pinned_repository_snapshot_yields_coordinates() -> None:
+    """Regression guard for the dead-column bug: the pinned WL OGD
+    snapshot must produce coordinates (it loaded ZERO before the fix)."""
+    locations = usd._load_wienerlinien_locations(usd.DEFAULT_WL_HALTEPUNKTE_PATH)
+
+    assert len(locations) > 1000
+    # A known WL DIVA (Herrengasse) must resolve via the authoritative key.
+    assert usd._wl_diva_key("60200506") in locations


### PR DESCRIPTION
This branch now carries **two related commits**. The second builds on the first (the consensus needs WL coordinates to actually load), so they ship together.

---

## Commit 1 — `fix(stations)`: load WL OGD coords via current CSV schema + DIVA key

### Problem
The directory build's Wiener-Linien coordinate tier was silently dead. `_load_wienerlinien_locations` read the pre-migration columns `NAME` / `WGS84_LAT` / `WGS84_LON`, but the canonical wienerlinien.at OGD-Echtzeit CSV (PR #1442) renamed those to `StopText` / `Latitude` / `Longitude` and exposes the `DIVA`. Result: `rows in CSV = 5123, coords loaded = 0` → no-op, so WL stations fell through to the **metered Google Places** tier (the entire 18/18 Google remainder were Vienna WL stops). A second defect: the index was keyed by normalized **name**, and `Wien …(WL)` never matches the bare WL stop name; the authoritative `DIVA` (present in both `stations.json` and the CSV) was unused.

### Fix
- Read current column names with a legacy fallback (`StopText`/`NAME`, `Latitude`/`WGS84_LAT`, …). Loader now yields **4122** coords (was 0).
- Index each stop by its authoritative `DIVA` (`diva:`, collision-safe).
- Resolve manual entries by `wl_diva` **before** name keys.

This is a root-cause/forward-looking fix; it deliberately does not rewrite the 18 already-populated entries (enrichment is idempotent and coordinate inertia keeps stable coords).

---

## Commit 2 — `feat(stations)`: reconcile WL/HAFAS coords via OSM-arbitrated consensus

Implements the Austrian-source coordinate priority **WL → HAFAS → OSM → Google** for the weekly refresh.

**Policy** (`src/places/coordinate_consensus.py`, pure + unit-tested):
- Wiener Linien is authoritative; HAFAS (ÖBB) is the second Austrian source.
- **WL & HAFAS agree** (≤ 150 m) → keep WL.
- **They disagree** → OpenStreetMap arbitrates by endorsing whichever candidate lies closer to it (OSM must be within a 500 m sanity radius of one of them).
- **Unresolvable** (OSM missing / implausible) → keep WL (highest priority) and log for review. Google stays the gap-fill of last resort for *coordinate-less* stations — never an arbiter between two Austrian sources.

**Where & how** (`scripts/update_wl_stations.py`): runs inside `merge_into_stations` on the fully merged list, so the ~40 multimodal overlap hubs already carry both `wl_diva` and the ÖBB-side HAFAS identity (`hafas_extId` / `eva_nr`). This is the last step that touches those coordinates, so it is the authoritative decision.

**Cost / safety:**
- HAFAS is queried **only** for the ~40 overlap entries (not all 1799 WL stops).
- OSM is fetched **lazily** — only when a disagreement actually needs an arbiter, so an all-agree run never touches the network.
- A missing HAFAS result is a **deliberate no-op**, so a transient HAFAS outage can never shift a coordinate.
- Gated by `WIEN_OEPNV_AT_RECONCILE` (default on); the budget-sensitive orchestrator wrapper test opts out, mirroring `WIEN_OEPNV_OSM_ENRICH`.

### Decisions baked in (from design discussion)
- **Cadence stays weekly** (cron `0 1 * * 0` unchanged).
- **Scope stays broad** (~2236 entries); `type=manual_foreign_city` / `manual_distant_at` stay "in directory, never in feed".
- **"Stadt Wien" is subsumed by WL** — the Vienna OGD stop data *is* the Wiener-Linien data already loaded — so there is no separate Stadt-Wien fetcher.

## Test plan
- [x] New `tests/test_at_coordinate_consensus.py` (17 cases): resolver matrix (agree / WL-only / OSM→WL / OSM→HAFAS / unresolved / boundary / invalid input) + the wired overlap pass with injected HAFAS/OSM fakes (agreement promotes WL, disagreement picks the OSM-endorsed source, HAFAS-miss is a no-op, non-overlap untouched, OSM fetched once, invalid/absent WL skipped).
- [x] Existing WL/merge/loader + coordinate-vs-Vienna-flag invariant tests green; broader affected sweep **611 passed**.
- [x] Gated wrapper orchestration test green (47 s).
- [x] `ruff` clean; `mypy --strict` clean on the new `src/` module + test; C901 complexity gate passes (0 new violations).

> Note: the new coordinates land on the next scheduled (or manual) refresh — the data file is regenerated by the cron, not committed here.

https://claude.ai/code/session_011q6w66hy5fL5jpwkKk7zPh

---
_Generated by [Claude Code](https://claude.ai/code/session_011q6w66hy5fL5jpwkKk7zPh)_