### PR TITLE
fix(stations): durably remove regenerating Handelskai eva-duplicate via bst_code override

### DIFF
--- a/data/stations_overrides.json
+++ b/data/stations_overrides.json
@@ -411,6 +411,13 @@
       "reason": "Wien Sofienalpenstraße, Roßkopfgasse (DIVA 60251359) shares the exact haltepunkte coordinates (48.2471756, 16.2189477) with Wien Roßkopfgasse (DIVA 60251355) — both DIVAs are in haltestellen.csv (with different official coordinates) but their haltepunkte all collapse to the same point. Keep the simpler-named modern entry (DIVA 60251355, newer haltepunkt id 8216); drop the legacy intersection-name variant (DIVA 60251359, older haltepunkt ids 3921/3922).",
       "added": "2026-05-16",
       "expires_when": "Wiener Linien retires DIVA 60251359 from haltestellen.csv OR moves its haltepunkte to the genuine intersection location, ~150 m southwest of DIVA 60251355"
+    },
+    {
+      "op": "remove",
+      "bst_code": "Nw  H2",
+      "reason": "The build re-creates a standalone oebb_geonetz Betriebsstelle record 'Handelskai' (bst_code 'Nw  H2', no wl_diva) each run; it duplicates the canonical 'Wien Handelskai' Verkehrsstation by eva_nr 8101934 and is a pure subset (same eva_nr/ifopt_id/address — the canonical entry additionally carries wl_diva 60201705, vor_id and WL stops). The duplicate trips the eva_nr identity-conflict gate (validate_stations.py exits 1) and makes the bare 'Handelskai' lookup resolve to the impoverished record. Keyed on bst_code because the record has no wl_diva and its eva_nr is shared with the canonical entry; removes every match so a regenerated copy cannot survive into the validator.",
+      "added": "2026-05-26",
+      "expires_when": "The build no longer emits a standalone oebb_geonetz 'Handelskai' (bst_code 'Nw  H2') record separate from the canonical 'Wien Handelskai' — e.g. the GeoNetz/OSM merge reconciles Betriebsstellen against the Verkehrsstation by eva_nr."
     }
   ]
 }

--- a/docs/stations_validation_report.md
+++ b/docs/stations_validation_report.md
@@ -1,6 +1,6 @@
 # Stationsverzeichnis-Validierungsbericht
 
-*Analysierte Stationen (gesamt)*: 2238
+*Analysierte Stationen (gesamt)*: 2237
 *Geladene GTFS-Stops*: 167
 *Geografische Duplikate*: 0
 *Alias-Probleme*: 0
@@ -9,9 +9,8 @@
 *Sicherheitswarnungen*: 0
 *Provider-Probleme*: 0
 *Stationsübergreifende-ID-Kollisionen*: 0
-*Identity-Field-Konflikte*: 1
+*Identity-Field-Konflikte*: 0
 *Namens-Probleme*: 0
 *Namens-Alias-Kollisionen*: 0
 
-## Identity-Field-Konflikte
-- eva\_nr=8101934 gemeinsam genutzt von [code:Nw H2 / source:oebb\_geonetz,osm, code:Hak / wl\_diva:60201705 / source:hafas,oebb,oebb\_geonetz,osm,wl] (Handelskai, Wien Handelskai)
+Keine Probleme festgestellt.

--- a/scripts/apply_station_overrides.py
+++ b/scripts/apply_station_overrides.py
@@ -246,20 +246,48 @@ def _op_patch_coords(stations: list[dict[str, Any]], override: dict[str, Any]) -
 
 
 def _op_remove(stations: list[dict[str, Any]], override: dict[str, Any]) -> str:
