### PR TITLE
fix(places): reject non-finite/bool coordinates, request formattedAddress

### DIFF
--- a/src/places/client.py
+++ b/src/places/client.py
@@ -133,7 +133,25 @@ _BREAKER: Final[CircuitBreaker] = CircuitBreaker(
     recovery_timeout=300.0,
 )
 
-FIELD_MASK_NEARBY = "places.id,places.displayName,places.location,places.types"
+# Field mask for the Nearby Search call. ``places.formattedAddress`` is
+# REQUIRED so the Google path actually populates ``Place.formatted_address``:
+# ``merge._infer_in_vienna`` keys the Vienna classification off the address
+# text ("wien" / "vienna") and ``merge._create_station`` / the update path
+# persist it to ``_formatted_address`` in ``data/stations.json``. Without it
+# the Places API omits the field from the response (the New API returns only
+# masked fields), ``formatted_address`` is always ``None`` and the whole
+# address-based signal silently degrades to bounding-box-only.
+#
+# Cost: ``formattedAddress`` sits in the same Pro (Basic) SKU tier as the
+# ``displayName`` / ``location`` / ``types`` fields already in the mask, so
+# the Nearby Search call's billing tier is UNCHANGED — no new cost is
+# incurred by requesting it. ``nextPageToken`` is intentionally NOT in the
+# mask (searchNearby does not accept it; pinned by
+# ``test_field_mask_excludes_next_page_token``).
+FIELD_MASK_NEARBY = (
+    "places.id,places.displayName,places.location,"
+    "places.types,places.formattedAddress"
+)
 DEFAULT_INCLUDED_TYPES: Sequence[str] = (
     "train_station",
     "subway_station",
@@ -345,7 +363,17 @@ class GooglePlacesClient:
             return None
         latitude = location.get("latitude")
         longitude = location.get("longitude")
-        if not isinstance(latitude, float | int) or not isinstance(longitude, float | int):
+        # ``bool`` is a subclass of ``int``: a smuggled ``true`` / ``false``
+        # would otherwise satisfy ``isinstance(..., float | int)`` and coerce
+        # to a bogus ``1.0`` / ``0.0`` that sails past the finite + WGS84-range
+        # guards below. Reject it as part of the same Zero-Trust "nonsensical
+        # coordinate" drop the NaN / Inf / out-of-range checks already enforce.
+        if (
+            isinstance(latitude, bool)
+            or isinstance(longitude, bool)
+            or not isinstance(latitude, float | int)
+            or not isinstance(longitude, float | int)
+        ):
             LOGGER.warning("Skipping place with invalid coordinates: %s", self._sanitize_arg(place_id))
             return None
         lat_value = float(latitude)

--- a/src/places/tiling.py
+++ b/src/places/tiling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -53,11 +54,43 @@ def _validate_tile_count(count: int) -> None:
 
 def _coerce_coordinate(raw: Mapping[str, object], key: str) -> float:
     value = raw.get(key)
-    if isinstance(value, float | int):
-        return float(value)
+    # ``bool`` is a subclass of ``int``: a JSON ``true`` / ``false`` would
+    # otherwise coerce to ``1.0`` / ``0.0`` and slip through as a silent
+    # bogus coordinate. Reject it explicitly before the numeric branch.
+    if isinstance(value, bool):
+        raise TypeError(f"Invalid {key!r} value in tile specification: {value!r}")
     if isinstance(value, str):
-        return float(value)
-    raise TypeError(f"Invalid {key!r} value in tile specification: {value!r}")
+        coerced = float(value)
+    elif isinstance(value, float | int):
+        try:
+            coerced = float(value)
+        except OverflowError as exc:
+            # A JSON integer with hundreds of digits parses to an
+            # arbitrary-precision Python ``int`` (the ``parse_float``
+            # non-finite hook never sees an integer literal) and overflows
+            # IEEE-754 here. Surface as ValueError so ``_parse_tiles``
+            # reports an invalid tile instead of letting the uncaught
+            # ``OverflowError`` escape the caller's
+            # ``except (OSError, ValueError)`` cron guard.
+            raise ValueError(
+                f"Out-of-range {key!r} value in tile specification: {value!r}"
+            ) from exc
+    else:
+        raise TypeError(f"Invalid {key!r} value in tile specification: {value!r}")
+    # Security (reader-side non-finite defence): the ``json.loads``
+    # ``parse_float`` / ``parse_constant`` hooks in ``load_tiles_from_env`` /
+    # ``load_tiles_from_file`` only fire for JSON *number* literals. A
+    # coordinate supplied as a JSON *string* (``"NaN"`` / ``"Infinity"`` /
+    # ``"-Infinity"`` / ``"1e1000"``) bypasses them entirely and ``float(...)``
+    # happily yields a non-finite value. Re-validate here so the in-memory
+    # tile list never carries a non-finite coordinate that would poison the
+    # downstream bounding-box / haversine math — the invariant the module's
+    # parse-boundary comments already assert.
+    if not math.isfinite(coerced):
+        raise ValueError(
+            f"Non-finite {key!r} value in tile specification: {value!r}"
+        )
+    return coerced
 
 
 def _parse_tiles(raw_tiles: Iterable[object]) -> list[Tile]:

--- a/tests/test_places_bundle_round12.py
+++ b/tests/test_places_bundle_round12.py
@@ -1,0 +1,160 @@
+"""Regression tests for the round-12 places-module bundle.
+
+Pins three coordinate / field-mask correctness fixes:
+
+1. ``src/places/tiling.py`` ``_coerce_coordinate`` rejects non-finite
+   coordinates supplied as JSON *strings* (``"NaN"`` / ``"Infinity"`` /
+   ``"1e999"``). The ``json.loads`` ``parse_float`` / ``parse_constant``
+   hooks only fire for JSON *number* literals, so a stringified coordinate
+   previously bypassed the module's documented non-finite defence and
+   landed ``float('inf')`` / ``float('nan')`` in a :class:`Tile`. It also
+   rejects ``bool`` coordinates (an ``int`` subclass) and converts the
+   huge-integer ``OverflowError`` into a clean ``ValueError``.
+
+2. ``src/places/client.py`` ``_parse_place`` rejects ``bool`` latitude /
+   longitude. ``bool`` is an ``int`` subclass, so a smuggled ``true`` /
+   ``false`` previously satisfied ``isinstance(..., float | int)`` and
+   coerced to a bogus ``1.0`` / ``0.0`` that sailed past the finite +
+   WGS84-range guards.
+
+3. ``src/places/client.py`` ``FIELD_MASK_NEARBY`` includes
+   ``places.formattedAddress`` so the production Google path actually
+   populates ``Place.formatted_address`` — ``merge._infer_in_vienna`` keys
+   the Vienna classification off the address text and the merge layer
+   persists ``_formatted_address`` to ``data/stations.json``. Pre-fix the
+   New Places API omitted the unmasked field and the whole address-based
+   signal silently degraded to bounding-box-only.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.places import tiling
+from src.places.client import (
+    FIELD_MASK_NEARBY,
+    GooglePlacesClient,
+    GooglePlacesConfig,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — tiling._coerce_coordinate: stringified non-finite / bool / overflow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw_value",
+    [
+        '[{"lat": "NaN", "lng": "16.3"}]',
+        '[{"lat": "Infinity", "lng": "16.3"}]',
+        '[{"lat": "16.3", "lng": "-Infinity"}]',
+        '[{"lat": "1e999", "lng": "16.3"}]',
+        '[{"lat": "16.3", "lng": "1e1000"}]',
+    ],
+)
+def test_load_tiles_from_env_rejects_stringified_non_finite(raw_value: str) -> None:
+    """A coordinate supplied as a JSON *string* bypasses the parse_float /
+    parse_constant hooks (which only fire for number literals);
+    ``_coerce_coordinate`` must re-validate finiteness and reject it."""
+    with pytest.raises(ValueError):
+        tiling.load_tiles_from_env(raw_value)
+
+
+def test_load_tiles_from_env_rejects_huge_int_coordinate() -> None:
+    """A several-hundred-digit JSON integer parses to an arbitrary-precision
+    Python ``int`` (the parse_float non-finite hook never sees an integer
+    literal) and ``float()`` overflows IEEE-754. The fix surfaces this as a
+    clean ``ValueError`` instead of an uncaught ``OverflowError`` that would
+    escape the caller's ``except (OSError, ValueError)`` cron guard."""
+    huge = "1" + "0" * 400
+    with pytest.raises(ValueError):
+        tiling.load_tiles_from_env(f'[{{"lat": {huge}, "lng": 16.3}}]')
+
+
+def test_load_tiles_from_env_rejects_bool_coordinate() -> None:
+    """``true`` / ``false`` (``bool`` is an ``int`` subclass) must not coerce
+    to ``1.0`` / ``0.0`` tile coordinates."""
+    with pytest.raises(ValueError):
+        tiling.load_tiles_from_env('[{"lat": true, "lng": 16.3}]')
+
+
+def test_load_tiles_from_env_accepts_stringified_finite_coordinate() -> None:
+    """Regression guard: a legitimate stringified *finite* coordinate still
+    parses to the expected :class:`Tile` — the fix must not over-reject."""
+    tiles = tiling.load_tiles_from_env('[{"lat": "48.2", "lng": "16.37"}]')
+    assert len(tiles) == 1
+    assert tiles[0].latitude == 48.2
+    assert tiles[0].longitude == 16.37
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — client._parse_place: reject bool coordinates
+# ---------------------------------------------------------------------------
+
+
+def _make_client() -> GooglePlacesClient:
+    config = GooglePlacesConfig(
+        api_key="test-api-key",
+        included_types=["train_station"],
+        language="de",
+        region="AT",
+        radius_m=1000,
+        timeout_s=5.0,
+        max_retries=0,
+    )
+    return GooglePlacesClient(config)
+
+
+def _place_payload(lat: object, lng: object) -> dict[str, object]:
+    return {
+        "id": "places/ChIJtest",
+        "displayName": {"text": "Wien Hbf"},
+        "location": {"latitude": lat, "longitude": lng},
+        "types": ["train_station"],
+        "formattedAddress": "Am Hauptbahnhof, 1100 Wien",
+    }
+
+
+@pytest.mark.parametrize(
+    ("lat", "lng"),
+    [(True, 16.37), (48.2, False), (True, False)],
+)
+def test_parse_place_rejects_bool_coordinate(lat: object, lng: object) -> None:
+    """``bool`` is an ``int`` subclass; a smuggled ``true`` / ``false`` must
+    NOT become a bogus ``1.0`` / ``0.0`` coordinate (pre-fix it passed the
+    ``isinstance(..., float | int)`` guard and both finite + range checks)."""
+    client = _make_client()
+    assert client._parse_place(_place_payload(lat, lng)) is None
+
+
+def test_parse_place_still_accepts_legitimate_coordinate() -> None:
+    """Regression guard: a normal float coordinate still produces a Place."""
+    client = _make_client()
+    place = client._parse_place(_place_payload(48.185222, 16.377778))
+    assert place is not None
+    assert place.latitude == 48.185222
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 — FIELD_MASK_NEARBY requests formattedAddress
+# ---------------------------------------------------------------------------
+
+
+def test_field_mask_includes_formatted_address() -> None:
+    """``places.formattedAddress`` must be in the mask, otherwise the New
+    Places API omits the field and merge._infer_in_vienna /
+    ``_formatted_address`` persistence silently lose the address signal."""
+    assert "places.formattedAddress" in FIELD_MASK_NEARBY
+    # Sibling invariant (pinned in test_fieldmask_and_types.py too):
+    # searchNearby does not accept nextPageToken in the field mask.
+    assert "nextPageToken" not in FIELD_MASK_NEARBY
+
+
+def test_parse_place_populates_formatted_address() -> None:
+    """With ``formattedAddress`` present, the parser surfaces it on
+    ``Place.formatted_address`` — the field the mask fix makes reachable in
+    production (the merge layer keys the Vienna classification off it)."""
+    client = _make_client()
+    place = client._parse_place(_place_payload(48.2, 16.37))
+    assert place is not None
+    assert place.formatted_address == "Am Hauptbahnhof, 1100 Wien"


### PR DESCRIPTION
## Summary

Round-12 audit follow-up bundle: three coordinate / field-mask correctness fixes in the Google Places ingestion path (`src/places/`).

## The three fixes

### 1. `tiling._coerce_coordinate` — stringified non-finite coordinates bypass the parse hooks

`load_tiles_from_env` / `load_tiles_from_file` parse JSON with the canonical `parse_float` / `parse_constant` non-finite hooks. Those hooks **only fire for JSON _number_ literals** — a coordinate supplied as a JSON _string_ (`{"lat": "NaN"}`, `{"lat": "Infinity"}`, `{"lat": "-Infinity"}`, `{"lat": "1e1000"}`) sails straight past them and `float(...)` happily produces `nan` / `inf`, which lands in a `Tile` and poisons the downstream bounding-box / haversine math. This directly violates the invariant the module's own parse-boundary comments assert ("the in-memory tile list never contains a non-finite coordinate").

The fix re-validates `math.isfinite()` **after** coercion (covering string-sourced values), and additionally:
- rejects `bool` coordinates (`true`/`false` → would otherwise coerce to `1.0`/`0.0`),
- converts the huge-integer `OverflowError` (`float(10**400)`) into a clean `ValueError` so an unbounded JSON integer can't escape the caller's `except (OSError, ValueError)` cron guard as an uncaught `OverflowError`.

### 2. `client._parse_place` — bool latitude/longitude bypass the coordinate guard

`bool` is a subclass of `int`, so a smuggled `{"location": {"latitude": true, "longitude": false}}` satisfied `isinstance(..., float | int)` and coerced to a bogus `(1.0, 0.0)` coordinate that passed both the finite **and** WGS84-range checks. This is a gap in the function's own documented Zero-Trust coordinate validation (which already rejects `NaN` / `Inf` / out-of-range from a "compromised upstream / MITM"). Now rejected as part of the same drop.

### 3. `client.FIELD_MASK_NEARBY` — missing `places.formattedAddress` silently drops the Vienna address signal

The Nearby Search field mask omitted `places.formattedAddress`. The New Places API returns **only masked fields**, so `Place.formatted_address` was **always `None` in production** — even though:
- `merge._infer_in_vienna` keys the Vienna classification off the address text (`"wien"` / `"vienna"`), falling back to bounding-box only when the address is absent, and
- `merge._create_station` / the update path persist `_formatted_address` to `data/stations.json`.

So the entire address-based Vienna signal silently degraded to bounding-box-only, and the documented `_formatted_address` field was never populated from the Google path. The fix adds `places.formattedAddress` to the mask.

> **Cost note:** `formattedAddress` sits in the **same Pro (Basic) SKU tier** as `displayName` / `location` / `types` already in the mask, so the Nearby Search call's billing tier is **unchanged** — no new cost is incurred. `nextPageToken` is intentionally **not** added (searchNearby rejects it; still pinned by `test_field_mask_excludes_next_page_token`).

## Regression tests (12 in new `tests/test_places_bundle_round12.py`)

- `test_load_tiles_from_env_rejects_stringified_non_finite` (5 cases) — `"NaN"` / `"Infinity"` / `"-Infinity"` / `"1e999"` / `"1e1000"` as JSON strings are rejected.
- `test_load_tiles_from_env_rejects_huge_int_coordinate` — a 400-digit integer surfaces as `ValueError`, not `OverflowError`.
- `test_load_tiles_from_env_rejects_bool_coordinate` — `true`/`false` rejected.
- `test_load_tiles_from_env_accepts_stringified_finite_coordinate` — over-rejection guard.
- `test_parse_place_rejects_bool_coordinate` (3 cases) + `test_parse_place_still_accepts_legitimate_coordinate`.
- `test_field_mask_includes_formatted_address` (and still excludes `nextPageToken`) + `test_parse_place_populates_formatted_address`.

## Test plan

- [x] `ruff check src/places/tiling.py src/places/client.py tests/test_places_bundle_round12.py` — clean
- [x] `mypy --no-pretty src tests/test_places_bundle_round12.py` — clean
- [x] `python scripts/check_complexity.py` — 0 new violations
- [x] **Full suite**: `pytest` → **8593 passed, 2 skipped** (incl. 12 new regression tests, all places + sentinel coordinate tests)

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_