### PR TITLE
fix(baustellen): stable GUID (drop volatile OBJECTID) to stop first_seen churn

### DIFF
--- a/scripts/update_baustellen_cache.py
+++ b/scripts/update_baustellen_cache.py
@@ -763,12 +763,16 @@ def _feature_to_event(feature: dict[str, Any]) -> ConstructionEvent | None:
     description = _format_description(properties, start, end)
     location = _build_location(properties, geometry)
     context = _build_context(properties)
-    identifier = (
-        properties.get("OGD_ID")
-        or properties.get("OBJECTID")
-        or properties.get("ID")
-        or title
-    )
+    # The Baustellen GUID must stay STABLE for the same physical construction
+    # site across WFS refreshes: it keys ``first_seen``, and a changing GUID
+    # makes the site look brand-new on every change, resetting first_seen so it
+    # perpetually dominates the first_seen-sorted feed. ``OBJECTID`` / ``ID`` are
+    # ArcGIS query-time row identifiers that are NOT stable across the upstream's
+    # re-indexing — observed churning 3x in two days for the *same* site
+    # (identical title + start + end, three different OBJECTIDs). Derive the
+    # identity from a stable open-data id when the layer offers one, otherwise
+    # from the stable title; never from the volatile OBJECTID/ID row number.
+    identifier = properties.get("OGD_ID") or title
     guid = make_guid("baustellen", str(identifier), start.isoformat() if start else "", end.isoformat() if end else "")
     pub_date = start or end or datetime.now(tz=VIENNA_TZ)
     return ConstructionEvent(

--- a/tests/test_update_baustellen_cache.py
+++ b/tests/test_update_baustellen_cache.py
@@ -181,6 +181,40 @@ def test_to_item_always_emits_required_starts_at_key() -> None:
     assert "ends_at" not in item
 
 
+def _bau_feature(*, name: str = "Brünner Straße 59", objectid: int = 1) -> dict[str, Any]:
+    return {
+        "properties": {
+            "BEZEICHNUNG": name,
+            "OBJEKT_BEGINN": "2026-05-17Z",
+            "OBJEKT_ENDE": "2026-08-14Z",
+            "OBJECTID": objectid,
+        },
+        "geometry": {},
+    }
+
+
+def test_guid_stable_across_objectid_churn() -> None:
+    """The Baustellen GUID must NOT depend on the volatile ArcGIS OBJECTID.
+
+    The upstream WFS re-assigns OBJECTID on re-indexing; if the GUID changed
+    with it, first_seen would reset every churn and the site would perpetually
+    dominate the first_seen-sorted feed. Same title + start + end must yield
+    one guid regardless of OBJECTID.
+    """
+    ev1 = update_baustellen_cache._feature_to_event(_bau_feature(objectid=111))
+    ev2 = update_baustellen_cache._feature_to_event(_bau_feature(objectid=999))
+    assert ev1 is not None and ev2 is not None
+    assert ev1.guid == ev2.guid
+
+
+def test_guid_differs_for_distinct_sites() -> None:
+    """Distinct sites (different title) still get distinct guids."""
+    ev1 = update_baustellen_cache._feature_to_event(_bau_feature(name="Brünner Straße 59"))
+    ev2 = update_baustellen_cache._feature_to_event(_bau_feature(name="Gentzgasse 1"))
+    assert ev1 is not None and ev2 is not None
+    assert ev1.guid != ev2.guid
+
+
 def test_collect_events_from_sample_payload() -> None:
     payload = json.loads(SAMPLE_PATH.read_text(encoding="utf-8"))
     events = update_baustellen_cache._collect_events(payload)


### PR DESCRIPTION
## Summary

**Root cause of the "feed is almost only Baustellen" symptom — a GUID-churn bug.**

The Baustellen GUID was:
```python
identifier = properties.get("OGD_ID") or properties.get("OBJECTID") or properties.get("ID") or title
guid = make_guid("baustellen", str(identifier), start_iso, end_iso)
```
The Stadt-Wien WFS (`BAUSTELLENLINOGD` / `BAUSTELLENPKTOGD`) provides **no `OGD_ID`**, so `identifier` resolved to **`OBJECTID`** — an ArcGIS *query-time row number* that is **not stable** across the upstream's re-indexing.

Forensic confirmation from `git` history: the same site **"Brünner Straße 59"** with *identical* `start` (2026-05-17) and `end` (2026-08-14) carried **three different GUIDs in two days** as OBJECTID churned (`59be6c29` → `ec4d867a` → `e27bfff5`).

Because the GUID keys `first_seen`, every churn made the site look brand-new → its `first_seen` reset to *now* → under the `first_seen`-descending sort + `MaxItems=10`, the whole Baustellen set **perpetually outranked** the stable-`first_seen` WL/ÖBB disruptions and flooded the feed. (The fetchers themselves were fine — WL 52, ÖBB 17, Baustellen 33; there were plenty of disruptions, just pushed below the cut.)

**Fix:** derive the identity from a stable open-data id when present, else the **stable title** — never from the volatile `OBJECTID`/`ID`. The GUID now stays constant for a site across WFS refreshes, so `first_seen` sticks and the feed rebalances toward real Störungen. One final `first_seen` reset happens on the next build as the scheme changes, then it stabilises.

Note: this is the actual fix for the symptom; the earlier sort tie-breaker (#1660) only helped at *equal* `first_seen`, which the churn prevented.

## Test plan

- [x] `ruff` (pinned 0.4.10) · `mypy --strict src tests` (529 files) · C901 gate (0 new) · `bandit` — all clean
- [x] New regression tests in `tests/test_update_baustellen_cache.py`:
  - guid **stable** when OBJECTID changes (same title+dates → same guid) — fails before the fix
  - distinct sites still get distinct guids
- [x] Full suite: **8491 passed**

https://claude.ai/code/session_014gFj4NxBem63x6kLZV8rLj

---
_Generated by [Claude Code](https://claude.ai/code/session_014gFj4NxBem63x6kLZV8rLj)_