### PR TITLE
fix(stations): drop eva-duplicate Handelskai record + guard eva_nr in validation

### DIFF
--- a/docs/stations_validation_report.md
+++ b/docs/stations_validation_report.md
@@ -1,6 +1,6 @@
 # Stationsverzeichnis-Validierungsbericht
 
-*Analysierte Stationen (gesamt)*: 2238
+*Analysierte Stationen (gesamt)*: 2237
 *Geladene GTFS-Stops*: 167
 *Geografische Duplikate*: 0
 *Alias-Probleme*: 0

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -892,14 +892,19 @@ def _find_identity_field_conflicts(
 ) -> Iterator[IdentityFieldConflict]:
     """Yield one issue per value that appears on more than one station.
 
-    Checks each of the four structural identifier fields
-    (``wl_diva`` / ``vor_id`` / ``bst_id`` / ``bst_code``). The
-    project's eindeutigkeits-Garantie pins these as primary keys; any
+    Checks each of the five structural identifier fields
+    (``wl_diva`` / ``vor_id`` / ``bst_id`` / ``bst_code`` / ``eva_nr``).
+    The project's eindeutigkeits-Garantie pins these as primary keys; any
     duplicate means two stations claim the same physical asset (post
     PR #1538 a ``google_places`` stub and a ``source: wl`` master
     shared the same DIVA for ten Innenstadt-U-Bahn stops because the
     WL merge step indexed by name and ``_normalize_key`` rendered
     ``Herrengasse`` and ``Wien Herrengasse (WL)`` as distinct keys).
+    ``eva_nr`` (the UIC station number) was added after an
+    ``oebb_geonetz`` Betriebsstelle record (``Handelskai``, bst_code
+    ``Nw  H2``) duplicated the canonical ``Wien Handelskai`` Verkehrs-
+    station — same ``eva_nr`` 8101934 — and slipped past the other four
+    keys because their ``bst_code`` / ``bst_id`` differ.
 
     Whitespace-stripped + lower-cased ``int`` / ``str`` values are
     compared; ``None`` and empty strings are ignored.  Distinct from
@@ -907,7 +912,7 @@ def _find_identity_field_conflicts(
     *alias* on one station shadows an *identity* field on a different
     station — this function fires on raw identity collisions.
     """
-    for field in ("wl_diva", "vor_id", "bst_id", "bst_code"):
+    for field in ("wl_diva", "vor_id", "bst_id", "bst_code", "eva_nr"):
         seen: dict[str, list[Mapping[str, object]]] = defaultdict(list)
         for entry in stations:
             val = entry.get(field)

--- a/tests/test_stations_validation_identity_conflicts.py
+++ b/tests/test_stations_validation_identity_conflicts.py
@@ -132,6 +132,48 @@ def test_bst_id_and_bst_code_duplicates_flagged(tmp_path: Path) -> None:
     assert fields == {"bst_id", "bst_code"}
 
 
+def test_eva_nr_duplicate_flagged(tmp_path: Path) -> None:
+    """Two records sharing the UIC ``eva_nr`` but with different
+    ``bst_code`` / ``bst_id`` — the Handelskai pattern, where an
+    ``oebb_geonetz`` Betriebsstelle record duplicated the canonical
+    ``Wien Handelskai`` Verkehrsstation — must be flagged. The pair slips
+    past the other four identifier keys because those differ."""
+    path = tmp_path / "stations.json"
+    entries = [
+        _make_entry(
+            name="Handelskai",
+            eva_nr="8101934",
+            bst_code="Nw  H2",
+            bst_id="1586",
+            source="oebb_geonetz,osm",
+            aliases=["Handelskai"],
+            latitude=48.242143,
+            longitude=16.385980,
+        ),
+        _make_entry(
+            name="Wien Handelskai",
+            eva_nr="8101934",
+            bst_code="Hak",
+            bst_id="779",
+            wl_diva="60201705",
+            source="hafas,oebb,oebb_geonetz,osm,wl",
+            aliases=["Wien Handelskai"],
+            latitude=48.241418,
+            longitude=16.384869,
+        ),
+    ]
+    path.write_text(json.dumps(entries), encoding="utf-8")
+
+    report = validate_stations(path)
+    eva_conflicts = [
+        c for c in report.identity_field_conflicts if c.field == "eva_nr"
+    ]
+    assert len(eva_conflicts) == 1
+    assert eva_conflicts[0].value == "8101934"
+    assert set(eva_conflicts[0].names) == {"Handelskai", "Wien Handelskai"}
+    assert report.has_issues
+
+
 def test_unique_identifiers_produce_no_conflicts(tmp_path: Path) -> None:
     path = tmp_path / "stations.json"
     entries = [


### PR DESCRIPTION
## Summary

Resolves the residual `Handelskai` duplicate surfaced by the latest `update-stations` run, and closes the validation blind spot that hid it.

A standalone `oebb_geonetz` Betriebsstelle record **`Handelskai`** (`bst_code "Nw  H2"`) duplicated the canonical **`Wien Handelskai`** Verkehrsstation. Both carry **`eva_nr` 8101934** (same physical station), but their `bst_code`/`bst_id` differ, so `_find_identity_field_conflicts` — which checked `wl_diva`/`vor_id`/`bst_id`/`bst_code` but **not `eva_nr`** — reported 0 issues. The bare `handelskai` lookup then resolved to the impoverished geonetz record (no `wl_diva`, no WL stops) instead of the rich canonical entry.

The duplicate was a pure subset of `Wien Handelskai`:

| field | `Handelskai` (removed) | `Wien Handelskai` (kept) |
|---|---|---|
| eva_nr | 8101934 | 8101934 |
| ifopt_id | at:49:1705 | at:49:1705 |
| address | 1200 Wien, | 1200 Wien, |
| wl_diva | — | 60201705 |
| vor_id | — | 490170500 |
| aliases / WL stops | 8 / 0 | 43 / 4 |

### Changes
- **Remove** the redundant record from `data/stations.json` → `handelskai` now resolves to `Wien Handelskai`. It's a round-trip relic (GeoNetz only *enriches* existing entries, never creates standalones), so it will not regenerate.
- **Add `eva_nr` to `_find_identity_field_conflicts`** so any future `eva_nr` duplicate is surfaced and fails `scripts/validate_stations.py` loudly instead of slipping through silently.

### Note on approach
This realises the approved "remove + `eva_nr` guard" option via **direct removal + the `eva_nr` check** rather than a literal `remove`-override: the record has no `wl_diva` (the override's only targeting key) and its `eva_nr` is shared with the canonical entry, so an override couldn't target it without extending the override schema. The `eva_nr` identity check is broader protection — it guards every station, and if this record (or any eva-dup) ever recurs, CI's `validate_stations` goes red rather than silent.

## Test plan
- [x] New `test_eva_nr_duplicate_flagged` in `tests/test_stations_validation_identity_conflicts.py`; full identity-conflict suite (10) green.
- [x] `handelskai` resolves to `Wien Handelskai`; `validate_stations.py` rc=0 (2237 stations, 0 issues incl. 0 identity conflicts); report regenerated.
- [x] 101 resolution/validation/dedup/override tests pass; `mypy --strict` clean; C901 gate clean.

https://claude.ai/code/session_012cboduM74dLCQ3jPtcjkrJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012cboduM74dLCQ3jPtcjkrJ)_