### PR TITLE
fix(update-cycle): retrying inline git push so action-download blips can't break the cycle

### DIFF
--- a/.github/workflows/update-cycle.yml
+++ b/.github/workflows/update-cycle.yml
@@ -25,7 +25,8 @@ name: Update cycle
 # ``actions/download-artifact`` glob/pattern semantics — that
 # silently kept ``build_feed`` from ever committing. The single-job
 # rewrite has zero artifact plumbing, no inter-job push race, and a
-# single auto-commit at the end so the operator-visible state moves
+# single inline commit + resilient push at the end (see the "Commit and
+# push cycle outputs" step) so the operator-visible state moves
 # atomically (or not at all). The trade-off is sequential runtime
 # (~3-5 min vs the DAG's ~2-3 min) and slightly less granular UI
 # observability — both acceptable for the 30-min cadence.
@@ -41,7 +42,10 @@ name: Update cycle
 #      + appends to ``data/stats/stoerungen_<YYYY>.csv``
 #   6. ``generate_markdown_stats.py`` patches the README markers and
 #      regenerates ``docs/statistik.md`` from the ledger
-#   7. ``git pull --rebase --autostash`` + single auto-commit
+#   7. ``git pull --rebase --autostash`` reconcile + a single inline
+#      ``git commit`` and a retrying, never-fail ``git push`` (no
+#      external commit action — see that step's header for the
+#      action-download-resilience rationale)
 #
 # Concurrency: the workflow holds the ``external-api-fetch`` lock
 # (shared with ``manual-full-refresh.yml`` and the dispatch-only
@@ -433,28 +437,102 @@ jobs:
             exit 1
           fi
 
