### PR TITLE
fix(cache): scope prune_cache to current provider; close cross-provider degradation-guard bypass

### DIFF
--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -291,11 +291,18 @@ def read_cache(provider: str) -> list[Any]:
     return []
 
 
-def prune_cache(max_age_hours: int = 48) -> None:
+def prune_cache(max_age_hours: int = 48, *, provider: str | None = None) -> None:
     """Evict cached files older than `max_age_hours` hours to prevent repo bloat.
 
     Iterates through the cache directory and deletes `events.json` files that
     are older than the specified age. Removes the provider directory if empty.
+
+    When *provider* is given, only that provider's cache directory is considered.
+    :func:`write_cache` uses this scoped form so a successful write for one
+    provider cannot prune another provider's stale-but-still-protected cache
+    out from under the data-degradation guard (which keys on
+    ``cache_file.exists()``). Operator-side callers may pass ``provider=None``
+    (the default) to keep the original repo-wide cleanup behaviour.
     """
     if max_age_hours <= 0:
         return
@@ -312,10 +319,13 @@ def prune_cache(max_age_hours: int = 48) -> None:
     now = datetime.now(UTC)
     cutoff = now - timedelta(hours=max_age_hours)
 
-    for provider_dir in _CACHE_DIR.iterdir():
-        if not provider_dir.is_dir():
-            continue
+    if provider is not None:
+        scoped_dir = _CACHE_DIR / provider
+        provider_dirs = [scoped_dir] if scoped_dir.is_dir() else []
+    else:
+        provider_dirs = [p for p in _CACHE_DIR.iterdir() if p.is_dir()]
 
+    for provider_dir in provider_dirs:
         cache_file = provider_dir / _CACHE_FILENAME
         if cache_file.exists():
             try:
@@ -394,8 +404,13 @@ def write_cache(provider: str, items: list[Any], *, pretty: bool | None = None) 
     # canonical attack-byte union and the scrub-and-drop semantics rationale.
     items = scrub_trojan_source_primitives(items)
 
-    prune_cache()
-
+    # NOTE: prune_cache MUST NOT run before the data-degradation guard below.
+    # A repo-wide prune at this point would delete *other* providers' stale
+    # caches and (if any of them is currently being protected by the
+    # degradation guard) leave their guard with no on-disk baseline to
+    # compare against — turning a future empty/sparse payload into a silent
+    # overwrite. The post-write scoped prune at the end of this function
+    # cleans up this provider's own stale state without touching siblings.
     cache_file = _cache_file(provider)
 
     # Data Degradation Guard
@@ -493,6 +508,14 @@ def write_cache(provider: str, items: list[Any], *, pretty: bool | None = None) 
             cache_file,
         )
         raise
+
+    # Per-provider stale-entry cleanup. Scoped to ``provider`` so this write
+    # cannot prune a sibling provider's still-protected cache (see the NOTE
+    # at the top of this function). For the file we just wrote this is a
+    # no-op since its mtime is current; the call is a documented hook for
+    # the original "prevent repo bloat" intent without the cross-provider
+    # data-destruction side-effect the unscoped form caused.
+    prune_cache(provider=provider)
 
 
 def write_status(provider: str, status: dict[str, Any]) -> None:

--- a/tests/test_cache_degradation_guard.py
+++ b/tests/test_cache_degradation_guard.py
@@ -1,9 +1,12 @@
 import json
+import os
+import time
 from pathlib import Path
 from typing import Any
 
 import pytest
 from unittest.mock import patch
+from src.utils import cache as cache_module
 from src.utils.cache import write_cache, DataDegradationError
 
 def test_cache_degradation_guard_bypass_on_new_cache(tmp_path: Path) -> None:
@@ -119,3 +122,42 @@ def test_cache_degradation_guard_bypass_on_corrupt_cache(tmp_path: Path) -> None
         with target_file.open("r", encoding="utf-8") as f:
             saved_data = json.load(f)
         assert len(saved_data) == 1
