### PR TITLE
feat(feed): break first_seen ties by category rank then pubDate

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -3135,9 +3135,34 @@ def _dedupe_items(items: list[FeedItem]) -> list[FeedItem]:
             out.append(it)
     return out
 
+# Feed-ordering priority by category, applied as a tie-breaker when several
+# items share the same ``first_seen``. Lower rank sorts first. ``Störung``
+# (WL/ÖBB live disruptions AND the Stammstrecke delay/cancellation monitor,
+# whose ``EVENT_CATEGORY`` is also ``"Störung"``) leads; ``Baustelle``
+# (long-running construction) trails; every other category (e.g. WL
+# ``Hinweis``) sits between. Keyed on the casefolded category so a provider
+# emitting ``"störung"`` still matches. Operator policy (2026-05): disruptions
+# matter more for the feed than construction.
+_CATEGORY_FEED_RANK: dict[str, int] = {
+    "störung": 0,
+    "baustelle": 2,
+}
+_DEFAULT_CATEGORY_FEED_RANK = 1
+
+
+def _category_feed_rank(item: FeedItem) -> int:
+    """Return the feed-priority rank for *item*'s category (lower sorts first)."""
+    category = item.get("category")
+    if isinstance(category, str):
+        return _CATEGORY_FEED_RANK.get(
+            category.strip().casefold(), _DEFAULT_CATEGORY_FEED_RANK
+        )
+    return _DEFAULT_CATEGORY_FEED_RANK
+
+
 def _recency_sort_key(
     item: FeedItem, state: dict[str, dict[str, Any]], now_utc: datetime
-) -> tuple[float, str]:
+) -> tuple[float, int, float, str]:
     """FIFO-by-``first_seen`` ordering for the feed: newest-appeared first.
 
     Sorts by the persisted (guid-stable) ``first_seen`` descending. An item
@@ -3145,12 +3170,29 @@ def _recency_sort_key(
     disruptions lead. No-longer-valid items are already removed upstream by
     :func:`_drop_old_items`, so the visible Top-N are the newest still-valid
     disruptions; older ones fall off the bottom as fresher ones arrive.
+
+    Ties on ``first_seen`` (a batch of items that surfaced in the SAME build —
+    e.g. a fresh set of construction sites that all get ``first_seen = now``)
+    are broken, in order, by:
+
+    1. **Category priority** (:func:`_category_feed_rank`) — live disruptions
+       (``Störung``: WL/ÖBB plus the Stammstrecke delay/cancellation monitor)
+       outrank long-running ``Baustelle`` items; everything else (e.g. WL
+       ``Hinweis``) sits between. Operator policy: Störungen are more important
+       for the feed than Baustellen.
+    2. **``pubDate`` descending** — the source's own recency signal; the more
+       recently published item leads. A missing/unparseable ``pubDate`` sorts
+       last within its group (``-inf`` → ``+inf`` after negation).
+    3. **guid** — final deterministic tiebreaker for a stable total order
+       (otherwise items tying on all of the above would shuffle between builds).
     """
     _, entry = _lookup_state(item, state)
     first_seen = _parse_first_seen(entry, now_utc) or now_utc
+    pub = _parse_datetime(item.get("pubDate"))
+    pub_ts = pub.timestamp() if isinstance(pub, datetime) else float("-inf")
     guid_val = item.get("guid")
     guid_str = str(guid_val) if guid_val else _identity_for_item(item)
-    return (-first_seen.timestamp(), guid_str)
+    return (-first_seen.timestamp(), _category_feed_rank(item), -pub_ts, guid_str)
 
 
 def _build_canonical_link(candidate: Any, ident: str) -> str:

--- a/tests/test_build_feed_sort.py
+++ b/tests/test_build_feed_sort.py
@@ -123,7 +123,7 @@ def test_stoerung_ranks_above_baustelle_on_first_seen_tie(
     build_feed = _import_build_feed(monkeypatch)
     now = datetime(2026, 5, 24, 12, 0, tzinfo=UTC)
     state: dict[str, dict[str, Any]] = {}  # empty → all first_seen == now
-    items = [
+    items: list[dict[str, Any]] = [
         {"title": "Bau", "category": "Baustelle", "guid": "b", "pubDate": now},
         {"title": "Stoer", "category": "Störung", "guid": "s", "pubDate": now},
         {"title": "Hint", "category": "Hinweis", "guid": "h", "pubDate": now},
@@ -139,7 +139,7 @@ def test_newer_pubdate_first_within_same_category_and_first_seen(
     build_feed = _import_build_feed(monkeypatch)
     now = datetime(2026, 5, 24, 12, 0, tzinfo=UTC)
     state: dict[str, dict[str, Any]] = {}
-    items = [
+    items: list[dict[str, Any]] = [
         {"title": "old-start", "category": "Baustelle", "guid": "a",
          "pubDate": datetime(2021, 2, 28, tzinfo=UTC)},
         {"title": "new-start", "category": "Baustelle", "guid": "b",
@@ -156,7 +156,7 @@ def test_missing_pubdate_sorts_last_within_group(
     build_feed = _import_build_feed(monkeypatch)
     now = datetime(2026, 5, 24, 12, 0, tzinfo=UTC)
     state: dict[str, dict[str, Any]] = {}
-    items = [
+    items: list[dict[str, Any]] = [
         {"title": "no-pub", "category": "Störung", "guid": "a", "pubDate": None},
         {"title": "has-pub", "category": "Störung", "guid": "b", "pubDate": now},
     ]

--- a/tests/test_build_feed_sort.py
+++ b/tests/test_build_feed_sort.py
@@ -70,15 +70,16 @@ def test_sort_key_handles_none_guid(monkeypatch: pytest.MonkeyPatch, tmp_path: P
     key2 = build_feed._recency_sort_key(item_missing_guid, state, now_utc)
     key3 = build_feed._recency_sort_key(item_str_guid, state, now_utc)
 
-    # Verify that the tiebreak (guid) part of the key is a string
-    assert isinstance(key1[1], str)
-    assert len(key1[1]) > 0
+    # Verify that the final-tiebreak (guid) part of the key is a string.
+    # Key shape: (-first_seen, category_rank, -pubDate, guid) → guid is last.
+    assert isinstance(key1[-1], str)
+    assert len(key1[-1]) > 0
 
-    assert isinstance(key2[1], str)
-    assert len(key2[1]) > 0
+    assert isinstance(key2[-1], str)
+    assert len(key2[-1]) > 0
 
-    assert isinstance(key3[1], str)
-    assert key3[1] == "some-guid"
+    assert isinstance(key3[-1], str)
+    assert key3[-1] == "some-guid"
 
 def test_deterministic_sorting_fallback(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
 
@@ -113,3 +114,51 @@ def test_deterministic_sorting_fallback(monkeypatch: pytest.MonkeyPatch, tmp_pat
 
     # We assert that the sorted result matches the one ordered by identities directly
     assert [it["title"] for it in sorted_items] == [x["item"]["title"] for x in expected_order]
+
+
+def test_stoerung_ranks_above_baustelle_on_first_seen_tie(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """On a first_seen tie (same build), Störung outranks Hinweis outranks Baustelle."""
+    build_feed = _import_build_feed(monkeypatch)
+    now = datetime(2026, 5, 24, 12, 0, tzinfo=UTC)
+    state: dict[str, dict[str, Any]] = {}  # empty → all first_seen == now
+    items = [
+        {"title": "Bau", "category": "Baustelle", "guid": "b", "pubDate": now},
+        {"title": "Stoer", "category": "Störung", "guid": "s", "pubDate": now},
+        {"title": "Hint", "category": "Hinweis", "guid": "h", "pubDate": now},
+    ]
+    ordered = sorted(items, key=lambda it: build_feed._recency_sort_key(it, state, now))
+    assert [it["title"] for it in ordered] == ["Stoer", "Hint", "Bau"]
+
+
+def test_newer_pubdate_first_within_same_category_and_first_seen(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same category + first_seen → newer pubDate leads (sinks old-start Baustellen)."""
+    build_feed = _import_build_feed(monkeypatch)
+    now = datetime(2026, 5, 24, 12, 0, tzinfo=UTC)
+    state: dict[str, dict[str, Any]] = {}
+    items = [
+        {"title": "old-start", "category": "Baustelle", "guid": "a",
+         "pubDate": datetime(2021, 2, 28, tzinfo=UTC)},
+        {"title": "new-start", "category": "Baustelle", "guid": "b",
+         "pubDate": datetime(2026, 4, 1, tzinfo=UTC)},
+    ]
+    ordered = sorted(items, key=lambda it: build_feed._recency_sort_key(it, state, now))
+    assert [it["title"] for it in ordered] == ["new-start", "old-start"]
+
+
+def test_missing_pubdate_sorts_last_within_group(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A null/unparseable pubDate sorts last within its (first_seen, category) group."""
+    build_feed = _import_build_feed(monkeypatch)
+    now = datetime(2026, 5, 24, 12, 0, tzinfo=UTC)
+    state: dict[str, dict[str, Any]] = {}
+    items = [
+        {"title": "no-pub", "category": "Störung", "guid": "a", "pubDate": None},
+        {"title": "has-pub", "category": "Störung", "guid": "b", "pubDate": now},
+    ]
+    ordered = sorted(items, key=lambda it: build_feed._recency_sort_key(it, state, now))
+    assert [it["title"] for it in ordered] == ["has-pub", "no-pub"]


### PR DESCRIPTION
## Summary

Improves the feed ordering tie-breaker. The feed sorts by `first_seen` descending, but the only tie-breaker was the **guid** — a SHA256 hash for Baustellen — so when a batch of items surfaces in the **same build** (e.g. the ~33 construction sites that all get `first_seen = now` after the recent Baustellen filter expansion), they ordered effectively at random.

`_recency_sort_key` now breaks `first_seen` ties by, in order:

1. **Category rank** — `Störung` (WL/ÖBB live disruptions **and** the Stammstrecke delay/cancellation monitor, whose `EVENT_CATEGORY` is also `"Störung"`) ranks above `Hinweis`, which ranks above `Baustelle`. Operator policy: disruptions matter more for the feed than long-running construction.
2. **`pubDate` descending** — the source's own recency signal; the more recently published item leads. A missing/unparseable `pubDate` sorts **last** within its group (`-inf` → `+inf` after negation). For Baustellen, `pubDate ≈ construction start`, so this also sinks old-start sites (e.g. one running since 2021) within their tie.
3. **guid** — unchanged, now the final deterministic tiebreaker for a stable total order across builds.

Key shape: `(-first_seen, category_rank, -pubDate, guid)`.

## Test plan

- [x] `ruff` (pinned 0.4.10) clean · `mypy --strict` clean (48 files) · C901 gate (0 new violations) · `bandit` clean
- [x] New regression tests in `tests/test_build_feed_sort.py` (each fails before the change):
  - `Störung` > `Hinweis` > `Baustelle` on a `first_seen` tie
  - newer `pubDate` first within the same category + `first_seen`
  - missing `pubDate` sorts last within its group
- [x] Updated the existing none-guid test for the new key shape (guid is now the final tuple element)
- [x] Full suite: **8489 passed**

https://claude.ai/code/session_014gFj4NxBem63x6kLZV8rLj

---
_Generated by [Claude Code](https://claude.ai/code/session_014gFj4NxBem63x6kLZV8rLj)_