### PR TITLE
fix(utils): scoped cache prune dir name + frozenset serialization

### DIFF
--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -320,7 +320,16 @@ def prune_cache(max_age_hours: int = 48, *, provider: str | None = None) -> None
     cutoff = now - timedelta(hours=max_age_hours)
 
     if provider is not None:
-        scoped_dir = _CACHE_DIR / provider
+        # ``write_cache`` and the read paths (:func:`_cache_file` /
+        # :func:`_status_file`) store each provider under
+        # ``sanitize_filename(provider)`` — e.g. ``"wl"`` → ``"wl_9d709a"`` —
+        # so the scoped prune MUST sanitise too. Pre-fix this joined the RAW
+        # provider name (``cache/wl``), a directory that never exists, so the
+        # ``is_dir()`` check failed, ``provider_dirs`` stayed empty and the
+        # post-write scoped prune in :func:`write_cache` was a permanent
+        # no-op: a provider's own ``events.json`` older than ``max_age_hours``
+        # was never evicted (silent repo bloat / indefinitely-stale cache).
+        scoped_dir = _CACHE_DIR / sanitize_filename(provider)
         provider_dirs = [scoped_dir] if scoped_dir.is_dir() else []
     else:
         provider_dirs = [p for p in _CACHE_DIR.iterdir() if p.is_dir()]

