### PR TITLE
fix(places): honour Retry-After on 429 from Google Places API

### DIFF
--- a/src/places/client.py
+++ b/src/places/client.py
@@ -17,7 +17,12 @@ import requests
 from ..utils.circuit_breaker import CircuitBreaker, CircuitState
 from ..utils.env import read_secret
 from ..utils.files import _reject_non_finite_constant, _reject_non_finite_float
-from ..utils.http import read_response_safe, session_with_retries, verify_response_ip
+from ..utils.http import (
+    parse_retry_after,
+    read_response_safe,
+    session_with_retries,
+    verify_response_ip,
+)
 from ..utils.logging import sanitize_log_arg, sanitize_log_message
 
 from .quota import MonthlyQuota, QuotaConfig
@@ -426,6 +431,13 @@ class GooglePlacesClient:
 
         while attempt <= self._config.max_retries:
             attempt += 1
+            # The 429 / 5xx branch below sets ``last_error`` to a
+            # ``GooglePlacesError`` (NOT a ``requests.RequestException``), so
+            # the legacy extraction from ``last_error.response.headers`` would
+            # silently miss every status-coded Retry-After. Capture the header
+            # at its source (inside the ``with response`` block, or from the
+            # exception's attached response on the connection-level path).
+            retry_after_header: str | None = None
             # Quota: count each HTTP attempt up-front. Google bills per request
             # regardless of HTTP status, so we must not wait for a 200 before
             # incrementing — otherwise retries on 429/5xx would silently eat
@@ -524,6 +536,11 @@ class GooglePlacesClient:
                         last_error = GooglePlacesError(
                             f"HTTP {response.status_code}: {detail}"
                         )
+                        # Capture Retry-After while the response context is
+                        # still open — the wrapping ``GooglePlacesError`` does
+                        # not carry the underlying response, so the legacy
+                        # exception-attached extraction below cannot see it.
+                        retry_after_header = response.headers.get("Retry-After")
                     elif response.status_code in {401, 403}:
                         _BREAKER.record_success()
                         details = self._extract_error_details(response)
@@ -538,8 +555,13 @@ class GooglePlacesClient:
             except requests.RequestException as exc:
                 last_error = exc
 
