### PR TITLE
fix(stations): eponymous station wins its own name in alias lookup

### DIFF
--- a/src/utils/stations.py
+++ b/src/utils/stations.py
@@ -131,6 +131,25 @@ def _normalize_token(value: str) -> str:
     return text.strip()
 
 
+def _name_owns_alias(name: str, alias_token: str) -> bool:
+    """Return True when *name* designates the station the alias is named after.
+
+    The eponymous station — the one literally called *alias_token* — should
+    win that alias over a neighbour that merely carries it as a cross-reference.
+    Comparing only ``_normalize_token(name)`` missed this because the stored
+    name keeps the ``Wien`` city qualifier and a ``(WL)`` / ``(VOR)`` provider
+    suffix (``"Wien Taborstraße (WL)"`` → ``"wien taborstrasse wl"``), which
+    never equals the bare ``"taborstrasse"`` key. The bare form is compared too.
+    """
+    if not alias_token:
+        return False
+    if _normalize_token(name) == alias_token:
+        return True
+    bare = re.sub(r"\s*\([^)]*\)\s*", " ", name)
+    bare = re.sub(r"^\s*[Ww]ien\s+", "", bare)
+    return _normalize_token(bare) == alias_token
+
+
 def _source_token_set(value: object) -> frozenset[str]:
     """Return the canonical set of provider source tokens for a station entry.
 
@@ -738,13 +757,20 @@ def _station_lookup() -> dict[str, StationInfo]:
             record_is_wl = record_tokens == frozenset({"wl"})
 
             alias_token = _normalize_token(alias_text)
-            record_token = _normalize_token(alias_record.name)
-            existing_token = _normalize_token(existing_record.name)
 
-            if alias_token and alias_token == record_token and alias_token != existing_token:
+            # Eponymous-name precedence: the station the alias is named after
+            # wins it over a neighbour that merely cross-references the name.
+            # ``_name_owns_alias`` also matches the bare name (``Wien`` prefix /
+            # ``(WL)`` suffix stripped), so "Wien Taborstraße (WL)" claims
+            # "taborstrasse" instead of the earlier-registered "Heinestraße"
+            # (and "Wien Kagran" instead of "Betriebshof Kagran").
+            record_named = _name_owns_alias(alias_record.name, alias_token)
+            existing_named = _name_owns_alias(existing_record.name, alias_token)
+
+            if record_named and not existing_named:
                 mapping[key] = (alias_record, strength)
                 continue
-            if alias_token and alias_token == existing_token and alias_token != record_token:
+            if existing_named and not record_named:
                 continue
 
             if existing_record.vor_id and alias_record.vor_id and existing_record.vor_id == alias_record.vor_id:

--- a/tests/test_station_eponymous_alias.py
+++ b/tests/test_station_eponymous_alias.py
@@ -11,13 +11,17 @@ matched the bare ``"taborstrasse"`` key and the earlier neighbour kept it
 """
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from src.utils import stations
+from src.utils.stations import StationInfo
 
 
-def _lookup_with(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, data: list[dict]) -> dict:
+def _lookup_with(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, data: list[dict[str, Any]]
+) -> dict[str, StationInfo]:
     temp_file = tmp_path / "stations.json"
     temp_file.write_text(json.dumps(data), encoding="utf-8")
     monkeypatch.setattr(stations, "_STATIONS_PATH", temp_file)

