### PR TITLE
fix(stations): don't flag a station's own-code alias as a cross-station collision

### DIFF
--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -858,15 +858,33 @@ def _find_cross_station_id_conflicts(
 
             if norm_alias in id_map:
                 for colliding_entry, field in id_map[norm_alias]:
-                    if colliding_entry is not entry:
-                        yield CrossStationIDIssue(
-                            identifier=_format_identifier(entry),
-                            name=str(entry.get("name", "")).strip() or "<unknown>",
-                            alias=alias.strip(),
-                            colliding_identifier=_format_identifier(colliding_entry),
-                            colliding_name=str(colliding_entry.get("name", "")).strip() or "<unknown>",
-                            colliding_field=field,
-                        )
+                    if colliding_entry is entry:
+                        continue
+                    # Skip when the alias is simply the entry's OWN identity
+                    # code in the same field. ``enrich_station_aliases``
+                    # deliberately lists a station's own ``bst_code`` among
+                    # its aliases, so a duplicate / shared-code record (e.g.
+                    # two "Mb  H2H" Siebenhirten entries) makes each copy's
+                    # own-code alias "shadow" the other's ``bst_code``. That
+                    # is a duplicate / shared-identity collision — surfaced
+                    # (non-blocking) by ``_find_identity_field_conflicts`` —
+                    # not a genuine alias-shadows-another-station ambiguity.
+                    # Firing here would auto-quarantine *every* copy and drop
+                    # the station entirely (Wien Siebenhirten / Handelskai).
+                    own_val = entry.get(field)
+                    if (
+                        isinstance(own_val, str | int)
+                        and _normalize_token(str(own_val)) == norm_alias
+                    ):
+                        continue
+                    yield CrossStationIDIssue(
+                        identifier=_format_identifier(entry),
+                        name=str(entry.get("name", "")).strip() or "<unknown>",
+                        alias=alias.strip(),
+                        colliding_identifier=_format_identifier(colliding_entry),
+                        colliding_name=str(colliding_entry.get("name", "")).strip() or "<unknown>",
+                        colliding_field=field,
+                    )
 
 
 def _find_identity_field_conflicts(

--- a/tests/test_stations_validation_self_collision_guard.py
+++ b/tests/test_stations_validation_self_collision_guard.py
@@ -1,0 +1,74 @@
+"""Regression tests for the cross-station-ID self-collision guard.
+
+``enrich_station_aliases`` deliberately lists each station's own
+``bst_code`` among its aliases. When two records describe the *same*
+physical station and share that ``bst_code`` (a duplicate / shared-code
+situation — e.g. an ``oebb_geonetz`` Siebenhirten record alongside a
+fresh ``oebb`` one, both ``bst_code "Mb  H2H"``), each copy's own-code
+alias "shadows" the other's ``bst_code``. Pre-fix, that fired
+``_find_cross_station_id_conflicts`` for *both* copies; the orchestrator's
+auto-quarantine then removed every entry sharing the identifier and the
+station vanished from ``data/stations.json`` (observed for Wien
+Siebenhirten / Wien Handelskai).
+
+The orchestrator dedup (PR #1671) only collapses byte-identical copies;
+this guard covers the near-identical (shared-``bst_code``, differing other
+fields) variant. The genuine condition — an alias shadowing a *different*
+station's identity field — must still fire.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.utils.stations_validation import (  # noqa: E402
+    _find_cross_station_id_conflicts,
+    _find_identity_field_conflicts,
+)
+
+
+def _siebenhirten(**overrides: Any) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "name": "Siebenhirten",
+        "bst_code": "Mb  H2H",
+        "aliases": ["Siebenhirten", "Mb  H2H"],
+    }
+    entry.update(overrides)
+    return entry
+
+
+def test_shared_bst_code_with_own_code_alias_is_not_cross_station_collision() -> None:
+    # Same physical station, same bst_code, each lists its own code as an
+    # alias; differ only in source/eva so the orchestrator's byte-identical
+    # dedup would NOT catch them. Must NOT be flagged as a cross-station
+    # collision (which would quarantine both copies).
+    a = _siebenhirten(eva_nr="8101523", source="oebb_geonetz,osm")
+    b = _siebenhirten(eva_nr="8101523", source="oebb")
+    assert list(_find_cross_station_id_conflicts([a, b])) == []
+
+
+def test_shared_bst_code_still_surfaced_as_identity_field_conflict() -> None:
+    # The real problem (two stations claiming one bst_code) is still reported
+    # — just by the non-blocking identity-field check, not the quarantine path.
+    a = _siebenhirten(eva_nr="8101523", source="oebb_geonetz,osm")
+    b = _siebenhirten(eva_nr="8101523", source="oebb")
+    conflicts = list(_find_identity_field_conflicts([a, b]))
+    assert any(c.field == "bst_code" and c.value == "Mb  H2H" for c in conflicts)
+
+
+def test_genuine_alias_shadow_of_other_station_still_flagged() -> None:
+    # B's alias equals a DIFFERENT station A's bst_code while B's own bst_code
+    # differs → real lookup ambiguity, must still fire.
+    a = {"name": "Station A", "bst_code": "900100", "aliases": ["A"]}
+    b = {"name": "Station B", "bst_code": "900200", "aliases": ["B", "900100"]}
+    issues = list(_find_cross_station_id_conflicts([a, b]))
+    assert len(issues) == 1
+    assert issues[0].alias == "900100"
+    assert issues[0].colliding_field == "bst_code"
+    assert issues[0].name == "Station B"
+    assert issues[0].colliding_name == "Station A"

--- a/tests/test_update_all_stations_dedupe.py
+++ b/tests/test_update_all_stations_dedupe.py
@@ -69,15 +69,21 @@ def test_dedupe_keeps_distinct_entries() -> None:
     assert len(deduped) == 2
 
 
-def test_duplicate_triggers_cross_station_collision_but_single_copy_is_clean() -> None:
-    """The end-to-end link: duplicate fires the collision, dedup clears it."""
+def test_dedupe_collapses_duplicate_and_result_is_collision_free() -> None:
+    """The dedup pass collapses byte-identical copies to one clean record.
+
+    The validator's self-collision guard (see
+    ``tests/test_stations_validation_self_collision_guard.py``) means two
+    same-``bst_code`` copies are no longer mis-flagged as a cross-station
+    collision, so neither the pair nor the single copy raises an issue; the
+    dedup pass additionally removes the redundant copy so the directory
+    never carries two identical records.
+    """
     duplicated = [_siebenhirten(), _siebenhirten()]
-    issues_with_dup = list(_find_cross_station_id_conflicts(duplicated))
-    # Both copies cross-collide on the shared ``bst_code``-as-alias.
-    assert len(issues_with_dup) >= 1
-    assert any(issue.colliding_field == "bst_code" for issue in issues_with_dup)
+    # Shared-bst_code self-shadow is guarded → no cross-station issue.
+    assert list(_find_cross_station_id_conflicts(duplicated)) == []
 
     deduped, removed = update_all_stations._dedupe_exact_duplicates(duplicated)
     assert removed == 1
-    # A single copy self-excludes (``colliding_entry is not entry``) → clean.
+    assert len(deduped) == 1
     assert list(_find_cross_station_id_conflicts(deduped)) == []


### PR DESCRIPTION
## Summary

Hardens the cross-station-ID collision check so a station's **own** `bst_code` (which `enrich_station_aliases` deliberately lists among its aliases) is no longer mis-flagged as shadowing another station's identity.

When two records describe the **same physical station** and share a `bst_code` — a duplicate / shared-code situation that is *not* byte-identical (e.g. an `oebb_geonetz` Siebenhirten record alongside a fresh `oebb` one, both `bst_code "Mb  H2H"`) — each copy's own-code alias "shadowed" the other's `bst_code`. `_find_cross_station_id_conflicts` then fired for **both** copies and the orchestrator's auto-quarantine removed every entry sharing that identifier, dropping the station entirely (the Wien Siebenhirten / Wien Handelskai failure mode).

### Change
- `_find_cross_station_id_conflicts` now skips a match when the matching alias is simply the entry's **own** value in that identity field. The genuine shared-id problem is still surfaced (non-blocking) by `_find_identity_field_conflicts`, and a real *alias-shadows-a-different-station* ambiguity still fires.
- This complements the byte-identical orchestrator dedup from #1671: that pass collapses exact duplicates; this guard covers the **near-identical** (shared-`bst_code`, differing other fields) variant that exact-dedup cannot catch.

### Note
One assertion in #1671's `test_update_all_stations_dedupe.py` asserted the *old* behaviour (a duplicate fires a cross-station collision). The guard intentionally prevents that mis-flag, so the test was updated to assert the new behaviour (dedup still collapses the redundant copy; the result is collision-free).

## Test plan
- [x] New `tests/test_stations_validation_self_collision_guard.py`: shared-`bst_code` own-code alias → **no** cross-station issue; still reported as an identity-field conflict; a genuine cross-station shadow still fires.
- [x] Existing `test_stations_validation_cross_id.py` / `_identity_conflicts.py` / `test_station_validation.py` and orchestrator tests — 126 passed.
- [x] `scripts/validate_stations.py` on real `data/stations.json` → 0 cross-station issues (rc=0).
- [x] `mypy --strict` clean on `src/utils/stations_validation.py`.

https://claude.ai/code/session_012cboduM74dLCQ3jPtcjkrJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012cboduM74dLCQ3jPtcjkrJ)_