-                if exc.response is not None and exc.response.status_code >= 500:
-                    _BREAKER.record_failure()
+                if exc.response is not None:
+                    if exc.response.status_code >= 500:
+                        _BREAKER.record_failure()
+                    # Connection-level RequestException occasionally carries a
+                    # response (e.g. a chunked-encoding error mid-body). Honour
+                    # Retry-After from there too so the two paths converge.
+                    retry_after_header = exc.response.headers.get("Retry-After")
 
                 LOGGER.warning(
                     "Request error (attempt %s/%s): %s",
@@ -557,15 +579,15 @@ class GooglePlacesClient:
 
             sleep_for = self._backoff(attempt)
 
-            # If we can access response, let's extract Retry-After
-            retry_after_val = None
-            header: str | None = None
-            try:
-                if isinstance(last_error, requests.RequestException) and last_error.response is not None:
-                    header = last_error.response.headers.get("Retry-After")
-                    if header and header.isdigit():
-                        retry_after_val = float(header)
-            except ValueError:
+            # Honour Retry-After captured from either path (status-coded 429
+            # or connection-level exception with attached response). Delegate
+            # numeric + HTTP-date parsing to :func:`parse_retry_after` — the
+            # places-client now matches the OEBB Retry-After handling instead
+            # of carrying its own ad-hoc ``isdigit()`` shape that rejected
+            # valid whitespace-padded / fractional / HTTP-date forms.
+            header: str | None = retry_after_header
+            retry_after_val: float | None = parse_retry_after(header)
+            if retry_after_val is None and header:
                 # Sentinel (Clear-Text-Logging Drift, places-client sibling
                 # of the ÖBB ``src/providers/oebb.py`` Retry-After fix):
                 # ``header`` is fully upstream-controlled HTTP header text

--- a/tests/places/test_client_quota_retries.py
+++ b/tests/places/test_client_quota_retries.py
@@ -150,3 +150,55 @@ def test_quota_increments_on_single_success(
 
     assert quota.counts["nearby"] == 1
     assert quota.daily_total == 1
+
+
+def test_retry_after_header_honoured_on_429(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 429 with ``Retry-After: N`` must drive the retry sleep to >= N.
+
+    Pre-fix the 429 path wrapped the upstream signal in a
+    ``GooglePlacesError`` (not a ``requests.RequestException``); the
+    extraction guard ``isinstance(last_error, requests.RequestException)``
+    therefore skipped the header entirely and the client backed off only
+    via ``_backoff(attempt)`` (~0.5 s on the first retry), re-hitting the
+    rate-limited endpoint while upstream was still asking us to wait.
+    """
+    sleeps: list[float] = []
+    monkeypatch.setattr("src.places.client.time.sleep", lambda s: sleeps.append(s))
+
+    first = _MockResponse(429)
+    first.headers["Retry-After"] = "30"
+    second = _MockResponse(200, b'{"places": []}')
+
+    session = MagicMock(spec=requests.Session)
+    session.post.side_effect = [first, second]
+    client, _, _ = _make_client(tmp_path, session)
+    client._post("places:searchNearby", {}, quota_kind="nearby")
+
+    # Exactly one sleep ran (between the 429 and the 200).
+    assert len(sleeps) == 1
+    # The 30 s Retry-After value beats the exponential backoff for attempt 1
+    # and stays under the hard 60 s cap.
+    assert 30.0 <= sleeps[0] <= 60.0
+
+
+def test_retry_after_header_honoured_with_whitespace_and_fraction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Forms like ``" 12.5 "`` are valid Retry-After payloads and must be
+    parsed; pre-fix the ``isdigit()`` precondition rejected them."""
+    sleeps: list[float] = []
+    monkeypatch.setattr("src.places.client.time.sleep", lambda s: sleeps.append(s))
+
+    first = _MockResponse(429)
+    first.headers["Retry-After"] = " 12.5 "
+    second = _MockResponse(200, b'{"places": []}')
+
+    session = MagicMock(spec=requests.Session)
+    session.post.side_effect = [first, second]
+    client, _, _ = _make_client(tmp_path, session)
+    client._post("places:searchNearby", {}, quota_kind="nearby")
+
+    assert len(sleeps) == 1
+    assert sleeps[0] >= 12.5


### PR DESCRIPTION
## Summary

Fourth-pass, line-by-line audit (follow-up to #1683, #1684, #1685). Fixes the one **HIGH-severity** active bug surfaced and lists the rest of round-4 findings (not changed here) for your decision.

### Fixed (with regression tests; ruff + mypy + C901 green)

**`src/places/client.py` — Google Places `Retry-After` on HTTP 429 was never honoured.**

The retry-loop extracted `Retry-After` from `last_error.response.headers` guarded by `isinstance(last_error, requests.RequestException)`. But the status-coded 429 branch wraps the upstream signal in a `GooglePlacesError` (not a `RequestException`), so the guard short-circuited and the header was **never** seen for the canonical HTTP 429 case. The client backed off only via `_backoff(attempt)` (~0.5 s on first retry), re-hitting the rate-limited endpoint while Google was still asking us to wait — burning quota and risking IP-level throttling. Fix captures the header at its source on both paths (429 inside the `with response:` block, and exception path from `exc.response.headers`), delegates parsing to `parse_retry_after` (accepts whitespace / fractional / HTTP-date forms — the legacy `isdigit()` precondition rejected all of those), and preserves the sanitised warning log so the existing log-injection sentinel still pins the defence. Two regression tests cover 30-second and " 12.5 " Retry-After payloads.

## Additional round-4 findings (NOT changed)

Three subagents covered oebb.py, the WL pipeline (`wiener_linien.py` + `wl_fetch.py` + `wl_lines.py`), and the places API clients (`osm_client.py` + `client.py`). Plus a personal audit of `update_stammstrecke_status.py`.

### HIGH severity (worth follow-up fixes)

- **`src/providers/wl_fetch.py:587, 692`** — `(ti.get("title") or ti.get("name") or "Meldung").strip()` raises `AttributeError` when upstream sends a non-string `title`/`name` (e.g. `{"title": 42}`). The traffic-info / news loop has no per-item `try`/`except`, so a single bad field crashes `fetch_events` → swallowed by `update_wl_cache.py`'s broad `except Exception` → stale cache silently kept.
- **`src/providers/wl_fetch.py:718`** — `" ".join([title_raw, poi.get("subtitle") or "", desc_raw, ...])` raises `TypeError` on a non-string `subtitle`. Same blast radius (whole batch aborted).

### MEDIUM

- **`src/places/client.py:343`** — `bool` is accepted as a valid coordinate (`isinstance(True, float | int) == True`). `lat=True, lon=False` round-trips as `1.0, 0.0` — "Null-Island"-style coords. The sibling OSM parser explicitly guards (`if isinstance(value, bool): return None`).
- **`src/places/client.py:131`** — `FIELD_MASK_NEARBY` omits the top-level `nextPageToken` (it's not under `places.`), so the pagination loop's `next_token` is always missing. Dormant today (`searchNearby` doesn't paginate), but the `_parse_place` code reads `formattedAddress` which is also not in the mask — always `None`.
- **`src/providers/oebb.py:583-588`** — `_normalize_endpoint_name` calls `partition(". ")` which splits at the FIRST period. For `"St. Pölten. Bitte Reisende"`, head becomes `"St"`; cleanup fails; garbled endpoint passes through.
- **`src/providers/oebb.py:1357`** — `_LINE_PREFIX_RE` makes the colon optional (`:?`), so colonless titles like `"R 5 Wien Hbf"` get parsed as `("R 5", "Wien Hbf")` and rebuilt with a wrong prefix. The companion `_LEADING_LINE_PREFIX_RE` correctly requires `:`.
- **`src/providers/oebb.py:1671-1690`** — `_derive_guid` falls back to `make_guid(title, link)` using the **post-cleanup** title. When `_clean_title_keep_places` output changes (added/removed station alias, cleanup rule tweak), the GUID shifts and the same upstream disruption emits as two separate feed items.
- **`src/providers/oebb.py:635-637, 1236-1237, 564-565`** — HTML strip/unescape order: `re.sub(r"<[^>]+>", " ", ...)` BEFORE `html.unescape(...)` lets double-escaped `&amp;lt;b&amp;gt;` survive step 1 and re-emerge as `<b>` after step 2. Should be unescape → strip.
- **`src/providers/wl_fetch.py:838-844`** — Two announcements of the same disruption (advance notice + real-time alert) merge with "take latest" `starts_at`, so the real-time event's NOW-time start is replaced by the advance notice's future date, hiding it from "active today" consumers.
- **`src/providers/wl_fetch.py:843-844`** — `ends_at` merge: `b["ends_at"] = None if (be is None or ee is None) else max(be, ee)`. A "no upper bound" merged result hides a definite end behind any None — propagates wrong overlap into the subset-removal step's `_intervals_overlap`.
- **`src/providers/wl_fetch.py:194-199`** — `_is_active` operates on the API-supplied `start`, not the title-corrected `real_start`. A disruption with `start=None`, `end=None` but a title date 6 months in the past silently surfaces.
- **`src/providers/wl_fetch.py:594-595`** — `_best_ts` falls back to `end` when `start` is missing, then `start = end` propagates into `real_start`, identity day, GUID and sort key — quietly tagging the item with the wrong day.
- **`src/providers/wl_fetch.py:621-625` + `wl_lines.py:294-303`** — Dict-shaped `relatedLines` (e.g. `[{"name": "U1"}]`) flow through `_tok(str(v))` and produce garbage tokens like `"NAMEU1"` that land in bucket key + GUID + emitted title. `_stop_names_from_related` has the proper `isinstance(s, dict)` gate; this sibling does not.

### LOW

- **`src/providers/wl_lines.py:225-228`** — `LINE_CODE_RE` uses `re.IGNORECASE`, so `[A-Z]` matches lowercase. `"Bauarbeiten a Karlsplatz"` yields bus line `A`.
- **`src/providers/oebb.py:1311-1315`** — `parse_retry_after` returns `0.0` for past HTTP-dates → `wait_seconds = 0.0` → immediate retry (defeats backoff under any 429 with a past date). Compounds with the round-3 `parse_retry_after` `+inf` finding.
- **`src/providers/oebb.py:1664`** — Title-truncation at 40 chars can end mid-HTML-tag for descriptions still carrying `<b>` markup.
- **`src/places/client.py:566` (now resolved by this PR's refactor)** — `header.isdigit()` rejected fractional / whitespace / HTTP-date Retry-After forms.
- **`src/providers/wl_fetch.py:962`** — Subset-removal can over-prune: independent disruptions on different lines that happen to share a `topic_key` collapse into the aggregate. Requires colliding topic_keys; rare.

### Dormant

- **`scripts/update_stammstrecke_status.py:1217-1222`** — Same rt_date midnight-rollover pattern as the round-3 hbf fix, but the caller chain (`_collect_sbahn_leg_observations` → `_leg_departure_delay_minutes`) is only reached from `update_stammstrecke_status.py.main()`, which no workflow invokes (only its helpers like `_observe_legs`/`_charge_one_request` are imported by the active hbf script).

### Audited and confirmed solid

`src/providers/vor.py` (auth signing + URL anchoring, MAC bytes match wire, quota write); `src/places/hafas_client.py` (profile validation, MAC, defensive walk, WGS84 + bool-excluded-from-int); `src/places/osm_client.py` (Overpass bbox/precision, name-priority, `out center tags` centroid fallback, dedup); the `src/utils/http.py` SSRF/redirect/response-IP-verification core.

## Test plan

- [x] `ruff check` — clean
- [x] `mypy` (changed files) — clean
- [x] `python scripts/check_complexity.py` — 0 new violations, 0 increased
- [x] `pytest tests/places/ tests/test_sentinel_places_client_retry_after_drift.py` — 97 passed (incl. 2 new regression tests; the log-injection sentinel still pins the defence)

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_