### PR TITLE
fix(wl): KW_RESTRICTION matches prefix-roots inside compound nouns (stop dropping valid disruptions)

### DIFF
--- a/src/providers/wl_text.py
+++ b/src/providers/wl_text.py
@@ -11,8 +11,20 @@ _VIENNA_TZ = ZoneInfo("Europe/Vienna")
 # ---------------- Relevanz-/Ausschluss-Filter ----------------
 
 KW_RESTRICTION = re.compile(
+    # Match the restriction root anywhere inside a German compound noun
+    # (``Baustelle``, ``Teilsperre``, ``Streckensperre``, ``Bauarbeiten``,
+    # ``Verspätungen``, ``Einschränkungen``, ``Signalstörung`` …). The
+    # bare-root pattern with ``\b`` on BOTH sides MISSED every inflection /
+    # compound of the prefix-roots below (``sperr``, ``baustell``, ``verspät``,
+    # ``einschränk``, ``unterbrech`` …): only the handful of roots that happen
+    # to be standalone words (``umleitung``, ``verkehr``, ``gesperrt``,
+    # standalone ``Störung`` / ``Ausfall``) ever matched, so the bulk of real
+    # WL disruption items were silently dropped at the mandatory inclusion
+    # gate in ``wl_fetch`` (and not rescued past ``KW_EXCLUDE``). Same fix
+    # shape as the sibling ``FACILITY_ONLY`` regex below, which documents this
+    # exact ``\b``-on-both-sides pitfall. Keyword list is unchanged.
     r"""
-    \b(
+    \b\w*(
         umleitung       # detour
         | ersatzverkehr  # replacement service
         | unterbrech     # interruption
@@ -31,7 +43,7 @@ KW_RESTRICTION = re.compile(
         | teilbetrieb    # partial service
         | pendelverkehr  # shuttle service
         | kurzstrecke    # short route
-    )\b
+    )\w*\b
     """,
     re.IGNORECASE | re.VERBOSE,
 )