-    diva = override["wl_diva"]
-    for i, entry in enumerate(stations):
-        value = entry.get("wl_diva")
-        if isinstance(value, str) and value.strip() == diva:
-            removed_name = entry.get("name", "?")
-            stations.pop(i)
-            return f"removed wl_diva={diva} ({removed_name!r}) at index {i}"
-    log.warning(
-        "remove: wl_diva=%s not present in stations.json — skipping "
-        "(the upstream may have removed it already; consider retiring "
-        "this override)",
-        diva,
-    )
-    return "skip (target missing)"
+    diva = override.get("wl_diva")
+    if isinstance(diva, str) and diva.strip():
+        target = diva.strip()
+        for i, entry in enumerate(stations):
+            value = entry.get("wl_diva")
+            if isinstance(value, str) and value.strip() == target:
+                removed_name = entry.get("name", "?")
+                stations.pop(i)
+                return f"removed wl_diva={target} ({removed_name!r}) at index {i}"
+        log.warning(
+            "remove: wl_diva=%s not present in stations.json — skipping "
+            "(the upstream may have removed it already; consider retiring "
+            "this override)",
+            target,
+        )
+        return "skip (target missing)"
+
+    # bst_code targeting: for oebb_geonetz Betriebsstellen that carry no
+    # wl_diva and that the build re-creates each run (e.g. the Handelskai
+    # "Nw  H2" record, which duplicates the canonical "Wien Handelskai" by
+    # eva_nr). Remove EVERY match so a regenerated copy cannot survive into
+    # the validator gate.
+    code = str(override.get("bst_code") or "").strip()
+    removed_names = [
+        str(entry.get("name", "?"))
+        for entry in stations
+        if isinstance(entry.get("bst_code"), str) and entry["bst_code"].strip() == code
+    ]
+    if not removed_names:
+        log.warning(
+            "remove: bst_code=%s not present in stations.json — skipping "
+            "(the upstream may have removed it already; consider retiring "
+            "this override)",
+            code,
+        )
+        return "skip (target missing)"
+    stations[:] = [
+        entry
+        for entry in stations
+        if not (isinstance(entry.get("bst_code"), str) and entry["bst_code"].strip() == code)
+    ]
+    return f"removed bst_code={code} ({removed_names!r})"
 
 
 _HANDLERS = {
@@ -321,8 +349,12 @@ def apply_overrides(
             )
             return 1
         has_diva = isinstance(diva, str) and bool(diva.strip())
+        bst_code = raw_override.get("bst_code")
+        has_bst_code = isinstance(bst_code, str) and bool(bst_code.strip())
         # ``patch_coords`` may key on ``eva_nr`` (manual ÖBB stations have no
-        # ``wl_diva``); ``restore`` / ``remove`` still require ``wl_diva``.
+        # ``wl_diva``); ``remove`` may key on ``bst_code`` (oebb_geonetz
+        # Betriebsstellen have no ``wl_diva``); ``restore`` still requires
+        # ``wl_diva``.
         if op == "patch_coords":
             has_eva = eva is not None and bool(str(eva).strip())
             if not (has_diva or has_eva):
@@ -331,12 +363,24 @@ def apply_overrides(
                     index,
                 )
                 return 1
+        elif op == "remove":
+            if not (has_diva or has_bst_code):
+                log.error(
+                    "Override #%d (op=remove) needs a wl_diva or bst_code",
+                    index,
+                )
+                return 1
         elif not has_diva:
             log.error(
                 "Override #%d (op=%s) missing or invalid wl_diva", index, op
             )
             return 1
-        ident = str(diva).strip() if has_diva else f"eva_nr={str(eva).strip()}"
+        if has_diva:
+            ident = str(diva).strip()
+        elif has_bst_code:
+            ident = f"bst_code={str(bst_code).strip()}"
+        else:
+            ident = f"eva_nr={str(eva).strip()}"
         handler = _HANDLERS[op]
         try:
             result = handler(stations, raw_override)

--- a/tests/test_apply_station_overrides.py
+++ b/tests/test_apply_station_overrides.py
@@ -349,6 +349,59 @@ def test_remove_missing_diva_warns(
     assert any("60251359" in r.getMessage() for r in caplog.records)
 
 
+def test_remove_by_bst_code_drops_all_matches(tmp_path: Path) -> None:
+    """``remove`` keyed on ``bst_code`` (for oebb_geonetz Betriebsstellen
+    that carry no wl_diva, e.g. the regenerating Handelskai 'Nw  H2'
+    record) removes EVERY matching entry, so a build that re-creates the
+    redundant record — even duplicated — cannot leave a copy behind."""
+    stations_path = tmp_path / "stations.json"
+    overrides_path = tmp_path / "overrides.json"
+
+    _write(stations_path, {"stations": [
+        {"name": "Wien Handelskai", "bst_code": "Hak", "wl_diva": "60201705",
+         "eva_nr": "8101934", "source": "oebb,wl",
+         "latitude": 48.2414, "longitude": 16.3849,
+         "in_vienna": True, "pendler": False, "aliases": ["Wien Handelskai"]},
+        {"name": "Handelskai", "bst_code": "Nw  H2", "eva_nr": "8101934",
+         "source": "oebb_geonetz,osm",
+         "latitude": 48.2421, "longitude": 16.3860,
+         "in_vienna": True, "pendler": False, "aliases": ["Handelskai"]},
+        {"name": "Handelskai", "bst_code": "Nw  H2", "eva_nr": "8101934",
+         "source": "oebb_geonetz,osm",
+         "latitude": 48.2421, "longitude": 16.3860,
+         "in_vienna": True, "pendler": False, "aliases": ["Handelskai"]},
+    ]})
+    _write(overrides_path, {"overrides": [
+        {"op": "remove", "bst_code": "Nw  H2", "reason": "test"}
+    ]})
+
+    rc = apply_station_overrides.apply_overrides(stations_path, overrides_path)
+    assert rc == 0
+    names = [s["name"] for s in _stations_from(stations_path)]
+    assert names == ["Wien Handelskai"]  # both "Nw  H2" copies removed
+
+
+def test_remove_missing_bst_code_warns(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    stations_path = tmp_path / "stations.json"
+    overrides_path = tmp_path / "overrides.json"
+
+    _write(stations_path, {"stations": [
+        {"name": "Other", "bst_code": "Xy", "source": "oebb",
+         "latitude": 48.1, "longitude": 16.1,
+         "in_vienna": True, "pendler": False, "aliases": ["Other"]},
+    ]})
+    _write(overrides_path, {"overrides": [
+        {"op": "remove", "bst_code": "Nw  H2", "reason": "test"}
+    ]})
+
+    with caplog.at_level(logging.WARNING, logger="apply_station_overrides"):
+        rc = apply_station_overrides.apply_overrides(stations_path, overrides_path)
+    assert rc == 0
+    assert any("Nw  H2" in r.getMessage() for r in caplog.records)
+
+
 # ---------------------------------------------------------------------------
 # Schema validation
 # ---------------------------------------------------------------------------
@@ -444,6 +497,11 @@ def test_committed_overrides_file_schema() -> None:
         if entry["op"] == "patch_coords":
             has_eva = entry.get("eva_nr") is not None and bool(str(entry["eva_nr"]).strip())
             assert has_diva or has_eva
+        elif entry["op"] == "remove":
+            # ``remove`` may key on ``bst_code`` for oebb_geonetz
+            # Betriebsstellen that carry no wl_diva.
+            has_bst_code = isinstance(entry.get("bst_code"), str) and bool(entry["bst_code"].strip())
+            assert has_diva or has_bst_code
         else:
             assert has_diva
         assert isinstance(entry.get("reason"), str) and entry["reason"]
@@ -473,6 +531,9 @@ def test_committed_overrides_cover_the_known_drifts() -> None:
         diva = o.get("wl_diva")
         if isinstance(diva, str) and diva.strip():
             return diva.strip()
+        bst_code = o.get("bst_code")
+        if isinstance(bst_code, str) and bst_code.strip():
+            return f"bst_code:{bst_code.strip()}"
         return f"eva:{str(o.get('eva_nr') or '').strip()}"
 
     by_op = {(o["op"], _ident(o)) for o in payload["overrides"]}
@@ -481,3 +542,4 @@ def test_committed_overrides_cover_the_known_drifts() -> None:
     assert ("patch_coords", "60201954") in by_op  # Leopoldine-Padaurek
     assert ("remove", "60251359") in by_op  # Sofienalpenstraße, Roßkopfgasse
     assert ("patch_coords", "eva:8100655") in by_op  # Bad Fischau geographic duplicate
+    assert ("remove", "bst_code:Nw  H2") in by_op  # Handelskai eva-duplicate


### PR DESCRIPTION
## Summary

Completes the Handelskai fix from #1674, which was **incomplete**: I deleted the redundant `oebb_geonetz` `Handelskai` (`bst_code "Nw  H2"`) record from `data/stations.json` assuming it wouldn't regenerate — but the build re-creates it every run.

**Evidence:** the #1674 merge commit had **0** `Nw  H2` records; the very next `update-stations` run committed it back (eva_nr 8101934 duplicate of the canonical `Wien Handelskai`). Because `eva_nr` is now an identity-conflict key (#1674), `scripts/validate_stations.py` **fails (exit 1)** on current `main` data. Update commits carry `[skip ci]` so `main` itself stayed green, but **the next PR's CI would go red** on the pre-existing duplicate.

## Durable fix (the remove-override approach, made regeneration-proof)
- **Extend `apply_station_overrides` `remove`** to target by **`bst_code`** — the record has no `wl_diva` (the only key `remove` supported) and its `eva_nr` is shared with the canonical entry, so eva-keying is unsafe. It removes **every** match so a duplicated regeneration can't leave a copy. The existing `wl_diva` path is unchanged.
- **Add the override** `{op: remove, bst_code: "Nw  H2"}` so each run drops the record after the build re-creates it and before validation.
- **Remove the record from committed `data/stations.json`** so CI is green immediately; `handelskai` again resolves to the canonical `Wien Handelskai`.

The `eva_nr` identity check from #1674 stays as the detector that surfaced this.

## Verification
- Applying the **committed** overrides to data with a re-added `Nw  H2` record removes it (proves it survives regeneration).
- `validate_stations.py` rc=0; `handelskai` → `Wien Handelskai`; report regenerated (2237 stations, 0 conflicts).

## Test plan
- [x] New `test_remove_by_bst_code_drops_all_matches` + `test_remove_missing_bst_code_warns`; updated the two committed-overrides schema/coverage tests for the new key. Full `test_apply_station_overrides` suite (18) green; 36 override+validation+resolution tests pass.
- [x] `mypy --strict` clean on the changed source + test; C901 gate clean.

https://claude.ai/code/session_012cboduM74dLCQ3jPtcjkrJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012cboduM74dLCQ3jPtcjkrJ)_