### PR TITLE
fix(wl): defensive shape check on relatedLines + drop LINE_CODE_RE IGNORECASE

### DIFF
--- a/src/providers/wl_lines.py
+++ b/src/providers/wl_lines.py
@@ -221,10 +221,20 @@ def _ensure_line_prefix(title: str, lines_disp: list[str]) -> str:
     return f"{wanted}: {body}" if body else wanted
 
 
-# Fallback-Linien aus Titeltext — vorher Datum/Zeit/Adressen maskieren
+# Fallback-Linien aus Titeltext — vorher Datum/Zeit/Adressen maskieren.
+#
+# Case-sensitivity (no ``re.IGNORECASE``): pre-fix the regex matched any
+# lowercase letter via the bare ``[A-Z]`` alternative under
+# ``IGNORECASE``, so a sentence-start German particle in the title
+# (``"Bauarbeiten a Karlsplatz"``, ``"e Linie"`` etc.) was extracted
+# as ``"a"`` / ``"e"``, upper-cased to ``"A"`` / ``"E"`` by
+# ``_clean_line_token`` and then accepted by ``_STRICT_LINE_TOKEN_RE``
+# as a bus / tram line letter. Real WL line codes are always
+# canonically upper-cased (``U6``, ``S40``, ``41E``, ``D``), so
+# requiring uppercase rejects the false positive without missing any
+# legitimate token.
 LINE_CODE_RE = re.compile(
     r"\b(?:U\d{1,2}|S\d{1,2}|N\d{1,3}|[0-9]{1,3}[A-Z]?|[A-Z])\b",
-    re.IGNORECASE,
 )
 RUF_BUS_RE = re.compile(r"Rufbus\s+([A-Za-z0-9]+)", re.IGNORECASE)
 DATE_FULL_RE = re.compile(r"\b\d{1,2}\.\d{1,2}\.(?:\d{2}|\d{4})\b")
@@ -295,6 +305,19 @@ def _make_line_pairs_from_related(rel_lines: list[Any]) -> list[tuple[str, str]]
     pairs: list[tuple[str, str]] = []
     seen: set[str] = set()
     for x in rel_lines:
+        # Defensive shape check (matches the sibling
+        # :func:`_stop_names_from_related` in ``wl_fetch.py``): WL
+        # ``relatedLines`` is documented as a flat list of line-code
+        # strings (``["U1", "U2"]``). A misbehaving / compromised
+        # upstream peer (or a tampered proxy response) may ship
+        # ``[{"name": "U1"}]`` instead — ``_tok`` would then call
+        # ``str(dict)`` and produce the garbage token ``"nameU1"``,
+        # which lands in the bucket key, the GUID, and the emitted
+        # title verbatim. Skip non-string entries so the malformed
+        # item simply contributes no tokens rather than poisoning
+        # the bucket.
+        if not isinstance(x, str):
+            continue
         tok = _tok(x)
         if not tok or tok in seen:
             continue

--- a/tests/test_wl_lines_pairs.py
+++ b/tests/test_wl_lines_pairs.py
@@ -1,4 +1,4 @@
-from src.providers.wl_lines import _tok, _make_line_pairs_from_related
+from src.providers.wl_lines import LINE_CODE_RE, _tok, _make_line_pairs_from_related
 
 
 def test_tok_returns_empty_for_none_and_empty() -> None:
@@ -9,3 +9,42 @@ def test_tok_returns_empty_for_none_and_empty() -> None:
 def test_make_line_pairs_from_related_ignores_none() -> None:
     pairs = _make_line_pairs_from_related(["5", None, "U1", ""])
     assert pairs == [("5", "5"), ("U1", "U1")]