+
+
+def test_write_cache_does_not_prune_sibling_providers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A successful write for one provider must not prune another provider's
+    stale cache out from under the data-degradation guard.
+
+    Pre-fix, ``write_cache`` ran an unscoped ``prune_cache()`` that iterated
+    every provider directory and deleted any ``events.json`` older than 48 h.
+    A repo-wide sibling prune therefore destroyed the on-disk baseline the
+    degradation guard depends on (``cache_file.exists()`` short-circuits to
+    False), turning a future empty/sparse payload into a silent overwrite.
+    """
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(cache_module, "_CACHE_DIR", cache_dir)
+
+    # Provider A: write a healthy cache, then artificially age its mtime
+    # past the 48 h cutoff so a repo-wide prune would target it.
+    write_cache("alpha", [{"id": i} for i in range(100)])
+    alpha_file = cache_module._cache_file("alpha")
+    assert alpha_file.exists()
+    aged = time.time() - 49 * 3600
+    os.utime(alpha_file, (aged, aged))
+
+    # Provider B writes successfully. Pre-fix this deleted alpha's cache.
+    write_cache("beta", [{"id": i} for i in range(50)])
+    assert alpha_file.exists(), (
+        "beta's write must not delete alpha's stale-but-still-protected cache"
+    )
+
+    # Alpha's degradation guard must still fire when its next upstream
+    # response is empty. Pre-fix the guard silently accepted [] because
+    # ``cache_file.exists()`` returned False after beta's prune.
+    with pytest.raises(DataDegradationError):
+        write_cache("alpha", [])
+    # The guard raised before atomic_write, so alpha's cache stays intact.
+    assert alpha_file.exists()


### PR DESCRIPTION
## Summary

Third-pass, line-by-line audit (follow-up to #1683, #1684). This fixes the highest-impact bug surfaced — **silent cross-provider cache destruction defeating the degradation guard** — and lists the remaining findings (none changed here) for your decision.

### Fixed (with regression test; ruff + mypy + C901 green)

**`src/utils/cache.py` — `write_cache` ran an unscoped `prune_cache()` that destroyed the data-degradation guard's baseline.**

`prune_cache()` was called at the top of `write_cache`, iterating every directory under `cache/` and deleting any `events.json` older than 48 h. Two real consequences (the second **reproduced**):

1. **Single-provider self-defeat** — A's own write deleted A's stale cache before the `cache_file.exists()` check; a degraded `[]` payload was then silently accepted.
2. **Cross-provider destruction** — B's successful write deleted A's stale-but-protected cache. A's next write hit a now-empty path, the guard short-circuited, A's empty payload overwrote the protected baseline.

Fix: add a keyword-only `provider=None` parameter to `prune_cache` (scopes to that dir when set); drop the early unscoped prune from `write_cache`; run a scoped `prune_cache(provider=provider)` AFTER `atomic_write` succeeds (a no-op for the just-written file, but preserves the original repo-bloat intent without touching siblings). The regression test reproduces the cross-provider scenario.

## Additional audit findings (NOT changed — for your call)

Three subagents covered `http.py` non-SSRF core, the cache/locking/serialize/text utils, and the upstream-cache scripts. The verified, real findings beyond the cache fix above:

**HIGH severity (worth fixing in a follow-up):**
- **`scripts/update_stammstrecke_hbf.py:675-680`** — `rt_date` falls back to `sched_date` when only `rtTime` is present, producing huge **negative delays** at midnight rollover (e.g. scheduled 23:55, rtTime "00:05" → −1430 min into the stats ledger).
- **`scripts/update_baustellen_cache.py:870-878`** — if every fetched site happens to be road-only, `relevant=[]` triggers `DataDegradationError` which is never caught by `main()` → unhandled exception kills the cron step.

**MEDIUM:**
- **`src/utils/http.py:62-71`** — `parse_retry_after` uses `\d` (Unicode digits accepted; `float('٠٤٢')==42.0` verified) and returns `+inf` for a 309-digit string. Only the current oebb caller clamps; future callers may sleep forever.
- **`src/utils/http.py:1622-1670`** — `read_response_safe` appends a chunk *before* the size check (max overshoot = `chunk_size`=8 KB). And the per-chunk read-timeout check is between chunks, so a single slow chunk bypasses it (relies on the adapter timeout).
- **`src/utils/http.py:207-241`** — evicted-session worker is strictly serial with 60 s sleeps; `cleanup_http_sessions` (atexit) never drains `_EVICTED_SESSIONS_QUEUE`. Burst evictions leak open sockets.
- **`src/utils/http.py:1002-1041`** — `_safe_rebuild_auth` strips sensitive *headers* on cross-origin redirect but leaves sensitive *query params* in `prepared_request.url`. Affects callers that use the session directly (e.g. `places/client.py` POST).
- **`src/utils/http.py:1947-1983`** — `_apply_method_downgrade` preserves the body on 307/308 cross-origin redirects (RFC-compliant, but most secure clients drop bodies cross-origin to avoid leaking POST-body credentials).
- **`src/utils/http.py:1660`** — `iter_content` decodes by default; the Content-Length pre-check bounds compressed bytes while the streaming loop measures decoded bytes — a gzip bomb is checked but only after each chunk is decoded.
- **`src/utils/cache.py:141, 322`** — `datetime.fromtimestamp(st_mtime, tz=UTC)` raises `OverflowError`/`ValueError` for mtimes > year 9999; the `except OSError` doesn't catch them.
- **`src/utils/locking.py:181`** — thread-lock `acquire()` has no timeout; non-reentrant Lock deadlocks on same-path recursion.
- **`scripts/update_baustellen_cache.py:209-247`** — `YYYY-MM-DDZ` date-only strings are treated as UTC midnight then converted to Vienna time → wrong start time (`02:00 Uhr` for a date-only field) and potentially wrong date across DST.
- **`scripts/enrich_station_aliases.py:430` (and `_load_vor_names`)** — reads CSV with `encoding="utf-8"`; a BOM-prefixed `vor-haltestellen.csv` makes the first row's first column read as `None`, silently dropping that VOR stop's name. Sibling `scripts/gtfs.py` correctly uses `utf-8-sig`.
- **`scripts/update_stammstrecke_hbf.py:801-826`** — cancelled departures with no `track` are dropped before the cancellation check, undercounting `ausfaelle_<year>.csv` (the dashboard's purpose).
- **`scripts/update_baustellen_cache.py:776`** — when start/end are both unknown, `pub_date` falls back to `datetime.now()` → every cron tick republishes the same site with a new pubDate (feed churn).
- **`scripts/update_stammstrecke_hbf.py:507`** — VAO HTTP 200 + `{"errorCode":"H730"}` (auth/quota) is treated as zero departures; failures look like clean runs.
- **`src/utils/http.py:2087-2115`** — `_compute_read_timeout` returns `0.0` for the `total_allowed_time==0` test convention; `read_response_safe` then enforces that strictly (existing test comment confirms the divergence).
- **`src/utils/http.py:551-576`** — `_strip_sensitive_params` re-encodes bare-key params (`?versioning` → `?versioning=`) and doesn't split semicolon-separated queries.

**LOW:**
- `src/utils/locking.py:88-92` — `ENOLCK` (NFS lock-table) isn't retried; EINTR branch is dead with `LOCK_NB`.
- `src/utils/locking.py:188` — `_release_thread_lock_ref` can `KeyError` on early-acquire failure.
- `src/utils/serialize.py:125-134` — `scrub_trojan_source_primitives` doesn't recurse into `set`/`frozenset`.
- `src/utils/text.py:201-202` — `truncate_html` short-circuits without closing tags when input ≤ limit.
- `src/utils/cache.py:116-126` — `_emit_cache_alert` drops alerts when `message` is an empty string.
- `scripts/extract_oebb_geonetz_stops.py:236-248` — fahrplanperiode reads only the first STP feature with `break` even if it has null dates.

### Audited and confirmed solid

`src/providers/vor.py` (auth signing: trailing-`/`-anchored URL match, MAC over wire-exact UTF-8 bytes, base-URL host-pinned, log sanitisation); `src/places/hafas_client.py` (profile validation, MAC bytes match wire, thread-safe lazy load, defensive response walk with bool-excluded-from-int check and WGS84 range validation); `src/utils/http.py` SSRF core (IPv4-mapped IPv6 / NAT64 / CGNAT / metadata all blocked under Python 3.11, `request_safe` redirect cap correct, response-IP verification fails closed).

## Test plan

- [x] `ruff check` — clean
- [x] `mypy --no-pretty src tests/test_cache_degradation_guard.py` — clean
- [x] `python scripts/check_complexity.py` — 0 new violations
- [x] `pytest tests/test_cache*.py tests/test_prune_cache_max_age_hours_cap.py` — 34 passed (incl. new regression)

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_