-      - name: Commit cycle outputs
-        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
-        with:
-          commit_message: 'chore: update cycle'
-          # Mirrors the proven-working ``manual-full-refresh.yml``
-          # commit pattern: ``add_options: -A`` catches every modified
-          # file in the workspace (cache files, CSV ledgers, quota
-          # counter, feed.xml, first_seen state, statistik.md, README,
-          # any future output added to the cycle) without having to
-          # maintain a brittle file_pattern allowlist that silently
-          # drops outputs whose path doesn't match a glob. The
-          # earlier file_pattern-based commit step on this workflow
-          # never produced a ``chore: update cycle`` commit on main —
-          # the auto-commit-action's ``git add ${pattern}`` shell-
-          # interpolation interacts oddly with the multi-line YAML
-          # ``|`` block scalar on the auto-cycle runner image, so a
-          # legitimate workspace diff occasionally looked like
-          # nothing-to-commit. ``-A`` makes that failure mode
-          # impossible.
-          # ``--force-with-lease`` mirrors ``manual-full-refresh.yml``
-          # so a concurrent push from ``update-stations.yml`` (Sundays)
-          # doesn't leave this commit hanging on a non-fast-forward
-          # rejection.
-          add_options: '-A'
-          push_options: '--force-with-lease'
+      # Inline ``git`` instead of an external commit action. This is the
+      # MOST IMPORTANT workflow in the project (the live feed's ~30-min
+      # heartbeat) and must never go red on a transient infrastructure
+      # blip. A ``uses:`` action is resolved and DOWNLOADED by the runner
+      # in the "Prepare all required actions" setup phase, BEFORE the
+      # first step runs; when codeload.github.com hiccups, that download
+      # fails and the whole job dies in setup — before any retry/fallback
+      # step could ever execute. (Observed 2026-05-26 12:30 UTC:
+      # ``git-auto-commit-action`` 404'd from codeload "after 1 attempts"
+      # and the entire tick was lost.) You cannot retry a ``uses:``
+      # download from inside the workflow, so the only robust fix is to
+      # not depend on one: ``git`` is pre-installed on the runner, needs
+      # no download, and lets us own the retry + never-fail logic below.
+      # The remaining ``uses:`` actions (checkout / setup-python / cache)
+      # are first-party and the cycle is idempotent, so a rare setup-phase
+      # miss on those self-heals on the next tick.
+      #
+      # Robustness contract (replaces the old action's behaviour 1:1 and
+      # then hardens it):
+      #   * ``git add -A`` — stage every workspace output (caches, CSV
+      #     ledgers, quota counter, feed XMLs, first_seen state,
+      #     statistik.md, README, feed-health, any future output). Mirrors
+      #     the former ``add_options: -A``; no brittle file_pattern.
+      #   * no changes -> clean no-op (exit 0), as the action did.
+      #   * push with up to 4 attempts and exponential backoff (2/4/8 s),
+      #     re-syncing onto any concurrent push (non-fast-forward) between
+      #     tries. ``--force-with-lease`` is preserved (mirrors
+      #     ``manual-full-refresh.yml``); the re-fetch refreshes the lease
+      #     so the replayed commit fast-forwards cleanly.
+      #   * if every attempt fails -> emit a ``::warning::`` and exit 0.
+      #     The just-built outputs are NOT published this tick, but the
+      #     repository keeps the last good commit and the next ~30-min
+      #     tick rebuilds and republishes from fresh caches. A skipped
+      #     publish is ~30 min of staleness; a red workflow would be
+      #     worse and would page the operator for a non-actionable blip.
+      - name: Commit and push cycle outputs
+        shell: bash
+        env:
+          # Keep ``git rebase --continue`` non-interactive (it would
+          # otherwise open an editor for the replayed commit message).
+          GIT_EDITOR: 'true'
+        run: |
+          # NOTE: intentionally NO ``-e`` — every failure below is
+          # handled explicitly so the step can guarantee exit 0.
+          set -uo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Cycle produced no changes — nothing to commit or push."
+            exit 0
+          fi
+          git commit -m "chore: update cycle"
+
+          branch="${GITHUB_REF_NAME}"
+          max_attempts=4
+          delay=2
+          attempt=1
+          while :; do
+            if git push --force-with-lease origin "HEAD:${branch}"; then
+              echo "Cycle outputs published on attempt ${attempt}/${max_attempts}."
+              exit 0
+            fi
+            if [ "${attempt}" -ge "${max_attempts}" ]; then
+              echo "::warning title=cycle-publish::git push failed after ${max_attempts} attempts; this tick's outputs were NOT published. The repository keeps the last good commit and the next ~30-min tick will rebuild and publish from fresh caches. Not failing the workflow."
+              exit 0
+            fi
+            echo "Push attempt ${attempt}/${max_attempts} failed; re-syncing with origin/${branch} and retrying in ${delay}s."
+            sleep "${delay}"
+            # Re-sync onto any concurrent push. ``update-stations.yml``
+            # (Sundays) and ``seo-guard.yml`` (daily) run in SEPARATE
+            # concurrency lanes and can legitimately land a push here, so
+            # the lease can go stale between attempts. ``git pull
+            # --rebase`` replays our single commit onto the new tip;
+            # tolerate a transient fetch failure (network blip) and just
+            # retry the push after the backoff.
+            if ! git pull --rebase --autostash origin "${branch}"; then
+              # A rebase replay can stop on a conflict. Every cycle output
+              # is a full regeneration, so the locally-built copy (the
+              # commit being replayed = "theirs" in rebase terms) wins.
+              # Append-only CSV ledgers auto-resolve via ``merge=union``
+              # (.gitattributes) and never reach here.
+              mapfile -t -d '' conflicts < <(git diff --name-only --diff-filter=U -z)
+              if [ "${#conflicts[@]}" -gt 0 ]; then
+                echo "::warning title=cycle-reconcile::rebase conflict on a concurrent push; keeping locally-built copies for: ${conflicts[*]}"
+                git checkout --theirs -- "${conflicts[@]}"
+                git add -- "${conflicts[@]}"
+                git rebase --continue || git rebase --abort || true
+              else
+                # Not a conflict (the fetch itself failed) — abort any
+                # half-started rebase and just retry the push.
+                git rebase --abort 2>/dev/null || true
+              fi
+            fi
+            attempt=$((attempt + 1))
+            delay=$((delay * 2))
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+* **Robustheit: 30-Minuten-Zyklus übersteht Action-Download-Ausfälle und
+  publiziert mit Retry + Never-Fail (2026-05-26)**: Der Lauf vom
+  2026-05-26 12:30 UTC von `update-cycle.yml` starb bereits in der
+  Setup-Phase („Prepare all required actions"), weil
+  `stefanzweifel/git-auto-commit-action` nicht von `codeload.github.com`
+  geladen werden konnte (404 „after 1 attempts"). Ein per `uses:`
+  referenzierter Action-Download wird vor dem ersten Step aufgelöst —
+  ein Retry/Fallback im Workflow kann dort nicht mehr greifen, der Job
+  ist tot, bevor irgendein Step läuft. Fix: Der finale Commit-/Push-
+  Schritt nutzt jetzt Inline-`git` (auf dem Runner vorinstalliert, kein
+  Download) statt der externen Action. `git add -A` bildet das frühere
+  `add_options: -A` 1:1 ab; bei „nichts zu committen" ist der Schritt ein
+  sauberer No-op. Der Push läuft mit bis zu 4 Versuchen und
+  exponentiellem Backoff (2/4/8 s) und re-synchronisiert zwischen den
+  Versuchen via `git pull --rebase --autostash` auf konkurrierende Pushes
+  (`update-stations.yml` sonntags, `seo-guard.yml` täglich liegen in
+  eigenen Concurrency-Lanes); `--force-with-lease` bleibt erhalten.
+  Rebase-Konflikte werden zugunsten der lokal gebauten Vollregeneration
+  aufgelöst (append-only CSV-Ledger lösen sich ohnehin über
+  `merge=union`). Schlägt jeder Versuch fehl, beendet der Schritt mit
+  `::warning::` statt rotem Status — die zuletzt veröffentlichten Daten
+  bleiben stehen und der nächste ~30-Minuten-Tick baut neu auf. Damit ist
+  die wichtigste Pipeline des Projekts gegen den beobachteten transienten
+  CDN-Ausfall **und** gegen Push-Fehler abgesichert. Der bestehende
+  Vertrag aus `tests/test_en_feed_workflow_deps.py` (torch-CPU-Install,
+  HuggingFace-Cache, `feed build`) bleibt unberührt.
+* **Doku: HAFAS-Profil wird wöchentlich (nicht pro Tick) aktualisiert
+  (2026-05-26)**: Die Docstrings in `src/places/hafas_client.py` und
+  `scripts/sync_hafas_profile.py` sagten „before each cron tick" bzw.
+  „so the cron pipeline always picks up the freshest credentials" und
+  erweckten so den Eindruck, das Profil werde alle 30 Minuten geladen.
+  Tatsächlich läuft `sync_hafas_profile.py` ausschließlich im
+  *wöchentlichen* `update-stations.yml` (Sonntags 01:00 UTC); der
+  30-Minuten-Zyklus liest nur das committete `data/hafas_profile.json`
+  und lädt nichts nach (der Laufzeit-Client cached zudem in-process).
+  Das Profil wird damit höchstens einmal pro Woche geladen. Docstrings
+  entsprechend präzisiert.
 * **Sicherheit: Stored-XSS im veröffentlichten `<content:encoded>`-Feld
   geschlossen (2026-05-24)**: `_compose_description` (`src/build_feed.py`)
   bettete den reinen Text aus `summary`/`time_line` un-escaped in den

--- a/scripts/sync_hafas_profile.py
+++ b/scripts/sync_hafas_profile.py
@@ -14,9 +14,14 @@ triple in the repository would silently break the HAFAS fallback inside
 :mod:`src.places.hafas_client`. This helper extracts the live values
 from the upstream ``public-transport/hafas-client`` project (the
 canonical community mirror of ÖBB's web-app profile) and persists them
-atomically to ``data/hafas_profile.json``. The CI workflow runs this
-script directly before ``scripts/update_station_directory.py`` so the
-cron pipeline always picks up the freshest credentials.
+atomically to ``data/hafas_profile.json``. Only the *weekly* station-
+directory workflow (``.github/workflows/update-stations.yml``, Sundays
+01:00 UTC) runs this script, directly before the directory refresh
+(``scripts/update_all_stations.py``) that actually consumes HAFAS
+enrichment, so the once-a-week rebuild picks up the freshest
+credentials. The ~30-min feed cycle (``update-cycle.yml``) does NOT run
+this sync — it only reads the committed ``data/hafas_profile.json`` —
+so the profile is fetched at most once per week, never per tick.
 
 The upstream OEBB profile is split across two JavaScript modules — the
 entry point ``p/oebb/index.js`` and the imported ``p/oebb/base.js``

--- a/src/places/hafas_client.py
+++ b/src/places/hafas_client.py
@@ -18,12 +18,19 @@ Resilience is layered to mirror the OSM Overpass client:
   size / content-type guards.
 
 The HAFAS profile (``salt`` / ``ver`` / ``aid`` / ``client``) is loaded
-lazily from ``data/hafas_profile.json``. The companion
-``scripts/sync_hafas_profile.py`` refreshes the file from upstream
-before each cron tick. When the profile is absent (developer's local
-machine, first-time clone) :func:`enrich_station_with_hafas` returns
-``None`` instead of raising — the caller treats HAFAS as unavailable
-and falls through to the Google Places tier.
+lazily from ``data/hafas_profile.json`` and cached in-process for the
+lifetime of the run — this module never fetches the profile over the
+network. The committed JSON *is* the cache. It is refreshed by the
+companion ``scripts/sync_hafas_profile.py``, which runs only in the
+*weekly* station-directory workflow
+(``.github/workflows/update-stations.yml``, Sundays 01:00 UTC), right
+before the directory rebuild that actually consumes HAFAS enrichment.
+The ~30-min feed cycle (``update-cycle.yml``) neither runs the sync nor
+reads this file, so the profile is fetched at most once per week — not
+per tick. When the profile is absent (developer's local machine,
+first-time clone) :func:`enrich_station_with_hafas` returns ``None``
+instead of raising — the caller treats HAFAS as unavailable and falls
+through to the Google Places tier.
 
 No external HAFAS client library is used. The Mgate request payload is
 constructed directly and — when the upstream profile carries a salt —

--- a/tests/test_sentinel_allow_nan_writer_audit_walker.py
+++ b/tests/test_sentinel_allow_nan_writer_audit_walker.py
@@ -81,7 +81,7 @@ the signature input and break the upstream verification step.
 
 Three documented sites live here today:
 
-* ``src/places/hafas_client.py:_serialise_payload`` (line 282) —
+* ``src/places/hafas_client.py:_serialise_payload`` (line 289) —
   the function builds the HAFAS wire-format request body whose bytes
   are hashed by the Mgate ``mac`` signing protocol. Setting
   ``allow_nan=False`` would not change today's call-graph (HAFAS
@@ -137,7 +137,7 @@ ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
         # committed to any operator-facing sidecar. The threat model
         # for the non-finite-literal axis (committed-to-main artefact)
         # does not apply.
-        ("src/places/hafas_client.py", 282),
+        ("src/places/hafas_client.py", 289),
         # Feed-item identity hash compute — the serialised bytes flow
         # into ``hashlib.sha256(...).hexdigest()`` on the very next
         # line and are not retained anywhere else. No parser-consumed
@@ -535,7 +535,7 @@ def test_allowlist_is_minimal_and_documented() -> None:
     # site for another (without updating the docstring) also fails.
     assert ALLOWLIST == frozenset(
         {
-            ("src/places/hafas_client.py", 282),
+            ("src/places/hafas_client.py", 289),
             ("src/build_feed.py", 2371),
             ("src/build_feed.py", 2380),
         }

--- a/tests/test_sentinel_trojan_source_audit_walker.py
+++ b/tests/test_sentinel_trojan_source_audit_walker.py
@@ -124,7 +124,7 @@ ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
         # HAFAS wire-format request body; bytes are hashed by the MAC
         # signing protocol and sent to the upstream HAFAS endpoint,
         # not committed to any operator-facing sidecar.
-        ("src/places/hafas_client.py", 282),
+        ("src/places/hafas_client.py", 289),
         # Feed-health JSON sink; per-field ``_CONTROL_CHARS_RE.sub("",
         # ...)`` calls at lines 726 / 729 / 777 strip the canonical
         # attack-byte union from every user-controlled string field
@@ -634,7 +634,7 @@ def test_allowlist_is_minimal_and_documented() -> None:
     # site for another (without updating the docstring) also fails.
     assert ALLOWLIST == frozenset(
         {
-            ("src/places/hafas_client.py", 282),
+            ("src/places/hafas_client.py", 289),
             ("src/feed/reporting.py", 846),
             ("src/feed/logging_safe.py", 247),
             ("src/feed/logging_safe.py", 258),


### PR DESCRIPTION
## Ausgangslage (aus den hochgeladenen Logs)

Der Lauf vom **2026-05-26 12:30 UTC** von `update-cycle.yml` starb bereits in der Setup-Phase *„Prepare all required actions"*, weil `stefanzweifel/git-auto-commit-action` nicht von `codeload.github.com` geladen werden konnte:

```
##[error]An action could not be found at the URI 'https://codeload.github.com/.../git-auto-commit-action/tar.gz/0470...'
##[error]Failed to download archive '...' after 1 attempts.
```

Eine per `uses:` referenzierte Action wird **vor dem ersten Step** aufgelöst und heruntergeladen. Schlägt das fehl, ist der Job tot, *bevor* irgendein Retry-/Fallback-Code laufen könnte — ein Retry aus dem Workflow heraus ist hier prinzipiell unmöglich.

> Nebenbefund zur ursprünglichen Frage: Das **HAFAS-Profil** wird hier **nicht** alle 30 min geladen. `sync_hafas_profile.py` läuft nur im wöchentlichen `update-stations.yml`; der 30-Minuten-Zyklus liest nur das committete `data/hafas_profile.json`. Die Docstrings, die „before each cron tick" suggerierten, waren irreführend und sind jetzt korrigiert.

## Änderungen

**1. `update-cycle.yml` — robuster Publish-Pfad (der wichtigste, must-not-fail Workflow)**
- Externe Commit-Action durch **Inline-`git`** ersetzt (vorinstalliert, kein Download → der beobachtete Fehlerklasse ist eliminiert).
- `git add -A` + „nichts zu committen"-No-op bilden das frühere `add_options: -A` 1:1 ab.
- **Push mit Retry**: bis zu 4 Versuche, exponentielles Backoff (2/4/8 s), Re-Sync via `git pull --rebase --autostash` auf konkurrierende Pushes zwischen den Versuchen; `--force-with-lease` bleibt erhalten. Rebase-Konflikte werden zugunsten der lokal gebauten Vollregeneration aufgelöst (append-only CSV-Ledger lösen sich über `merge=union`).
- **Never-Fail**: schlägt jeder Versuch fehl → `::warning::` + `exit 0`. Der zuletzt veröffentlichte Stand bleibt, der nächste ~30-Min-Tick baut neu auf.

**2. Doku-Drift HAFAS-Profil**
- `src/places/hafas_client.py` und `scripts/sync_hafas_profile.py`: präzisiert, dass das Profil **wöchentlich** (nicht pro Tick) aktualisiert wird und der Laufzeit-Client nur die committete, in-process gecachte JSON liest.

**3. CHANGELOG.md** — zwei Einträge unter `[Unreleased]`.

## Bewusste Scope-Grenzen
- Die verbleibenden `uses:`-Actions (`checkout`/`setup-python`/`cache`) sind First-Party und lassen sich nicht aus dem Workflow heraus retryen; da der Zyklus idempotent ist, heilt ein seltener Setup-Fehler dort beim nächsten Tick von selbst.
- Echte Build-Fehler (`feed build`) bleiben bewusst sichtbar (roter Status) — sie zu verschlucken würde stale Daten mit grünem Badge veröffentlichen, das schlechteste Ergebnis für die Live-Pipeline.
- Robustheit wurde gezielt nur auf den 30-Min-Zyklus angewandt; dieselbe Inline-Behandlung kann auf Wunsch auf `build-feed`/`update-stations`/`seo-guard`/`manual-full-refresh` ausgeweitet werden.

## Test plan
- [x] YAML parst (`yaml.safe_load`), Inline-Skript `bash -n`-sauber.
- [x] `git-auto-commit-action` nicht mehr in `update-cycle.yml` referenziert; torch/HF-Cache/`feed build`-Steps unangetastet.
- [x] `tests/test_en_feed_workflow_deps.py` — **9 passed** (Vertrag für alle 3 Feed-Workflows).
- [ ] Beobachten: nächster Live-Tick erzeugt weiterhin `chore: update cycle` auf `main`.

https://claude.ai/code/session_01BKQYsSo8mxLik877dJAJFc

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKQYsSo8mxLik877dJAJFc)_