### PR TITLE
fix(wl): defensive str() coercion on upstream-controlled fields

### DIFF
--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -583,9 +583,9 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
             ):
                 continue
 
-            title_raw = (ti.get("title") or ti.get("name") or "Meldung").strip()
+            title_raw = str(ti.get("title") or ti.get("name") or "Meldung").strip()
             title = _tidy_title_wl(title_raw)
-            desc_raw = (ti.get("description") or "").strip()
+            desc_raw = str(ti.get("description") or "").strip()
             # Do NOT strip HTML here, we need to preserve links (Task 3)
             desc = desc_raw
             if _is_facility_only(title_raw, desc_raw):
@@ -687,14 +687,16 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
             # with empty ``title`` but a populated ``name`` (real WL
             # News payload shape) doesn't collapse to the literal
             # placeholder "Hinweis".
-            title_raw = (
+            title_raw = str(
                 poi.get("title") or poi.get("name") or "Hinweis"
             ).strip()
             title = _tidy_title_wl(title_raw)
-            desc_raw = (poi.get("description") or "").strip()
+            desc_raw = str(poi.get("description") or "").strip()
             # Do NOT strip HTML here, we need to preserve links (Task 3)
             desc = desc_raw
-            if _is_facility_only(title_raw, desc_raw, poi.get("subtitle") or ""):
+            if _is_facility_only(
+                title_raw, desc_raw, str(poi.get("subtitle") or "")
+            ):
                 continue
 
             tinfo = _coerce_dict(poi.get("time"))
@@ -715,7 +717,7 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
             text_for_filter = " ".join(
                 [
                     title_raw,
-                    poi.get("subtitle") or "",
+                    str(poi.get("subtitle") or ""),
                     desc_raw,
                     str(attrs.get("status") or ""),
                     str(attrs.get("state") or ""),

--- a/tests/test_wl_fetch.py
+++ b/tests/test_wl_fetch.py
@@ -207,3 +207,66 @@ def test_fetch_events_uses_extra_context_when_no_stops(monkeypatch: pytest.Monke
     desc = events[0]["description"]
     assert "Station: Karlsplatz" in desc
     assert "Location: Ausgang Oper" in desc
+
+
+def test_fetch_events_tolerates_non_string_title_and_description(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A truthy non-string ``title`` / ``description`` from a misbehaving
+    upstream peer must not crash the whole batch.
+
+    Pre-fix the inline ``(ti.get("title") or ti.get("name") or "Meldung").strip()``
+    chain raised ``AttributeError`` when the value was an ``int`` / ``list`` /
+    ``dict`` (because ``or`` short-circuits to the truthy non-string value and
+    ``.strip()`` is then called on it). ``update_wl_cache.py``'s broad
+    ``except Exception`` then swallowed the crash and kept the stale cache —
+    one bad upstream field disabled the WL refresh for every other item in
+    the same batch.
+    """
+    now = datetime.now(UTC).isoformat()
+    bad_traffic_info = {
+        "title": 42,
+        "description": ["unexpected", "list"],
+        "time": {"start": now},
+        "attributes": {},
+    }
+    good_traffic_info = _base_event(title="Sperre Karlsplatz")
+
+    _setup_fetch(
+        monkeypatch,
+        traffic_infos=[bad_traffic_info, good_traffic_info],
+        news=[],
+    )
+
+    # Pre-fix this would propagate AttributeError out of fetch_events.
+    events = fetch_events(timeout=0)
+    # The well-formed item survives; the malformed item must not abort the batch.
+    titles = [str(event.get("title", "")) for event in events]
+    assert any("Karlsplatz" in title for title in titles)
+
+
+def test_fetch_events_tolerates_non_string_news_subtitle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-string ``subtitle`` in the news payload must not raise
+    ``TypeError`` inside ``" ".join(...)``.
+
+    Pre-fix only ``attrs.get("status")`` / ``attrs.get("state")`` were
+    routed through ``str(... or "")``; ``poi.get("subtitle") or ""``
+    returned the truthy non-string value directly, so a dict / list /
+    int subtitle aborted the entire news loop.
+    """
+    now = datetime.now(UTC).isoformat()
+    bad_news = {
+        "title": "Hinweis",
+        "subtitle": {"unexpected": "dict-shape"},
+        "description": "Description text",
+        "time": {"start": now},
+        "attributes": {},
+    }
+
+    _setup_fetch(monkeypatch, traffic_infos=[], news=[bad_news])
+
+    # Pre-fix this would propagate TypeError out of fetch_events.
+    events = fetch_events(timeout=0)
+    assert isinstance(events, list)


### PR DESCRIPTION
## Summary

Fifth-pass, line-by-line audit (follow-up to #1683, #1684, #1685, #1686). Fixes the round-4 HIGH-severity finding and lists the (large) round-5 finding set for your decision.

### Fixed (with regression tests; ruff + mypy + C901 green)

**`src/providers/wl_fetch.py` — non-string upstream `title` / `description` / `subtitle` crashed the whole WL batch.**

The fetch loop ran `.strip()` and `" ".join(...)` directly on values pulled from the upstream JSON without any type check. `ti.get("title") or ti.get("name") or "Meldung"` short-circuits to the first truthy value, so an upstream peer returning `{"title": 42}` / `{"description": ["x"]}` / `{"subtitle": {"k": "v"}}` produced an `AttributeError` (on `.strip()`) or `TypeError` (on `" ".join`) that crashed `fetch_events` entirely. `update_wl_cache.py`'s broad `except Exception` then swallowed the crash — **one bad upstream field disabled the WL refresh for the whole batch and the stale cache was silently kept.**

Fix: `str(...)` coercion at every upstream-controlled value before `.strip()` / `" ".join(...)` / `_is_facility_only(...)`. Mirrors the defensive shape already in place for `attrs.get("status")` / `attrs.get("state")` on the same lines. Two regression tests cover the traffic-info and news-payload paths.

## Round-5 audit findings (NOT changed)

Three subagents covered `build_feed.py` post-filters + `main()`, the places consensus/normalize/tiling/quota, plus my personal verification.

### HIGH severity

- **`src/places/normalize.py:22-29`** — `normalize_name` does not strip punctuation. `normalize_name("Wien Hbf") != normalize_name("Wien Hbf.")` and `normalize_name("Wien-Hbf") != normalize_name("Wien Hbf")`. The dedup matcher in `merge.py:253-256` uses `normalize_name(place.name) == normalize_name(station.name)`; punctuation drift between sources (Google `Wien Hbf` vs OSM `Wien Hbf.`) creates duplicate station rows silently.
- **`src/places/normalize.py:24-25`** — `if len(name) > 250: return name` short-circuits, returning the un-normalised input. Two equivalent strings (one mixed-case, one lowercased) longer than 250 chars normalise differently and break dedup.
- **`src/places/quota.py:187-189`** — `daily_total` field is silently coerced to `0` on a non-int or negative value, while sibling counters `total` (179-181) and `counts[k]` (174-177) *raise* `ValueError` on the same conditions. A corrupted/tampered state file with `"daily_total": -1` or `"daily_total": "999"` resets the daily cap for the entire day. Bypasses the `PLACES_LIMIT_DAILY` budget.

### MEDIUM

- **`src/places/tiling.py:54-60`** — `_coerce_coordinate` string-path bypasses the non-finite defence: `"lat": "NaN"` / `"lng": "Infinity"` slip past the `parse_constant`/`parse_float` JSON hooks because they only fire on JSON-bare tokens.
- **`src/places/quota.py:86-89`** — `month_key` uses UTC, `daily_key` uses Europe/Vienna. The 1-2 h drift around month-end means consumption is attributed to the December bucket but counted in the January day, vanishing at `maybe_reset_month()`.
- **`src/build_feed.py:2537-2542`** — Shared-concurrency semaphore is order-dependent. If provider A has no `*_MAX_WORKERS` env but B (same `concurrency_key`) has `=3`, A runs unbounded while B is throttled — defeats the intended group limit.
- **`src/build_feed.py:4440-4447`** — `_save_state` failure is swallowed (`log.warning`) but `report.finish(build_successful=True)` still fires. Monitoring records success while `first_seen`/translations/stats drift out of sync with the on-disk feed → next-run `_count_new_items` over-counts, churning pubDates.

### LOW

- **`src/build_feed.py:700-704`** — `_call_fetch_with_timeout` swallows any internal `TypeError` from `fetch(timeout=…)` and retries `fetch()` without timeout — duplicates HTTP requests, side effects, and provider events when the inner error is not actually the kwarg-rejection it was meant to catch.
- **`src/build_feed.py:451-457`** — `init_providers` relies on `feed/providers.py` having ALREADY registered the defaults via module-import side effect to populate `_REGISTRY` for the env→cache-key fallback. A future lazy-registration refactor would make `resolve_provider_name` fall through to `loader.__name__`, producing `cache_key="read_cache_wl"` and a `__name__="read_cache_read_cache_wl"` mutation.
- **`src/build_feed.py:196-277`** — `_post_filter_wl`'s Störung-without-line-prefix drop is gated inside `if isinstance(title, str) and title:`, so a non-string/missing title — the exact case the gate is supposed to catch ("user can't disambiguate affected line") — bypasses the drop.

### Audited and confirmed solid

`coordinate_consensus.py` (tie-break correctly favours closer-to-OSM, `_intervals_overlap` inputs are aware), `tiling.py` non-string-coords already known, `quota.can_consume` `>=` boundaries, `_detect_stale_caches` tz, `_validate_configuration`, `_log_startup_summary`, `_provider_env_slug`, the env-resolution helpers, the lint() exit-code logic, `_post_filter_oebb`, `_post_filter_baustellen`, `_strip_wl_description_line_prefix`, `_strip_trailing_directional_marker`.

## Test plan

- [x] `ruff check` — clean
- [x] `mypy` (changed files) — clean
- [x] `python scripts/check_complexity.py` — 0 new violations, 0 increased
- [x] `pytest tests/test_wl_fetch*.py tests/test_post_filter_wl*.py tests/test_wl_iso_timezone.py` — 80 passed (incl. 2 new regression tests)

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_