### PR TITLE
fix(seo): drop relative hreflang from site.html English-feed link

### DIFF
--- a/docs/site.html
+++ b/docs/site.html
@@ -16,7 +16,7 @@
 
   <link rel="canonical" href="https://origamihase.github.io/wien-oepnv/site.html">
   <link rel="alternate" type="application/rss+xml" title="Wien ÖPNV Feed" href="feed.xml">
-  <link rel="alternate" type="application/rss+xml" title="Vienna Public Transport Feed (English)" href="feed.en.xml" hreflang="en">
+  <link rel="alternate" type="application/rss+xml" title="Vienna Public Transport Feed (English)" href="feed.en.xml">
   <link rel="icon" type="image/svg+xml" href="assets/site-favicon.svg">
   <link rel="stylesheet" href="assets/site.min.css?v=75e06550aa21">
   <!-- The dashboard fetches the statistics CSVs from raw.githubusercontent.com

--- a/tests/test_site_html_seo_head.py
+++ b/tests/test_site_html_seo_head.py
@@ -1,0 +1,72 @@
+"""Sentinel guard for the SEO-critical ``<head>`` links in ``docs/site.html``.
+
+A Lighthouse audit nulled the whole SEO category because the English-feed
+``<link rel="alternate">`` carried ``hreflang="en"`` on a *relative* href
+(``feed.en.xml``). Lighthouse's hreflang audit rejects that with the reason
+"Relative href value" -- a relative hreflang href is invalid, so the audit
+scores 0 and the category cannot resolve to a passing score.
+
+The dashboard ships a single, JS-localised page: ``site.html`` serves both
+German and English from the *same* URL (the language toggle rewrites the DOM
+in place), so there is no distinct per-language URL for hreflang to point at
+and the page therefore carries no hreflang alternates at all. If one is ever
+(re)introduced it MUST be fully qualified. This guard encodes exactly that
+rule -- plus an absolute, single canonical -- so the SEO regression that
+slipped past the ``seo-guard`` workflow (which only validates the generated
+sitemap/llms/feed/robots artefacts, never ``site.html``'s head) can never
+ship silently again.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SITE_HTML = Path(__file__).resolve().parents[1] / "docs" / "site.html"
+
+_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_LINK_RE = re.compile(r"<link\b[^>]*>", re.IGNORECASE)
+_ATTR_RE = re.compile(r'([a-zA-Z][\w:-]*)\s*=\s*"([^"]*)"')
+
+
+def _link_tags() -> list[dict[str, str]]:
+    # Strip comments first so prose inside the head's explanatory comment
+    # blocks can never be mistaken for a real <link> tag.
+    html = _COMMENT_RE.sub("", SITE_HTML.read_text(encoding="utf-8"))
+    tags: list[dict[str, str]] = []
+    for raw in _LINK_RE.findall(html):
+        attrs = {k.lower(): v for k, v in _ATTR_RE.findall(raw)}
+        attrs["__raw__"] = raw
+        tags.append(attrs)
+    return tags
+
+
+def _is_absolute(url: str) -> bool:
+    return url.startswith("https://") or url.startswith("http://")
+
+
+def test_every_hreflang_link_uses_an_absolute_href() -> None:
+    offenders = [
+        tag["__raw__"]
+        for tag in _link_tags()
+        if "hreflang" in tag and not _is_absolute(tag.get("href", ""))
+    ]
+    assert not offenders, (
+        "docs/site.html: every <link hreflang=...> must use a fully-qualified "
+        "(absolute) href. Lighthouse rejects a relative hreflang href with "
+        '"Relative href value", which zeroes the hreflang audit and nulls the '
+        f"SEO category. Offending tag(s): {offenders}"
+    )
+
+
+def test_canonical_link_is_present_and_absolute() -> None:
+    canonicals = [tag for tag in _link_tags() if tag.get("rel") == "canonical"]
+    assert len(canonicals) == 1, (
+        "docs/site.html must declare exactly one <link rel='canonical'> so "
+        f"search engines have a single, unambiguous self-reference; found "
+        f"{len(canonicals)}"
+    )
+    href = canonicals[0].get("href", "")
+    assert _is_absolute(href), (
+        f"docs/site.html canonical href must be absolute, got: {href!r}"
+    )


### PR DESCRIPTION
## Was Lighthouse meldet

Ein Lighthouse-Audit von `https://origamihase.github.io/wien-oepnv/site.html` (LH 13.0.2, mobile + desktop) zeigt in der **SEO**-Kategorie:

| Audit | Ergebnis | Ursache |
|---|---|---|
| `hreflang` | **FAIL** (Score 0) | „Relative href value" |
| `link-text` | **ERROR** | `AnchorElements` gatherer: `Cannot read properties of undefined (reading 'objectId')` |
| `crawlable-anchors` | **ERROR** | gleicher gatherer |
| **SEO-Gesamtscore** | **`null`** | zwei Pflicht-Audits brechen mit Fehler ab → Kategorie nicht berechenbar |

## Was dieser PR behebt (der eine echte Projekt-Bug)

`docs/site.html` deklarierte den englischen Feed mit `hreflang="en"` auf einer **relativen** URL:

```diff
- <link rel="alternate" type="application/rss+xml" title="Vienna Public Transport Feed (English)" href="feed.en.xml" hreflang="en">
+ <link rel="alternate" type="application/rss+xml" title="Vienna Public Transport Feed (English)" href="feed.en.xml">
```

`hreflang` verlangt **voll qualifizierte** URLs; Lighthouse lehnt eine relative href mit der Begründung „Relative href value" ab und der hreflang-Audit scort 0.

`site.html` liefert **beide Sprachen unter derselben URL** aus (der Sprachumschalter schreibt das DOM in-place um) – es gibt also keine eigene Sprach-URL, auf die `hreflang` zeigen könnte. Das spiegelt `docs/_includes/head-custom.html`, das den Feed bereits **ohne** hreflang einbindet. Die RSS-Auto-Discovery bleibt unberührt: der englische Feed behält seinen `rel=alternate` / `type` / `title`-Link.

## Wofür dieser PR den „SEO-Bot" härtet

Der `seo-guard.yml`-Workflow validiert ausschließlich die **generierten** Artefakte (sitemap.xml, llms.txt, feed.xml, robots.txt) – **nie** den `<head>` von `site.html`. Genau diese Lücke ließ den relativen hreflang durchrutschen. Neu: `tests/test_site_html_seo_head.py` (im Stil von `test_site_html_structured_data.py`) erzwingt:

- jeder `<link hreflang>` in `site.html` muss eine absolute href haben (genau die Lighthouse-Regel)
- `canonical` bleibt absolut und genau einmal vorhanden

## Nicht in diesem PR: `link-text` / `crawlable-anchors` (kein Projekt-Defekt)

Beide Audits hängen am selben `AnchorElements`-Gatherer. Der Crash ist ein **bekannter Upstream-Regress** in Lighthouse/Chrome:

- Lighthouse-Issue [#16860](https://github.com/GoogleChrome/lighthouse/issues/16860) (offen, **P1**), Fix-PR [#17027](https://github.com/GoogleChrome/lighthouse/pull/17027)
- Chrome ≥ 144 liefert eine `DOM.resolveNode`-Antwort **ohne** Remote-Objekt; LH 13.0.x liest `…object.objectId` ungeprüft → der gemeldete Fehler. Regress zwischen Chrome 143 → 144 (der Report nutzte Chrome 148).
- Brechen zwei Audits einer Kategorie ab, kann Lighthouse den Kategorie-Score nicht bilden → SEO `null`.

Aus dem Projekt heraus **nicht behebbar**. Klärt sich, sobald der LH-Fix (#17027) ausgeliefert ist, bzw. mit einem Audit unter Chrome ≤ 143. Nach beidem (hreflang gefixt **und** Gatherer-Fix) erreicht die Seite 100 % SEO.

## Test plan

- [x] `pytest tests/test_site_html_seo_head.py` – neuer Guard grün (2 passed)
- [x] `pytest tests/test_site_html_structured_data.py` – bestehender site.html-Sentinel grün
- [x] `pytest tests/test_i18n_coverage_gate.py` – 19 passed; `scripts/check_i18n_coverage.py` ok (73 HTML-Keys gematcht)
- [x] `python scripts/optimize_site_assets.py --check` – kein Cache-Bust-Drift (exit 0)
- [x] `pytest tests/scripts/test_optimize_site_assets.py` – 11 passed

https://claude.ai/code/session_01X1oE9gaTJ1T9qThQV8MMDB

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1oE9gaTJ1T9qThQV8MMDB)_