### PR TITLE
fix(baustellen,schema): emit required starts_at; allow null pubDate

### DIFF
--- a/docs/schema/events.schema.json
+++ b/docs/schema/events.schema.json
@@ -49,9 +49,9 @@
       "description": "Projektinterne Kennung zur Nachverfolgung von 'first_seen'."
     },
     "pubDate": {
-      "type": "string",
+      "type": ["string", "null"],
       "format": "date-time",
-      "description": "Veröffentlichungszeitpunkt der Meldung (ISO-8601)."
+      "description": "Veröffentlichungszeitpunkt der Meldung (ISO-8601). Kann null sein, wenn die Quelle keinen parsebaren Zeitstempel liefert (z. B. WL-Items ohne Zeitfeld, ÖBB-Items mit fehlendem pubDate)."
     },
     "starts_at": {
       "type": ["string", "null"],

--- a/scripts/update_baustellen_cache.py
+++ b/scripts/update_baustellen_cache.py
@@ -228,9 +228,15 @@ class ConstructionEvent:
             "link": self.link,
             "guid": self.guid,
             "pubDate": self.pub_date,
+            # ``starts_at`` is a schema-required key (events.schema.json) that
+            # every other provider (WL/ÖBB/Stammstrecke) always emits, with a
+            # null value when unknown. Emit it unconditionally here too — the
+            # former ``if self.starts_at`` guard dropped the key entirely for a
+            # Baustelle without a parseable start date, producing a cache item
+            # that violates the published schema. ``ends_at`` stays optional
+            # (it is NOT in the schema's ``required`` set).
+            "starts_at": self.starts_at,
         }
-        if self.starts_at:
-            item["starts_at"] = self.starts_at
         if self.ends_at:
             item["ends_at"] = self.ends_at
         if self.context:

--- a/tests/test_update_baustellen_cache.py
+++ b/tests/test_update_baustellen_cache.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import socket
 import sys
-from datetime import date
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 
@@ -156,6 +156,29 @@ def test_parse_range_still_reads_explicit_until_date() -> None:
     start, end = update_baustellen_cache._parse_range(properties)
     assert start is not None and start.date() == date(2026, 3, 1)
     assert end is not None and end.date() == date(2026, 4, 15)
+
+
+def test_to_item_always_emits_required_starts_at_key() -> None:
+    """``starts_at`` is a schema-required key (events.schema.json) that every
+    other provider emits — null when unknown. A Baustelle without a parsed
+    start must still emit it as null, not drop the key entirely."""
+    event = update_baustellen_cache.ConstructionEvent(
+        guid="g1",
+        title="Test",
+        description="desc",
+        starts_at=None,
+        ends_at=None,
+        pub_date=datetime(2026, 3, 1, tzinfo=UTC),
+    )
+    item = event.to_item()
+    assert "starts_at" in item and item["starts_at"] is None
+    for key in (
+        "source", "category", "title", "description", "link", "guid",
+        "pubDate", "starts_at",
+    ):
+        assert key in item, f"schema-required key {key!r} missing from to_item()"
+    # ends_at is optional in the schema → still omitted when None.
+    assert "ends_at" not in item
 
 
 def test_collect_events_from_sample_payload() -> None:


### PR DESCRIPTION
## Summary

Two schema-accuracy / provider-consistency fixes found during a manual review of the non-Python surfaces (JSON schema + providers):

- **`events.schema.json` forbade a null `pubDate`** — but every provider can legitimately emit one. WL items without any parseable time field set `pubDate=None` (the code comments it "None erlaubt", `wl_fetch.py:905`); ÖBB items with a missing/malformed `<pubDate>` get `None` from `_parse_dt_rfc2822`. The published schema typed `pubDate` as a required **non-null** string, so a strict consumer validating `events.json` would wrongly reject those events. `pubDate` is now typed `["string", "null"]`, matching `starts_at` (key always present, value nullable). The schema is documentation only — not used for validation anywhere — so this is a pure accuracy fix.

- **Baustellen dropped the schema-required `starts_at` key** — `to_item` emitted `starts_at` only when truthy (`if self.starts_at`), so a construction site without a parseable start date produced a cache item **missing** the key entirely. WL, ÖBB and Stammstrecke all emit `starts_at` unconditionally (null when unknown), and the schema lists it as `required`. Baustellen was the lone outlier whose output could violate the schema. It now emits `starts_at` unconditionally (null when unknown); `ends_at` stays optional (not in the schema's `required` set).

Both are low-severity (the committed caches currently carry non-null `starts_at`/`pubDate` for every event, so neither is triggered by today's data), but each is a real schema↔data contract mismatch.

Also reviewed and found clean: `docs/assets/site.js` (XSS-safe by construction — single trusted `innerHTML` sink; all feed/CSV data via `textContent`/SVG; `safeHttpsUrl` rejects `javascript:`/`data:`), and the CI workflows (no script-injection vectors; the `update-cycle.yml` Vienna-midnight dashboard gate `[ "$(date +%H%M)" -lt 30 ]` parses leading-zero values as decimal, verified).

## Test plan

- [x] `ruff` (pinned 0.4.10) clean · `mypy --strict` clean (48 files) · C901 gate (0 new violations)
- [x] `events.schema.json` is valid JSON
- [x] New regression test: `tests/test_update_baustellen_cache.py` — `to_item()` always carries the schema-required keys (`starts_at` present and null for a no-start Baustelle)
- [x] Full suite: **8484 passed, 2 skipped**

https://claude.ai/code/session_014gFj4NxBem63x6kLZV8rLj

---
_Generated by [Claude Code](https://claude.ai/code/session_014gFj4NxBem63x6kLZV8rLj)_