### PR TITLE
fix(ci): stop concurrent-push race that left first_seen.json unmerged

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Append-only, year-partitioned statistics ledgers. ``src/utils/stats.py``
+# only ever appends rows (file mode "a", stable header written once on
+# creation), so a 3-way merge during a concurrent-push rebase / autostash
+# re-apply must KEEP BOTH sides' appended rows. Git's built-in ``union``
+# driver concatenates the divergent tails — the correct, lossless semantics
+# for an append-only ledger; picking one side would silently drop logged
+# disruptions / cancellations / delays. Without this a conflict on these
+# files left an unmerged index that crashed the downstream auto-commit (see
+# the reconcile step in ``.github/workflows/update-cycle.yml``).
+data/stats/*.csv merge=union

--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -29,11 +29,22 @@ on:
 permissions:
   contents: read
 
-# Independent concurrency lane — this workflow does no API I/O so
-# it does not need to share the ``external-api-fetch`` lock with the
-# data-fetcher workflows.
+# Concurrency lane. On ``main`` this workflow commits ``chore: rebuild
+# feed`` — touching ``data/first_seen.json`` and the feed XMLs — to the
+# SAME branch that ``update-cycle.yml`` and ``manual-full-refresh.yml``
+# push to. Those run in the ``external-api-fetch`` group; if this workflow
+# kept its own lane it could push to ``main`` WHILE a cycle tick is
+# mid-build, and the cycle's ``git pull --rebase --autostash`` would then
+# re-apply its autostash on top of our just-pushed ``first_seen.json`` —
+# leaving an unmerged index that crashed the cycle's auto-commit (observed
+# 2026-05-25). Sharing ``external-api-fetch`` on ``main`` serialises the
+# three feed-writing workflows so two of them can never race the same pull
+# window. Non-``main`` (PR / branch) builds keep their own per-ref lane —
+# they only verify code changes and never push (see the
+# ``if: github.ref == 'refs/heads/main'`` guards on the commit steps), so
+# they stay parallel and fast.
 concurrency:
-  group: build-feed-${{ github.ref }}
+  group: ${{ github.ref == 'refs/heads/main' && 'external-api-fetch' || format('build-feed-{0}', github.ref) }}
   cancel-in-progress: false
 
 jobs:
@@ -139,7 +150,49 @@ jobs:
 
       - name: Pull concurrent remote changes
         if: github.ref == 'refs/heads/main'
-        run: git pull --rebase --autostash
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # ``git pull --rebase --autostash`` does NOT fail when the
+          # autostash RE-APPLY conflicts: the rebase (fast-forward onto a
+          # concurrent push) succeeds, the failed ``git stash apply`` is
+          # only a warning, and the step still exits 0 — leaving an UNMERGED
+          # index. The next step (git-auto-commit-action) then dies with the
+          # opaque "error: you need to resolve your current index first"
+          # (observed 2026-05-25 on update-cycle.yml, the mirror of this
+          # commit pattern). The shared ``external-api-fetch`` concurrency
+          # lane now serialises the feed-writing workflows so this collision
+          # should not recur; the block below is the defense-in-depth
+          # backstop that keeps ANY residual concurrent push (a manual push,
+          # a future workflow) from re-introducing the silent-unmerged-index
+          # failure.
+          git pull --rebase --autostash
+
+          # Append-only ledgers (``data/stats/*.csv``) auto-resolve via the
+          # ``merge=union`` driver in ``.gitattributes`` — both sides' rows
+          # are kept, so they never surface as unmerged here. Everything
+          # else this build writes (feed XMLs, README, the ``first_seen``
+          # state) is a full regeneration from the on-disk caches, so on the
+          # rare residual conflict the locally built copy is authoritative.
+          mapfile -t -d '' conflicts < <(git diff --name-only --diff-filter=U -z)
+          if [ "${#conflicts[@]}" -gt 0 ]; then
+            echo "::warning title=reconcile::autostash re-apply conflicted on a concurrent push; keeping locally-built copies for: ${conflicts[*]}"
+            # In a stash-apply conflict, stage 3 ("--theirs") is the stashed
+            # locally-built version; stage 2 is the just-pulled upstream.
+            git checkout --theirs -- "${conflicts[@]}"
+            git add -- "${conflicts[@]}"
+            # A conflicted ``git stash apply`` leaves the autostash entry on
+            # the stash stack; drop it so it cannot leak into a later run.
+            git stash drop || true
+          fi
+
+          # Never hand an unmerged index to the auto-commit step.
+          if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
+            echo "::error title=reconcile::unresolved merge conflicts remain after reconcile" >&2
+            git diff --name-only --diff-filter=U >&2
+            exit 1
+          fi
 
       - name: Commit and push changes
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/manual-full-refresh.yml
+++ b/.github/workflows/manual-full-refresh.yml
@@ -205,7 +205,50 @@ jobs:
 
       # ----- 5) Aenderungen committen und pushen -----
       - name: Pull concurrent remote changes
-        run: git pull --rebase --autostash
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # ``git pull --rebase --autostash`` does NOT fail when the
+          # autostash RE-APPLY conflicts: the rebase (fast-forward onto a
+          # concurrent push) succeeds, the failed ``git stash apply`` is
+          # only a warning, and the step still exits 0 — leaving an UNMERGED
+          # index. The next step (git-auto-commit-action) then dies with the
+          # opaque "error: you need to resolve your current index first"
+          # (observed 2026-05-25 on update-cycle.yml, the mirror of this
+          # commit pattern). The shared ``external-api-fetch`` concurrency
+          # lane now serialises the feed-writing workflows so this collision
+          # should not recur; the block below is the defense-in-depth
+          # backstop that keeps ANY residual concurrent push (a manual push,
+          # a future workflow) from re-introducing the silent-unmerged-index
+          # failure.
+          git pull --rebase --autostash
+
+          # Append-only ledgers (``data/stats/*.csv``) auto-resolve via the
+          # ``merge=union`` driver in ``.gitattributes`` — both sides' rows
+          # are kept, so they never surface as unmerged here. Everything
+          # else this refresh writes (feed XMLs, README, statistik.md, the
+          # station directory, the ``first_seen`` state) is a full
+          # regeneration, so on the rare residual conflict the locally built
+          # copy is authoritative.
+          mapfile -t -d '' conflicts < <(git diff --name-only --diff-filter=U -z)
+          if [ "${#conflicts[@]}" -gt 0 ]; then
+            echo "::warning title=reconcile::autostash re-apply conflicted on a concurrent push; keeping locally-built copies for: ${conflicts[*]}"
+            # In a stash-apply conflict, stage 3 ("--theirs") is the stashed
+            # locally-built version; stage 2 is the just-pulled upstream.
+            git checkout --theirs -- "${conflicts[@]}"
+            git add -- "${conflicts[@]}"
+            # A conflicted ``git stash apply`` leaves the autostash entry on
+            # the stash stack; drop it so it cannot leak into a later run.
+            git stash drop || true
+          fi
+
+          # Never hand an unmerged index to the auto-commit step.
+          if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
+            echo "::error title=reconcile::unresolved merge conflicts remain after reconcile" >&2
+            git diff --name-only --diff-filter=U >&2
+            exit 1
+          fi
 
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7

--- a/.github/workflows/update-cycle.yml
+++ b/.github/workflows/update-cycle.yml
@@ -387,7 +387,51 @@ jobs:
       # ----- Single atomic commit -----------------------------------------
 
       - name: Pull concurrent remote changes
-        run: git pull --rebase --autostash
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # ``git pull --rebase --autostash`` does NOT fail when the
+          # autostash RE-APPLY conflicts: the rebase (fast-forward onto a
+          # concurrent push) succeeds, the failed ``git stash apply`` is
+          # only a warning, and the step still exits 0 — leaving an UNMERGED
+          # index. The next step (git-auto-commit-action) then dies with the
+          # opaque "error: you need to resolve your current index first"
+          # (observed 2026-05-25: build-feed.yml pushed ``chore: rebuild
+          # feed`` mid-cycle and both runs had rewritten
+          # ``data/first_seen.json``). The shared ``external-api-fetch``
+          # concurrency lane now serialises the feed-writing workflows so
+          # this collision should not recur; the block below is the
+          # defense-in-depth backstop that keeps ANY residual concurrent
+          # push (a manual push, a future workflow) from re-introducing the
+          # silent-unmerged-index failure.
+          git pull --rebase --autostash
+
+          # Append-only ledgers (``data/stats/*.csv``) auto-resolve via the
+          # ``merge=union`` driver in ``.gitattributes`` — both sides' rows
+          # are kept, so they never surface as unmerged here. Everything
+          # else the cycle writes (feed XMLs, README, statistik.md, the
+          # ``first_seen`` state) is a full regeneration from the freshly
+          # fetched caches, so on the rare residual conflict the locally
+          # built copy is authoritative.
+          mapfile -t -d '' conflicts < <(git diff --name-only --diff-filter=U -z)
+          if [ "${#conflicts[@]}" -gt 0 ]; then
+            echo "::warning title=reconcile::autostash re-apply conflicted on a concurrent push; keeping locally-built copies for: ${conflicts[*]}"
+            # In a stash-apply conflict, stage 3 ("--theirs") is the stashed
+            # locally-built version; stage 2 is the just-pulled upstream.
+            git checkout --theirs -- "${conflicts[@]}"
+            git add -- "${conflicts[@]}"
+            # A conflicted ``git stash apply`` leaves the autostash entry on
+            # the stash stack; drop it so it cannot leak into a later run.
+            git stash drop || true
+          fi
+
+          # Never hand an unmerged index to the auto-commit step.
+          if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
+            echo "::error title=reconcile::unresolved merge conflicts remain after reconcile" >&2
+            git diff --name-only --diff-filter=U >&2
+            exit 1
+          fi
 
       - name: Commit cycle outputs
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7


### PR DESCRIPTION
## Problem

The **Update cycle** job failed in *Commit cycle outputs* (`stefanzweifel/git-auto-commit-action`):

```
error: you need to resolve your current index first
data/first_seen.json: needs merge
Error: Invalid status code: 1
```

The real damage happened one step earlier. From the run log (2026-05-25 11:01 UTC):

```
Updating 4a0c182ad..1bf395f4a        ← pulled `chore: rebuild feed`
Created autostash: 0ea04456f
Fast-forward
 data/first_seen.json | 30 +++++...
Applying autostash resulted in conflicts.   ← but the step still exits 0
```

### Root cause

`build-feed.yml` (lane `build-feed-<ref>`) and `update-cycle.yml` (lane `external-api-fetch`) **both** run `feed build` — which rewrites `data/first_seen.json` — and both push to `main`, but from **separate concurrency lanes**, so they can push at the same time.

Reconstructed timeline (UTC):

| Time | Event |
|---|---|
| 10:58:57 | PR #1663 merged → push to `src/**` **triggers `build-feed.yml`** |
| 11:00:08 | this `update-cycle` tick starts (IFTTT) |
| 11:00:12 | `build-feed.yml` pushes `chore: rebuild feed` (+30 lines in `first_seen.json`) |
| 11:01:01 | cycle pulls it → autostash re-apply **conflicts** on `first_seen.json` |
| 11:01:03 | auto-commit dies on the unmerged index |

`git pull --rebase --autostash` **exits 0 even when the autostash re-apply conflicts** (only the rebase has to succeed; the failed `git stash apply` is just a warning). So the *Pull* step stayed green and handed an **unmerged index** to the auto-commit action, which then failed with the opaque message above.

The same fragile `pull --rebase --autostash` + auto-commit pattern is also in `build-feed.yml` and `manual-full-refresh.yml`.

## Fix (defense-in-depth, both layers)

- **Structural** — `build-feed.yml` now shares the `external-api-fetch` lane on `main`, so the three feed-writing workflows (`update-cycle`, `build-feed`, `manual-full-refresh`) can never push to `main` concurrently. PR/branch builds keep their own per-ref lane (they never push), so code-change verification stays parallel and fast.
- **Backstop** — the reconcile step in all three workflows now detects any unmerged paths after the autostash pull, keeps the locally-built copy (renders + `first_seen` state), drops the leftover autostash, and **fails loudly if any conflict remains** — it never hands an unmerged index to the commit step.
- **Lossless ledgers** — new `.gitattributes` entry `data/stats/*.csv merge=union`. The statistics CSVs are append-only (`src/utils/stats.py` writes mode `"a"`), so git's built-in `union` driver keeps **both** sides' rows instead of conflicting / dropping logged disruptions.

## Test plan

- [x] All three workflows parse as valid YAML.
- [x] Reproduced the exact autostash-apply conflict in a sandbox repo (same `Applying autostash resulted in conflicts` message) and verified the reconcile: index ends clean, leftover stash dropped, locally-built `first_seen.json`/render wins, **CSV unioned to keep both rows**.
- [x] Happy path (clean autostash apply, non-overlapping local edits) and the no-local-changes path both run clean under `set -euo pipefail` (empty conflicts array is a no-op).
- [ ] Observe the next live `update cycle` + a `build-feed` run on `main` to confirm green end-to-end.

https://claude.ai/code/session_015vVUdKJyG1iXfzfr6UUdDN

---
_Generated by [Claude Code](https://claude.ai/code/session_015vVUdKJyG1iXfzfr6UUdDN)_