### PR TITLE
fix: fd leak in atomic_write, new-item miscount, stats year-file timezone

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -3038,8 +3038,6 @@ def _count_new_items(
     items: Sequence[FeedItem],
     state: dict[str, dict[str, Any]],
 ) -> int:
-    if not isinstance(state, dict):
-        return sum(1 for it in items if isinstance(it, dict))
     count = 0
     for it in items:
         if not isinstance(it, dict):

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -3038,13 +3038,20 @@ def _count_new_items(
     items: Sequence[FeedItem],
     state: dict[str, dict[str, Any]],
 ) -> int:
-    existing = set(state.keys()) if isinstance(state, dict) else set()
+    if not isinstance(state, dict):
+        return sum(1 for it in items if isinstance(it, dict))
     count = 0
     for it in items:
         if not isinstance(it, dict):
             continue  # type: ignore[unreachable]
-        ident = _identity_for_item(it)
-        if ident not in existing:
+        # The state is persisted under the guid-preferring key scheme
+        # (:func:`_state_key_for_item`, with a legacy-identity fallback) used
+        # by both the writer and the age-out. Comparing the raw content
+        # identity (:func:`_identity_for_item`) against guid-keyed state
+        # counted every guid-bearing item as "new" on every run — use the
+        # same lookup so an already-tracked item is recognised.
+        _key, entry = _lookup_state(it, state)
+        if entry is None:
             count += 1
     return count
 

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -103,6 +103,7 @@ def atomic_write(
     unique_id = secrets.token_hex(16)
     tmp_path = target.with_name(f"{target.name}.{unique_id}.tmp")
 
+    fd: int | None = None
     f: IO[Any] | None = None
     try:
         flags = os.O_CREAT | os.O_EXCL
@@ -123,13 +124,17 @@ def atomic_write(
             pass
 
         f = open(fd, mode, encoding=encoding, newline=newline)
+        # The file object now owns the descriptor — closing ``f`` closes
+        # ``fd``. Null the raw handle so the failure path never double-closes
+        # it (a re-used fd could by then belong to an unrelated file).
+        fd = None
         yield f
         f.flush()
         os.fsync(f.fileno())
 
         # Set permissions before moving into place and closing
         try:
-            os.fchmod(fd, permissions)
+            os.fchmod(f.fileno(), permissions)
         except OSError:
             pass
 
@@ -156,6 +161,14 @@ def atomic_write(
             except Exception as close_exc:
                 import logging
                 logging.getLogger(__name__).warning("Failed to close temporary file", exc_info=close_exc)
+        elif fd is not None:
+            # ``os.open`` succeeded but ``open(fd, ...)`` never took ownership
+            # (e.g. an invalid ``encoding`` raises LookupError before the file
+            # object is built). Close the raw descriptor so it does not leak.
+            try:
+                os.close(fd)
+            except OSError:
+                pass
         # Cleanup temp file
         if os.path.exists(tmp_path):
             try:

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -67,6 +67,39 @@ DEFAULT_MAX_ZIP_ENTRIES = 1000
 DEFAULT_MAX_ZIP_FILENAME_LENGTH = 1024
 
 
+def _close_and_cleanup_failed_write(
+    f: IO[Any] | None, fd: int | None, tmp_path: Path
+) -> None:
+    """Best-effort cleanup after a failed :func:`atomic_write`.
+
+    Closes whichever descriptor is still open — the file object when
+    ``open(fd, ...)`` succeeded, otherwise the raw ``fd`` from ``os.open``
+    (which would leak if ``open(fd, ...)`` raised before taking ownership) —
+    then removes the temporary file.
+    """
+    log = logging.getLogger(__name__)
+    # Close if still open (e.g. exception during yield)
+    if f is not None:
+        try:
+            f.close()
+        except Exception as close_exc:
+            log.warning("Failed to close temporary file", exc_info=close_exc)
+    elif fd is not None:
+        # ``os.open`` succeeded but ``open(fd, ...)`` never took ownership
+        # (e.g. an invalid ``encoding`` raises LookupError before the file
+        # object is built). Close the raw descriptor so it does not leak.
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+    # Cleanup temp file
+    if os.path.exists(tmp_path):
+        try:
+            os.unlink(tmp_path)
+        except OSError as unlink_exc:
+            log.warning("Failed to remove temporary file", exc_info=unlink_exc)
+
+
 @contextmanager
 def atomic_write(
     path: str | Path,
@@ -154,28 +187,7 @@ def atomic_write(
                 raise FileExistsError(f"File {target} already exists") from exc
 
     except Exception:
-        # Close if still open (e.g. exception during yield)
-        if f is not None:
-            try:
-                f.close()
-            except Exception as close_exc:
-                import logging
-                logging.getLogger(__name__).warning("Failed to close temporary file", exc_info=close_exc)
-        elif fd is not None:
-            # ``os.open`` succeeded but ``open(fd, ...)`` never took ownership
-            # (e.g. an invalid ``encoding`` raises LookupError before the file
-            # object is built). Close the raw descriptor so it does not leak.
-            try:
-                os.close(fd)
-            except OSError:
-                pass
-        # Cleanup temp file
-        if os.path.exists(tmp_path):
-            try:
-                os.unlink(tmp_path)
-            except OSError as unlink_exc:
-                import logging
-                logging.getLogger(__name__).warning("Failed to remove temporary file", exc_info=unlink_exc)
+        _close_and_cleanup_failed_write(f, fd, tmp_path)
         raise
 
 

--- a/src/utils/stats.py
+++ b/src/utils/stats.py
@@ -764,7 +764,12 @@ def read_recent_stammstrecke_observations(
     # passes one, but the API is public) would otherwise silently skip the
     # intermediate years' ledgers. ``range`` is identical to the former
     # ``{cutoff.year, now.year}`` set for the ≤1-year windows used today.
-    years = list(range(cutoff.year, now.year + 1))
+    # Year-file names are derived from the *Vienna-local* year at write time
+    # (:func:`append_stammstrecke_row` uses ``to_vienna(timestamp).year``), so
+    # the file-selection range must localise too. A UTC-aware ``now`` in the
+    # first hour(s) after a Vienna New-Year would otherwise scan only the
+    # previous year's ledger and miss rows just written to the new one.
+    years = list(range(to_vienna(cutoff).year, to_vienna(now).year + 1))
     observations: list[StammstreckeObservation] = []
     for year in years:
         path = folder / f"stammstrecke_{year:04d}.csv"

--- a/tests/test_build_feed_count_new_items.py
+++ b/tests/test_build_feed_count_new_items.py
@@ -1,0 +1,47 @@
+"""Regression tests for :func:`src.build_feed._count_new_items`.
+
+The persisted ``first_seen`` state is keyed by the guid-preferring scheme
+(:func:`_state_key_for_item`). ``_count_new_items`` previously compared the raw
+content identity (:func:`_identity_for_item`) against those keys, so every
+guid-bearing item was miscounted as "new" on every run. These tests pin the
+corrected behaviour: an item already tracked in the state is not counted.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import src.build_feed as bf
+
+
+def _wl_item(guid: str) -> dict[str, object]:
+    return {
+        "title": "U6: Störung im Bereich Längenfeldgasse",
+        "source": "Wiener Linien",
+        "category": "Störung",
+        "guid": guid,
+        "starts_at": datetime(2026, 5, 1, tzinfo=UTC),
+    }
+
+
+def test_count_new_items_recognises_guid_keyed_state() -> None:
+    item = _wl_item("WL-123")
+    key = bf._state_key_for_item(item)
+    # Sanity: the state key is the guid, not the content identity.
+    assert key == "WL-123"
+    assert bf._identity_for_item(item) != key
+
+    state = {key: {"first_seen": "2026-05-01T00:00:00+00:00"}}
+    assert bf._count_new_items([item], state) == 0
+
+
+def test_count_new_items_counts_genuinely_new_items() -> None:
+    seen = _wl_item("WL-123")
+    state = {bf._state_key_for_item(seen): {"first_seen": "2026-05-01T00:00:00+00:00"}}
+
+    fresh = _wl_item("WL-999")
+    assert bf._count_new_items([seen, fresh], state) == 1
+
+
+def test_count_new_items_empty_state_counts_all() -> None:
+    items = [_wl_item("WL-1"), _wl_item("WL-2")]
+    assert bf._count_new_items(items, {}) == 2

--- a/tests/test_build_feed_count_new_items.py
+++ b/tests/test_build_feed_count_new_items.py
@@ -9,13 +9,17 @@ corrected behaviour: an item already tracked in the state is not counted.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
 import src.build_feed as bf
+from src.feed_types import FeedItem
 
 
-def _wl_item(guid: str) -> dict[str, object]:
+def _wl_item(guid: str) -> FeedItem:
     return {
         "title": "U6: Störung im Bereich Längenfeldgasse",
+        "link": "https://example.invalid/u6",
+        "description": "Test disruption",
         "source": "Wiener Linien",
         "category": "Störung",
         "guid": guid,
@@ -30,13 +34,15 @@ def test_count_new_items_recognises_guid_keyed_state() -> None:
     assert key == "WL-123"
     assert bf._identity_for_item(item) != key
 
-    state = {key: {"first_seen": "2026-05-01T00:00:00+00:00"}}
+    state: dict[str, dict[str, Any]] = {key: {"first_seen": "2026-05-01T00:00:00+00:00"}}
     assert bf._count_new_items([item], state) == 0
 
 
 def test_count_new_items_counts_genuinely_new_items() -> None:
     seen = _wl_item("WL-123")
-    state = {bf._state_key_for_item(seen): {"first_seen": "2026-05-01T00:00:00+00:00"}}
+    state: dict[str, dict[str, Any]] = {
+        bf._state_key_for_item(seen): {"first_seen": "2026-05-01T00:00:00+00:00"}
+    }
 
     fresh = _wl_item("WL-999")
     assert bf._count_new_items([seen, fresh], state) == 1

--- a/tests/test_utils_files.py
+++ b/tests/test_utils_files.py
@@ -1,6 +1,7 @@
 import builtins
 import os
 from pathlib import Path
+from typing import Any
 import pytest
 from src.utils.files import atomic_write
 
@@ -98,13 +99,13 @@ def test_atomic_write_closes_raw_fd_when_file_open_fails(
         closed.append(fd)
         real_os_close(fd)
 
-    real_open = builtins.open
+    real_open: Any = builtins.open
 
     def failing_open(file: object, *args: object, **kwargs: object) -> object:
         # Fail only the descriptor-adopting open performed by atomic_write.
         if isinstance(file, int) and file in opened:
             raise LookupError("unknown encoding: definitely-not-a-codec")
-        return real_open(file, *args, **kwargs)  # type: ignore[arg-type]
+        return real_open(file, *args, **kwargs)
 
     monkeypatch.setattr(os, "open", tracking_os_open)
     monkeypatch.setattr(os, "close", tracking_os_close)

--- a/tests/test_utils_files.py
+++ b/tests/test_utils_files.py
@@ -1,3 +1,4 @@
+import builtins
 import os
 from pathlib import Path
 import pytest
@@ -73,3 +74,49 @@ def test_atomic_write_permissions(tmp_path: Path) -> None:
 
     mode2 = target2.stat().st_mode & 0o777
     assert mode2 == 0o644
+
+
+def test_atomic_write_closes_raw_fd_when_file_open_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If ``open(fd, ...)`` raises (e.g. bad encoding) the raw descriptor
+    from ``os.open`` must be closed, not leaked."""
+    target = tmp_path / "leak.txt"
+    opened: list[int] = []
+    closed: list[int] = []
+
+    real_os_open = os.open
+
+    def tracking_os_open(*args: object, **kwargs: object) -> int:
+        fd = real_os_open(*args, **kwargs)  # type: ignore[arg-type]
+        opened.append(fd)
+        return fd
+
+    real_os_close = os.close
+
+    def tracking_os_close(fd: int) -> None:
+        closed.append(fd)
+        real_os_close(fd)
+
+    real_open = builtins.open
+
+    def failing_open(file: object, *args: object, **kwargs: object) -> object:
+        # Fail only the descriptor-adopting open performed by atomic_write.
+        if isinstance(file, int) and file in opened:
+            raise LookupError("unknown encoding: definitely-not-a-codec")
+        return real_open(file, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(os, "open", tracking_os_open)
+    monkeypatch.setattr(os, "close", tracking_os_close)
+    monkeypatch.setattr(builtins, "open", failing_open)
+
+    with pytest.raises(LookupError):
+        with atomic_write(target) as handle:
+            handle.write("never reached")
+
+    assert opened, "os.open was not exercised"
+    # The descriptor opened before the failed open(fd, ...) must be closed.
+    assert opened[0] in closed
+    # No temp file and no target should be left behind.
+    assert not any(p.name.endswith(".tmp") for p in tmp_path.iterdir())
+    assert not target.exists()

--- a/tests/test_utils_stats.py
+++ b/tests/test_utils_stats.py
@@ -691,3 +691,33 @@ def test_append_stammstrecke_row_does_not_modify_safe_text(tmp_path: Path) -> No
     assert rows[0][3] == "Meidling"
     # Numeric formatting unchanged.
     assert rows[0][4] == "5.50"
+
+
+def test_read_recent_observations_localizes_year_at_new_year_boundary(
+    tmp_path: Path,
+) -> None:
+    """File selection must use the Vienna-local year (matching the writer).
+
+    A row written at 2027-01-01 00:30 Vienna (= 2026-12-31 23:30 UTC) lands in
+    ``stammstrecke_2027.csv``. Reading with a UTC-aware ``now`` that is still
+    2026 in UTC but already 2027 in Vienna must still find that row, i.e. the
+    reader must scan the 2027 ledger rather than only the UTC ``now.year``.
+    """
+    written_at = datetime(2026, 12, 31, 23, 30, tzinfo=UTC)
+    stats_utils.append_stammstrecke_row(
+        timestamp=written_at,
+        direction="Meidling",
+        delay_minutes=6.0,
+        stats_dir=tmp_path,
+    )
+    # Confirm the writer placed the row in the *new* year's ledger.
+    assert (tmp_path / "stammstrecke_2027.csv").exists()
+
+    now_utc = datetime(2026, 12, 31, 23, 45, tzinfo=UTC)  # 2027-01-01 00:45 Vienna
+    observations = stats_utils.read_recent_stammstrecke_observations(
+        now=now_utc,
+        window=timedelta(hours=2),
+        stats_dir=tmp_path,
+    )
+    assert len(observations) == 1
+    assert observations[0].direction == "Meidling"


### PR DESCRIPTION
## Summary

A thorough bug-hunt across the codebase (static analysis + module-by-module audit). This PR fixes the three highest-confidence, lowest-risk bugs found; the rest are written up below for your decision.

### Fixed (with regression tests; ruff + mypy clean)

1. **`src/utils/files.py` — `atomic_write` descriptor leak.**
   `fd = os.open(...)` is only ever closed via `f.close()`. If the subsequent `open(fd, …)` raises (e.g. an invalid `encoding` → `LookupError`, or `MemoryError` building the buffered wrapper), `f` is still `None`, the `except` skips the close, and the raw descriptor leaks. Repeated failures exhaust the process fd table. Fix: track the raw `fd`, close it on that path, use `f.fileno()` for the post-open `fchmod`, and null the handle once ownership transfers so the success path can never double-close a re-used descriptor.

2. **`src/build_feed.py` — `_count_new_items` key-scheme mismatch.**
   State is persisted under the guid-preferring scheme (`_state_key_for_item`), but the new-item count compared each item's *content* identity (`_identity_for_item`). For any guid-bearing item the two never match, so every such item was counted as "new" on every run — the `Neue Items seit letztem State` health metric was permanently inflated. Fix: use `_lookup_state`, the same lookup the writer and age-out use. (Metric-only; no feed-output change.)

3. **`src/utils/stats.py` — Stammstrecke year-file selection ignored timezone.**
   `read_recent_stammstrecke_observations` chose per-year ledger files by the raw `now`/`cutoff` `.year`, while the writer names files by the **Vienna-local** year (`to_vienna(timestamp).year`). A UTC-aware `now` in the first hour(s) after a Vienna New-Year would scan only the previous year's file and miss rows just written to the new one. Fix: localize the year range via `to_vienna()`. (Latent for the current caller, which passes a Vienna-aware `now`; the function is public and documented to accept any aware datetime.)

### Additional findings (NOT changed here — flagged for your call)

- **`src/places/merge.py:312-323`** — when a Google place is *distance*-matched to a station that already has a different valid `_google_place_id`, the place_id is (correctly) not overwritten, but `latitude`/`longitude` **are** overwritten unconditionally. Two places near one station can leave the stored coords pointing at a different place than the stored ID. Bounded to `max_distance_m` (~150 m), ID is mostly internal. Suggested fix: gate the coord update on the same condition as the place_id update.
- **`src/utils/circuit_breaker.py`** — the class docstring promises "in HALF_OPEN, exactly one probe is admitted," but `call()` releases the lock before invoking `func`, so concurrent callers in HALF_OPEN all probe. Latent unless the breaker-wrapped clients (OSM/HAFAS/Stammstrecke-Hbf) are called concurrently. Either enforce single-probe under the lock or relax the docstring.
- **`src/providers/vor.py` quota durability** — for the 1-call-per-tick Stammstrecke workload, the request-count batching never flushes mid-process, so each charge relies on the `atexit` flush (which does not run on SIGKILL/OOM). This is already acknowledged in code comments and bounded by the daily cap; setting the effective batch to 1 for that path would make each charge durable. Low priority / by-design.
- **Low / latent / stylistic:** `wl_text.py` 2-digit `ab DD.MM.YY` years fall back to nearest-year resolution; `baustellen.py` `_OEPNV_RE` `\blinien?\b` can fire on negated/operator text; `tiling.py` accepts string-typed coords past the non-finite guard; `_infer_in_vienna` substring `"wien"` (currently unreachable); `apply_station_overrides.py` rewrites `stations.json` even on a no-op; `generate_markdown_stats.py` AUSFAELLE README gate keyed only on delay rows.

## Test plan

- [x] `ruff check src scripts` — clean
- [x] `mypy` (strict) — clean
- [x] New tests: `tests/test_utils_files.py`, `tests/test_utils_stats.py`, `tests/test_build_feed_count_new_items.py` — pass
- [ ] Full suite (`pytest`, excluding the asset-optimizer test that needs optional `rcssmin`/`Pillow`) — running; result to be confirmed

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_