+
+
+def test_make_line_pairs_from_related_rejects_dict_shaped_entries() -> None:
+    """A non-string ``relatedLines`` entry must NOT pollute the bucket.
+
+    Pre-fix ``_tok`` called ``str(dict)`` which produced ``"nameU1"`` for
+    ``{"name": "U1"}`` — a garbage token that landed in the bucket key,
+    the GUID and the emitted title verbatim. The defensive
+    ``isinstance(x, str)`` gate skips the malformed entry so it
+    contributes zero tokens.
+    """
+    pairs = _make_line_pairs_from_related(
+        ["U6", {"name": "U1"}, ["U2"], 42, "13A"]
+    )
+    # Only the two well-formed string entries survive.
+    assert pairs == [("U6", "U6"), ("13A", "13A")]
+
+
+def test_line_code_re_rejects_lowercase_bare_letter() -> None:
+    """``LINE_CODE_RE`` must not match a lowercase bare letter.
+
+    Pre-fix the regex carried ``re.IGNORECASE`` and the bare ``[A-Z]``
+    alternative therefore matched a sentence-start German particle
+    (``"a"`` / ``"e"`` etc.). The matched lowercase letter was then
+    upper-cased by ``_clean_line_token`` and accepted by
+    ``_STRICT_LINE_TOKEN_RE`` as a bus / tram line letter.
+    """
+    # "Bauarbeiten a Karlsplatz" — the bare lowercase "a" must NOT
+    # be picked up as a line code. The capitalised station tokens
+    # ("Bauarbeiten", "Karlsplatz") are multi-letter and never
+    # matched the single-letter alternative.
+    assert LINE_CODE_RE.findall("Bauarbeiten a Karlsplatz") == []
+    # Regression guard: real upper-cased bare letter (WL tram D) is
+    # still extracted.
+    assert "D" in LINE_CODE_RE.findall("Linie D im Bauarbeiten-Modus")
+    # Regression guard: canonical digit-bearing codes still match.
+    assert "U6" in LINE_CODE_RE.findall("U6: Sperre")
+    assert "S40" in LINE_CODE_RE.findall("S40 verspätet")
+    assert "41E" in LINE_CODE_RE.findall("Bus 41E Umleitung")


### PR DESCRIPTION
## Summary

Round-8 audit follow-up: two defensive fixes in `src/providers/wl_lines.py`. Both close upstream-shape-poisoning paths into the WL bucket-key, GUID and emitted-title surfaces.

### Fixes

**1. `_make_line_pairs_from_related` rejects dict-shaped entries**

`_tok` previously called `str(v)` on any value and stripped non-alphanumerics, so a misbehaving upstream peer shipping `[{"name": "U1"}]` (legitimately the dict shape WL's API uses for `relatedStops`) landed the garbage token `"nameU1"` in the bucket key, the GUID, and the emitted title verbatim. Now gates each entry on `isinstance(x, str)`, mirroring the existing gate in the sibling `_stop_names_from_related`.

**2. `LINE_CODE_RE` drops `re.IGNORECASE`**

The pre-fix regex matched any lowercase letter via the bare `[A-Z]` alternative, so a sentence-start German particle in a title (`"Bauarbeiten a Karlsplatz"`, `"e Linie"` etc.) was extracted as `"a"` / `"e"`, upper-cased by `_clean_line_token`, and accepted by `_STRICT_LINE_TOKEN_RE` as a bus / tram line letter — surfacing non-existent lines in the feed. Real WL line codes are always canonically upper-cased (`U6`, `S40`, `41E`, `D`), so the tightening loses no legitimate token.

## Three WL findings I evaluated but did NOT fix

* **`_is_active` not reused with `real_start`** — the existing code comment at `wl_fetch.py:609-611` documents that advance notices SHOULD surface based on the API publication time, not the title-corrected event start. That is a deliberate design choice, not a bug.
* **`_best_ts` substitutes `end` for `start`** — provides a useful temporal anchor for items with only `end`; rejecting the fallback would silently drop those items from the active filter. Defensible.
* **`ends_at` merge masks definite end behind `None`** — the `None` semantics ("end unknown / ongoing") is consistent with `_intervals_overlap` which substitutes `datetime.max` for `None`. Changing this is a wider design decision affecting subset-removal.

## Test plan

- [x] `ruff check src/providers/wl_lines.py tests/test_wl_lines_pairs.py` — clean
- [x] `mypy --no-pretty src tests/test_wl_lines_pairs.py` — clean
- [x] `python scripts/check_complexity.py` — 0 new violations, 0 increased
- [x] `pytest tests/test_wl_*.py tests/test_post_filter_wl*.py tests/test_wl_address_two_word_streets.py` — **96 passed** (incl. 2 new regression tests)

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_