--- a/src/utils/serialize.py
+++ b/src/utils/serialize.py
@@ -169,7 +169,7 @@ def serialize_for_cache(
         return value.isoformat()
 
     # Container types - check for cycles
-    if isinstance(value, dict | list | tuple | set):
+    if isinstance(value, dict | list | tuple | set | frozenset):
         if _stack is None:
             _stack = set()
 
@@ -189,7 +189,15 @@ def serialize_for_cache(
                     serialize_for_cache(item, _stack, _depth + 1, max_depth)
                     for item in value
                 ]
-            if isinstance(value, set):
+            if isinstance(value, set | frozenset):
+                # ``frozenset`` is NOT a subclass of ``set`` (sibling types),
+                # so it must be matched explicitly — pre-fix a frozenset value
+                # fell through to the ``return value`` tail and then crashed
+                # ``json.dump`` with "Object of type frozenset is not JSON
+                # serializable", despite this function's documented job of
+                # producing a JSON-serializable structure. Mirrors the
+                # ``set | frozenset`` handling already used by the sibling
+                # serialiser in ``src/feed/logging_safe.py``.
                 serialized = [
                     serialize_for_cache(item, _stack, _depth + 1, max_depth)
                     for item in value

--- a/tests/test_cache_degradation_guard.py
+++ b/tests/test_cache_degradation_guard.py
@@ -124,6 +124,56 @@ def test_cache_degradation_guard_bypass_on_corrupt_cache(tmp_path: Path) -> None
         assert len(saved_data) == 1
 
 
+def test_scoped_prune_evicts_providers_own_stale_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The scoped ``prune_cache(provider=...)`` must actually evict THIS
+    provider's own ``events.json`` once it is older than ``max_age_hours``.
+
+    Pre-fix the scoped branch joined the RAW provider name
+    (``cache/alpha``) while every read/write path stores the provider under
+    ``sanitize_filename(provider)`` (``cache/alpha_<hash>``). The raw
+    directory never exists, so ``is_dir()`` failed and the scoped prune was
+    a permanent no-op — a provider's own stale cache lived forever (silent
+    repo bloat / indefinitely-stale data served past max_age).
+    """
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(cache_module, "_CACHE_DIR", cache_dir)
+
+    write_cache("alpha", [{"id": i} for i in range(100)])
+    alpha_file = cache_module._cache_file("alpha")
+    assert alpha_file.exists()
+    # Age it past the 48 h cutoff.
+    aged = time.time() - 49 * 3600
+    os.utime(alpha_file, (aged, aged))
+
+    cache_module.prune_cache(max_age_hours=48, provider="alpha")
+
+    assert not alpha_file.exists(), (
+        "scoped prune must evict alpha's own >max_age stale events.json "
+        "(pre-fix it looked in the non-existent raw 'cache/alpha' dir)"
+    )
+
+
+def test_scoped_prune_keeps_providers_fresh_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Safety guard: the scoped prune must NOT delete a freshly-written
+    cache (the immediate post-write case), only one older than max_age."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    monkeypatch.setattr(cache_module, "_CACHE_DIR", cache_dir)
+
+    write_cache("alpha", [{"id": i} for i in range(100)])
+    alpha_file = cache_module._cache_file("alpha")
+    assert alpha_file.exists()
+
+    # Fresh mtime — the just-written file must survive the post-write prune.
+    cache_module.prune_cache(max_age_hours=48, provider="alpha")
+    assert alpha_file.exists()
+
+
 def test_write_cache_does_not_prune_sibling_providers(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_serialize_for_cache.py
+++ b/tests/test_serialize_for_cache.py
@@ -43,6 +43,24 @@ def test_serialize_nested_collections_are_json_friendly() -> None:
     assert all(isinstance(item["tags"], list) for item in result["items"])
     assert isinstance(result["metadata"], list)
 
+def test_serialize_frozenset_to_sorted_list() -> None:
+    # ``frozenset`` is NOT a subclass of ``set`` — pre-fix it fell through
+    # to the pass-through tail and crashed ``json.dump`` with "Object of
+    # type frozenset is not JSON serializable". It must be converted to a
+    # deterministically sorted list exactly like ``set``.
+    import json
+
+    result = serialize_for_cache({"tags": frozenset({"b", "a", "c"})})
+    assert result == {"tags": ["a", "b", "c"]}
+    # Round-trips through json.dump (the actual downstream consumer).
+    assert json.dumps(result) == '{"tags": ["a", "b", "c"]}'
+
+
+def test_serialize_nested_frozenset_inside_containers() -> None:
+    result = serialize_for_cache([frozenset({3, 1, 2}), {"x": frozenset({"z"})}])
+    assert result == [[1, 2, 3], {"x": ["z"]}]
+
+
 def test_serialize_circular_reference_raises_value_error() -> None:
     circular_dict: dict[str, object] = {"a": 1}
     circular_dict["b"] = circular_dict


### PR DESCRIPTION
## Summary

Round-13 audit bundle — two `src/utils/` correctness fixes found in a fresh line-by-line sweep.

## The two fixes

### 1. `cache.py::prune_cache(provider=...)` — scoped prune targeted a directory that never exists

`write_cache` and the read paths (`_cache_file` / `_status_file`) store each provider under `sanitize_filename(provider)` — e.g. `"wl"` → `"wl_9d709a"` (the real on-disk dirs are `wl_9d709a`, `oebb_c40d21`, `baustellen_d438c3`). But the **scoped** branch of `prune_cache` joined the **raw** provider name:

```python
scoped_dir = _CACHE_DIR / provider          # cache/wl  ← never exists
provider_dirs = [scoped_dir] if scoped_dir.is_dir() else []
```

`cache/wl` never exists, so `is_dir()` is `False`, `provider_dirs` stays empty, and the post-write scoped prune that `write_cache` runs every cron cycle (`prune_cache(provider=provider)`) was a **permanent no-op for every provider**. A provider's own `events.json` older than `max_age_hours` was therefore never evicted — silent repo bloat and indefinitely-stale cache served well past `max_age`.

The existing sibling-prune regression test masked this because it mocked `_cache_file` to return the raw-name path, so the buggy scoped dir happened to align with the data dir. Fix: sanitise the scoped directory name so it matches the writer.

### 2. `serialize.py::serialize_for_cache` — `frozenset` crashed `json.dump`

`serialize_for_cache` handled `set` but not `frozenset`. `frozenset` is **not** a subclass of `set` (sibling types), so `isinstance(value, set)` is `False` for a frozenset — it fell through to the `return value` tail and then crashed `json.dump` with *"Object of type frozenset is not JSON serializable"*, despite the function's documented job of producing a JSON-serializable structure. Now handled alongside `set` (serialize members, deterministic sort), mirroring the `set | frozenset` handling already used by the sibling serialiser in `src/feed/logging_safe.py`.

## Regression tests

- `tests/test_cache_degradation_guard.py`:
  - `test_scoped_prune_evicts_providers_own_stale_cache` — **verified to fail pre-fix** (stale `alpha_<hash>/events.json` not evicted) and pass post-fix.
  - `test_scoped_prune_keeps_providers_fresh_cache` — safety guard: a freshly-written cache is **not** deleted.
- `tests/test_serialize_for_cache.py`:
  - `test_serialize_frozenset_to_sorted_list` (incl. `json.dumps` round-trip) + `test_serialize_nested_frozenset_inside_containers`.

## Test plan

- [x] `ruff check` — clean (both src + tests)
- [x] `mypy --no-pretty src tests/test_cache_degradation_guard.py tests/test_serialize_for_cache.py` — clean (50 files)
- [x] focused: `pytest tests/test_cache_degradation_guard.py tests/test_serialize_for_cache.py tests/test_serialize_depth_limit.py` — all pass
- [x] regression bug-catch verified by reverting the cache fix (test fails) and restoring (test passes)

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_