### PR TITLE
fix(wl): resolve bare title dates to nearest year, parse spelled-out months

### DIFF
--- a/src/providers/wl_text.py
+++ b/src/providers/wl_text.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime, timedelta, UTC
+from datetime import date, datetime, UTC
 from zoneinfo import ZoneInfo
+
+_VIENNA_TZ = ZoneInfo("Europe/Vienna")
 
 # ---------------- Relevanz-/Ausschluss-Filter ----------------
 
@@ -112,48 +114,127 @@ def _tidy_title_wl(title: str) -> str:
 
 # ---------------- Datum aus Titel extrahieren ----------------
 
-_DATE_FROM_TITLE_RE = re.compile(r"ab\s+(\d{1,2})\.(\d{1,2})\.(\d{4})?", re.IGNORECASE)
+# German month names incl. the Austrian variants ``Jänner`` (Januar)
+# and ``Feber`` (Februar) — both occur in real Wiener-Linien titles.
+_MONTHS_DE: dict[str, int] = {
+    "jänner": 1,
+    "januar": 1,
+    "februar": 2,
+    "feber": 2,
+    "märz": 3,
+    "april": 4,
+    "mai": 5,
+    "juni": 6,
+    "juli": 7,
+    "august": 8,
+    "september": 9,
+    "oktober": 10,
+    "november": 11,
+    "dezember": 12,
+}
 
-def extract_date_from_title(title: str, reference_date: datetime | None = None) -> datetime | None:
+# ``ab DD.MM.[YYYY]`` — numeric form (trailing dot after the month is
+# mandatory, matching the legacy pattern).
+_DATE_NUMERIC_RE = re.compile(
+    r"ab\s+(\d{1,2})\.(\d{1,2})\.(\d{4})?",
+    re.IGNORECASE,
+)
+# ``ab DD. <Monat> [YYYY]`` — spelled-out form WL uses for advance
+# notices (e.g. ``ab 07. April 2026``). The legacy code ignored this
+# shape entirely, so those start dates silently fell back to the API
+# publication date.
+_DATE_MONTHNAME_RE = re.compile(
+    r"ab\s+(\d{1,2})\.?\s*("
+    + "|".join(re.escape(m) for m in _MONTHS_DE)
+    + r")\b(?:\s+(\d{4}))?",
+    re.IGNORECASE | re.UNICODE,
+)
+
+
+def _extract_day_month_year(title: str) -> tuple[int, int, int | None] | None:
+    """Return ``(day, month, year_or_None)`` from the first ``ab`` date.
+
+    Tries the numeric form first, then the spelled-out month form. The
+    two patterns are mutually exclusive, so order only decides which
+    wins when a title (pathologically) carries both.
     """
