### PR TITLE
fix(audit): four HIGH-severity follow-up fixes from rounds 3-5

### DIFF
--- a/scripts/update_baustellen_cache.py
+++ b/scripts/update_baustellen_cache.py
@@ -875,6 +875,17 @@ def main() -> int:
             skipped,
             len(events),
         )
+    # Empty payload would trigger ``DataDegradationError`` in
+    # ``write_cache`` when a populated cache already exists, and the
+    # uncaught error would crash the cron step. Skip the write
+    # instead — the pinned previous cache stays valid and the
+    # non-zero exit surfaces the issue to the cron wrapper.
+    if not relevant:
+        LOGGER.warning(
+            "Baustellen: 0 ÖPNV-relevante Einträge nach Filter – "
+            "Cache wird NICHT überschrieben, gepinnter Snapshot bleibt aktiv."
+        )
+        return 1
     write_cache("baustellen", relevant)
     if used_fallback:
         # Exit 2 = "degraded": the cache was written from the bundled

--- a/scripts/update_stammstrecke_hbf.py
+++ b/scripts/update_stammstrecke_hbf.py
@@ -158,7 +158,7 @@ import sys
 from collections.abc import Iterable, Mapping
 from contextlib import ExitStack
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Final
 
@@ -672,10 +672,23 @@ def _departure_delay_minutes(dep: Mapping[str, Any]) -> float | None:
     if not rt_time:
         return None
 
-    rt_date = dep.get("rtDate") or dep.get("rtDepDate") or sched_date
+    rt_date_explicit = dep.get("rtDate") or dep.get("rtDepDate")
+    rt_date = rt_date_explicit or sched_date
     actual = _parse_vao_dt(rt_date, rt_time)
     if actual is None:
         return None
+
+    # Midnight-rollover heuristic: when VAO omits ``rtDate`` (we fell
+    # back to ``sched_date``) AND the resulting ``actual`` lies more
+    # than 12 h BEFORE ``scheduled``, the realtime departure has
+    # crossed midnight relative to the schedule (e.g. scheduled
+    # 23:55, rtTime "00:05" → actual computed as same-day 00:05 yields
+    # a meaningless ≈-23:50 h "delay"). Bump ``actual`` by one day so
+    # the recorded delay reflects the true wall-clock difference. The
+    # 12 h threshold separates a legitimate (small-magnitude) early
+    # departure from a midnight wrap.
+    if rt_date_explicit is None and (scheduled - actual) > timedelta(hours=12):
+        actual = actual + timedelta(days=1)
 
     return (actual - scheduled).total_seconds() / 60.0
 

--- a/src/places/normalize.py
+++ b/src/places/normalize.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import unicodedata
 
 # The canonical Haversine implementation lives in ``src.utils.geo``;
@@ -12,6 +13,19 @@ from ..utils.geo import calculate_distance_meters as haversine_m
 __all__ = ["normalize_name", "haversine_m"]
 
 
+# Runs of any non-alphanumeric ASCII character (punctuation, hyphens,
+# slashes, brackets, separators, leftover non-Latin glyphs, etc.) are
+# collapsed to a single space. Applied AFTER casefold + accent-strip so
+# the remaining alphabet is reliably ``[0-9a-z]``.
+_NON_ALNUM_RUN_RE = re.compile(r"[^0-9a-z]+")
+
+# Hard cap on the normalised result. The matcher in
+# :mod:`src.places.merge` only ever compares for equality, so the cap
+# bounds matcher memory without affecting comparison semantics for any
+# real-world station name (the longest legitimate entry is ~80 chars).
+_NORMALISED_MAX_LEN = 250
+
+
 def _strip_accents(value: str) -> str:
     """Return ``value`` without any accent characters."""
 
@@ -20,10 +34,27 @@ def _strip_accents(value: str) -> str:
 
 
 def normalize_name(name: str) -> str:
-    """Normalise ``name`` for fuzzy comparisons."""
-    if len(name) > 250:
-        return name
+    """Normalise ``name`` for fuzzy comparisons.
 
+    Whitespace is collapsed, case is folded, accents are stripped, and
+    runs of punctuation / non-alphanumeric characters are collapsed to
+    a single space. The result is bounded at :data:`_NORMALISED_MAX_LEN`
+    characters.
+
+    Without the punctuation collapse the station-dedup matcher in
+    :mod:`src.places.merge` treated ``"Wien Hbf"`` and ``"Wien Hbf."``
+    (or ``"Wien-Hbf"``) as different stations and produced duplicate
+    rows whenever upstream sources disagreed on a trailing dot, a
+    hyphen, or a parenthetical suffix. The length cap used to be a
+    pre-normalisation short-circuit (``if len(name) > 250: return name``)
+    that returned the raw input unchanged — so a case-mixed overlong
+    string and its lowercased twin compared unequal, defeating the
+    same dedup invariant.
+    """
     stripped = " ".join(name.strip().split())
     lowered = stripped.casefold()
-    return _strip_accents(lowered)
+    no_accents = _strip_accents(lowered)
+    collapsed = _NON_ALNUM_RUN_RE.sub(" ", no_accents).strip()
+    if len(collapsed) > _NORMALISED_MAX_LEN:
+        collapsed = collapsed[:_NORMALISED_MAX_LEN].rstrip()
+    return collapsed

--- a/src/places/quota.py
+++ b/src/places/quota.py
@@ -182,11 +182,19 @@ class MonthlyQuota:
 
         daily_key = raw.get("daily_key", "")
         if not isinstance(daily_key, str):
-            daily_key = ""
+            raise ValueError("Quota state field 'daily_key' must be a string")
 
+        # Strict validation mirrors the sibling ``total`` / ``counts`` checks
+        # above. The pre-fix silent coerce-to-0 let a corrupted state file
+        # (compromised CI runner, partial flush + power loss, operator
+        # mis-edit) bypass the daily cap (``PLACES_LIMIT_DAILY``) for the
+        # whole day — while a sibling negative ``total`` still aborted the
+        # load. Inconsistent strictness is a budget-escape vector.
         daily_total = raw.get("daily_total", 0)
         if not isinstance(daily_total, int) or daily_total < 0:
-            daily_total = 0
+            raise ValueError(
+                "Quota field 'daily_total' must be a non-negative integer"
+            )
 
         return cls(
             month_key=month,

--- a/tests/places/test_quota.py
+++ b/tests/places/test_quota.py
@@ -112,3 +112,48 @@ def test_resolve_quota_state_path_prefers_env(tmp_path: Path) -> None:
 def test_resolve_quota_state_path_rejects_outside_repo(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
         resolve_quota_state_path({"PLACES_QUOTA_STATE": str(tmp_path / "custom.json")})
+
+
+def test_load_rejects_negative_daily_total(tmp_path: Path) -> None:
+    """A corrupted state file with ``daily_total < 0`` must raise, mirroring
+    the sibling ``total`` / ``counts`` validation.
+
+    Pre-fix the field was silently coerced to ``0`` while the same condition
+    on ``total`` raised — letting a planted/corrupted state file reset the
+    daily counter every load and bypass ``PLACES_LIMIT_DAILY`` for an entire
+    day. Inconsistent strictness is a budget-escape vector.
+    """
+    path = tmp_path / "places_quota.json"
+    path.write_text(
+        json.dumps(
+            {
+                "month": "2024-05",
+                "counts": {"nearby": 0, "text": 0, "details": 0},
+                "total": 0,
+                "daily_key": "2024-05-15",
+                "daily_total": -1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="daily_total"):
+        MonthlyQuota.load(path, now_func=lambda: _utc(2024, 5, 15))
+
+
+def test_load_rejects_non_int_daily_total(tmp_path: Path) -> None:
+    """A non-int ``daily_total`` (e.g. ``"999"`` as a string) must raise."""
+    path = tmp_path / "places_quota.json"
+    path.write_text(
+        json.dumps(
+            {
+                "month": "2024-05",
+                "counts": {"nearby": 0, "text": 0, "details": 0},
+                "total": 0,
+                "daily_key": "2024-05-15",
+                "daily_total": "999",
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="daily_total"):
+        MonthlyQuota.load(path, now_func=lambda: _utc(2024, 5, 15))

--- a/tests/providers/test_google_places_import.py
+++ b/tests/providers/test_google_places_import.py
@@ -51,6 +51,41 @@ def test_normalize_name_handles_accents_and_spacing() -> None:
     assert normalize_name("  Wíen   Mítte  ") == "wien mitte"
 
 
+def test_normalize_name_collapses_punctuation_so_dedup_matcher_agrees() -> None:
+    """``Wien Hbf`` / ``Wien Hbf.`` / ``Wien-Hbf`` / ``Wien (Hbf)`` must
+    all normalise to the same string.
+
+    Pre-fix the dedup matcher in :mod:`src.places.merge` compared the raw
+    casefold + accent-strip output, so any punctuation difference between
+    sources (Google vs OSM vs WL) produced a duplicate station row.
+    """
+    base = normalize_name("Wien Hbf")
+    assert base == "wien hbf"
+    assert normalize_name("Wien Hbf.") == base
+    assert normalize_name("Wien-Hbf") == base
+    assert normalize_name("Wien (Hbf)") == base
+    # Trailing comma + casing variant.
+    assert normalize_name("WIEN, HBF") == base
+    # Cross-source: ``St. Pölten`` (with abbreviated saint) vs ``St Pölten``.
+    assert normalize_name("St. Pölten") == normalize_name("St Pölten")
+
+
+def test_normalize_name_caps_result_length_without_breaking_equality() -> None:
+    """A name > 250 chars must still normalise (case-folded, etc.) AND two
+    overlong strings that differ only in case must compare equal.
+
+    Pre-fix ``if len(name) > 250: return name`` returned the raw input,
+    so a mixed-case overlong string and its lowercased twin compared
+    unequal — defeating the dedup invariant exactly when it mattered.
+    """
+    upper = "Hauptbahnhof Wien " * 20  # ~360 chars
+    lower = upper.lower()
+    norm_upper = normalize_name(upper)
+    norm_lower = normalize_name(lower)
+    assert norm_upper == norm_lower
+    assert len(norm_upper) <= 250
+
+
 def test_haversine_distance_matches_reference() -> None:
     distance = haversine_m(48.2065, 16.384, 48.207, 16.3845)
     assert distance == pytest.approx(66.8129884753474, rel=1e-6)

--- a/tests/scripts/test_update_stammstrecke_hbf.py
+++ b/tests/scripts/test_update_stammstrecke_hbf.py
@@ -237,6 +237,40 @@ def test_departure_delay_minutes_uses_rt_date_when_present() -> None:
     assert script._departure_delay_minutes(dep) == 10.0
 
 
+def test_departure_delay_minutes_handles_midnight_rollover_without_rt_date() -> None:
+    """``rtDate`` omitted across midnight must NOT produce a ~-24 h delay.
+
+    Pre-fix the fallback ``rt_date = sched_date`` parked the realtime
+    departure at the same calendar day as the schedule, so a train
+    scheduled 23:55 running ~10 min late (rtTime ``00:05``) computed
+    as actual = 2026-05-15 00:05 − scheduled = 2026-05-15 23:55 =
+    −1430 min. That meaningless negative value then biases the
+    per-direction mean in the stats ledger. The 12 h rollover-
+    heuristic adds one day to ``actual`` so the true 10-min delay
+    surfaces.
+    """
+    dep = {
+        "date": "2026-05-15",
+        "time": "23:55:00",
+        # rtDate intentionally omitted; only rtTime is supplied.
+        "rtTime": "00:05:00",
+    }
+    delay = script._departure_delay_minutes(dep)
+    assert delay == 10.0
+
+
+def test_departure_delay_minutes_small_early_departure_not_treated_as_rollover() -> None:
+    """A small (< 12 h) early departure stays negative — only large
+    backwards gaps trigger the day-bump heuristic."""
+    dep = {
+        "date": "2026-05-15",
+        "time": "12:00:00",
+        # rtDate omitted; rtTime is 2 min EARLY (not a rollover).
+        "rtTime": "11:58:00",
+    }
+    assert script._departure_delay_minutes(dep) == -2.0
+
+
 # ---- _collect_hbf_observations --------------------------------------------
 
 

--- a/tests/test_update_baustellen_cache.py
+++ b/tests/test_update_baustellen_cache.py
@@ -319,9 +319,17 @@ def test_fetch_layers_returns_none_when_all_layers_fail(monkeypatch: pytest.Monk
 def test_main_negotiates_output_format(monkeypatch: pytest.MonkeyPatch) -> None:
     """The configured ``json`` token returns nothing (the production
     failure mode); the negotiation must fall through to the next variant
-    and use it as a live success — NOT the degraded fallback."""
+    and use it as a live success — NOT the degraded fallback.
+
+    The payload now carries one ÖPNV-relevant feature so the post-filter
+    yields a non-empty ``relevant`` list and the empty-payload-skip path
+    is not what's under test here.
+    """
     seen: list[str] = []
-    payload = {"type": "FeatureCollection", "features": []}
+    payload = {
+        "type": "FeatureCollection",
+        "features": [_bau_feature(name="U6 Bauarbeiten Großfeldsiedlung")],
+    }
 
     def fake_fetch_remote(url: str, timeout: int) -> dict[str, Any] | None:
         seen.append(url)
@@ -805,6 +813,49 @@ def test_load_fallback_handles_json_depth_bomb(
     assert result is None
     assert any(
         "ungültiges JSON" in record.getMessage()
+        for record in caplog.records
+        if record.name == "update_baustellen_cache"
+    )
+
+
+def test_main_skips_write_on_empty_relevant_payload(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A live fetch yielding 0 ÖPNV-relevant entries must NOT trigger the
+    ``DataDegradationError`` path in ``write_cache``.
+
+    Pre-fix the empty payload reached ``write_cache("baustellen", [])`` which
+    raised ``DataDegradationError`` when the prior cache had items. The error
+    was never caught by ``main()``, so the cron step crashed with a non-zero
+    traceback rather than the clean "kept stale cache" signal the operator
+    can read.
+    """
+    import logging
+
+    calls: list[tuple[str, list[dict[str, Any]]]] = []
+
+    def fake_fetch_remote(url: str, timeout: int) -> dict[str, Any]:
+        # Live fetch returns a well-formed but empty FeatureCollection
+        # (e.g. transient upstream that legitimately had no construction
+        # sites, or every site filtered out as non-ÖPNV).
+        return {"type": "FeatureCollection", "features": []}
+
+    def capture_cache(provider: str, items: list[dict[str, Any]]) -> None:
+        calls.append((provider, items))
+
+    monkeypatch.setattr(update_baustellen_cache, "_fetch_remote", fake_fetch_remote)
+    monkeypatch.setattr(update_baustellen_cache, "write_cache", capture_cache)
+    caplog.set_level(logging.WARNING, logger="update_baustellen_cache")
+
+    exit_code = update_baustellen_cache.main()
+
+    # write_cache must NOT have been called — the pinned snapshot stays intact.
+    assert calls == []
+    # Non-zero exit so the cron wrapper surfaces the kept-stale state.
+    assert exit_code != 0
+    # The operator-facing warning explains what happened.
+    assert any(
+        "0 ÖPNV-relevante" in record.getMessage()
         for record in caplog.records
         if record.name == "update_baustellen_cache"
     )


### PR DESCRIPTION
## Summary

Round-6 audit follow-up: fixes the four **HIGH-severity** items flagged across rounds 3-5 that were "found but not fixed". Each is an independent, well-scoped change with its own regression test; bundled into one PR (one commit per fix) for review convenience.

## The four fixes

### 1. `scripts/update_baustellen_cache.py` — empty ÖPNV-relevant payload no longer crashes (commit `5ec5900`)

When a live fetch yielded 0 ÖPNV-relevant entries (every site filtered out as road-only), the script called `write_cache("baustellen", [])` which raised `DataDegradationError` against the populated prior cache. `main()` did not catch it — the cron step crashed with a non-zero traceback rather than the clean "kept stale cache" signal. Now detects the empty case explicitly, emits a WARNING, and `return 1` so the pinned snapshot stays intact.

(Pre-existing `test_main_negotiates_output_format` payload implicitly relied on the buggy `write_cache([])` path; updated to carry one ÖPNV-relevant feature so the test still verifies format negotiation, not the unrelated empty-payload behaviour.)

### 2. `src/places/quota.py` — strict validation on persisted `daily_total` (commit `a68fc7e`)

`MonthlyQuota.load` silently coerced a non-int / negative `daily_total` to `0`, while the sibling counters `total` and `counts[k]` raised on the same conditions. A corrupted state file with `"daily_total": -1` or `"daily_total": "999"` reset the daily counter every load → **bypassed `PLACES_LIMIT_DAILY` for an entire day**. Now raises `ValueError` to mirror the siblings. Also tightens `daily_key` (was silently coerced to `""`).

### 3. `scripts/update_stammstrecke_hbf.py` — midnight rollover when `rtDate` omitted (commit `ee0a812`)

A delayed departure across midnight without an explicit `rtDate` (scheduled 23:55, `rtTime` `"00:05"`) parked the realtime departure on the same calendar day as the schedule. The delay then computed as ≈ **−1430 minutes** — a huge meaningless negative value that biased the per-direction mean in `data/stats/stammstrecke_YYYY.csv` downward by hundreds of minutes per occurrence. Applied a 12 h rollover heuristic: when `rtDate` was NOT supplied AND `actual` lies more than 12 hours before `scheduled`, advance `actual` by one day. The 12 h threshold separates a legitimate small-magnitude early departure from a true midnight wrap.

### 4. `src/places/normalize.py` — punctuation collapse + post-normalisation length cap (commit `e906025`)

The dedup matcher in `src.places.merge` used `normalize_name(place.name) == normalize_name(station.name)`. Without collapsing punctuation the upstream sources disagreed too easily — `"Wien Hbf"` ≠ `"Wien Hbf."`, `"Wien-Mitte"` ≠ `"Wien Mitte"`, `"St. Pölten"` ≠ `"St Pölten"` — producing **silent duplicate station rows** every time Google, OSM, or WL spelled a station differently. Additionally, the pre-normalisation `if len(name) > 250: return name` short-circuit returned the raw input, so a mixed-case overlong string and its lowercased twin compared unequal — defeating the dedup invariant exactly when it mattered. Fix collapses any non-alphanumeric run to a single space after casefold + accent-strip, then caps the **result** length to 250.

## Test plan

- [x] `ruff check` — clean (one pre-existing `S603` in an unrelated test only flagged by ruff 0.15.x in my local env; CI uses 0.4.x where it's silent — verified by stashing my changes and re-running).
- [x] `mypy --strict` — no new errors in src/.
- [x] `python scripts/check_complexity.py` — 0 new violations, 0 increased.
- [x] `pytest tests/places/ tests/providers/ tests/scripts/ tests/test_update_baustellen_cache.py tests/test_cache*` — **565 passed** (incl. 7 new regression tests).

## Audited and confirmed solid across rounds 1-5

`vor.py` auth+quota, `hafas_client.py` MAC, `request_safe` SSRF/redirect/response-IP, `feed/config.py` path-traversal + env clamps, `feed/stammstrecke.py` time windows, `feed/merge.py` dedup thresholds, the recency sort key / link / CDATA pipeline.

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_