### PR TITLE
fix(http): four defence-in-depth fixes (parse_retry_after, read_response_safe, evicted-pool drain, cross-origin query-secret strip)

### DIFF
--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -7,6 +7,7 @@ import ipaddress
 import logging
 import atexit
 import collections
+import math
 import os
 import re
 import socket
@@ -60,7 +61,15 @@ def parse_retry_after(
     if not header:
         return None
     if _RETRY_AFTER_NUMERIC_RE.fullmatch(header):
-        return max(0.0, float(header))
+        # ``float(header)`` returns ``+inf`` for ~309-digit strings (and
+        # Python's ``\d`` also matches Unicode decimal digits). Reject
+        # any non-finite parsed value so a hostile / malformed upstream
+        # cannot persuade a caller — present or future — to ``time.sleep``
+        # for effectively forever.
+        parsed_seconds = float(header)
+        if not math.isfinite(parsed_seconds):
+            return None
+        return max(0.0, parsed_seconds)
     try:
         parsed = parsedate_to_datetime(header)
     except (TypeError, ValueError):
@@ -68,7 +77,10 @@ def parse_retry_after(
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)
     reference = now if now is not None else datetime.now(UTC)
-    return max(0.0, (parsed - reference).total_seconds())
+    delta_seconds = (parsed - reference).total_seconds()
+    if not math.isfinite(delta_seconds):
+        return None
+    return max(0.0, delta_seconds)
 
 
 _DEFAULT_RETRY_OPTIONS: dict[str, Any] = {
@@ -1039,6 +1051,17 @@ def _safe_rebuild_auth(self: requests.Session, prepared_request: requests.Prepar
             if _is_sensitive_header(header_name):
                 del headers[header_name]
 
+        # Also strip sensitive QUERY parameters from the redirect URL.
+        # ``request_safe`` does this inside its manual redirect loop via
+        # ``_strip_redirect_secrets``, but callers that hit ``Session``
+        # directly (e.g. ``places/client.py`` POSTs that use the session's
+        # native redirect handling) only reach THIS hook. Without the
+        # strip, a cross-origin redirect target receives the auth token
+        # in the URL line of the next request — defeating the header
+        # strip immediately above.
+        if url is not None:
+            prepared_request.url = _strip_sensitive_params(url)
+
 
 def session_with_retries(
     user_agent: str,
@@ -1662,11 +1685,16 @@ def read_response_safe(
             response.close()
             raise requests.Timeout(f"Read timed out after {read_timeout} seconds")
 
-        chunks.append(chunk)
-        received += len(chunk)
-        if received > max_bytes:
+        # Check the prospective size BEFORE appending so the worst-case
+        # in-memory buffer is bounded by ``max_bytes`` (not
+        # ``max_bytes + chunk_size``). Matters for callers that pass a
+        # small ``max_bytes`` cap (e.g. a 1 KiB health probe) — the
+        # pre-fix loop could buffer 8 KiB before raising.
+        if received + len(chunk) > max_bytes:
             response.close()
             raise ValueError(f"Response too large (> {max_bytes} bytes)")
+        chunks.append(chunk)
+        received += len(chunk)
     return b"".join(chunks)
 
 
@@ -2344,5 +2372,24 @@ def cleanup_http_sessions() -> None:
                     sanitize_log_arg(str(exc)),
                 )
         _HTTP_SESSION_CACHE.clear()
+
+    # Also drain any sessions still pending in the eviction queue. The
+    # background ``_cleanup_evicted_sessions_thread`` only closes one
+    # entry per 60 s grace window, so a burst of evictions can leave
+    # several sessions queued at shutdown. Without this drain, atexit
+    # closed the active cache but leaked the queued sockets — visible
+    # to test fixtures via ``responses`` ResourceWarnings.
+    while True:
+        try:
+            session, _eviction_time = _EVICTED_SESSIONS_QUEUE.get_nowait()
+        except queue.Empty:
+            break
+        try:
+            session.close()
+        except Exception as exc:
+            log.debug(
+                "Error closing evicted HTTP session during cleanup: %s",
+                sanitize_log_arg(str(exc)),
+            )
 
 atexit.register(cleanup_http_sessions)

--- a/tests/test_http_bundle_fixes.py
+++ b/tests/test_http_bundle_fixes.py
@@ -1,0 +1,188 @@
+"""Regression tests for the round-7 http.py bundle.
+
+Pins four defence-in-depth fixes:
+
+1. ``parse_retry_after`` rejects non-finite parsed values (e.g. a
+   309-digit numeric header that ``float()`` lifts to ``+inf``).
+2. ``read_response_safe`` checks the prospective body size BEFORE
+   appending the chunk, so the in-memory buffer is bounded by
+   ``max_bytes`` even for callers that pass a small cap.
+3. ``cleanup_http_sessions`` drains the eviction queue at atexit,
+   not just the active cache.
+4. ``_safe_rebuild_auth`` strips sensitive query parameters from the
+   redirected URL when crossing an origin (the existing header strip
+   covered only the header surface).
+"""
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from src.utils.http import (
+    _EVICTED_SESSIONS_QUEUE,
+    _safe_rebuild_auth,
+    cleanup_http_sessions,
+    parse_retry_after,
+    read_response_safe,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fix #1 — parse_retry_after rejects non-finite parsed values
+# ---------------------------------------------------------------------------
+
+
+def test_parse_retry_after_rejects_oversized_numeric_payload() -> None:
+    """A 400-digit numeric header parses as ``+inf``; the helper must
+    return ``None`` rather than let a caller ``time.sleep(+inf)``."""
+    assert parse_retry_after("9" * 400) is None
+
+
+def test_parse_retry_after_accepts_normal_values() -> None:
+    """Regression guard: legitimate numeric values still parse cleanly."""
+    assert parse_retry_after("0") == 0.0
+    assert parse_retry_after("60") == 60.0
+    assert parse_retry_after("3.5") == pytest.approx(3.5)
+
+
+# ---------------------------------------------------------------------------
+# Fix #2 — read_response_safe bounds the in-memory buffer at max_bytes
+# ---------------------------------------------------------------------------
+
+
+class _ResponseStub:
+    """Minimal Response-like double for ``read_response_safe``.
+
+    ``iter_content`` returns the chunks we hand it; ``headers`` is a
+    plain dict and ``close`` is a no-op stub.
+    """
+
+    def __init__(self, chunks: list[bytes], headers: dict[str, str] | None = None) -> None:
+        self._chunks = chunks
+        self.headers = headers or {}
+        self.closed = False
+
+    def iter_content(self, chunk_size: int = 8192) -> Any:
+        return iter(self._chunks)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_read_response_safe_caps_buffer_before_overshoot() -> None:
+    """Pre-fix the chunk was appended BEFORE the size check, so the
+    in-memory buffer could grow to ``max_bytes + chunk_size``.
+
+    With ``max_bytes=10`` and a 5-byte first chunk + an 8 KiB second
+    chunk the pre-fix loop would buffer 8197 bytes before raising. The
+    post-fix loop refuses the second chunk on the prospective check —
+    the buffer never grows past ``max_bytes`` (plus the chunk currently
+    inspected, which is not in ``chunks``).
+    """
+    big_chunk = b"x" * 8192
+    response = _ResponseStub([b"hello", big_chunk])
+    with pytest.raises(ValueError, match="Response too large"):
+        read_response_safe(cast("requests.Response", response), max_bytes=10)
+    assert response.closed is True
+
+
+def test_read_response_safe_accepts_at_the_cap() -> None:
+    """Boundary check: ``received == max_bytes`` is allowed."""
+    response = _ResponseStub([b"abcdef"])
+    data = read_response_safe(cast("requests.Response", response), max_bytes=6)
+    assert data == b"abcdef"
+
+
+# ---------------------------------------------------------------------------
+# Fix #3 — cleanup_http_sessions drains _EVICTED_SESSIONS_QUEUE
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_http_sessions_drains_evicted_queue() -> None:
+    """Sessions queued for delayed close must be closed at atexit too.
+
+    Pre-fix ``cleanup_http_sessions`` only walked ``_HTTP_SESSION_CACHE``;
+    a burst of evictions queued beyond what the 60 s grace-window worker
+    closed before shutdown leaked the underlying sockets.
+    """
+    fake_session = MagicMock(spec=requests.Session)
+    _EVICTED_SESSIONS_QUEUE.put((fake_session, 0.0))
+    try:
+        cleanup_http_sessions()
+        fake_session.close.assert_called_once()
+        assert _EVICTED_SESSIONS_QUEUE.empty()
+    finally:
+        # Defence-in-depth: leave the queue empty for sibling tests.
+        while not _EVICTED_SESSIONS_QUEUE.empty():
+            _EVICTED_SESSIONS_QUEUE.get_nowait()
+
+
+# ---------------------------------------------------------------------------
+# Fix #4 — _safe_rebuild_auth strips sensitive query params cross-origin
+# ---------------------------------------------------------------------------
+
+
+def _build_prepared_request(url: str) -> requests.PreparedRequest:
+    req = requests.Request("GET", url)
+    session = requests.Session()
+    try:
+        return session.prepare_request(req)
+    finally:
+        session.close()
+
+
+def test_safe_rebuild_auth_strips_query_secrets_cross_origin() -> None:
+    """A cross-origin redirect must not carry ``access_token=…`` in the
+    URL of the next request.
+
+    The existing header-strip path covered Authorization / Cookie /
+    X-Api-Key; sensitive QUERY parameters were left intact. Callers
+    that use the session's native redirect handling (instead of the
+    manual loop in ``request_safe``) would otherwise hand the token
+    to the attacker-controlled redirect target via the URL line.
+    """
+    original_request = MagicMock()
+    original_request.url = "https://origin.example.com/login"
+    prepared = _build_prepared_request(
+        "https://attacker.example.com/callback?access_token=SECRET123&id=42"
+    )
+    redirect_response = MagicMock(spec=requests.Response)
+    redirect_response.headers = {"Location": prepared.url}
+    redirect_response.request = original_request
+
+    session = requests.Session()
+    try:
+        _safe_rebuild_auth(session, prepared, redirect_response)
+    finally:
+        session.close()
+
+    assert prepared.url is not None
+    assert "access_token" not in prepared.url
+    # The benign query key survives.
+    assert "id=42" in prepared.url
+
+
+def test_safe_rebuild_auth_same_origin_redirect_preserves_url() -> None:
+    """Same-origin redirects must NOT have query params stripped — the
+    strip-on-cross-origin gate keys exclusively on host/scheme/port
+    change."""
+    original_request = MagicMock()
+    original_request.url = "https://api.example.com/auth"
+    prepared = _build_prepared_request(
+        "https://api.example.com/auth/callback?access_token=SECRET&id=42"
+    )
+    redirect_response = MagicMock(spec=requests.Response)
+    redirect_response.headers = {"Location": prepared.url}
+    redirect_response.request = original_request
+
+    session = requests.Session()
+    try:
+        _safe_rebuild_auth(session, prepared, redirect_response)
+    finally:
+        session.close()
+
+    assert prepared.url is not None
+    assert "access_token=SECRET" in prepared.url


### PR DESCRIPTION
## Summary

Round-7 audit follow-up: four defence-in-depth fixes in `src/utils/http.py`, all flagged across rounds 3-5 as MEDIUM-severity items "found but not fixed". Each is an independent, well-scoped change in a single shared file; bundled into one PR for review convenience.

## The four fixes

### 1. `parse_retry_after` rejects non-finite parsed values

`float("9" * 309)` lifts to `+inf`, and Python's `\d` also matches Unicode decimal digits (`'٤٢' → 42.0`). A future caller that doesn't clamp the result would `time.sleep(+inf)`. The numeric branch now `math.isfinite`-gates the result, and the HTTP-date branch does the same for huge `parsedate_to_datetime` outputs (year-9999 deltas).

### 2. `read_response_safe` checks size BEFORE appending the chunk

Pre-fix the chunk was appended first, so the in-memory buffer could grow to `max_bytes + chunk_size` (8 KiB over). Negligible for the default 10 MB cap; meaningful for callers that pass a small cap (a 1 KiB health probe could buffer 8 KiB before raising). The new ordering bounds the buffer at `max_bytes`.

### 3. `cleanup_http_sessions` drains `_EVICTED_SESSIONS_QUEUE` at atexit

The background grace-period worker closes one queued session per 60 s, so a burst of evictions can leave several sessions queued at shutdown. Pre-fix `atexit` only walked `_HTTP_SESSION_CACHE`; the queued sockets leaked. The new cleanup runs a `get_nowait()` drain loop after closing the active cache.

### 4. `_safe_rebuild_auth` strips sensitive query parameters cross-origin

The existing strip covered `Authorization` / `Cookie` / `X-Api-Key` headers, but a token in `?access_token=…` flowed through to the attacker-controlled redirect target via the URL line of the next request — defeating the header strip immediately above. Callers that hit the session directly (e.g. `places/client.py` POSTs use the session's native redirect handling, not the manual loop in `request_safe`) only reach this hook. Now also calls `_strip_sensitive_params(url)` on the redirected URL when host/scheme/port changes.

## Regression tests (7 new in `tests/test_http_bundle_fixes.py`)

- `parse_retry_after` rejects 400-digit overflow + regression guard for legitimate values (`"60"`, `"3.5"`).
- `read_response_safe` refuses the overshoot chunk + boundary test at `received == max_bytes`.
- `cleanup_http_sessions` drains the eviction queue + closes the queued session (uses `MagicMock(spec=requests.Session)`).
- `_safe_rebuild_auth` strips `access_token` cross-origin + preserves the same-origin redirect.

## Test plan

- [x] `ruff check src/utils/http.py tests/test_http_bundle_fixes.py` — clean
- [x] `mypy --no-pretty src/utils/http.py tests/test_http_bundle_fixes.py` — clean for changed code
- [x] `python scripts/check_complexity.py` — 0 new violations, 0 increased
- [x] `pytest tests/test_http_*.py tests/test_retry_after_cap.py tests/test_slowloris.py tests/test_oebb_rate_limit.py tests/test_sentinel_places_client_retry_after_drift.py tests/places/test_client_quota_retries.py` — **53 passed** (incl. all sibling Retry-After + auth-leak + DoS sentinel tests, which still cover the unchanged invariants).

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_