-    Extrahierte ein Datum der Form 'ab DD.MM.[YYYY]' aus dem Titel.
-    Falls das Jahr fehlt, wird versucht, es anhand von reference_date zu raten.
+    match = _DATE_NUMERIC_RE.search(title)
+    if match:
+        day_str, month_str, year_str = match.groups()
+        return int(day_str), int(month_str), int(year_str) if year_str else None
+    match = _DATE_MONTHNAME_RE.search(title)
+    if match:
+        day_str, month_word, year_str = match.groups()
+        return (
+            int(day_str),
+            _MONTHS_DE[month_word.lower()],
+            int(year_str) if year_str else None,
+        )
+    return None
+
+
+def _resolve_missing_year(month: int, day: int, reference_date: datetime) -> int | None:
+    """Resolve a missing year to the ``DD.MM`` occurrence nearest *reference_date*.
+
+    WL omits the year only around the turn of the year, so picking the
+    occurrence closest to the publication/validity reference resolves
+    the Dec->Jan rollover without a magic past-window constant. Ties
+    favour the future occurrence (``ab`` denotes a start, i.e. an
+    advance notice). Crucially, the callsite only *applies* the result
+    when it is strictly later than the API start, so a date resolved
+    into the recent past is safely discarded in favour of the reliable
+    API start rather than being fabricated a year ahead.
+
+    Returns ``None`` when ``DD.MM`` is invalid in every candidate year
+    (e.g. ``29.02`` with no nearby leap year).
+    """
+    if reference_date.tzinfo is None:
+        reference_date = reference_date.replace(tzinfo=UTC)
+    ref_date = reference_date.astimezone(_VIENNA_TZ).date()
+    best_key: tuple[int, int] | None = None
+    best_year: int | None = None
+    for year in (ref_date.year - 1, ref_date.year, ref_date.year + 1):
+        try:
+            candidate = date(year, month, day)
+        except ValueError:
+            continue
+        key = (abs((candidate - ref_date).days), -year)
+        if best_key is None or key < best_key:
+            best_key, best_year = key, year
+    return best_year
+
+
+def extract_date_from_title(
+    title: str, reference_date: datetime | None = None
+) -> datetime | None:
+    """Extract an ``ab <Datum>`` start date from a Wiener-Linien title.
+
+    Recognises both the numeric ``ab DD.MM.[YYYY]`` and the spelled-out
+    ``ab DD. <Monat> [YYYY]`` forms (incl. the Austrian ``Jänner`` /
+    ``Feber``). A missing year is resolved against *reference_date*
+    (default: now in UTC) via :func:`_resolve_missing_year`. Returns a
+    midnight Europe/Vienna datetime, or ``None`` when no parseable date
+    is present.
     """
     if not title:
         return None
     if len(title) > 500:
         title = title[:500]
 
-    match = _DATE_FROM_TITLE_RE.search(title)
-    if not match:
+    parsed = _extract_day_month_year(title)
+    if parsed is None:
         return None
+    day, month, year = parsed
 
-    day_str, month_str, year_str = match.groups()
-    day, month = int(day_str), int(month_str)
-
-    if reference_date is None:
-        reference_date = datetime.now(UTC)
-
-    if year_str:
-        year = int(year_str)
-    else:
-        # Jahr raten:
-        # Zunächst aktuelles Jahr (basierend auf reference_date)
-        year = reference_date.year
-        try:
-            candidate = datetime(year, month, day, tzinfo=ZoneInfo("Europe/Vienna"))
-        except ValueError:
+    if year is None:
+        if reference_date is None:
+            reference_date = datetime.now(UTC)
+        year = _resolve_missing_year(month, day, reference_date)
+        if year is None:
             return None
 
-        # Wenn das Datum mehr als 3 Monate in der Vergangenheit liegt im Vergleich zum Referenzdatum,
-        # nehmen wir an, dass das nächste Jahr gemeint ist (z.B. im Dez 'ab Jan').
-        if candidate < reference_date - timedelta(days=90):
-            year += 1
-
     try:
-        # Wir setzen die Zeit auf 04:00 (Betriebsbeginn?) oder 00:00?
-        # Um Konsistenz mit Kalendern zu wahren, ist 00:00 (Mitternacht) am sichersten.
-        return datetime(year, month, day, tzinfo=ZoneInfo("Europe/Vienna"))
+        return datetime(year, month, day, tzinfo=_VIENNA_TZ)
     except ValueError:
         return None
 

--- a/tests/test_wl_date_correction.py
+++ b/tests/test_wl_date_correction.py
@@ -105,3 +105,29 @@ def test_reproduction_linie_n62_date_mismatch(monkeypatch: pytest.MonkeyPatch) -
     assert ev["pubDate"].year == 2025
     assert ev["pubDate"].month == 12
     assert ev["pubDate"].day == 12