--- a/tests/test_station_eponymous_alias.py
+++ b/tests/test_station_eponymous_alias.py
@@ -1,0 +1,73 @@
+"""Regression tests for eponymous-station alias precedence in ``_station_lookup``.
+
+When two stations contend for the same normalized alias at equal match
+strength, the station the alias is *named after* must win it — even when a
+neighbour that merely cross-references the name was registered earlier in
+file order. Pre-fix the eponymous check compared the bare alias key against
+``_normalize_token(full_name)``, which keeps the ``Wien`` prefix and ``(WL)``
+suffix (``"Wien Taborstraße (WL)"`` → ``"wien taborstrasse wl"``), so it never
+matched the bare ``"taborstrasse"`` key and the earlier neighbour kept it
+(observed: ``Taborstraße`` → Heinestraße, ``Kagran`` → Betriebshof Kagran).
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from src.utils import stations
+
+
+def _lookup_with(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, data: list[dict]) -> dict:
+    temp_file = tmp_path / "stations.json"
+    temp_file.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.setattr(stations, "_STATIONS_PATH", temp_file)
+    stations._station_entries.cache_clear()
+    stations._station_lookup.cache_clear()
+    try:
+        return stations._station_lookup()
+    finally:
+        stations._station_entries.cache_clear()
+        stations._station_lookup.cache_clear()
+
+
+def test_eponymous_station_wins_over_earlier_neighbour(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Heinestraße is registered FIRST and cross-references "Taborstraße";
+    # the eponymous "Wien Taborstraße (WL)" comes later and must win.
+    data = [
+        {"name": "Wien Heinestraße (WL)", "wl_diva": "1", "source": "wl",
+         "aliases": ["Heinestraße", "Taborstraße"]},
+        {"name": "Wien Taborstraße (WL)", "wl_diva": "2", "source": "wl",
+         "aliases": ["Taborstraße"]},
+    ]
+    lut = _lookup_with(tmp_path, monkeypatch, data)
+    assert lut["taborstrasse"].name == "Wien Taborstraße (WL)"
+
+
+def test_station_wins_bare_name_over_earlier_depot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The depot ("Bahnhof Kagran" → "kagran") is registered first; the public
+    # "Wien Kagran (WL)" station must still own the bare "Kagran" lookup.
+    data = [
+        {"name": "Wien Betriebshof Kagran (WL)", "wl_diva": "1", "source": "wl",
+         "aliases": ["Bahnhof Kagran"]},
+        {"name": "Wien Kagran (WL)", "wl_diva": "2", "source": "wl",
+         "aliases": ["Kagran"]},
+    ]
+    lut = _lookup_with(tmp_path, monkeypatch, data)
+    assert lut["kagran"].name == "Wien Kagran (WL)"
+
+
+def test_non_eponymous_collision_keeps_first_registered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Neither station is named "Collision" → the eponymous rule must NOT fire;
+    # the historical first-registered-wins behaviour is preserved.
+    data = [
+        {"name": "First Station", "wl_diva": "1", "source": "wl", "aliases": ["Collision"]},
+        {"name": "Second Station", "wl_diva": "2", "source": "wl", "aliases": ["Collision"]},
+    ]
+    lut = _lookup_with(tmp_path, monkeypatch, data)
+    assert lut["collision"].name == "First Station"


### PR DESCRIPTION
## Summary

Fixes a pre-existing station-name resolution bug found while reviewing `main`: the alias lookup (`src/utils/stations.py:_station_lookup`) resolved several stations' **own name** to a different neighbouring station.

The equal-strength tie-break already tried to prefer the station an alias is *named after* (lines 744–748), but it compared the bare alias key against `_normalize_token(full_name)`. Since `_normalize_token` keeps the `Wien` prefix and `(WL)`/`(VOR)` suffix (`"Wien Taborstraße (WL)"` → `"wien taborstrasse wl"`), it never matched the bare `"taborstrasse"` key, so the rule never fired. The earlier-registered neighbour that merely cross-references the name then kept it by file order.

### Symptoms (before)
| Lookup | resolved to | should be | dist |
|---|---|---|---|
| `Kagran` | Wien **Betriebshof** Kagran | Wien Kagran | 103 m |
| `Taborstraße` | Wien Heinestraße | Wien Taborstraße | 346 m |
| `Siebensterngasse` | Wien Kirchengasse | Wien Siebensterngasse | 362 m |
| `Schwenkgasse` | Wien Gatterholzgasse | Wien Schwenkgasse | 688 m |
| `Nußdorfer Straße` | Wien Alserbachstraße | Wien Nußdorfer Straße | — |
| `Gräßlplatz` | Wien Geiereckstraße | Wien Gräßlplatz | — |
| `Haus des Meeres` | Wien Barnabitengasse | Wien Haus des Meeres | — |

(~9 stations total; low functional impact since the wrong targets are all nearby and in Vienna, so feed relevance is unaffected — but the exact station identity was wrong.)

### Change
- Add `_name_owns_alias(name, alias_token)` which matches the alias against both the full *and* the **bare** name (strip leading `Wien ` and any parenthetical provider suffix), and use it in the tie-break.
- Benign ties — two entries both named after the alias, e.g. `Wien Atzgersdorf` vs the WL `Bhf. Atzgersdorf` stop — still fall through to the historical first-registered behaviour.

## Test plan
- [x] New `tests/test_station_eponymous_alias.py`: eponymous station wins over an earlier neighbour and over an earlier depot; a non-eponymous collision still keeps the first-registered entry.
- [x] Real `data/stations.json`: all ~9 cases now resolve to the eponymous station; the 8 remaining bare-name matches are the correct canonical resolutions (WL `Bhf. X` → `Wien X`); benign cases (floridsdorf, meidling, hütteldorf, atzgersdorf, karlsplatz, praterstern, hernals, zentralfriedhof) unchanged.
- [x] 159 station-resolution-dependent tests pass; `mypy --strict` clean; C901 gate clean.

https://claude.ai/code/session_012cboduM74dLCQ3jPtcjkrJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012cboduM74dLCQ3jPtcjkrJ)_