### PR TITLE
fix(feed): enforce EN title/summary length caps in translation overlay

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -3710,8 +3710,17 @@ def _apply_lang_overlay(
     # next build trusts the cache instead of evicting and recomputing.
     _stamp_translation_epoch(ident, state)
 
+    # Mirror the DE length contract (see ``_format_item_content`` lines
+    # ~3826-3839): German→English expansion (compound nouns split into
+    # several words) can push a translated title past ``TITLE_CHAR_LIMIT``
+    # or a summary past the 180-char TV-screen cap. The DE strings fed into
+    # translation were already capped, so re-apply both caps to the
+    # translated output to keep the EN feed within the same contract.
     title_en = _sanitize_text(title_raw)
-    summary_en = _sanitize_text(summary_raw)
+    if len(title_en) > feed_config.TITLE_CHAR_LIMIT:
+        title_en = title_en[: feed_config.TITLE_CHAR_LIMIT].rstrip() + " …"
+    title_en = _WHITESPACE_RE.sub(" ", title_en).strip()
+    summary_en = _truncate_summary_180(_sanitize_text(summary_raw))
     time_line_en = _translate_time_line_en(time_line_de)
     desc_text_truncated_en, desc_html_en = _compose_description(
         summary_en, time_line_en

--- a/tests/test_feed_translation.py
+++ b/tests/test_feed_translation.py
@@ -165,3 +165,45 @@ def test_apply_lang_overlay_passthrough_for_de() -> None:
     )
     out = build_feed._apply_lang_overlay(base, "X", "[Seit 01.01.2026]", "id", "de", {})
     assert out is base
+
+
+def test_apply_lang_overlay_enforces_en_length_caps() -> None:
+    """The EN overlay must honour the same TITLE_CHAR_LIMIT / 180-char summary
+    caps as the DE path — German→English expansion can otherwise overflow them.
+
+    The translation cache is pre-seeded (at the current epoch so it is not
+    evicted) so the ML pipeline is never invoked.
+    """
+    base = build_feed.FormattedContent(
+        guid="g",
+        link="https://example.com",
+        title_cdata="T",
+        desc_text_truncated="kurze deutsche Zusammenfassung",
+        desc_cdata="X",
+        raw_desc="X",
+        title_out="kurzer deutscher Titel",
+        desc_html="X",
+    )
+    ident = "len-cap-id"
+    long_title = "Very long translated title segment " * 20  # ~700 chars
+    long_summary = "Very long translated summary sentence. " * 20  # ~780 chars
+    state: dict[str, dict[str, Any]] = {
+        ident: {
+            "translations": {
+                "epoch": build_feed._TRANSLATION_CACHE_EPOCH,
+                "en": {"title": long_title, "summary": long_summary},
+            }
+        }
+    }
+
+    out = build_feed._apply_lang_overlay(
+        base, "kurze deutsche Zusammenfassung", "", ident, "en", state
+    )
+
+    # Confirm the seeded cache was used (not a fail-safe passthrough to base).
+    assert out is not base
+    # Title respects TITLE_CHAR_LIMIT (plus the trailing " …" ellipsis).
+    assert len(out.title_out) <= build_feed.feed_config.TITLE_CHAR_LIMIT + 2
+    assert out.title_out.endswith("…")
+    # Summary respects the 180-char TV-screen cap (time line is empty here).
+    assert len(out.desc_text_truncated) <= 180


### PR DESCRIPTION
## Summary

Second-pass, line-by-line audit (follow-up to #1683). This fixes the one **active** bug found; the remaining findings are latent/low and listed below for your decision (not changed here).

### Fixed (with regression test; ruff + mypy + C901 green)

**`src/build_feed.py` — EN feed bypassed the DE length caps.**
The DE rendering path caps the title at `TITLE_CHAR_LIMIT` (256) and the summary at the 180-char "TV-screen" limit (`_format_item_content`, ~L3826-3839). The English overlay (`_apply_lang_overlay`) rebuilt its output from the freshly translated strings and applied **neither** cap. German→English expansion (compound nouns splitting into multiple words) can push a translated title past 256 chars or a summary past 180, so the published `docs/feed.en.xml` item violated the length contract the DE item honours. Now mirrors both caps. (Low severity, but a real published-output inconsistency.)

## Additional findings (NOT changed — for your call)

Verified real, but latent or low-impact:

- **`src/feed/providers.py` — shared-loader cache-name collision.** `register_provider` mutates `loader._provider_cache_name`, and `resolve_provider_name` reads that attribute before the registry. If a plugin registers the *same* callable under two providers with different `cache_key`s, the second registration overwrites the first, so both resolve to the last cache key (wrong cache alerts / sync-vs-async classification in `build_feed`). **Latent**: the default providers all use distinct functions. Fix: prefer `_REGISTRY[env].cache_key` over the function attribute.
- **`src/feed/providers.py` — plugin `register_providers` exception is swallowed, then `PROVIDERS` still processed**, leaving a half-registered module marked "loaded". Low (misbehaving-plugin only).
- **`src/feed/reporting.py` — `ProviderReport.finish` unconditionally overwrites `items`/`detail` with `None`** on a second `finish()` call. Not reachable on the normal single-finish path; low.
- **`src/utils/stations_validation.py` — `bst_id`/`bst_code` require `isinstance(str)`.** A future writer storing them as JSON ints would falsely report "Invalid bst_id". **Latent**: today all 162 entries store them as strings.
- **`src/utils/stations_validation.py` — `_extract_source_tokens` list-branch doesn't `.strip()`** (string-branch does), so a source stored as `[" vor"]` wouldn't match. Latent (sources are comma-strings today).
- **`src/utils/secret_scanner.py` — Mailchimp regex lacks a left word boundary** (false-positive risk inside longer hex, not a miss).

### Audited and confirmed solid (no bugs)

`utils/http.py` SSRF core (IPv4-mapped IPv6 / NAT64 / CGNAT / metadata all blocked under Python 3.11), the `request_safe` redirect cap + secret-stripping + response-IP verification; `feed/config.py` path-traversal + env clamps; `feed/stammstrecke.py` time-window/episode logic; `build_feed` recency sort key / link / CDATA; `feed/merge.py` dedup thresholds; `scripts/sync_hafas_profile.py` credential extraction + validation.

## Test plan

- [x] `ruff check` — clean
- [x] `mypy` (changed files) — clean
- [x] `python scripts/check_complexity.py` — 0 new violations
- [x] `tests/test_feed_translation.py` (9 tests incl. new cap test) — pass

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_