+
+def test_monthname_advance_notice_sets_starts_at(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Spelled-out month form (real WL shape, e.g. "ab 07. April 2026").
+    # The legacy regex ignored it, so starts_at silently fell back to the
+    # API publication date; it must now win as the effective start.
+    traffic_info = _base_event(
+        title="56A: Bauarbeiten Maxingstraße ab 07. April 2026",
+        time={"start": "2026-01-10T00:00:00.000+01:00"},
+        attributes={"relatedLines": ["56A"]},
+    )
+
+    _setup_fetch(monkeypatch, traffic_infos=[traffic_info])
+
+    events = fetch_events()
+    assert len(events) == 1
+    ev = events[0]
+
+    start_dt = ev["starts_at"]
+    assert start_dt.year == 2026
+    assert start_dt.month == 4
+    assert start_dt.day == 7
+
+    # PubDate should remain the API publication date.
+    assert ev["pubDate"].year == 2026
+    assert ev["pubDate"].month == 1
+    assert ev["pubDate"].day == 10

--- a/tests/test_wl_extract_date_from_title.py
+++ b/tests/test_wl_extract_date_from_title.py
@@ -1,0 +1,85 @@
+"""Unit tests for ``wl_text.extract_date_from_title``.
+
+Covers the year-rollover resolution (the previously untested branch) and
+the spelled-out German month form (incl. the Austrian ``Jänner`` /
+``Feber``) that the legacy regex ignored.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from src.providers.wl_text import extract_date_from_title
+
+VIENNA = ZoneInfo("Europe/Vienna")
+
+
+def _ref(year: int, month: int, day: int) -> datetime:
+    return datetime(year, month, day, 12, 0, tzinfo=VIENNA)
+
+
+def test_numeric_explicit_year() -> None:
+    got = extract_date_from_title("Linie 4A: Verlegung ab 12.01.2026")
+    assert got == datetime(2026, 1, 12, tzinfo=VIENNA)
+
+
+def test_numeric_missing_year_december_reference_rolls_to_january() -> None:
+    # Published 20 Dec 2025, "ab 02.01." => 2 Jan 2026 (nearest occurrence).
+    got = extract_date_from_title("ab 02.01.", reference_date=_ref(2025, 12, 20))
+    assert got == datetime(2026, 1, 2, tzinfo=VIENNA)
+
+
+def test_numeric_missing_year_january_reference_keeps_previous_december() -> None:
+    # Regression: the legacy "+1-only" heuristic stamped this as Dec 2026
+    # (~12 months in the future). The nearest-occurrence rule correctly
+    # resolves it to the recent past (Dec 2025).
+    got = extract_date_from_title("ab 28.12.", reference_date=_ref(2026, 1, 5))
+    assert got == datetime(2025, 12, 28, tzinfo=VIENNA)
+
+
+def test_monthname_explicit_year() -> None:
+    got = extract_date_from_title(
+        "56A/58A: Bauarbeiten Maxingstraße ab 07. April 2026"
+    )
+    assert got == datetime(2026, 4, 7, tzinfo=VIENNA)
+
+
+@pytest.mark.parametrize(
+    ("title", "expected_month"),
+    [
+        ("Umleitung ab 03. Jänner 2026", 1),
+        ("Umleitung ab 15. Feber 2026", 2),
+        ("Umleitung ab 9. März 2026", 3),
+        ("Umleitung ab 01. Juni 2026", 6),
+        ("Umleitung ab 03. November 2025", 11),
+    ],
+)
+def test_monthname_variants(title: str, expected_month: int) -> None:
+    got = extract_date_from_title(title)
+    assert got is not None
+    assert got.month == expected_month
+
+
+def test_monthname_missing_year_rolls_to_january() -> None:
+    got = extract_date_from_title("ab 02. Jänner", reference_date=_ref(2025, 12, 20))
+    assert got == datetime(2026, 1, 2, tzinfo=VIENNA)
+
+
+def test_no_date_returns_none() -> None:
+    assert extract_date_from_title("10A/42A: Umleitung Lidlgasse") is None
+
+
+def test_empty_title_returns_none() -> None:
+    assert extract_date_from_title("") is None
+
+
+def test_invalid_calendar_date_returns_none() -> None:
+    # 31 February never exists -> datetime() raises -> None.
+    assert extract_date_from_title("ab 31.02.2026") is None
+
+
+def test_naive_reference_is_treated_as_utc() -> None:
+    # A naive reference must not raise and resolves like the aware case.
+    got = extract_date_from_title("ab 02.01.", reference_date=datetime(2025, 12, 20))
+    assert got == datetime(2026, 1, 2, tzinfo=VIENNA)


### PR DESCRIPTION
## Kontext

Audit der Jahreswechsel-Logik im gesamten Projekt: Statistik-Ledger (`stats.py`), VAO-Verspätungen/Ausfälle, README-Snapshot und Feed-Datumsformat sind alle korrekt und teils explizit getestet, weil sie mit vollständigen Zeitstempeln (inkl. Jahr) arbeiten. Die **einzige** Stelle, die ein fehlendes Jahr *rät* — `wl_text.extract_date_from_title` — war nicht beweisbar korrekt und ungetestet.

## Summary

- **Jahreswechsel-Fix:** Die alte Heuristik addierte nur Jahre (`+1`, wenn das Datum >90 Tage zurückliegt) und behandelte damit ausschließlich den Dezember→Januar-Fall. Ein nacktes „ab 28.12." Anfang Januar wurde so ~12 Monate in die Zukunft (Dez **2026**) statt in die jüngste Vergangenheit (Dez **2025**) gestempelt. Ersetzt durch eine **Nearest-Occurrence-Regel** ohne Magic-Number: das aufgelöste Jahr ist das `DD.MM`, das dem Referenzdatum am nächsten liegt. Da der Callsite (`wl_fetch.py`) das Titel-Datum nur übernimmt, wenn es **echt später** als der API-`start` ist, wird ein in die jüngste Vergangenheit aufgelöstes Datum sicher verworfen (Fallback auf den verlässlichen API-`start`), statt ein Jahr nach vorn erfunden zu werden.
- **Neuer Datumstyp:** Erkennt jetzt die ausgeschriebene Form „ab DD. *Monat* [YYYY]" (inkl. der österreichischen Varianten **Jänner**/**Feber**), die reale WL-Titel für Vorankündigungen nutzen (z. B. „ab 07. April 2026"). Die bisherige nur-numerische Regex ignorierte diese Form, sodass das effektive Startdatum still auf das Veröffentlichungsdatum zurückfiel (im aktuellen Cache real 3/59 Meldungen betroffen).
- Saubere Trennung in `_extract_day_month_year` (Parsing) und `_resolve_missing_year` (Jahreslogik); `ZoneInfo("Europe/Vienna")` als Modulkonstante gehoben.

## Test plan

- [x] `tests/test_wl_extract_date_from_title.py` (neu): explizites Jahr (numerisch + Monatsname), Jahresgrenze Dez→Jan, **Regressionstest** Jan→Dez (alt: 2026, neu: 2025), Monatsnamen-Varianten inkl. Jänner/Feber, ungültiges Datum, naive Referenz.
- [x] `tests/test_wl_date_correction.py`: bestehende Tests grün + neuer End-to-End-Test für die Monatsnamen-Vorankündigung (`starts_at` = effektives Datum, `pubDate` = Veröffentlichung).
- [x] Regressionslauf der WL/Titel/Merge-Suite: 129 passed.
- [x] `ruff check` sauber; `mypy` sauber für `wl_text.py`.

## Nicht in diesem PR (bewusst, kleiner Blast-Radius)

Die Display-Bereinigung `_tidy_title_wl` entfernt weiterhin nur die numerische „ab DD.MM."-Form aus dem Titeltext (nicht die Monatsnamen-Form). Eine Angleichung würde die Dedup-/Merge-Keys (`title_core`) verändern und ist als separater Schritt sinnvoller — rein kosmetisch (Datum erscheint ggf. doppelt), kein Korrektheitsproblem.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhnDWcquMaW5KRiVNb4KTh)_