--- a/tests/test_wl_restriction_keyword_boundary.py
+++ b/tests/test_wl_restriction_keyword_boundary.py
@@ -1,0 +1,72 @@
+"""Regression test for the ``KW_RESTRICTION`` word-boundary fix.
+
+Pre-fix ``KW_RESTRICTION`` wrapped its keyword roots in ``\\b(...)\\b``. The
+trailing ``\\b`` requires the root to be a COMPLETE word, but the list is
+deliberately built from prefix-roots (``sperr``, ``baustell``, ``verspät``,
+``einschränk``, ``unterbrech`` …). So every common German inflection /
+compound — ``Baustelle``, ``Teilsperre``, ``Bauarbeiten``, ``Verspätungen``,
+``Einschränkungen``, ``Signalstörung`` — FAILED the gate, and the item was
+silently dropped at the mandatory WL-news inclusion gate in ``wl_fetch`` (and
+not rescued past ``KW_EXCLUDE``). Only the handful of roots that happen to be
+standalone words (``umleitung``, ``verkehr``, ``gesperrt``, standalone
+``Störung`` / ``Ausfall``) ever matched.
+
+The fix mirrors the sibling ``FACILITY_ONLY`` regex in the same module:
+``\\b\\w*(...)\\w*\\b`` matches the root anywhere inside a compound noun.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.providers.wl_text import KW_RESTRICTION
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Prefix-root compounds / inflections — ALL dropped pre-fix.
+        "Baustelle Reumannplatz",
+        "Bauarbeiten Linie 2",
+        "Gleisbauarbeiten an der Trasse",
+        "Teilsperre Praterstern",
+        "Streckensperre Linie U4",
+        "Sperre",
+        "Sperrung der Station",
+        "Verspätungen auf der Linie 13A",
+        "Einschränkungen im Betrieb",
+        "Betriebsunterbrechung",
+        "Zugausfall",
+        "Signalstörung",
+        "Kurzführung der Linie U6",
+        # Full-word roots that already matched pre-fix — regression guard that
+        # the broadened pattern did not regress the previously-working cases.
+        "Umleitung Linie 5",
+        "Ersatzverkehr eingerichtet",
+        "Strecke gesperrt",
+        "Störung",
+    ],
+)
+def test_kw_restriction_matches_compound_disruptions(text: str) -> None:
+    assert KW_RESTRICTION.search(text) is not None, (
+        f"{text!r} must pass the WL restriction gate — pre-fix the trailing "
+        r"\b dropped this compound/inflection of a prefix-root."
+    )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Sommerfest am Rathausplatz",
+        "Eröffnung der neuen Station",
+        "Gewinnspiel zum Jubiläum",
+        "Information zum Ticketkauf",
+        "Willkommen bei den Wiener Linien",
+        "Linie 2 fährt wieder planmäßig",
+    ],
+)
+def test_kw_restriction_rejects_non_disruptions(text: str) -> None:
+    """The broadened pattern must NOT start matching obvious non-disruptions
+    (promo / info / normal-service notices)."""
+    assert KW_RESTRICTION.search(text) is None, (
+        f"{text!r} is not a disruption and must not pass the restriction gate."
+    )


### PR DESCRIPTION
## Summary

Round-13 follow-up: a **severe** false-negative in the Wiener-Linien restriction-keyword gate that silently dropped the bulk of real WL disruption items from the public feed.

## The bug

`src/providers/wl_text.py::KW_RESTRICTION` wrapped its keyword roots in `\b(...)\b`. The **trailing** `\b` requires each root to be a *complete word*, but the list is deliberately built from **prefix-roots** (`sperr`, `baustell`, `verspät`, `einschränk`, `unterbrech`, `kurzführung`, …). So every common German inflection / compound failed the gate:

| Input (real WL titles) | pre-fix | post-fix |
|---|---|---|
| `Baustelle`, `Bauarbeiten`, `Gleisbauarbeiten` | ❌ dropped | ✅ matched |
| `Sperre`, `Sperrung`, `Teilsperre`, `Streckensperre` | ❌ dropped | ✅ matched |
| `Verspätungen`, `Einschränkungen` | ❌ dropped | ✅ matched |
| `Betriebsunterbrechung`, `Zugausfall`, `Signalstörung` | ❌ dropped | ✅ matched |
| `Umleitung`, `Verkehr`, `gesperrt`, standalone `Störung` | ✅ matched | ✅ matched |

Only the handful of roots that happen to be standalone words ever matched.

### Why it matters

`KW_RESTRICTION` is the **mandatory inclusion gate** for every WL `newsList`/Hinweis POI (`wl_fetch.py:726` — `if not KW_RESTRICTION.search(text_for_filter): continue`) and the rescue test past `KW_EXCLUDE` (`wl_fetch.py:616`). So a large fraction of legitimate construction / closure / delay alerts were silently dropped from `docs/feed.xml` **every cron cycle**.

### Why it's a bug, not design

The sibling `FACILITY_ONLY` regex in the **same module** (lines 44–52) documents this exact pitfall — *"the bare-root pattern with `\b` on both sides misses real ÖBB titles like `Technische Störung des Personenlift`"* — and was already fixed with `\b\w*(...)\w*\b`. The inline comments (`# closure prefix`, `# construction site`) prove the roots are meant as prefixes. `KW_RESTRICTION` simply never received the same fix.

## The fix

Minimal and surgical — change **only** the boundary wrapper `\b(...)\b` → `\b\w*(...)\w*\b` (root may appear anywhere inside a compound noun), mirroring `FACILITY_ONLY`. **The keyword list is unchanged.** Both usages move in the safe direction (keep more valid items / rescue more past `KW_EXCLUDE`).

## Regression test

`tests/test_wl_restriction_keyword_boundary.py`:
- 17 disruption forms (compounds/inflections previously dropped) now match.
- 6 non-disruptions (`Sommerfest`, `Eröffnung`, `Gewinnspiel`, `Information`, `Willkommen`, normal-service) still rejected — guards against over-matching.

## Test plan

- [x] `ruff check` — clean
- [x] `mypy --no-pretty src tests/test_wl_restriction_keyword_boundary.py` — clean
- [x] `pytest` WL suite (`test_wl_fetch`, `test_post_filter_wl`, `test_compound_facility_drop`, `test_wl_title`, `test_wl_news_title_fallback`, new corpus) — **59 passed**, no regressions

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_