### PR TITLE
fix(stats,baustellen): non-finite guard, multi-year read, BIS key

### DIFF
--- a/scripts/update_baustellen_cache.py
+++ b/scripts/update_baustellen_cache.py
@@ -193,7 +193,13 @@ END_KEYS: tuple[str, ...] = (
     "ENDE_DATUM",
     "DATUM_BIS",
     "BIS_DATUM",
-    "BIS",
+    # NB: bare "BIS" is intentionally NOT an end-date key. It is a spatial
+    # "to" descriptor (sibling of BIS_NR / BIS_KM / ABSCHNITT_BIS in
+    # TO_KEYS); the explicit date variants are DATUM_BIS / BIS_DATUM. Since
+    # _parse_datetime uses the lenient dateutil parser, a spatial value such
+    # as a bare house number ("22") would otherwise be misread as a date
+    # (day-of-current-month), planting a bogus ends_at/GUID and risking the
+    # item being aged out as already-expired.
 )
 
 

--- a/src/utils/stats.py
+++ b/src/utils/stats.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import csv
 import io
 import logging
+import math
 import os
 import re
 from dataclasses import dataclass
@@ -407,6 +408,20 @@ def append_stammstrecke_row(
     The function is best-effort: filesystem errors are logged and
     swallowed so the upstream cron pipeline always exits cleanly.
     """
+    # Defense-in-depth (non-finite floor): a non-finite delay would be
+    # rendered as the literal "nan"/"inf" into the ledger, which the
+    # reader's ``float(raw_delay)`` re-accepts — silently poisoning every
+    # downstream mean/threshold aggregation. Upstream producers guard
+    # against this today, but the project pins ``allow_nan=False`` on every
+    # JSON sink for exactly this reason; mirror that floor here at the CSV
+    # write boundary. Skip the row (best-effort contract: log + return
+    # False, never raise) rather than write a corrupt value.
+    if not math.isfinite(delay_minutes):
+        LOGGER.warning(
+            "Nicht-finiter delay_minutes (%r) – Stammstrecke-Zeile übersprungen.",
+            delay_minutes,
+        )
+        return False
     when = to_vienna(timestamp)
     path = stats_path("stammstrecke", when.year, base_dir=stats_dir)
     row = (
@@ -744,7 +759,12 @@ def read_recent_stammstrecke_observations(
         return []
     cutoff = now - window
     folder = stats_dir if stats_dir is not None else DEFAULT_STATS_DIR
-    years = sorted({cutoff.year, now.year})
+    # Read every calendar year the window spans, not just its two
+    # boundaries: a window wider than one full year (no current caller
+    # passes one, but the API is public) would otherwise silently skip the
+    # intermediate years' ledgers. ``range`` is identical to the former
+    # ``{cutoff.year, now.year}`` set for the ≤1-year windows used today.
+    years = list(range(cutoff.year, now.year + 1))
     observations: list[StammstreckeObservation] = []
     for year in years:
         path = folder / f"stammstrecke_{year:04d}.csv"

--- a/tests/test_update_baustellen_cache.py
+++ b/tests/test_update_baustellen_cache.py
@@ -140,6 +140,24 @@ def test_parse_range_handles_duration(duration: str, expected_start: date, expec
     assert end is not None and end.date() == expected_end
 
 
+def test_parse_range_ignores_spatial_bis_value() -> None:
+    """Bare ``BIS`` is a spatial 'to' descriptor (sibling of BIS_NR/BIS_KM),
+    not an end-date. A house-number value like '22' must NOT be coerced by the
+    lenient date parser into a bogus end-date (day-22-of-current-month)."""
+    properties = {"OBJEKT_BEGINN": "2026-03-01Z", "BIS": "22"}
+    start, end = update_baustellen_cache._parse_range(properties)
+    assert start is not None and start.date() == date(2026, 3, 1)
+    assert end is None
+
+
+def test_parse_range_still_reads_explicit_until_date() -> None:
+    """The explicit date keys (DATUM_BIS / BIS_DATUM) remain valid end-dates."""
+    properties = {"OBJEKT_BEGINN": "2026-03-01Z", "DATUM_BIS": "2026-04-15Z"}
+    start, end = update_baustellen_cache._parse_range(properties)
+    assert start is not None and start.date() == date(2026, 3, 1)
+    assert end is not None and end.date() == date(2026, 4, 15)
+
+
 def test_collect_events_from_sample_payload() -> None:
     payload = json.loads(SAMPLE_PATH.read_text(encoding="utf-8"))
     events = update_baustellen_cache._collect_events(payload)

--- a/tests/test_utils_stats.py
+++ b/tests/test_utils_stats.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import csv
 import sys
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
@@ -119,6 +119,44 @@ def test_append_stammstrecke_row_returns_false_on_io_error(
         stats_dir=tmp_path / "nope",
     )
     assert ok is False
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_append_stammstrecke_row_rejects_non_finite_delay(
+    tmp_path: Path, bad: float
+) -> None:
+    """A non-finite delay must be skipped (return False, write nothing) so the
+    ledger never carries a literal nan/inf that the reader re-accepts."""
+    ok = stats_utils.append_stammstrecke_row(
+        timestamp=datetime(2026, 5, 4, 8, 0, tzinfo=VIENNA_TZ),
+        direction="Meidling",
+        delay_minutes=bad,
+        stats_dir=tmp_path,
+    )
+    assert ok is False
+    assert not (tmp_path / "stammstrecke_2026.csv").exists()
+
+
+def test_read_recent_reads_intermediate_years(tmp_path: Path) -> None:
+    """A window wider than one year must read the middle years' ledgers, not
+    just the two boundary years."""
+    for year in (2024, 2025, 2026):
+        stats_utils.append_stammstrecke_row(
+            timestamp=datetime(year, 6, 1, 12, 0, tzinfo=VIENNA_TZ),
+            direction="Meidling",
+            delay_minutes=10.0,
+            stats_dir=tmp_path,
+        )
+
+    result = stats_utils.read_recent_stammstrecke_observations(
+        now=datetime(2026, 6, 2, 12, 0, tzinfo=VIENNA_TZ),
+        window=timedelta(days=900),  # cutoff ~2023-12 → spans 2024+2025+2026
+        stats_dir=tmp_path,
+    )
+
+    # The 2025 ledger sits strictly between the boundary years; the former
+    # {cutoff.year, now.year} set skipped it entirely.
+    assert {obs.timestamp.year for obs in result} == {2024, 2025, 2026}
 
 
 # ---- Disruption writer ----------------------------------------------------


### PR DESCRIPTION
## Summary

Three reported audit findings (defensive / latent-bug hardening), now fixed:

- **`append_stammstrecke_row` accepted non-finite delays** (`src/utils/stats.py`). A `NaN`/`inf` `delay_minutes` was rendered as the literal `"nan"`/`"inf"` into the CSV ledger, which the reader's `float(raw_delay)` re-accepts — silently poisoning every downstream mean/threshold aggregation. The writer now rejects non-finite input at the CSV boundary (logs + returns `False` per its best-effort/never-raises contract), mirroring the `allow_nan=False` floor the JSON sinks already pin.

- **`read_recent_stammstrecke_observations` skipped intermediate years** (`src/utils/stats.py`). `years = {cutoff.year, now.year}` read only the two boundary years, so a window wider than one full year silently dropped the middle years' ledgers. Now reads `range(cutoff.year, now.year + 1)` — identical to the former set for the ≤1-year windows in use today.

- **`BIS` was a date key AND a spatial key** (`scripts/update_baustellen_cache.py`). Bare `BIS` is a spatial "to" descriptor (sibling of `BIS_NR`/`BIS_KM`/`ABSCHNITT_BIS` in `TO_KEYS`), but it was also listed last in the date `END_KEYS`. Because `_parse_datetime` uses the lenient `dateutil` parser, a bare house number like `"22"` was coerced into a bogus day-of-current-month end-date (wrong `ends_at`/GUID, risk of the item being aged out as expired). Removed `BIS` from `END_KEYS`; the explicit date variants `DATUM_BIS`/`BIS_DATUM` remain.

These were the three items reported (not auto-fixed) in the manual audit that produced #1656 and #1657. Items 1 and 2 are not reachable by current callers (defense-in-depth); item 3 is reachable but its impact was schema-dependent.

## Test plan

- [x] `ruff` (pinned 0.4.10) clean · `mypy --strict` clean (48 files) · C901 gate (0 new violations) · `bandit` clean
- [x] New regression tests (each fails before the fix):
  - `tests/test_utils_stats.py` — non-finite delay rejected (NaN/±inf, parametrized) + multi-year window reads the intermediate year
  - `tests/test_update_baustellen_cache.py` — spatial `BIS` not parsed as a date; `DATUM_BIS` still honoured
- [x] Full suite: **8483 passed, 2 skipped**

https://claude.ai/code/session_014gFj4NxBem63x6kLZV8rLj

---
_Generated by [Claude Code](https://claude.ai/code/session_014gFj4NxBem63x6kLZV8rLj)_