### PR TITLE
fix(stations,cli): drop distant-name wl_stop contamination + complete validate summary

### DIFF
--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -1121,6 +1121,78 @@ def _all_pairs_within(
     return True
 
 
+def _drop_distant_name_contamination(
+    entries: list[dict[str, object]], *, threshold_m: float = 2000.0
+) -> int:
+    """Strip aliases / wl_stops whose name is a *different* station located
+    more than *threshold_m* away.
+
+    A Wiener-Linien DIVA legitimately groups physically nearby stops, and a
+    grouped stop's StopText sometimes equals a neighbouring station's name
+    (interchanges, depots) — those resolve to a station a few hundred metres
+    away and stay. But a genuinely mislabelled stop pollutes the alias index:
+    e.g. a stop sitting *at Grinzing* carrying the name ``Karlsplatz`` (6.4 km
+    away) made ``station_info("Karlsplatz")`` resolve to Grinzing. Only the
+    > threshold cases are dropped; the sweep that motivated this guard found
+    exactly one such case across the whole directory, with no false positives
+    among the legitimate sub-2-km interchange names. Returns the number of
+    alias/stop tokens dropped. Mutates *entries* in place.
+    """
+    from src.utils.stations import _normalize_token
+
+    def _bare(name: object) -> str:
+        text = re.sub(r"\s*\((?:WL|VOR)\)\s*$", "", str(name or ""))
+        return _normalize_token(re.sub(r"^Wien\s+", "", text))
+
+    # bare canonical-name token -> coordinates of the owning station(s)
+    name_coords: dict[str, list[tuple[float, float]]] = {}
+    for entry in entries:
+        lat, lon = entry.get("latitude"), entry.get("longitude")
+        if isinstance(lat, int | float) and isinstance(lon, int | float):
+            token = _bare(entry.get("name"))
+            if token:
+                name_coords.setdefault(token, []).append((float(lat), float(lon)))
+
+    def _is_distant(label: object, own: str, elat: float, elon: float) -> bool:
+        if not isinstance(label, str):
+            return False
+        token = _normalize_token(label)
+        owners = name_coords.get(token)
+        if not token or token == own or not owners:
+            return False
+        return all(
+            _haversine_m(elat, elon, owner_lat, owner_lon) > threshold_m
+            for owner_lat, owner_lon in owners
+        )
+
+    dropped = 0
+    for entry in entries:
+        lat, lon = entry.get("latitude"), entry.get("longitude")
+        if not isinstance(lat, int | float) or not isinstance(lon, int | float):
+            continue
+        elat, elon, own = float(lat), float(lon), _bare(entry.get("name"))
+
+        aliases = entry.get("aliases")
+        if isinstance(aliases, list):
+            kept = [a for a in aliases if not _is_distant(a, own, elat, elon)]
+            if len(kept) != len(aliases):
+                dropped += len(aliases) - len(kept)
+                entry["aliases"] = kept
+
+        stops = entry.get("wl_stops")
+        if isinstance(stops, list):
+            kept_stops = [
+                s
+                for s in stops
+                if not (isinstance(s, dict) and _is_distant(s.get("name"), own, elat, elon))
+            ]
+            if len(kept_stops) != len(stops):
+                dropped += len(stops) - len(kept_stops)
+                entry["wl_stops"] = kept_stops
+
+    return dropped
+
+
 def _merge_entry_group(group: list[dict[str, object]]) -> dict[str, object]:
     """Fold a list of co-located duplicate entries into one.
 
@@ -1729,6 +1801,15 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     wl_entries = build_wl_entries(haltestellen, haltepunkte, vor_mapping)
     log.info("Prepared %d WL station entries", len(wl_entries))
+
+    # Drop mislabelled stop names that resolve to a far-away station (an
+    # upstream WL DIVA-grouping artefact). Without this a stop sitting at
+    # one station but carrying another's name (observed: a Grinzing stop
+    # named "Karlsplatz", 6.4 km off) pollutes the alias index and resolves
+    # lookups to the wrong station.
+    contaminated = _drop_distant_name_contamination(wl_entries)
+    if contaminated:
+        log.info("Dropped %d distant-name-contaminating alias/stop token(s)", contaminated)
 
     # Austrian-source coordinate consensus (WL → HAFAS → OSM → Google).
     # Env-disabled via ``WIEN_OEPNV_AT_RECONCILE=0`` — mirrors the

--- a/src/cli.py
+++ b/src/cli.py
@@ -338,7 +338,10 @@ def _handle_stations_validate(args: argparse.Namespace) -> int:
 
     # Avoid printing potentially sensitive coordinate details to stdout.
     # Instead, print a high-level summary; full details are available in the
-    # optional report file.
+    # optional report file. All nine categories are listed so the summary
+    # matches ``report.has_issues`` / ``--fail-on-issues`` — previously it
+    # omitted cross-station-ID, identity-field, provider and naming issues,
+    # so a clean-looking summary could hide a non-zero exit.
     sys.stdout.write(
         "Stations validation summary: "
         f"{report.total_stations} stations analysed, "
@@ -346,6 +349,10 @@ def _handle_stations_validate(args: argparse.Namespace) -> int:
         f"{len(report.alias_issues)} alias issues, "
         f"{len(report.coordinate_issues)} coordinate anomalies, "
         f"{len(report.gtfs_issues)} GTFS mismatches, "
+        f"{len(report.cross_station_id_issues)} cross-station ID collisions, "
+        f"{len(report.identity_field_conflicts)} identity-field conflicts, "
+        f"{len(report.provider_issues)} provider issues, "
+        f"{len(report.naming_issues)} naming issues, "
         f"{len(report.security_issues)} security warnings.\n"
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,6 +79,10 @@ def test_cli_stations_validate_writes_report(tmp_path: Path, monkeypatch: pytest
         coordinate_issues: list[str] = []
         gtfs_issues: list[str] = []
         security_issues: list[str] = []
+        cross_station_id_issues: list[str] = []
+        identity_field_conflicts: list[str] = []
+        provider_issues: list[str] = []
+        naming_issues: list[str] = []
 
         def to_markdown(self) -> str:
             return "dummy-report\n"

--- a/tests/test_update_wl_stations_merge.py
+++ b/tests/test_update_wl_stations_merge.py
@@ -959,3 +959,46 @@ def test_merge_sources_emits_alphabetical_order() -> None:
         update_wl_stations._merge_sources("google_places,vor", "vor", "wl")
         == "google_places,vor,wl"
     )
+
+
+def test_drop_distant_name_contamination() -> None:
+    """A wl_stop/alias named like a >2km station is dropped; a nearby
+    interchange name is kept. Mirrors the real Grinzing→Karlsplatz case."""
+    entries: list[dict[str, object]] = [
+        {
+            "name": "Wien Grinzing (WL)",
+            "latitude": 48.2554,
+            "longitude": 16.3421,
+            "aliases": ["Grinzing", "Karlsplatz", "Grinzinger Allee"],
+            "wl_stops": [
+                {"stop_id": "1", "name": "Grinzing", "latitude": 48.2554, "longitude": 16.3421},
+                {"stop_id": "2", "name": "Karlsplatz", "latitude": 48.2554, "longitude": 16.3421},
+            ],
+        },
+        {  # 6.4 km from Grinzing → its name on Grinzing is contamination
+            "name": "Wien Karlsplatz",
+            "latitude": 48.2008,
+            "longitude": 16.3694,
+            "aliases": ["Karlsplatz"],
+            "wl_stops": [],
+        },
+        {  # ~250 m from Grinzing → legitimate nearby interchange name, kept
+            "name": "Wien Grinzinger Allee (WL)",
+            "latitude": 48.2540,
+            "longitude": 16.3450,
+            "aliases": ["Grinzinger Allee"],
+            "wl_stops": [],
+        },
+    ]
+
+    dropped = update_wl_stations._drop_distant_name_contamination(entries)
+
+    assert dropped == 2  # the far "Karlsplatz" alias + the "Karlsplatz" wl_stop
+    grinzing = cast(Mapping[str, object], entries[0])
+    aliases = cast("list[str]", grinzing["aliases"])
+    stops = cast("list[Mapping[str, object]]", grinzing["wl_stops"])
+    assert "Karlsplatz" not in aliases
+    assert all(s.get("name") != "Karlsplatz" for s in stops)
+    # nearby interchange name and own name are preserved
+    assert "Grinzinger Allee" in aliases
+    assert "Grinzing" in aliases


### PR DESCRIPTION
## Summary

Two related station-directory / validation hardening fixes.

### 1. Drop distant-name-contaminating wl_stop aliases (`scripts/update_wl_stations.py`, `data/stations.json`)
A Wiener-Linien DIVA can group a **mislabelled** stop whose `StopText` is a *different* station's name far away. Observed: `stop_id 7354` sits **at Grinzing** yet is named **"Karlsplatz"** (6.4 km away). Since `_station_lookup` derives an alias from every `wl_stop` name, this made `station_info("Karlsplatz")` resolve to **Grinzing**.

`_drop_distant_name_contamination` strips an alias / `wl_stop` whose name matches a different station's canonical name **> 2 km** away (a deliberately **conservative** threshold — see note below), wired into `update_wl_stations.main()` and applied once to the committed `data/stations.json` (Grinzing loses the bogus alias + stop; 7-line diff).

**On the threshold:** a per-stop-coordinate sweep showed the *remaining* co-named stops form a **continuous 32 m → 978 m gradient with no clean gap** — and a clearly **legitimate** alias (`Oper, Karlsplatz` → `Karlsplatz`, same interchange) sits at **164 m**, *farther* than several borderline cases. So a tight (e.g. 50 m) threshold would drop legitimate interchange aliases (false positives). 2 km only fires on **unambiguous** gross mislabels (the Grinzing class) with zero false positives; the subtle sub-1 km cases are a judgement call better left to review than a blunt auto-drop.

### 2. Complete the `stations validate` CLI summary (`src/cli.py`)
The stdout summary printed only **5 of 9** `ValidationReport` categories (it omitted cross-station-ID collisions, identity-field conflicts, provider issues, naming issues). Since `--fail-on-issues` keys on `has_issues` (all 9), the exit code could be non-zero while the summary read "all clean". Now lists all nine.

## Test plan

- [x] `ruff` · `mypy --strict src tests` (529 files) · C901 gate (0 new) · `bandit` — clean
- [x] New regression test for the guard (far name dropped, nearby interchange kept); CLI `DummyReport` updated for the 9-category summary
- [x] Verified: `station_info("Karlsplatz")` → `"Wien Karlsplatz"`; `station_info("Grinzing")` unchanged; 0 contaminations > 2 km remain
- [x] Full suite: **8492 passed**

https://claude.ai/code/session_014gFj4NxBem63x6kLZV8rLj