### PR TITLE
fix(ci): harden autostash reconcile in update-stations & seo-guard

### DIFF
--- a/.github/workflows/seo-guard.yml
+++ b/.github/workflows/seo-guard.yml
@@ -138,7 +138,39 @@ jobs:
         # the push (rather than overwriting) and the run is retried
         # by the next docs/** push that triggers seo-guard.
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        run: git pull --rebase --autostash
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # ``git pull --rebase --autostash`` does NOT fail when the autostash
+          # RE-APPLY conflicts (the rebase succeeds, the failed stash apply is
+          # only a warning, the step exits 0) — it would hand an UNMERGED
+          # index to the auto-commit step, which dies with "you need to
+          # resolve your current index first" (the failure fixed for the feed
+          # workflows on 2026-05-25). This job only ever modifies
+          # docs/sitemap.xml + docs/llms.txt — both fully regenerated above —
+          # so on a conflict the locally built copy is authoritative and the
+          # conflict set stays within the file_pattern committed below.
+          git pull --rebase --autostash
+
+          mapfile -t -d '' conflicts < <(git diff --name-only --diff-filter=U -z)
+          if [ "${#conflicts[@]}" -gt 0 ]; then
+            echo "::warning title=reconcile::autostash re-apply conflicted on a concurrent push; keeping locally-built copies for: ${conflicts[*]}"
+            # In a stash-apply conflict, stage 3 ("--theirs") is the stashed
+            # locally-built version; stage 2 is the just-pulled upstream.
+            git checkout --theirs -- "${conflicts[@]}"
+            git add -- "${conflicts[@]}"
+            # A conflicted ``git stash apply`` leaves the autostash entry on
+            # the stash stack; drop it so it cannot leak into a later run.
+            git stash drop || true
+          fi
+
+          # Never hand an unmerged index to the auto-commit step.
+          if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
+            echo "::error title=reconcile::unresolved merge conflicts remain after reconcile" >&2
+            git diff --name-only --diff-filter=U >&2
+            exit 1
+          fi
 
       - name: Commit sitemap changes
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'

--- a/.github/workflows/update-stations.yml
+++ b/.github/workflows/update-stations.yml
@@ -126,15 +126,51 @@ jobs:
       - name: Regenerate validation report
         run: python -m src.cli stations validate --output docs/stations_validation_report.md
 
-      - name: Prepare repository (rebase main)
+      - name: Pull concurrent remote changes
+        shell: bash
         run: |
+          set -euo pipefail
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Single conflict-safe rebase onto the current remote tip. (This
+          # replaces two back-to-back ``git pull --rebase --autostash`` steps
+          # that both re-pulled ``origin/main`` — the second made the first
+          # redundant.) ``git pull --rebase --autostash`` does NOT fail when
+          # the autostash RE-APPLY conflicts: the rebase succeeds, the failed
+          # ``git stash apply`` is only a warning, and the step still exits 0
+          # — leaving an UNMERGED index that crashes the downstream
+          # auto-commit with "you need to resolve your current index first"
+          # (the failure fixed for the feed workflows on 2026-05-25). The
+          # station directory really can collide here: manual-full-refresh.yml
+          # also runs ``update_all_stations.py`` and writes
+          # ``data/stations.json`` from a separate concurrency lane.
           git fetch origin main
           git pull --rebase --autostash origin main
 
-      - name: Pull concurrent remote changes
-        run: git pull --rebase --autostash
+          # Every file this job writes (stations.json, the validation report,
+          # the HAFAS profile, the Places quota counter) is a full
+          # regeneration, so on a conflict the locally built copy is
+          # authoritative.
+          mapfile -t -d '' conflicts < <(git diff --name-only --diff-filter=U -z)
+          if [ "${#conflicts[@]}" -gt 0 ]; then
+            echo "::warning title=reconcile::autostash re-apply conflicted on a concurrent push; keeping locally-built copies for: ${conflicts[*]}"
+            # In a stash-apply conflict, stage 3 ("--theirs") is the stashed
+            # locally-built version; stage 2 is the just-pulled upstream.
+            git checkout --theirs -- "${conflicts[@]}"
+            git add -- "${conflicts[@]}"
+            # A conflicted ``git stash apply`` leaves the autostash entry on
+            # the stash stack; drop it so it cannot leak into a later run.
+            git stash drop || true
+          fi
+
+          # Never hand an unmerged index to the auto-commit step.
+          if [ -n "$(git diff --name-only --diff-filter=U)" ]; then
+            echo "::error title=reconcile::unresolved merge conflicts remain after reconcile" >&2
+            git diff --name-only --diff-filter=U >&2
+            exit 1
+          fi
 
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7


### PR DESCRIPTION
## Follow-up to #1665

#1665 fixed the concurrent-push race for the three **feed-writing** workflows (`update-cycle`, `build-feed`, `manual-full-refresh`). The two remaining workflows that push to `main` still used the bare `git pull --rebase --autostash`, which **exits 0 even when the autostash re-apply conflicts** — leaving an unmerged index that crashes `git-auto-commit-action` with `error: you need to resolve your current index first`.

This PR applies the same hardened reconcile to both.

## Changes

- **`update-stations.yml`** — collapses the two back-to-back, redundant `git pull --rebase --autostash` steps (*Prepare repository* + *Pull concurrent remote changes* — the second just re-pulled the same `origin/main`) into a single conflict-safe reconcile. This closes a **real** gap: both `update-stations.yml` and `manual-full-refresh.yml` run `update_all_stations.py` and write `data/stations.json`, from separate concurrency lanes, so they can collide. `manual-full-refresh` was hardened in #1665; `update-stations` was the remaining loser-of-the-race.
- **`seo-guard.yml`** — hardens its pull step the same way. This job only ever modifies `docs/sitemap.xml` + `docs/llms.txt` (the verify steps only read), so the conflict set — and thus the resolved+staged files — stays within the `file_pattern` it commits (verified, see below). Note: no other workflow writes those two files, so this is primarily defensive/future-proofing.

On conflict the reconcile keeps the locally-built copy (every file these jobs write is a full regeneration), drops the leftover autostash, and **fails loudly if any unmerged path remains** — never handing an unmerged index to the commit step.

## Deliberately *not* changed

Concurrency lanes are left as-is. Folding the **weekly** station refresh / **daily** SEO job into the `external-api-fetch` lane would over-couple them with the 30-min cycle for a low-probability race that the hardened reconcile already makes fail-safe. The proportionate fix here is the reconcile (B), not the structural lane merge (A).

## Test plan

- [x] Both workflows parse as valid YAML; no trailing whitespace; CodeQL `Analyze (actions)` should validate them.
- [x] Sandbox-reproduced the **seo-guard** scenario (concurrent writer changes `sitemap.xml`): autostash conflict → reconcile keeps the local build → index clean → a `file_pattern`-style commit contains **only** `docs/sitemap.xml` + `docs/llms.txt` (no scope creep).
- [x] The reconcile block is identical to the one verified end-to-end in #1665 (conflict resolution, happy path, and no-local-changes path all clean under `set -euo pipefail`).
- [ ] Observe the next weekly `update-stations` run (and any `seo-guard` run) on `main` complete green.

https://claude.ai/code/session_015vVUdKJyG1iXfzfr6UUdDN

---
_Generated by [Claude Code](https://claude.ai/code/session_015vVUdKJyG1iXfzfr6UUdDN)_