### PR TITLE
fix(stations): Bad Fischau coordinate (eva_nr override) + green up Baustellen Hbf test

### DIFF
--- a/data/stations_overrides.json
+++ b/data/stations_overrides.json
@@ -10,6 +10,15 @@
   },
   "overrides": [
     {
+      "op": "patch_coords",
+      "eva_nr": "8100655",
+      "latitude": 47.831202,
+      "longitude": 16.171251,
+      "reason": "Bad Fischau (eva 8100655) and Bad Fischau-Brunn (eva 8100653) were both enriched to Bad Fischau-Brunn's position (47.826685, 16.173239), so two distinct manual_distant_at OEBB stations shared one coordinate (geographic-duplicate validator finding, distance 0). Re-points Bad Fischau to its authoritative OEBB Geo-Netz coordinate (data/oebb_geonetz_stops.json, bsts_id 442); the two stations are ~490 m apart in reality. Bad Fischau-Brunn is left untouched (already within the 150 m inertia tolerance of its Geo-Netz position).",
+      "added": "2026-05-24",
+      "expires_when": "The enrichment assigns eva 8100655 (Bad Fischau) its own coordinate distinct from eva 8100653, e.g. by reconciling manual_distant_at entries against oebb_geonetz by eva_nr."
+    },
+    {
       "op": "restore",
       "wl_diva": "60200558",
       "reason": "Wiener Linien retired all haltepunkte for DIVA 60200558 (Wien Unter St. Veit, Hummelgasse) but the station itself stays in haltestellen.csv. The WL build step skips DIVAs without haltepunkte, so the station drops from stations.json each cron tick. Restored from PR #1537 (the merge commit f755e8a snapshot).",

--- a/docs/stations_validation_report.md
+++ b/docs/stations_validation_report.md
@@ -2,7 +2,7 @@
 
 *Analysierte Stationen (gesamt)*: 2238
 *Geladene GTFS-Stops*: 167
-*Geografische Duplikate*: 1
+*Geografische Duplikate*: 0
 *Alias-Probleme*: 0
 *Koordinaten-Anomalien*: 0
 *GTFS-Abweichungen*: 0
@@ -12,5 +12,4 @@
 *Identity-Field-Konflikte*: 0
 *Namens-Probleme*: 0
 
-## Geografische Duplikate
-- (47.82668, 16.17324) → source:hafas,manual,oebb\_geonetz, source:hafas,manual,oebb\_geonetz
+Keine Probleme festgestellt.

--- a/scripts/apply_station_overrides.py
+++ b/scripts/apply_station_overrides.py
@@ -144,6 +144,21 @@ def _find_by_diva(stations: list[dict[str, Any]], diva: str) -> dict[str, Any] |
     return None
 
 
+def _find_by_eva(stations: list[dict[str, Any]], eva: str) -> dict[str, Any] | None:
+    """Return the first station entry with matching ``eva_nr``, or None.
+
+    Lets ``patch_coords`` target the manual ÖBB-station entries
+    (``type=manual_*``) that carry an ``eva_nr`` but no ``wl_diva``.
+    ``eva_nr`` is a string in stations.json; ``str(...)`` keeps the match
+    robust against a defensively int-typed value.
+    """
+    for entry in stations:
+        value = entry.get("eva_nr")
+        if value is not None and str(value).strip() == eva:
+            return entry
+    return None
+
+
 def _alpha_insertion_index(stations: list[dict[str, Any]], target_name: str) -> int:
     """Pick a sorted insertion index by case-insensitive ``name``.
 
@@ -178,14 +193,23 @@ def _op_restore(stations: list[dict[str, Any]], override: dict[str, Any]) -> str
 
 
 def _op_patch_coords(stations: list[dict[str, Any]], override: dict[str, Any]) -> str:
-    diva = override["wl_diva"]
-    target = _find_by_diva(stations, diva)
+    # Target by wl_diva (WL stops) or, as a fallback, eva_nr (manual ÖBB
+    # stations that carry no wl_diva). The apply loop guarantees at least
+    # one identifier is present.
+    diva = override.get("wl_diva")
+    if isinstance(diva, str) and diva.strip():
+        target = _find_by_diva(stations, diva.strip())
+        key_desc = f"wl_diva={diva.strip()}"
+    else:
+        eva_key = str(override.get("eva_nr") or "").strip()
+        target = _find_by_eva(stations, eva_key)
+        key_desc = f"eva_nr={eva_key}"
     if target is None:
         log.warning(
-            "patch_coords: wl_diva=%s not present in stations.json — "
-            "skipping (the upstream may have removed the station; "
-            "consider retiring this override)",
-            diva,
+            "patch_coords: %s not present in stations.json — skipping "
+            "(the upstream may have removed the station; consider "
+            "retiring this override)",
+            key_desc,
         )
         return "skip (target missing)"
 
@@ -217,8 +241,8 @@ def _op_patch_coords(stations: list[dict[str, Any]], override: dict[str, Any]) -
                         changed_fields.append(f"wl_stops[{sid}].{sub}")
 
     if not changed_fields:
-        return f"skip (no change, wl_diva={diva})"
-    return f"patched wl_diva={diva}, fields={changed_fields}"
+        return f"skip (no change, {key_desc})"
+    return f"patched {key_desc}, fields={changed_fields}"
 
 
 def _op_remove(stations: list[dict[str, Any]], override: dict[str, Any]) -> str:
@@ -289,24 +313,37 @@ def apply_overrides(
             return 1
         op = raw_override.get("op")
         diva = raw_override.get("wl_diva")
+        eva = raw_override.get("eva_nr")
         if op not in _ALLOWED_OPS:
             log.error(
                 "Override #%d has unknown op %r (allowed: %s)",
                 index, op, sorted(_ALLOWED_OPS),
             )
             return 1
-        if not isinstance(diva, str) or not diva.strip():
+        has_diva = isinstance(diva, str) and bool(diva.strip())
+        # ``patch_coords`` may key on ``eva_nr`` (manual ÖBB stations have no
+        # ``wl_diva``); ``restore`` / ``remove`` still require ``wl_diva``.
+        if op == "patch_coords":
+            has_eva = eva is not None and bool(str(eva).strip())
+            if not (has_diva or has_eva):
+                log.error(
+                    "Override #%d (op=patch_coords) needs a wl_diva or eva_nr",
+                    index,
+                )
+                return 1
+        elif not has_diva:
             log.error(
                 "Override #%d (op=%s) missing or invalid wl_diva", index, op
             )
             return 1
+        ident = str(diva).strip() if has_diva else f"eva_nr={str(eva).strip()}"
         handler = _HANDLERS[op]
         try:
             result = handler(stations, raw_override)
         except OverrideError as exc:
-            log.error("Override #%d (op=%s, wl_diva=%s): %s", index, op, diva, exc)
+            log.error("Override #%d (op=%s, %s): %s", index, op, ident, exc)
             return 1
-        log.info("Override #%d (op=%s, wl_diva=%s): %s", index, op, diva, result)
+        log.info("Override #%d (op=%s, %s): %s", index, op, ident, result)
         if not result.startswith("skip"):
             applied += 1
 

--- a/tests/test_apply_station_overrides.py
+++ b/tests/test_apply_station_overrides.py
@@ -229,6 +229,78 @@ def test_patch_coords_missing_diva_warns_but_does_not_fail(
     assert _stations_from(stations_path)[0]["wl_diva"] == "99999999"
 
 
+def test_patch_coords_by_eva_nr_targets_manual_station(tmp_path: Path) -> None:
+    """patch_coords can key on eva_nr for manual ÖBB stations (no wl_diva).
+
+    Mirrors the Bad Fischau / Bad Fischau-Brunn fix: two distinct
+    manual_distant_at stations shared one coordinate; re-pointing one by
+    its eva_nr separates them.
+    """
+    stations_path = tmp_path / "stations.json"
+    overrides_path = tmp_path / "overrides.json"
+
+    _write(stations_path, {"stations": [
+        {"name": "Bad Fischau", "eva_nr": "8100655", "type": "manual_distant_at",
+         "source": "hafas,manual,oebb_geonetz", "in_vienna": False, "pendler": False,
+         "latitude": 47.826685, "longitude": 16.173239, "aliases": ["Bad Fischau"]},
+        {"name": "Bad Fischau-Brunn", "eva_nr": "8100653", "type": "manual_distant_at",
+         "source": "hafas,manual,oebb_geonetz", "in_vienna": False, "pendler": False,
+         "latitude": 47.826685, "longitude": 16.173239, "aliases": ["Bad Fischau-Brunn"]},
+    ]})
+    _write(overrides_path, {"overrides": [
+        {
+            "op": "patch_coords",
+            "eva_nr": "8100655",
+            "reason": "test",
+            "latitude": 47.831202,
+            "longitude": 16.171251,
+        }
+    ]})
+
+    rc = apply_station_overrides.apply_overrides(stations_path, overrides_path)
+    assert rc == 0
+
+    by_name = {s["name"]: s for s in _stations_from(stations_path)}
+    assert (by_name["Bad Fischau"]["latitude"], by_name["Bad Fischau"]["longitude"]) == (47.831202, 16.171251)
+    # The sibling entry (different eva_nr) must stay put.
+    assert (by_name["Bad Fischau-Brunn"]["latitude"], by_name["Bad Fischau-Brunn"]["longitude"]) == (47.826685, 16.173239)
+
+
+def test_patch_coords_missing_eva_warns_but_does_not_fail(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    stations_path = tmp_path / "stations.json"
+    overrides_path = tmp_path / "overrides.json"
+    _write(stations_path, {"stations": [
+        {"name": "Other", "eva_nr": "9999999", "source": "manual",
+         "latitude": 48.1, "longitude": 16.1, "in_vienna": False, "pendler": False,
+         "aliases": ["Other"]},
+    ]})
+    _write(overrides_path, {"overrides": [
+        {"op": "patch_coords", "eva_nr": "8100655", "reason": "test",
+         "latitude": 47.831202, "longitude": 16.171251},
+    ]})
+    with caplog.at_level(logging.WARNING, logger="apply_station_overrides"):
+        rc = apply_station_overrides.apply_overrides(stations_path, overrides_path)
+    assert rc == 0
+    assert any("8100655" in r.getMessage() for r in caplog.records)
+    assert _stations_from(stations_path)[0]["latitude"] == 48.1
+
+
+def test_patch_coords_requires_diva_or_eva(tmp_path: Path) -> None:
+    stations_path = tmp_path / "stations.json"
+    overrides_path = tmp_path / "overrides.json"
+    _write(stations_path, {"stations": [
+        {"name": "X", "wl_diva": "1", "source": "wl", "latitude": 48.1,
+         "longitude": 16.1, "in_vienna": True, "pendler": False, "aliases": ["X"]},
+    ]})
+    _write(overrides_path, {"overrides": [
+        {"op": "patch_coords", "reason": "no identifier", "latitude": 48.2, "longitude": 16.2},
+    ]})
+    rc = apply_station_overrides.apply_overrides(stations_path, overrides_path)
+    assert rc == 1
+
+
 # ---------------------------------------------------------------------------
 # Remove
 # ---------------------------------------------------------------------------
@@ -366,7 +438,14 @@ def test_committed_overrides_file_schema() -> None:
     for entry in payload["overrides"]:
         assert isinstance(entry, dict)
         assert entry["op"] in {"restore", "patch_coords", "remove"}
-        assert isinstance(entry.get("wl_diva"), str) and entry["wl_diva"].strip()
+        # Identifier: wl_diva for WL stops; patch_coords may instead key on
+        # eva_nr (manual ÖBB stations carry no wl_diva).
+        has_diva = isinstance(entry.get("wl_diva"), str) and bool(entry["wl_diva"].strip())
+        if entry["op"] == "patch_coords":
+            has_eva = entry.get("eva_nr") is not None and bool(str(entry["eva_nr"]).strip())
+            assert has_diva or has_eva
+        else:
+            assert has_diva
         assert isinstance(entry.get("reason"), str) and entry["reason"]
         # Every override must document its retire condition so future
         # maintainers know when to drop it.
@@ -380,16 +459,25 @@ def test_committed_overrides_file_schema() -> None:
 
 
 def test_committed_overrides_cover_the_known_drifts() -> None:
-    """The committed overrides file targets exactly the four DIVAs
-    that the 2026-05-16 audit identified as recurring upstream defects.
+    """The committed overrides file targets exactly the known upstream
+    defects: the four 2026-05-16 audit DIVAs plus the Bad Fischau
+    geographic-duplicate fix (eva-keyed, 2026-05-24).
 
     If this set ever needs to change, update the assertion intentionally
     — silent drift in the override list is itself a regression.
     """
     path = REPO_ROOT / "data" / "stations_overrides.json"
     payload = json.loads(path.read_text(encoding="utf-8"))
-    by_op_diva = {(o["op"], o["wl_diva"]) for o in payload["overrides"]}
-    assert ("restore", "60200558") in by_op_diva  # Hummelgasse
-    assert ("patch_coords", "60201955") in by_op_diva  # Halblehenweg
-    assert ("patch_coords", "60201954") in by_op_diva  # Leopoldine-Padaurek
-    assert ("remove", "60251359") in by_op_diva  # Sofienalpenstraße, Roßkopfgasse
+
+    def _ident(o: dict[str, Any]) -> str:
+        diva = o.get("wl_diva")
+        if isinstance(diva, str) and diva.strip():
+            return diva.strip()
+        return f"eva:{str(o.get('eva_nr') or '').strip()}"
+
+    by_op = {(o["op"], _ident(o)) for o in payload["overrides"]}
+    assert ("restore", "60200558") in by_op  # Hummelgasse
+    assert ("patch_coords", "60201955") in by_op  # Halblehenweg
+    assert ("patch_coords", "60201954") in by_op  # Leopoldine-Padaurek
+    assert ("remove", "60251359") in by_op  # Sofienalpenstraße, Roßkopfgasse
+    assert ("patch_coords", "eva:8100655") in by_op  # Bad Fischau geographic duplicate

--- a/tests/test_baustellen_relevance.py
+++ b/tests/test_baustellen_relevance.py
@@ -26,7 +26,28 @@ from src.providers.baustellen import (
 from src.utils import stations
 
 # Real directory coordinates (data/stations.json).
-WIEN_HBF = (48.185184, 16.376413)  # bst_id 900100, in_vienna
+_STATIONS_JSON = Path(__file__).resolve().parents[1] / "data" / "stations.json"
+
+
+def _directory_coord(name: str) -> tuple[float, float]:
+    """Return a station's authoritative ``(lat, lon)`` from the committed
+    directory.
+
+    Derived rather than hard-coded so the fixture tracks consensus-driven
+    coordinate updates — the WL→HAFAS→OSM reconciliation re-points
+    multimodal hubs such as Hauptbahnhof to the WL/OSM-agreed position —
+    instead of pinning a value that silently drifts out of the matching
+    radius.
+    """
+    payload = json.loads(_STATIONS_JSON.read_text(encoding="utf-8"))
+    entries = payload["stations"] if isinstance(payload, dict) else payload
+    for entry in entries:
+        if entry.get("name") == name:
+            return (float(entry["latitude"]), float(entry["longitude"]))
+    raise AssertionError(f"{name!r} not found in {_STATIONS_JSON}")
+
+
+WIEN_HBF = _directory_coord("Wien Hauptbahnhof")  # multimodal hub, in_vienna
 MOEDLING = (48.085628, 16.295474)  # bst_id 1377, pendler
 # A point deep in the Donau-Auen floodplain — no rail Bahnhof for km.
 FAR_AWAY = (48.170000, 16.520000)


### PR DESCRIPTION
## Problem

The weekly validation report flagged **1 geographic duplicate**: two distinct `manual_distant_at` ÖBB stations sharing one coordinate.

| Station | eva_nr | stored (before) | ÖBB Geo-Netz (authoritative) |
|---|---|---|---|
| **Bad Fischau** | 8100655 | 47.826685, 16.173239 | **47.831202, 16.171251** |
| Bad Fischau-Brunn | 8100653 | 47.826685, 16.173239 | 47.826903, 16.1733 |

Bad Fischau had wrongly inherited Bad Fischau-Brunn's position (distance 0 between two distinct stations); the two are ~490 m apart in reality.

## Fix

Re-point **Bad Fischau** to its authoritative `data/oebb_geonetz_stops.json` coordinate (bsts_id 442) via a curated `patch_coords` override. Bad Fischau-Brunn is left untouched (already within the 150 m inertia tolerance of its Geo-Netz position).

The override layer only matched **`wl_diva`**, but these manual entries carry only **`eva_nr`** — so `patch_coords` (and the apply-loop validation) is extended to also key on `eva_nr`. `restore` / `remove` still require `wl_diva`; the schema surface stays narrow.

After applying: the two stations are **524 m** apart and the validator reports **0 geographic duplicates** (`docs/stations_validation_report.md` regenerated). `data/stations.json` is updated so the fix is effective immediately and re-asserted on every future run.

## Also in this PR — green up `main`'s CI

`test_baustellen_relevance.py` hard-coded Wien Hauptbahnhof's **old** ÖBB coordinate. The WL→HAFAS→OSM consensus (PR #1654) re-pointed Hauptbahnhof ~182 m to the WL/OSM-agreed position — past the 150 m Baustellen radius — and the weekly cron applied that move via `[skip ci]`, so three relevance tests were red on `main` and on every PR. The fixture now **derives** Hauptbahnhof's coordinate from `data/stations.json`, so it tracks the authoritative position and won't drift out of the radius on future reconciliations. (Coordinate move itself accepted as designed: WL is authoritative, OSM corroborated WL over HAFAS.)

## Test plan
- [x] New override tests: `patch_coords` by `eva_nr` separates two co-located manual stations; missing-eva target warns + no-ops; an override with neither `wl_diva` nor `eva_nr` is rejected. Committed-overrides schema/coverage tests updated for the eva-keyed entry.
- [x] `test_baustellen_relevance.py` green (64 passed) with the directory-derived fixture.
- [x] Full local suite: `8464 passed, 2 skipped` (the 3 previously-failing baustellen tests now pass).
- [x] `ruff` clean; `mypy --strict` clean on changed test + script.
- [x] Validator: `0 geographic duplicates, 0 alias issues, 0 coordinate anomalies, 0 security warnings`.

https://claude.ai/code/session_011q6w66hy5fL5jpwkKk7zPh

---
_Generated by [Claude Code](https://claude.ai/code/session_011q6w66hy5fL5jpwkKk7zPh)_