### PR TITLE
docs(development): sync event-format table with nullable schema

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -319,8 +319,9 @@ for event in wl_events:
 
 ### Datenformat der Ereignisse
 
-Unabhängig vom Provider folgen alle Ereignisse derselben Struktur, die auch im Feed verwendet wird. Die wichtigsten Felder im
-JSON-Cache (Strings im ISO-8601-Format) bzw. bei direkter Python-Nutzung (Python-`datetime`-Objekte) sind:
+Unabhängig vom Provider folgen alle Ereignisse derselben Struktur, die auch im Feed verwendet wird. Die Zeitfelder liegen
+im JSON-Cache als ISO-8601-Strings (bzw. bei direkter Python-Nutzung als `datetime`-Objekte) vor und dürfen `null` sein.
+Die wichtigsten Felder sind:
 
 | Feld        | Beschreibung                                                                                  |
 | ----------- | --------------------------------------------------------------------------------------------- |
@@ -330,16 +331,19 @@ JSON-Cache (Strings im ISO-8601-Format) bzw. bei direkter Python-Nutzung (Python
 | `description` | Ausführliche Beschreibung inkl. Zusatzinfos wie Umleitungen, betroffene Haltestellen usw.     |
 | `link`      | Referenz-URL zur Originalmeldung oder weiterführenden Infos.                                   |
 | `guid`      | Stabile eindeutige Kennung, geeignet als Primärschlüssel.                                      |
-| `pubDate`   | Veröffentlichungszeitpunkt der Meldung.                                                        |
-| `starts_at` | Technischer Startzeitpunkt des Ereignisses (häufig identisch mit `pubDate`).                    |
+| `pubDate`   | Veröffentlichungszeitpunkt der Meldung; `null`, wenn die Quelle keinen parsebaren Zeitstempel liefert (z. B. WL-Items ohne Zeitfeld). |
+| `starts_at` | Technischer Startzeitpunkt der Maßnahme (häufig identisch mit `pubDate`); `null`, wenn nicht ermittelbar.                    |
 | `ends_at`   | Optionales Ende der Maßnahme; `null`, wenn unbekannt oder bereits vergangen.                   |
+| `first_seen` | Zeitpunkt, an dem die Meldung erstmals im Feed erschien (projektintern via `data/first_seen.json` gepflegt).                |
 | `_identity` | Projektinterner Schlüssel zur Nachverfolgung des „first seen“-Zeitpunkts (optional vorhanden). |
 
 Eine formale Beschreibung steht als [JSON-Schema](schema/events.schema.json)
-bereit und eignet sich für Validierungen in Drittprojekten. Alle Felder sind als
-Unicode-Strings hinterlegt, zusätzliche provider-spezifische Hilfsfelder werden
-vor dem JSON-Export entfernt, sodass die Datensätze stabil und schema-konform
-bleiben.
+bereit und eignet sich für Validierungen in Drittprojekten. Pflichtfelder
+sind `source`, `category`, `title`, `description`, `link`, `guid`, `pubDate`
+und `starts_at`; die Zeitfelder `pubDate`, `starts_at` und `ends_at` dürfen
+`null` sein. Alle übrigen Werte sind Unicode-Strings; zusätzliche
+provider-spezifische Hilfsfelder werden vor dem JSON-Export entfernt, sodass
+die Datensätze stabil und schema-konform bleiben.
 
 ## Stationsverzeichnis
 


### PR DESCRIPTION
## Hintergrund

Erneuter Doku-Audit unter der Direktive „aktueller Stand, vollständig & fehlerfrei, auf Deutsch", mit ausdrücklichem Blick auf die jüngsten Projektänderungen (30+ Commits seit PR #1628).

## Audit-Ergebnis: gesund, eine echte Drift

### ✅ Was geprüft und in Ordnung ist

- **Regression-Check meiner Löschungen (PR #1628)**: Keine toten Verweise auf `.jules/`, `docs/performance_monitoring_plan.md` oder `docs/strict-typing-*.md` in Code, Tests, Workflows oder Doku.
- **`.jules/sentinel.md` ist wieder da** — aber als bewusst neu angelegtes, schlankes Security-Journal (353 statt vormals ~30.000 Zeilen, Neustart 2026-05-24 via PR #1629). Es ist **nirgends in der User-Doku verlinkt** → internes Entwickler-Artefakt, kein Doku-Scope, nicht angefasst.
- **`docs/llms.txt`** (neues SEO/GEO-Artefakt nach llms.txt-Standard): deutsch, korrekt, und in `docs/development.md` (Skript-Tabelle Z. 581 + SEO-Sektion Z. 661) vollständig dokumentiert.
- **`docs/stations_diff.md`** wird inzwischen **deutsch in Produktion generiert** (mein Renderer-Fix aus PR #1628 wirkt: „Hinzugefügt/Entfernt/Umbenannt/Koordinaten verschoben").
- **`docs/architecture.md`-Übersetzung**: 0 gebrochene interne Anchor-Links, 0 externe `#anchor`-Verweise betroffen.
- **Sprach-Fingerprint** über alle inhaltsreichen User-Docs: durchgehend Deutsch.
- **Keine neuen undokumentierten Env-Vars oder CLI-Subbefehle** durch die jüngsten Commits.

### ⚠️ Behobene Drift

`docs/development.md` Event-Format-Tabelle hinkte der Schema-Änderung aus **PR #1659** hinterher (`pubDate` und `starts_at` wurden nullable, `type: ["string","null"]`):

- `pubDate`: jetzt dokumentiert als „`null`, wenn die Quelle keinen parsebaren Zeitstempel liefert" (deckungsgleich mit der Schema-Beschreibung).
- `starts_at`: nullable-Fall ergänzt.
- `first_seen`: fehlende Tabellenzeile ergänzt — das Feld ist Teil des exportierten Schemas, war aber nicht gelistet.
- Schluss-Satz „Alle Felder sind als Unicode-Strings hinterlegt" durch eine korrekte Pflichtfeld-vs-nullable-Zusammenfassung ersetzt, die der `required`-Liste und den drei nullable-Zeitfeldern des Schemas entspricht.

## Verifikation

- Event-Tabelle gegen `docs/schema/events.schema.json` abgeglichen (`required`-Liste + Property-Typen via JSON-Parse).
- Tabelle weiterhin wohlgeformt (Spaltenzahl unverändert).
- Reiner Markdown-Diff (+12/−8 Zeilen), keine Code-Pfade berührt.

## Test plan

- [x] Event-Tabelle deckungsgleich mit Schema-`required` + nullable-Typen
- [x] Keine toten Verweise auf in PR #1628 gelöschte Dateien
- [x] Alle User-Docs weiterhin DE
- [x] architecture.md ohne Anchor-Bruch
- [ ] CI grün (rein Markdown; keine Code-Gates betroffen)

https://claude.ai/code/session_011QD7QvHgY7Tg6zWgGLR5VH

---
_Generated by [Claude Code](https://claude.ai/code/session_011QD7QvHgY7Tg6zWgGLR5VH)_