### PR TITLE
fix(build_feed): trust introspection, share semaphores across concurrency group, surface state-save failures

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -695,12 +695,18 @@ def _fetch_supports_timeout(fetch: Any) -> bool:
 def _call_fetch_with_timeout(
     fetch: Any, timeout: int | float | None, supports_timeout: bool
 ) -> Any:
-    """Invoke the fetch callable, passing the timeout if supported."""
+    """Invoke the fetch callable, passing the timeout if supported.
+
+    Trusts the :func:`_fetch_supports_timeout` introspection result —
+    pre-fix the ``except TypeError: return fetch()`` retry caught any
+    TypeError raised from INSIDE the fetch body (e.g. an ``int(timeout)``
+    conversion failure, a type-assertion error), then re-invoked the
+    fetcher with no kwargs. The retry duplicated HTTP requests, side
+    effects, quota debits, and the ``report.provider_started`` event
+    sequence — masking the real internal error behind a doubled run.
+    """
     if supports_timeout:
-        try:
-            return fetch(timeout=None if timeout is None else timeout)
-        except TypeError:
-            return fetch()
+        return fetch(timeout=None if timeout is None else timeout)
     return fetch()
 
 # ---------------- Helpers ----------------
@@ -2521,7 +2527,31 @@ def _submit_network_fetches(
     futures: dict[Any, tuple[Any, str, int]] = {}
     deadlines: dict[Any, float | None] = {}
     pending: set[Any] = set()
-    semaphores: dict[str, BoundedSemaphore] = {}
+
+    # Pre-compute the per-group worker limit across ALL fetchers BEFORE
+    # the main submit loop. Pre-fix the loop only registered a
+    # semaphore when the CURRENT fetcher's own per-provider env-limit
+    # was set, so a sibling provider in the same ``concurrency_key``
+    # group without its own env override ran unbounded — silently
+    # defeating the operator-intended shared cap. If two group members
+    # set different positive limits, the tighter one (``min``) wins so
+    # the group respects every member's stated upper bound.
+    group_limits: dict[str, int] = {}
+    for fetch in network_fetchers:
+        provider_name = provider_names.get(fetch, _provider_display_name(fetch))
+        env_name = provider_envs.get(fetch)
+        concurrency_key = _provider_concurrency_key(fetch, provider_name)
+        worker_limit = _provider_worker_limit(
+            fetch, env_name, provider_name, concurrency_key
+        )
+        if worker_limit is not None and worker_limit > 0:
+            current = group_limits.get(concurrency_key)
+            group_limits[concurrency_key] = (
+                min(current, worker_limit) if current is not None else worker_limit
+            )
+    semaphores: dict[str, BoundedSemaphore] = {
+        key: BoundedSemaphore(limit) for key, limit in group_limits.items()
+    }
 
     for fetch in network_fetchers:
         provider_name = provider_names.get(fetch, _provider_display_name(fetch))
@@ -2534,12 +2564,10 @@ def _submit_network_fetches(
         worker_limit = _provider_worker_limit(
             fetch, env_name, provider_name, concurrency_key
         )
-        semaphore: BoundedSemaphore | None = None
-        if worker_limit is not None and worker_limit > 0:
-            semaphore = semaphores.get(concurrency_key)
-            if semaphore is None:
-                semaphore = BoundedSemaphore(worker_limit)
-                semaphores[concurrency_key] = semaphore
+        # Every member of a group with a positive limit picks up the
+        # pre-computed shared semaphore — including members whose OWN
+        # ``worker_limit`` resolved to ``None``.
+        semaphore: BoundedSemaphore | None = semaphores.get(concurrency_key)
         if timeout_override is not None:
             log.debug(
                 "Provider %s nutzt Timeout-Override von %ss",
@@ -4444,6 +4472,16 @@ def main() -> int:
             log.warning(
                 "State speichern fehlgeschlagen (%s) – Feed wurde geschrieben, State bleibt veraltet.",
                 sanitize_log_arg(str(e)),
+            )
+            # Surface the failure on the structured report so monitoring
+            # / dashboards see "degraded" instead of a clean
+            # ``build_successful=True``. Pre-fix the swallowed exception
+            # let the run report record a fully-successful build while
+            # first_seen / translations / stats counters silently
+            # drifted out of sync with the on-disk feed.
+            report.add_warning(
+                f"State save failed: {sanitize_log_arg(type(e).__name__)} — "
+                "first_seen / translations / stats may drift on the next run."
             )
 
         total_duration = perf_counter() - job_start

--- a/tests/test_build_feed_bundle_round11.py
+++ b/tests/test_build_feed_bundle_round11.py
@@ -1,0 +1,202 @@
+"""Regression tests for the round-11 build_feed bundle.
+
+Pins three correctness fixes in ``src/build_feed.py``:
+
+1. ``_call_fetch_with_timeout`` no longer double-calls the fetcher when
+   an inner ``TypeError`` is raised. Pre-fix the ``except TypeError:
+   return fetch()`` retry caught any TypeError raised from inside the
+   fetch body (e.g. an ``int()`` conversion error) and re-invoked the
+   fetcher with no kwargs — duplicating HTTP requests, side effects,
+   and the ``report.provider_*`` event sequence.
+2. ``_submit_network_fetches`` pre-computes the per-group worker limit
+   across ALL fetchers before the main submit loop. Pre-fix a sibling
+   provider in a shared ``concurrency_key`` group without its own env
+   override ran unbounded — silently defeating the operator-intended
+   shared cap.
+3. ``_save_state`` failure surfaces as a structured warning on the
+   ``report`` so dashboards see "degraded" instead of a clean
+   ``build_successful=True``.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import src.build_feed as build_feed
+from src.feed.reporting import RunReport
+
+
+# ---------------------------------------------------------------------------
+# Fix #1 — _call_fetch_with_timeout no longer double-calls on inner TypeError
+# ---------------------------------------------------------------------------
+
+
+def test_call_fetch_with_timeout_does_not_swallow_inner_typeerror() -> None:
+    """Pre-fix the ``except TypeError: return fetch()`` retry doubled
+    every fetcher that raised a TypeError from INSIDE its body. The
+    introspection result from ``_fetch_supports_timeout`` is now
+    trusted — the retry is gone, the TypeError propagates and the
+    caller's per-provider error handler attributes it correctly."""
+    calls: list[tuple[Any, ...]] = []
+
+    def buggy_fetch(*, timeout: int | None = None) -> None:
+        calls.append(("call", timeout))
+        # Simulate an internal type assertion failure — NOT a kwarg
+        # rejection — that pre-fix was misattributed by the catch.
+        raise TypeError("internal: timeout must be int")
+
+    with pytest.raises(TypeError, match="internal"):
+        build_feed._call_fetch_with_timeout(
+            buggy_fetch, timeout=5, supports_timeout=True
+        )
+
+    # Single invocation — the swallow-and-retry path is gone.
+    assert len(calls) == 1
+
+
+def test_call_fetch_with_timeout_still_skips_kwarg_when_unsupported() -> None:
+    """Regression guard: when ``supports_timeout=False`` the fetcher is
+    called with no kwargs (legacy callable signature)."""
+    received: list[tuple[Any, ...]] = []
+
+    def legacy_fetch() -> str:
+        received.append(("called",))
+        return "ok"
+
+    result = build_feed._call_fetch_with_timeout(
+        legacy_fetch, timeout=5, supports_timeout=False
+    )
+    assert result == "ok"
+    assert received == [("called",)]
+
+
+# ---------------------------------------------------------------------------
+# Fix #2 — _submit_network_fetches shares the semaphore across the group
+# ---------------------------------------------------------------------------
+
+
+def test_submit_network_fetches_shares_semaphore_across_concurrency_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When two providers share a ``concurrency_key`` and only one of
+    them has an env-set worker limit, the OTHER must also pick up the
+    shared semaphore. Pre-fix the single-pass loop registered a
+    semaphore only when the CURRENT fetcher's own per-provider limit
+    was set, so the sibling ran unbounded against the same upstream."""
+    # Two distinct fetcher objects sharing one concurrency_key.
+    fetch_a = MagicMock(__name__="fetch_a")
+    fetch_b = MagicMock(__name__="fetch_b")
+
+    semaphores_seen: dict[str, Any] = {}
+
+    def fake_build_run_fetch(
+        fetch: Any,
+        timeout: int,
+        supports_timeout: bool,
+        semaphore: Any,
+        provider_name: str,
+    ) -> Any:
+        # Record which semaphore each fetcher got.
+        semaphores_seen[provider_name] = semaphore
+        return lambda: None  # no-op runner
+
+    # ``_provider_concurrency_key`` returns the SAME key for both
+    # providers — they form one group.
+    monkeypatch.setattr(
+        build_feed, "_provider_concurrency_key",
+        lambda fetch, name: "shared-pool",
+    )
+    # Only provider B has an env-set positive limit.
+    monkeypatch.setattr(
+        build_feed, "_provider_worker_limit",
+        lambda fetch, env_name, name, key: 3 if name == "provider_b" else None,
+    )
+    monkeypatch.setattr(
+        build_feed, "_provider_timeout_override",
+        lambda *_a, **_kw: 5,
+    )
+    monkeypatch.setattr(
+        build_feed, "_fetch_supports_timeout", lambda *_a, **_kw: False,
+    )
+    monkeypatch.setattr(build_feed, "_build_run_fetch", fake_build_run_fetch)
+
+    executor = MagicMock()
+    executor.submit = lambda func: MagicMock()
+    report = RunReport(statuses=[("provider_a", True), ("provider_b", True)])
+
+    build_feed._submit_network_fetches(
+        executor,
+        [fetch_a, fetch_b],
+        provider_names={fetch_a: "provider_a", fetch_b: "provider_b"},
+        provider_envs={fetch_a: "PROV_A_ENABLE", fetch_b: "PROV_B_ENABLE"},
+        report=report,
+    )
+
+    # Both providers must share the SAME semaphore object — pre-fix
+    # provider A had no semaphore while provider B was throttled.
+    assert semaphores_seen["provider_a"] is not None
+    assert semaphores_seen["provider_b"] is not None
+    assert semaphores_seen["provider_a"] is semaphores_seen["provider_b"]
+
+
+# ---------------------------------------------------------------------------
+# Fix #3 — _save_state failure surfaces as a warning on the report
+# ---------------------------------------------------------------------------
+
+
+def test_save_state_failure_calls_report_add_warning_in_main() -> None:
+    """AST sentinel: ``main()`` MUST call ``report.add_warning(...)``
+    inside the ``except`` arm that wraps the ``_save_state(...)`` call.
+
+    Pre-fix the exception was log-only and ``report.finish`` still
+    recorded ``build_successful=True`` with no structured warning, so
+    monitoring / dashboards saw a fully-successful build while
+    first_seen / translations / stats drifted out of sync with the
+    on-disk feed.
+    """
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(build_feed))
+    main_func: ast.FunctionDef | None = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "main":
+            main_func = node
+            break
+    assert main_func is not None, "build_feed.main not found"
+
+    found_warning_call = False
+    for node in ast.walk(main_func):
+        if not isinstance(node, ast.Try):
+            continue
+        # Try body calls _save_state?
+        calls_save_state = any(
+            isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Name)
+            and n.func.id == "_save_state"
+            for n in ast.walk(node)
+        )
+        if not calls_save_state:
+            continue
+        # Any except handler calls *.add_warning?
+        for handler in node.handlers:
+            for inner in ast.walk(handler):
+                if (
+                    isinstance(inner, ast.Call)
+                    and isinstance(inner.func, ast.Attribute)
+                    and inner.func.attr == "add_warning"
+                ):
+                    found_warning_call = True
+                    break
+            if found_warning_call:
+                break
+        if found_warning_call:
+            break
+
+    assert found_warning_call, (
+        "build_feed.main() must call report.add_warning(...) inside the "
+        "except arm wrapping _save_state(...). Pre-fix the exception was "
+        "silently logged and the build still reported as fully successful."
+    )

--- a/tests/test_sentinel_allow_nan_writer_audit_walker.py
+++ b/tests/test_sentinel_allow_nan_writer_audit_walker.py
@@ -93,7 +93,7 @@ Three documented sites live here today:
   motivates the non-finite-literal axis (committed-to-main artefact
   that strict parsers must handle) does not apply.
 
-* ``src/build_feed.py:_identity_for_item`` (lines 2371 and 2380) —
+* ``src/build_feed.py:_identity_for_item`` (lines 2377 and 2386) —
   two ``json.dumps(item, sort_keys=True, default=str)`` calls compute
   the SHA-256 input for the feed-item identity hash. The serialised
   bytes flow into ``hashlib.sha256(raw.encode("utf-8")).hexdigest()``
@@ -142,8 +142,8 @@ ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
         # into ``hashlib.sha256(...).hexdigest()`` on the very next
         # line and are not retained anywhere else. No parser-consumed
         # artefact, so the threat model does not apply.
-        ("src/build_feed.py", 2371),
-        ("src/build_feed.py", 2380),
+        ("src/build_feed.py", 2377),
+        ("src/build_feed.py", 2386),
     }
 )
 
@@ -536,7 +536,7 @@ def test_allowlist_is_minimal_and_documented() -> None:
     assert ALLOWLIST == frozenset(
         {
             ("src/places/hafas_client.py", 289),
-            ("src/build_feed.py", 2371),
-            ("src/build_feed.py", 2380),
+            ("src/build_feed.py", 2377),
+            ("src/build_feed.py", 2386),
         }
     )


### PR DESCRIPTION
## Summary

Round-11 audit follow-up bundle: three correctness fixes in `src/build_feed.py`. All MEDIUM-severity items flagged in round 5.

## The three fixes

### 1. `_call_fetch_with_timeout` no longer double-calls on inner `TypeError`

Pre-fix the `except TypeError: return fetch()` retry caught any `TypeError` from INSIDE the fetch body (e.g. an `int()` conversion error, a type assertion) and re-invoked the fetcher with no kwargs — **duplicating HTTP requests, side effects, quota debits, and the `report.provider_*` event sequence**. The introspection result from `_fetch_supports_timeout` is now trusted; an internal `TypeError` propagates so the caller's per-provider error handler attributes it correctly.

### 2. `_submit_network_fetches` shares the semaphore across the group

Pre-fix the single-pass loop registered a semaphore only when the CURRENT fetcher's own per-provider env-limit was set. A sibling provider in a shared `concurrency_key` group without its own per-provider env override ran **unbounded** — silently defeating the operator-intended shared cap. The new two-pass approach pre-computes the per-group worker limit across ALL fetchers; if two group members set different positive limits, the tighter one (`min`) wins so the group respects every member's stated upper bound.

### 3. `_save_state` failure surfaces as a structured warning

Pre-fix the exception was log-only and `report.finish(build_successful=True)` still fired — monitoring / dashboards saw a **fully-successful build** while `first_seen` / translations / stats counters silently drifted out of sync with the on-disk feed. The new `report.add_warning(...)` line in the except arm marks the build as degraded for any consumer that reads `RunReport.warnings` (markdown / JSON health surfaces, GitHub issue triage).

## Regression tests (4 in new `tests/test_build_feed_bundle_round11.py`)

- `test_call_fetch_with_timeout_does_not_swallow_inner_typeerror` — a fetcher that raises `TypeError` from inside is invoked exactly ONCE; the exception propagates.
- `test_call_fetch_with_timeout_still_skips_kwarg_when_unsupported` — regression guard for the legacy no-kwarg path.
- `test_submit_network_fetches_shares_semaphore_across_concurrency_group` — two providers sharing a `concurrency_key` with only one having an env-set limit both receive the SAME (shared) semaphore.
- `test_save_state_failure_calls_report_add_warning_in_main` — AST sentinel that pins `main()`'s except arm around `_save_state(...)` to invoke `*.add_warning(...)` so a future refactor can't silently drop the warning.

## Test plan

- [x] `ruff check src/build_feed.py tests/test_build_feed_bundle_round11.py` — clean
- [x] `mypy --no-pretty src tests/test_build_feed_bundle_round11.py` — clean (filtering pre-existing `src/utils/http.py` urllib3-typing env noise)
- [x] `python scripts/check_complexity.py` — 0 new violations, 0 increased
- [x] `pytest tests/test_build_feed*.py tests/test_collect_items_timeout.py tests/test_first_seen_*.py tests/test_provider_plugins.py` — **43 passed** (incl. 4 new regression tests)

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_