### PR TITLE
fix(places): unquote cast so CodeQL sees the Any import as used

### DIFF
--- a/src/places/client.py
+++ b/src/places/client.py
@@ -635,7 +635,7 @@ class GooglePlacesClient:
             for detail_item in details:
                 if not isinstance(detail_item, dict):
                     continue
-                detail_dict = cast('dict[str, Any]', detail_item)
+                detail_dict = cast(dict[str, Any], detail_item)
                 detail_type = detail_dict.get("@type")
                 if not isinstance(detail_type, str) or not detail_type.endswith("BadRequest"):
                     continue


### PR DESCRIPTION
## Summary

Follow-up hardening to PR #1669. A one-line change in `src/places/client.py` that removes the quotes around the `cast` target type:

```python
-                detail_dict = cast('dict[str, Any]', detail_item)
+                detail_dict = cast(dict[str, Any], detail_item)
```

## Background — why this matters

In PR #1669 the `Any` import was used **only** inside the string annotation `cast('dict[str, Any]', detail_item)`. CodeQL's `py/unused-import` query does not parse string literals as name references, so it flagged the `Any` import as unused. A **Copilot Autofix** then removed `Any` from the import (commit `b4a6e7f`), which broke both CI gates:

- `ruff check` → `F821 Undefined name 'Any'`
- `mypy --strict` → `error: Name "Any" is not defined [name-defined]`

That break was already repaired by re-adding the import (commit `4ac8e6e`, merged in #1669). **However, the underlying condition still held on `main`:** `Any` remained used only inside a string, so the next CodeQL run would re-flag it and the autofix could remove it again — an oscillation loop.

This change makes `Any` a **real name reference** in a runtime-evaluated expression, which CodeQL recognises as a use. It is semantically identical:

- **mypy:** `cast(dict[str, Any], x)` and `cast('dict[str, Any]', x)` are equivalent.
- **runtime:** `cast`'s first argument is always evaluated (it is a normal call argument, not an annotation, so `from __future__ import annotations` does not stringify it); `dict[str, Any]` evaluates to a `types.GenericAlias` and `cast` returns the value unchanged.

This is the only site in `src/` carrying this trap — the other string-quoted casts (`wl_fetch.py`, `build_feed.py`, `http.py`) reference `datetime`/`int`, which have other real uses in their files and are therefore not flagged.

## Test plan

- [x] `ruff check src/places/client.py` — All checks passed
- [x] `mypy --strict src/places/client.py` — Success, no issues
- [x] Runtime sanity: `cast(dict[str, Any], {'a': 1})` evaluates and returns the value unchanged
- [x] Behaviour unchanged — `detail_dict` is still narrowed to `dict[str, Any]` for the subsequent `.get(...)` calls

https://claude.ai/code/session_011zr9HJndMmoXTWeifqj1yy

---
_Generated by [Claude Code](https://claude.ai/code/session_011zr9HJndMmoXTWeifqj1yy)_