### PR TITLE
fix(logging,lint): prune JSON-format logs & sanitise lint stdout

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -4146,8 +4146,18 @@ def lint() -> int:
         if missing_guid_items:
             print("\nEinträge ohne GUID:")
             for item in missing_guid_items:
-                source = item.get("source") or "unbekannt"
-                title = item.get("title") or "<ohne Titel>"
+                # Security: ``source`` / ``title`` are upstream-controlled and
+                # reach this operator-facing stdout sink BEFORE the per-item
+                # ``_format_item_content`` sanitisation runs (lint never formats
+                # the items). Route both through ``_sanitize_text`` so the
+                # canonical ``_CONTROL_RE`` floor (C0/C1 + BiDi + zero-width +
+                # line/paragraph separators + Tag/VS blocks) is stripped here too
+                # — the sibling duplicate-group print already sanitises its
+                # titles via ``_summarize_duplicates``; this closes the
+                # un-sanitised sibling path (Trojan-Source / terminal-escape /
+                # log-forgery on the lint report).
+                source = _sanitize_text(str(item.get("source") or "unbekannt"))
+                title = _sanitize_text(str(item.get("title") or "<ohne Titel>"))
                 print(f"- {source}: {title}")
 
         provider_failures = report.has_errors()

--- a/src/feed/logging.py
+++ b/src/feed/logging.py
@@ -96,6 +96,50 @@ def configure_logging() -> None:
 
 _LOG_TIMESTAMP_RE = re.compile(r"^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}),(\d{3})")
 
+# Record-header timestamp for the JSON formatter (active when
+# ``LOG_FORMAT=json``). ``SafeJSONFormatter`` emits one object per line whose
+# FIRST key is the ISO-8601 ``timestamp`` (see
+# ``src/feed/logging_safe.py``): ``{"timestamp": "2026-05-24T20:01:00+02:00", …}``.
+# Without this, ``prune_log_file`` matched only the plain ``%(asctime)s`` shape
+# (``YYYY-MM-DD HH:MM:SS,mmm``); every JSON line fell through as a "continuation"
+# line, the whole file collapsed into one un-timestamped group, and time-based
+# retention silently became a no-op for JSON logs.
+_LOG_JSON_TIMESTAMP_RE = re.compile(r'^\s*\{\s*"timestamp"\s*:\s*"([^"]+)"')
+
+
+def _parse_log_record_timestamp(line: str) -> datetime | None:
+    """Return the leading record timestamp of a log *line*, normalised to
+    :data:`LOG_TIMEZONE`, or ``None`` for continuation / unparseable lines.
+
+    Handles BOTH emitted formats so :func:`prune_log_file` honours the
+    retention window regardless of ``LOG_FORMAT``:
+
+      * plain ``%(asctime)s`` — ``YYYY-MM-DD HH:MM:SS,mmm`` (``SafeFormatter``)
+      * JSON — ``{"timestamp": "<ISO-8601>", …}`` (``SafeJSONFormatter``)
+    """
+    parsed: datetime | None = None
+    match = _LOG_TIMESTAMP_RE.match(line)
+    if match:
+        try:
+            parsed = datetime.strptime(
+                f"{match.group(1)} {match.group(2)},{match.group(3)}",
+                "%Y-%m-%d %H:%M:%S,%f",
+            )
+        except ValueError:
+            return None
+    else:
+        json_match = _LOG_JSON_TIMESTAMP_RE.match(line)
+        if json_match:
+            try:
+                parsed = datetime.fromisoformat(json_match.group(1))
+            except ValueError:
+                return None
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=LOG_TIMEZONE)
+    return parsed.astimezone(LOG_TIMEZONE)
+
 # Security: ``MAX_LOG_PRUNE_KEEP_DAYS`` is the retention-window ceiling for the
 # in-place log-pruning helper. ``prune_log_file`` consumes ``keep_days`` as
 # ``cutoff = now - timedelta(days=keep_days)`` (direct ``datetime - timedelta``
@@ -174,7 +218,7 @@ def prune_log_file(path: Path, *, now: datetime, keep_days: int = 7) -> None:
     grouped: list[list[str]] = []
     current: list[str] = []
     for line in raw_lines:
