### PR TITLE
refactor(places): use shared CircuitBreaker for Google Places client

### DIFF
--- a/src/places/client.py
+++ b/src/places/client.py
@@ -9,7 +9,7 @@ import secrets
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final, cast
+from typing import Any, Final, cast
 from collections.abc import Iterable, Iterator, Sequence
 
 import requests

--- a/src/places/client.py
+++ b/src/places/client.py
@@ -9,7 +9,7 @@ import secrets
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Final, cast
+from typing import Final, cast
 from collections.abc import Iterable, Iterator, Sequence
 
 import requests

--- a/src/places/client.py
+++ b/src/places/client.py
@@ -9,11 +9,12 @@ import secrets
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Final, cast
 from collections.abc import Iterable, Iterator, Sequence
 
 import requests
 
+from ..utils.circuit_breaker import CircuitBreaker, CircuitState
 from ..utils.env import read_secret
 from ..utils.files import _reject_non_finite_constant, _reject_non_finite_float
 from ..utils.http import read_response_safe, session_with_retries, verify_response_ip
@@ -111,6 +112,22 @@ MAX_TIMEOUT_S = 25.0
 # the ``MAX_TIMEOUT_S`` cap pattern above.
 MAX_REQUEST_RETRIES = 10
 
+# Resilience: shared per-process circuit breaker for the Google Places
+# upstream, replacing the former per-instance ``_consecutive_5xx_errors``
+# counter. Trips to OPEN after 5 consecutive 5xx responses (failure
+# threshold unchanged), short-circuiting further calls — and therefore
+# further per-attempt quota debits — until the 300 s recovery window
+# elapses and a single HALF_OPEN probe re-tests the upstream. The quota
+# accounting in ``_post`` is deliberately left untouched: the monthly
+# free-tier cap is enforced solely by ``MonthlyQuota.can_consume`` and is
+# independent of this breaker. ``recovery_timeout`` mirrors the HAFAS
+# enrichment breaker (``src/places/hafas_client.py``).
+_BREAKER: Final[CircuitBreaker] = CircuitBreaker(
+    "google_places",
+    failure_threshold=5,
+    recovery_timeout=300.0,
+)
+
 FIELD_MASK_NEARBY = "places.id,places.displayName,places.location,places.types"
 DEFAULT_INCLUDED_TYPES: Sequence[str] = (
     "train_station",
@@ -205,7 +222,6 @@ class GooglePlacesClient:
         self._radius_m = RADIUS_M
         self._max_result_count = MAX_RESULTS
         self._rank_preference = RANK_PREF
-        self._consecutive_5xx_errors = 0
 
     def __enter__(self) -> GooglePlacesClient:
         return self
@@ -398,8 +414,14 @@ class GooglePlacesClient:
         attempt = 0
         last_error: Exception | None = None
 
-        # Check circuit breaker before starting requests
-        if self._consecutive_5xx_errors >= 5:
+        # Resilience: short-circuit before issuing (and quota-debiting) any
+        # request while the shared breaker is OPEN. Reading ``state`` lazily
+        # performs the OPEN→HALF_OPEN transition once ``recovery_timeout``
+        # has elapsed, so the next call is admitted as a probe. The value is
+        # read into a fresh local at each check site because ``record_failure``
+        # below can re-open the breaker between the two checks.
+        breaker_state = _BREAKER.state
+        if breaker_state is CircuitState.OPEN:
             raise GooglePlacesError("Circuit breaker open: too many consecutive 5xx errors")
 
         while attempt <= self._config.max_retries:
@@ -453,7 +475,7 @@ class GooglePlacesClient:
                     self.request_count += 1
 
                     if response.status_code == 200:
-                        self._consecutive_5xx_errors = 0
+                        _BREAKER.record_success()
                         try:
                             # Security: pin parse_constant + parse_float hooks
                             # that reject NaN / Infinity / -Infinity literals
@@ -496,18 +518,18 @@ class GooglePlacesClient:
 
                     if response.status_code in {429, 500, 502, 503, 504}:
                         if response.status_code != 429:
-                            self._consecutive_5xx_errors += 1
+                            _BREAKER.record_failure()
 
                         detail = _sanitize_error_detail(response.text, secrets=[self._config.api_key])
                         last_error = GooglePlacesError(
                             f"HTTP {response.status_code}: {detail}"
                         )
                     elif response.status_code in {401, 403}:
-                        self._consecutive_5xx_errors = 0
+                        _BREAKER.record_success()
                         details = self._extract_error_details(response)
                         raise GooglePlacesPermissionError(details)
                     else:
-                        self._consecutive_5xx_errors = 0
+                        _BREAKER.record_success()
                         message = self._format_error_message(response)
                         raise GooglePlacesError(
                             f"Failed to fetch places ({response.status_code}): {message}"
@@ -517,7 +539,7 @@ class GooglePlacesClient:
                 last_error = exc
 
                 if exc.response is not None and exc.response.status_code >= 500:
-                    self._consecutive_5xx_errors += 1
+                    _BREAKER.record_failure()
 
                 LOGGER.warning(
                     "Request error (attempt %s/%s): %s",
@@ -529,7 +551,8 @@ class GooglePlacesClient:
             if attempt > self._config.max_retries:
                 break
 
-            if self._consecutive_5xx_errors >= 5:
+            breaker_state = _BREAKER.state
+            if breaker_state is CircuitState.OPEN:
                 raise GooglePlacesError("Circuit breaker open: too many consecutive 5xx errors")
 
             sleep_for = self._backoff(attempt)

--- a/src/utils/circuit_breaker.py
+++ b/src/utils/circuit_breaker.py
@@ -21,10 +21,11 @@ failure opens it again with a fresh timer.
 
 Why a project-local primitive instead of a third-party library:
 
-* The codebase has three ad-hoc resilience implementations
-  (``places/client.py`` instance counter, ``vor.py`` Emergency Stop,
-  WL/ÖBB urllib3-only). A shared primitive eliminates drift when a
-  fourth provider is added.
+* The codebase grew several ad-hoc resilience implementations
+  (``vor.py`` Emergency Stop, WL/ÖBB urllib3-only, and the former
+  ``places/client.py`` per-instance 5xx counter — since migrated to
+  this primitive). A shared primitive eliminates drift as further
+  providers adopt it.
 * The third-party options (``circuitbreaker``, ``pybreaker``) bring
   larger surface than we need and don't compose cleanly with our
   existing ``session_with_retries`` plumbing.
@@ -104,10 +105,10 @@ class CircuitBreaker:
       :class:`CircuitBreakerOpen` for ``recovery_timeout`` seconds.
       This prevents self-DDoS against a known-down upstream.
 
-    The recommended adoption pattern for a new provider (and the only
-    pattern in use today by Google Places) is to *wrap* the
-    network-fetcher entry point with the breaker, leaving the
-    underlying ``session_with_retries`` retry policy unchanged::
+    Two adoption styles are in use. The recommended one for a simple
+    network-fetcher entry point is to *wrap* it with :meth:`call`,
+    leaving the underlying ``session_with_retries`` retry policy
+    unchanged (OSM, HAFAS and the Stammstrecke-Hbf monitor)::
 
         _BREAKER = CircuitBreaker("yourapi", failure_threshold=5,
                                    recovery_timeout=300.0)
@@ -118,6 +119,13 @@ class CircuitBreaker:
             except CircuitBreakerOpen:
                 log.warning("yourapi breaker open; returning empty list")
                 return []
+
+    When the breaker must interleave with an in-method retry loop and
+    per-attempt accounting (Google Places: only 5xx count as failures,
+    and each HTTP attempt debits the monthly quota *before* it runs),
+    drive it with the lower-level :meth:`record_success` /
+    :meth:`record_failure` and read :attr:`state` to short-circuit,
+    rather than :meth:`call`.
 
     Args:
         name: Human-readable identifier used in log messages

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,6 +303,7 @@ def _eagerly_import_breaker_modules() -> None:
     for module_name in (
         "src.places.osm_client",
         "src.places.hafas_client",
+        "src.places.client",
     ):
         try:
             importlib.import_module(module_name)

--- a/tests/places/test_client_circuit_breaker.py
+++ b/tests/places/test_client_circuit_breaker.py
@@ -1,0 +1,140 @@
+"""Circuit-breaker behaviour for the Google Places client.
+
+The Places client drives the shared ``src.utils.circuit_breaker``
+primitive through the lower-level ``record_*`` / ``state`` API (rather
+than :meth:`CircuitBreaker.call`) so that only 5xx responses count as
+failures and each HTTP attempt still debits the monthly quota *before*
+it runs. These tests pin the trip point (5 consecutive 5xx) and the OPEN
+short-circuit that protects both the upstream and the per-attempt quota
+budget.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from collections.abc import Iterator
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from src.places.client import (
+    _BREAKER,
+    GooglePlacesClient,
+    GooglePlacesConfig,
+    GooglePlacesError,
+)
+from src.utils.circuit_breaker import CircuitState
+
+# ``max_retries=5`` admits up to six attempts per ``_post`` call, enough
+# for a single call to accumulate five consecutive 5xx and trip the
+# breaker mid-loop without spilling into a second ``_post``.
+_CONFIG = GooglePlacesConfig(
+    api_key="dummy",
+    included_types=["bus_station"],
+    language="de",
+    region="AT",
+    radius_m=1000,
+    timeout_s=1.0,
+    max_retries=5,
+    max_result_count=20,
+)
+
+
+class _MockSocket:
+    def getpeername(self) -> tuple[str, int]:
+        return ("8.8.8.8", 443)
+
+
+class _MockRaw:
+    def __init__(self) -> None:
+        self.connection = MagicMock()
+        self.connection.sock = _MockSocket()
+        self._connection = self.connection
+
+
+class _MockResponse:
+    def __init__(self, status: int, body: bytes = b"{}") -> None:
+        self.status_code = status
+        self.headers: dict[str, str] = {}
+        self.raw = _MockRaw()
+        self.url = "https://places.googleapis.com/v1/places:searchNearby"
+        self._content = body
+        self._content_consumed = False
+        self.text = body.decode("utf-8", errors="replace")
+
+    def iter_content(self, chunk_size: int = 1) -> Iterator[bytes]:
+        yield self._content
+
+    def json(self, **kwargs: Any) -> Any:
+        import json
+
+        return json.loads(self._content, **kwargs)
+
+    def close(self) -> None:
+        pass
+
+    def __enter__(self) -> _MockResponse:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        pass
+
+
+def test_breaker_trips_after_five_consecutive_5xx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Five consecutive 5xx responses open the breaker and stop the loop."""
+    monkeypatch.setattr("src.places.client.time.sleep", lambda _s: None)
+    session = MagicMock(spec=requests.Session)
+    session.post.return_value = _MockResponse(503)
+    client = GooglePlacesClient(_CONFIG, session=session)
+
+    with pytest.raises(GooglePlacesError, match="Circuit breaker open"):
+        client._post("places:searchNearby", {}, quota_kind="nearby")
+
+    # Exactly five requests went out: the fifth 5xx trips the breaker, and
+    # the post-attempt guard raises before a sixth request is issued.
+    assert session.post.call_count == 5
+    assert _BREAKER.state is CircuitState.OPEN
+
+
+def test_open_breaker_short_circuits_without_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Once OPEN, the next call fails fast at the pre-loop guard — no I/O."""
+    monkeypatch.setattr("src.places.client.time.sleep", lambda _s: None)
+    session = MagicMock(spec=requests.Session)
+    session.post.return_value = _MockResponse(503)
+    client = GooglePlacesClient(_CONFIG, session=session)
+
+    with pytest.raises(GooglePlacesError, match="Circuit breaker open"):
+        client._post("places:searchNearby", {}, quota_kind="nearby")
+    assert session.post.call_count == 5
+
+    # The breaker streak persists per process, so a subsequent call
+    # short-circuits at the pre-loop guard: no further request — and
+    # therefore no further quota debit — is issued.
+    with pytest.raises(GooglePlacesError, match="Circuit breaker open"):
+        client._post("places:searchNearby", {}, quota_kind="nearby")
+    assert session.post.call_count == 5
+
+
+def test_success_resets_failure_streak(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 200 between 5xx responses clears the streak, so the breaker holds."""
+    monkeypatch.setattr("src.places.client.time.sleep", lambda _s: None)
+    session = MagicMock(spec=requests.Session)
+    session.post.side_effect = [
+        _MockResponse(503),
+        _MockResponse(503),
+        _MockResponse(503),
+        _MockResponse(503),
+        _MockResponse(200, b'{"places": []}'),
+    ]
+    client = GooglePlacesClient(_CONFIG, session=session)
+
+    result = client._post("places:searchNearby", {}, quota_kind="nearby")
+
+    assert result == {"places": []}
+    assert _BREAKER.state is CircuitState.CLOSED
+    assert session.post.call_count == 5


### PR DESCRIPTION
## Summary

The Google Places client (`src/places/client.py`) was the last place in the `places` tier carrying its own ad-hoc resilience logic — a per-instance `_consecutive_5xx_errors` integer — while OSM, HAFAS and the Stammstrecke-Hbf monitor already share `src.utils.circuit_breaker.CircuitBreaker`. This migrates the client to a module-level shared breaker (`"google_places"`, `failure_threshold=5`, `recovery_timeout=300s`), eliminating the divergence.

The swap is **faithful** — the integer's read/write points are mapped 1:1 onto the breaker API:

- 5xx (500/502/503/504, and `RequestException` with a 5xx response) → `record_failure()`
- 200 / 401 / 403 / other status → `record_success()` (resets the streak)
- 429 → **neither** (rate-limit stays neutral, exactly as before)
- pre-loop and post-attempt `>= 5` guards → `state is OPEN` checks

Trip point is unchanged at 5 consecutive 5xx. The only genuinely new behaviour is bounded **HALF_OPEN recovery** (one probe per 300s), which is itself quota-gated where quota is active.

## API-limit safety (the key review point)

The monthly Google free-tier cap is enforced **solely** by `MonthlyQuota.can_consume` / `consume` inside `_post`, which is **completely independent** of the breaker and is **left byte-for-byte untouched** by this PR. The breaker is self-DDoS protection only; it can never *raise* the call ceiling — in any path it only ever fails fast and *reduces* calls. The OPEN short-circuit still runs before any request, so it also prevents per-attempt quota debits while open.

## Also in this PR

- Register the new breaker in the `tests/conftest.py` reset-fixture eager-import list (keeps the autouse `reset_circuit_breakers` isolation complete from session start).
- New regression tests (`tests/places/test_client_circuit_breaker.py`) for the trip / OPEN short-circuit / success-reset paths — this code path previously had **no** dedicated coverage.
- Correct the now-stale `CircuitBreaker` docstring, which described `places/client.py` as ad-hoc and wrongly claimed Google Places used the `call()` wrap pattern; it now documents both adoption styles (`call()` wrap vs. low-level `record_*`/`state`).

## Test plan

- [x] `pytest tests/test_circuit_breaker.py tests/places/ tests/providers/` — 137 passed
- [x] Station-directory / fetch / verify / sentinel / orchestrator suites — 43 passed
- [x] Stammstrecke, provider, build_feed, collect_items, saboteur-chaos suites — 249 passed
- [x] `mypy --strict` (per `pyproject.toml`) — Success, no issues in 48 source files
- [x] `ruff check` on changed files — All checks passed
- [x] Verified quota logic (`can_consume` / per-attempt debit) is unchanged in the diff

https://claude.ai/code/session_01KCsoW5F5gcBHyxKMS2wVhe

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCsoW5F5gcBHyxKMS2wVhe)_