-        if _LOG_TIMESTAMP_RE.match(line):
+        if _parse_log_record_timestamp(line) is not None:
             if current:
                 grouped.append(current)
             current = [line]
@@ -188,21 +232,12 @@ def prune_log_file(path: Path, *, now: datetime, keep_days: int = 7) -> None:
 
     filtered: list[str] = []
     for record_lines in grouped:
-        first = record_lines[0]
-        match = _LOG_TIMESTAMP_RE.match(first)
-        if not match:
+        ts = _parse_log_record_timestamp(record_lines[0])
+        if ts is None:
+            # No parseable record timestamp (continuation line / unknown
+            # shape) — keep conservatively rather than risk dropping data.
             filtered.extend(record_lines)
             continue
-        ts_raw = f"{match.group(1)} {match.group(2)},{match.group(3)}"
-        try:
-            ts = datetime.strptime(ts_raw, "%Y-%m-%d %H:%M:%S,%f")
-        except ValueError:
-            filtered.extend(record_lines)
-            continue
-        if ts.tzinfo is None:
-            ts = ts.replace(tzinfo=LOG_TIMEZONE)
-        else:
-            ts = ts.astimezone(LOG_TIMEZONE)
         if ts >= cutoff:
             filtered.extend(record_lines)
 

--- a/tests/test_feed_lint.py
+++ b/tests/test_feed_lint.py
@@ -60,7 +60,6 @@ def test_feed_lint_sanitizes_missing_guid_output(
     this guards the sibling "Einträge ohne GUID" path against Trojan-Source /
     terminal-escape / log-forgery on the lint report.
     """
-    now = datetime.now(UTC)
     # RLO (U+202E), zero-width space (U+200B), ANSI ESC (U+001B), BEL (U+0007)
     evil_title = "Bar\u202e\u200b\x1b[31m\x07evil"
     items = [_make_item("bar", guid=None, title=evil_title)]

--- a/tests/test_feed_lint.py
+++ b/tests/test_feed_lint.py
@@ -50,6 +50,35 @@ def test_feed_lint_reports_duplicates_and_missing_guid(
     assert exit_code == 1
 
 
+def test_feed_lint_sanitizes_missing_guid_output(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A guid-less item carrying control / BiDi / zero-width bytes in its
+    title must not leak them raw into the operator-facing lint stdout.
+
+    The duplicate-group print already sanitises via ``_summarize_duplicates``;
+    this guards the sibling "Einträge ohne GUID" path against Trojan-Source /
+    terminal-escape / log-forgery on the lint report.
+    """
+    now = datetime.now(UTC)
+    # RLO (U+202E), zero-width space (U+200B), ANSI ESC (U+001B), BEL (U+0007)
+    evil_title = "Bar\u202e\u200b\x1b[31m\x07evil"
+    items = [_make_item("bar", guid=None, title=evil_title)]
+
+    monkeypatch.setattr(build_feed, "_invoke_collect_items", lambda report: list(items))
+    monkeypatch.setattr(build_feed, "_load_state", lambda: {})
+    monkeypatch.setattr(build_feed, "_detect_stale_caches", lambda report, now: [])
+
+    build_feed.lint()
+
+    out = capsys.readouterr().out
+    assert "Einträge ohne GUID" in out
+    for bad in ("\u202e", "\u200b", "\x1b", "\x07"):
+        assert bad not in out, f"unsanitised {bad!r} leaked into lint stdout"
+    # The visible text still surfaces so the operator sees the offending item.
+    assert "Bar" in out and "evil" in out
+
+
 def test_feed_lint_ok_without_issues(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_log_pruning_safety.py
+++ b/tests/test_log_pruning_safety.py
@@ -83,3 +83,53 @@ def test_prune_log_file_actually_prunes(tmp_path: Path) -> None:
 
     assert "Old Message" not in content
     assert "New Message" in content
+
+
+def test_prune_log_file_prunes_json_format(tmp_path: Path) -> None:
+    """JSON-format logs (LOG_FORMAT=json) must be age-pruned too.
+
+    ``SafeJSONFormatter`` emits one object per line whose first key is an
+    ISO-8601 ``timestamp``. The plain ``%(asctime)s`` regex never matches that
+    shape, so before the fix every JSON line was treated as a continuation
+    line and time-based retention silently did nothing.
+    """
+    log_file = tmp_path / "test_prune_json.log"
+
+    old_date = datetime.now(UTC) - timedelta(days=10)
+    new_date = datetime.now(UTC)
+
+    old_line = (
+        f'{{"timestamp": "{old_date.isoformat()}", "level": "INFO", '
+        f'"logger": "x", "message": "Old JSON Message"}}\n'
+    )
+    new_line = (
+        f'{{"timestamp": "{new_date.isoformat()}", "level": "INFO", '
+        f'"logger": "x", "message": "New JSON Message"}}\n'
+    )
+
+    log_file.write_text(old_line + new_line, encoding="utf-8")
+
+    prune_log_file(log_file, now=new_date, keep_days=7)
+
+    content = log_file.read_text(encoding="utf-8")
+
+    assert "Old JSON Message" not in content
+    assert "New JSON Message" in content
+
+
+def test_prune_log_record_timestamp_parses_both_formats() -> None:
+    """The shared parser recognises plain + JSON record headers and rejects
+    continuation lines."""
+    from src.feed.logging import _parse_log_record_timestamp
+
+    assert _parse_log_record_timestamp("2026-05-24 20:01:00,123 INFO x: hi") is not None
+    assert (
+        _parse_log_record_timestamp(
+            '{"timestamp": "2026-05-24T20:01:00+02:00", "level": "INFO"}'
+        )
+        is not None
+    )
+    # Continuation line (traceback) — no leading timestamp.
+    assert _parse_log_record_timestamp('    File "x.py", line 1, in <module>') is None
+    # Malformed JSON timestamp value — rejected, not crashing.
+    assert _parse_log_record_timestamp('{"timestamp": "not-a-date", "level": "INFO"}') is None


### PR DESCRIPTION
## Summary

Two operator-facing defects found during a careful manual + agent-assisted audit:

- **`prune_log_file` silently skips JSON logs** (`src/feed/logging.py`). `_LOG_TIMESTAMP_RE` only matches the plain `%(asctime)s` shape (`YYYY-MM-DD HH:MM:SS,mmm`). When `LOG_FORMAT=json` (a documented option), `SafeJSONFormatter` emits one JSON object per line beginning with `{"timestamp": "<ISO-8601>"` — which never matches, so every line folds into a single un-timestamped group and time-based retention (`keep_days`) becomes a no-op. A shared `_parse_log_record_timestamp` helper now recognises **both** formats, so retention is honoured regardless of `LOG_FORMAT`. (The refactor also drops `prune_log_file`'s McCabe complexity from 17 → 15.)

- **`lint()` leaks unsanitised upstream data to operator stdout** (`src/build_feed.py`). The "Einträge ohne GUID" block printed each item's `title`/`source` **raw**, while the sibling duplicate-group print already routes its titles through `_sanitize_text` via `_summarize_duplicates` — whose docstring explicitly names this stdout as a sink that must inherit the canonical control-char floor. The missing-guid path was the un-sanitised sibling (Trojan-Source / ANSI-escape / log-forgery vector on the lint report). Both fields now pass through `_sanitize_text`.

Both are low-severity but genuine; each is a "drift" where most code defends but one sibling path does not.

## Test plan

- [x] `ruff` (pinned 0.4.10) clean
- [x] `mypy --strict` clean (48 files)
- [x] C901 complexity gate passes (0 new violations)
- [x] New regression tests:
  - `tests/test_log_pruning_safety.py` — JSON-format pruning + the dual-format helper
  - `tests/test_feed_lint.py` — missing-guid stdout strips control/BiDi/zero-width bytes
- [x] Full suite: **8477 passed, 2 skipped**

https://claude.ai/code/session_014gFj4NxBem63x6kLZV8rLj

---
_Generated by [Claude Code](https://claude.ai/code/session_014gFj4NxBem63x6kLZV8rLj)_