### PR TITLE
feat(stammstrecke): require two consecutive trains over threshold to start an episode

### DIFF
--- a/docs/reference/stammstrecke_provider_logic.md
+++ b/docs/reference/stammstrecke_provider_logic.md
@@ -8,7 +8,7 @@ zwei Module:
 | Komponente | Verantwortlichkeit |
 | :--- | :--- |
 | `scripts/update_stammstrecke_hbf.py` | Refresh-Producer (aktiv seit 2026-05-15): wird vom IFTTT-getriggerten `update-cycle.yml` (~alle 30 Min auf :00/:30) als Pipeline-Schritt aufgerufen, fragt einmal pro Tick die VOR/VAO `/departureBoard`-API am Wien Hauptbahnhof ab und hängt eine aggregierte Beobachtungs-Zeile pro Richtung an `data/stats/stammstrecke_<YYYY>.csv` sowie eine Zeile pro Ausfall an `data/stats/ausfaelle_<YYYY>.csv` (CSV-Ledger). Die geteilte Pending-Trip- und Recently-Finalised-Infrastruktur wird per Import aus dem Legacy-Modul `scripts/update_stammstrecke_status.py` wiederverwendet — letzteres wird vom Cron-Workflow nicht mehr direkt aufgerufen. |
-| `src/feed/stammstrecke.py` | Feed-Renderer: liest die zuletzt geschriebenen Zeilen, prüft für jede Richtung über ein 1-Stunden-Fenster, ob mindestens zwei Beobachtungen die 9-Minuten-Schwelle überschreiten, und erzeugt — ggf. — einen schema-konformen FeedItem. |
+| `src/feed/stammstrecke.py` | Feed-Renderer: liest die zuletzt geschriebenen Zeilen, prüft für jede Richtung über ein 1-Stunden-Fenster, ob mindestens zwei **aufeinanderfolgende** Beobachtungen die 9-Minuten-Schwelle überschreiten, und erzeugt — ggf. — einen schema-konformen FeedItem. |
 
 Diese Architektur entstand in zwei Schritten:
 
@@ -230,6 +230,7 @@ Cache zu lesen oder zu schreiben.
 | Name | Wert | Bedeutung |
 | :--- | :--- | :--- |
 | `DELAY_THRESHOLD_MINUTES` | `9.0` | Schwellenwert pro Beobachtung; wird vom Trigger-Gate konsumiert. |
+| `TRIGGER_CONSECUTIVE_COUNT` | `2` | Anzahl **aufeinanderfolgender** Beobachtungen (zeitlich benachbart), die jeweils strikt über `DELAY_THRESHOLD_MINUTES` liegen müssen, damit eine Episode starten darf. |
 | `FEED_WINDOW` | `1 h` | Zeitfenster (rückwirkend von `now`), in dem das Trigger-Gate ausgewertet wird. |
 | `EPISODE_LOOKBACK` | `6 h` | Max. Rückblick zur Bestimmung des `first_seen`-Zeitpunkts der laufenden Episode. |
 | `EPISODE_GAP_TOLERANCE` | `70 min` | Maximale Lücke zwischen zwei Beobachtungen, ehe eine Episode als beendet gilt (deckt einen ausgefallenen Cron-Tick ab). |
@@ -247,21 +248,30 @@ Pro Richtung und pro Build:
    Direction `Praterstern`).
 2. Filtere auf das jüngste `FEED_WINDOW` (1 Stunde) — typischerweise
    2 Beobachtungen pro Richtung.
-3. **Trigger**: emittiere ein Event genau dann, wenn **mindestens zwei**
-   Beobachtungen in dieser Untermenge **strikt** über
-   `DELAY_THRESHOLD_MINUTES` liegen. Die 2-aus-N-Regel verhindert,
-   dass ein einzelner Ausreißer eine Richtung allein ins Event drückt;
-   bei der typischen Stichprobengröße (2 Beobachtungen pro Stunde)
-   müssen also beide jüngsten Ticks die Schwelle reißen.
+3. **Trigger**: emittiere ein Event genau dann, wenn **mindestens
+   `TRIGGER_CONSECUTIVE_COUNT` (zwei) aufeinanderfolgende**
+   Beobachtungen in dieser Untermenge — zeitlich benachbart, ohne eine
+   darunterliegende Beobachtung dazwischen — **strikt** über
+   `DELAY_THRESHOLD_MINUTES` liegen. Die Regel verlangt eine
+   *anhaltende* Verspätung: weder ein einzelner Ausreißer noch zwei
+   hohe Ticks, die einen erholten (sub-Schwellen-)Tick umklammern,
+   lösen allein aus. Bei der typischen Stichprobengröße (2 Beobachtungen
+   pro Stunde) müssen also beide jüngsten Ticks die Schwelle reißen.
 4. **Anzeigewert**: das Event-`description`-Feld zeigt den **Mittelwert**
    (`mean`) der Beobachtungen im Feed-Fenster — für End-Nutzer:innen
    leichter interpretierbar als der Median.
 5. **`first_seen`**: gehe vom jüngsten Above-Threshold-Sample im
    6-Stunden-Lookback rückwärts und nimm den frühesten Zeitpunkt einer
    zusammenhängenden Folge mit `> DELAY_THRESHOLD_MINUTES` und
-   Sample-Abstand `≤ EPISODE_GAP_TOLERANCE` als Episode-Start. Dieser
-   Wert geht in `starts_at`, `first_seen`, `guid`-Hash und das
-   `Seit DD.MM.YYYY`-Datum ein.
+   Sample-Abstand `≤ EPISODE_GAP_TOLERANCE` als Episode-Start. Kurze
+   Unterschreitungen der Schwelle werden dabei **überbrückt**, nicht als
+   Episodenende gewertet: sub-Schwellen-Samples werden vor dem
+   Rückwärtslauf herausgefiltert, sodass ein kurzer Einbruch zwischen
+   zwei hohen Samples die Episode nur dann beendet, wenn die dadurch
+   entstehende Lücke `EPISODE_GAP_TOLERANCE` übersteigt — das hält das
+   Episoden-Datum über die kurzen Erholungen einer anhaltenden Störung
+   stabil. Dieser Wert geht in `starts_at`, `first_seen`, `guid`-Hash
+   und das `Seit DD.MM.YYYY`-Datum ein.
 
 ### Event-Schema
 

--- a/src/feed/stammstrecke.py
+++ b/src/feed/stammstrecke.py
@@ -55,6 +55,14 @@ VIENNA_TZ: Final = ZoneInfo("Europe/Vienna")
 # observations only) and the feed provider here owns the entire
 # rendering contract.
 DELAY_THRESHOLD_MINUTES: Final[float] = 9.0
+# Minimum number of *consecutive* in-window observations (adjacent in
+# time order) that must each carry a delay strictly greater than
+# ``DELAY_THRESHOLD_MINUTES`` before a direction's episode is allowed to
+# start. Two back-to-back cron samples above the threshold approximate a
+# sustained ≥30-minute exceedance (given the ~30-minute observation
+# cadence); a lone outlier sample — or two high samples separated by a
+# sub-threshold dip — must not fire on its own.
+TRIGGER_CONSECUTIVE_COUNT: Final[int] = 2
 EVENT_SOURCE: Final = "VOR/VAO"
 EVENT_CATEGORY: Final = "Störung"
 EVENT_TITLE: Final = "S-Bahn Stammstrecke Verspätungen"
@@ -69,11 +77,14 @@ EVENT_LINK: Final = (
 # 2026-05-09 design directive ("Die Meldung im RSS-Feed soll ganz
 # aktuelle Meldungen der letzten Stunde anzeigen") and follows the
 # observation cadence (one row per direction per 30 minutes → window
-# typically holds 2 rows). The trigger gate requires at least 2 trains
-# in the given direction with a delay strictly greater than the threshold
-# within the window (defensive: a single high outlier cannot push the
-# direction past the threshold on its own); the value rendered in the
-# feed item description is the *mean* (more intuitive for end users).
+# typically holds 2 rows). The trigger gate requires
+# ``TRIGGER_CONSECUTIVE_COUNT`` (2) *consecutive* observations in the
+# given direction — adjacent in time order — each with a delay strictly
+# greater than the threshold within the window (defensive: neither a
+# single high outlier nor two high samples straddling a below-threshold
+# dip can push the direction past the threshold on their own); the value
+# rendered in the feed item description is the *mean* of all in-window
+# observations (more intuitive for end users).
 #
 # ``EPISODE_LOOKBACK`` — when computing ``first_seen`` for the current
 # above-threshold episode, we walk back further: the earliest
@@ -151,16 +162,32 @@ def _episode_start(
     direction_obs: list[StammstreckeObservation],
     now: datetime,
 ) -> datetime | None:
-    """Find the earliest contiguous threshold-exceeding observation back from *now*.
+    """Find the start timestamp of the current above-threshold episode.
 
-    Walks the observations in *direction_obs* (which the caller has
-    already filtered to the per-direction subset and sorted ascending)
-    backwards from the most recent row. The episode terminates at the
-    first row whose delay is at or below the threshold OR whose gap
-    to the next-newer observation exceeds
-    :data:`EPISODE_GAP_TOLERANCE`. Returns the timestamp of the
-    earliest row that survives both gates, or ``None`` when no
-    contiguous above-threshold observations exist.
+    Considers only the above-threshold rows in *direction_obs* (the
+    caller passes the per-direction subset). Rows whose delay is at or
+    below :data:`DELAY_THRESHOLD_MINUTES` are filtered out up front and
+    are NOT treated as episode boundaries — see the note below. The
+    surviving rows are walked from the most recent backwards; the
+    episode terminates at the first gap *between consecutive
+    above-threshold rows* that exceeds :data:`EPISODE_GAP_TOLERANCE`,
+    and the timestamp of the oldest row reached before that gap is
+    returned. Returns ``None`` when no row exceeds the threshold.
+
+    Short sub-threshold dips are bridged, not terminating. Because the
+    below-threshold rows are dropped before the walk, a brief dip
+    between two above-threshold samples does not end the episode — it
+    only widens the gap the two surviving rows straddle. The episode
+    ends across a dip solely when that widened gap exceeds
+    :data:`EPISODE_GAP_TOLERANCE` (i.e. the dip, a genuine data gap, or
+    the two combined, outlasted one tolerated missed observation). This
+    keeps the ``[Seit DD.MM.YYYY]`` label and the item GUID stable
+    across the momentary recoveries that punctuate a sustained
+    disruption rather than resetting them on every transient dip. The
+    trigger decision in :func:`compute_stammstrecke_events` is
+    independent of this function — bridging here changes only the
+    displayed episode-start date and the GUID, never whether an event
+    fires.
     """
     above_threshold = [
         obs for obs in direction_obs if obs.delay_minutes > DELAY_THRESHOLD_MINUTES
@@ -176,6 +203,34 @@ def _episode_start(
         episode_start = obs.timestamp
         previous = obs.timestamp
     return episode_start
+
+
+def _has_consecutive_exceedance(
+    observations: list[StammstreckeObservation],
+    *,
+    required: int = TRIGGER_CONSECUTIVE_COUNT,
+) -> bool:
+    """Return ``True`` when *required* time-adjacent observations each exceed the threshold.
+
+    Walks *observations* in ascending-timestamp order, tracking the
+    length of the current run of consecutive samples whose delay is
+    strictly greater than :data:`DELAY_THRESHOLD_MINUTES`, and returns
+    as soon as a run reaches *required*. A sample at or below the
+    threshold resets the run to zero, so two high samples that straddle
+    a sub-threshold dip do NOT satisfy the gate. This enforces the
+    "two *consecutive* trains over 9 minutes" episode-start rule rather
+    than the weaker "any two trains over 9 minutes anywhere in the
+    window" count.
+    """
+    run = 0
+    for obs in sorted(observations, key=lambda o: o.timestamp):
+        if obs.delay_minutes > DELAY_THRESHOLD_MINUTES:
+            run += 1
+            if run >= required:
+                return True
+        else:
+            run = 0
+    return False
 
 
 def _build_event(
@@ -222,9 +277,12 @@ def compute_stammstrecke_events(
     *now* defaults to :func:`datetime.now` in Europe/Vienna. The
     function emits at most one event per direction in
     :data:`DIRECTIONS` and returns an empty list when no direction has
-    at least 2 observations with a delay over *feed_window* exceeding
-    :data:`DELAY_THRESHOLD_MINUTES`. The displayed value in the feed
-    item is the *mean* of the same observations — see the module-
+    :data:`TRIGGER_CONSECUTIVE_COUNT` *consecutive* observations within
+    *feed_window* whose delay strictly exceeds
+    :data:`DELAY_THRESHOLD_MINUTES` (two adjacent samples over the
+    threshold — a lone outlier, or two high samples straddling a
+    sub-threshold dip, does not fire). The displayed value in the feed
+    item is the *mean* of all in-window observations — see the module-
     level note on the trigger / display split.
 
     Used by :func:`src.feed.providers.read_cache_stammstrecke` as the
@@ -266,15 +324,17 @@ def compute_stammstrecke_events(
         recent = [obs for obs in direction_obs if obs.timestamp >= feed_window_start]
         if not recent:
             continue
-        delays = [obs.delay_minutes for obs in recent]
-        # Trigger gate: requires at least 2 trains in the given direction
-        # with a delay strictly greater than the threshold within the feed window.
-        # Display value: mean — easier for end users to interpret.
+        # Trigger gate: an episode may only start when
+        # ``TRIGGER_CONSECUTIVE_COUNT`` (2) *consecutive* in-window
+        # observations each carry a delay strictly greater than the
+        # threshold — two adjacent cron samples over 9 minutes. A lone
+        # outlier, or two high samples straddling a below-threshold dip,
+        # does not fire. The displayed value is the *mean* of all
+        # in-window observations (easier for end users to interpret).
         # See module docstring "Window lengths".
-        delayed_count = sum(1 for d in delays if d > DELAY_THRESHOLD_MINUTES)
-        if delayed_count < 2:
+        if not _has_consecutive_exceedance(recent):
             continue
-        avg_delay = mean(delays)
+        avg_delay = mean([obs.delay_minutes for obs in recent])
         episode_start = _episode_start(direction_obs=direction_obs, now=current)
         if episode_start is None:
             # Degenerate case: ``_episode_start`` returned None despite
@@ -305,5 +365,6 @@ __all__ = [
     "EVENT_SOURCE",
     "EVENT_TITLE",
     "FEED_WINDOW",
+    "TRIGGER_CONSECUTIVE_COUNT",
     "compute_stammstrecke_events",
 ]

--- a/tests/test_feed_stammstrecke_trigger.py
+++ b/tests/test_feed_stammstrecke_trigger.py
@@ -1,12 +1,15 @@
 """Trigger semantics for :mod:`src.feed.stammstrecke`.
 
-The Stammstrecke feed event is fired when at least **two** CSV rows in
-a direction's last-hour window carry a sample-mean delay strictly
-greater than :data:`DELAY_THRESHOLD_MINUTES` (9 minutes). Each CSV row
+The Stammstrecke feed event is fired when at least
+:data:`TRIGGER_CONSECUTIVE_COUNT` (**two**) *consecutive* CSV rows in a
+direction's last-hour window each carry a sample-mean delay strictly
+greater than :data:`DELAY_THRESHOLD_MINUTES` (9 minutes) — adjacent in
+time order, with no below-threshold sample between them. Each CSV row
 is itself the mean of multiple trains finalised by the same cron tick
 (typically 10-15 since the 2026-05-15 ``/departureBoard`` + track-filter
-migration), so the trigger requires sustained widespread delay, not a
-single outlier train.
+migration), so the trigger requires a *sustained* widespread delay — not
+a single outlier train, and not two bad ticks that merely bracket a
+recovered one.
 
 This module pins:
 
@@ -20,6 +23,9 @@ This module pins:
    single-tick outliers from triggering the feed entry).
 4. The empty / sub-threshold cases: no rows or all rows ≤ 9 min must
    produce zero events.
+5. The *consecutive* gate: two above-threshold rows separated by a
+   sub-threshold dip must NOT fire, while any back-to-back
+   above-threshold pair within the window must.
 """
 
 from __future__ import annotations
@@ -33,6 +39,7 @@ from src.feed import stammstrecke as feed_module
 from src.feed.stammstrecke import (
     DELAY_THRESHOLD_MINUTES,
     FEED_WINDOW,
+    TRIGGER_CONSECUTIVE_COUNT,
     compute_stammstrecke_events,
 )
 from src.utils.stats import StammstreckeObservation
@@ -196,6 +203,62 @@ def test_empty_observations_yield_no_events() -> None:
     assert events == []
 
 
+# ---- Consecutive gate: adjacency, not mere count -----------------------
+
+
+def test_two_high_rows_straddling_a_dip_do_not_fire() -> None:
+    """Two above-threshold rows with a recovered tick between them → no event.
+
+    Behaviour pin for the "two *consecutive* trains" rule. Under the
+    earlier "any two rows above threshold in the window" count this
+    fired (the two 12-minute rows made ``delayed_count == 2``); the
+    consecutive gate must reject it because the high samples are not
+    adjacent — a sub-threshold sample sits between them, so the delay
+    was not sustained across two back-to-back observations.
+    """
+
+    obs = [
+        _obs(when=NOW - timedelta(minutes=45), direction="Praterstern", delay=12.0),
+        _obs(when=NOW - timedelta(minutes=25), direction="Praterstern", delay=5.0),
+        _obs(when=NOW - timedelta(minutes=5), direction="Praterstern", delay=12.0),
+    ]
+    events = _run(obs)
+    assert events == []
+
+
+def test_consecutive_pair_after_an_initial_dip_fires() -> None:
+    """A below-threshold sample followed by two consecutive high rows → 1 event.
+
+    The gate is satisfied by *any* run of two adjacent above-threshold
+    samples within the window, so an episode that ramps up mid-window
+    (one good tick, then two sustained bad ticks) still fires. Firing is
+    driven by the consecutive pair, not by the windowed mean — note the
+    mean here (≈8.3) is itself below threshold, yet the event fires.
+    """
+
+    obs = [
+        _obs(when=NOW - timedelta(minutes=50), direction="Praterstern", delay=4.0),
+        _obs(when=NOW - timedelta(minutes=25), direction="Praterstern", delay=10.0),
+        _obs(when=NOW - timedelta(minutes=5), direction="Praterstern", delay=11.0),
+    ]
+    events = _run(obs)
+    assert len(events) == 1
+    assert "in Richtung Praterstern" in events[0]["description"]
+
+
+def test_three_consecutive_above_threshold_fire() -> None:
+    """A run longer than the required pair still fires (run length ≥ 2)."""
+
+    obs = [
+        _obs(when=NOW - timedelta(minutes=50), direction="Meidling", delay=10.0),
+        _obs(when=NOW - timedelta(minutes=25), direction="Meidling", delay=11.0),
+        _obs(when=NOW - timedelta(minutes=5), direction="Meidling", delay=12.0),
+    ]
+    events = _run(obs)
+    assert len(events) == 1
+    assert "in Richtung Meidling" in events[0]["description"]
+
+
 # ---- Direction isolation: north and south fire independently -----------
 
 
@@ -221,3 +284,9 @@ def test_threshold_constant_is_9_minutes() -> None:
 
     assert DELAY_THRESHOLD_MINUTES == 9.0
     assert FEED_WINDOW == timedelta(hours=1)
+
+
+def test_consecutive_count_constant_is_two() -> None:
+    """Pin the consecutive-train requirement so a drift trips the test."""
+
+    assert TRIGGER_CONSECUTIVE_COUNT == 2


### PR DESCRIPTION
## Summary

Two changes to `src/feed/stammstrecke.py`, both requested:

### 1. Episode trigger: two *consecutive* trains over threshold
The trigger gate now starts an episode **only** when `TRIGGER_CONSECUTIVE_COUNT` (2) **time-adjacent** in-window observations *each* exceed `DELAY_THRESHOLD_MINUTES` (9 min, strict `>`) within the 60-minute `FEED_WINDOW`.

- **Before:** "any two above-threshold rows anywhere in the window" (`delayed_count < 2`). This fired even when a recovered, sub-threshold tick sat *between* the two high samples.
- **After:** a run-length check (`_has_consecutive_exceedance`) that resets on any below-or-equal-threshold sample, so two highs **straddling a dip no longer fire**.
- `DELAY_THRESHOLD_MINUTES = 9.0` and `FEED_WINDOW = 1h` were already correct; the count is now the named constant `TRIGGER_CONSECUTIVE_COUNT: Final[int] = 2` (single source of truth, exported in `__all__`).
- Display value (windowed **mean**) and the `_episode_start`/`first_seen` logic are unchanged.

### 2. `_episode_start` docstring corrected to match behavior (Option a)
The old docstring claimed a below-threshold row *terminates* the episode. The code actually filters below-threshold rows out up front and only checks gap-tolerance, so a brief dip is **bridged**. Docstring now states this accurately: short sub-threshold dips are bridged (not episode boundaries); an episode ends across a dip only when the resulting gap exceeds `EPISODE_GAP_TOLERANCE`. This keeps the `[Seit DD.MM.YYYY]` label and item GUID stable across momentary recoveries and is independent of the trigger decision. **No behavior change** — docstring only.

## Why Option (a)
Bridging avoids fragmenting an episode (and re-publishing affected items) on a single barely-below-threshold sample; longer recoveries still end the episode via gap-tolerance.

## Consistency
Updated the `compute_stammstrecke_events` docstring, the `FEED_WINDOW` module comment, the inline trigger comment, `__all__`, and the German reference doc `docs/reference/stammstrecke_provider_logic.md` (table row, constants table, trigger step 3, `first_seen` step 5).

## Tests
- New behavioral pins in `tests/test_feed_stammstrecke_trigger.py`: dip-straddle must **not** fire (the case that changed); dip-then-pair **fires**; 3-run **fires**; plus a `TRIGGER_CONSECUTIVE_COUNT == 2` pin. Module docstring updated.
- All pre-existing trigger tests still pass (the canonical 2-rows-in-window case is unaffected — the change only bites when ≥3 rows fall in one window with a dip between highs).

## Verification
- `ruff` clean, `mypy --strict` clean on the changed module.
- **Full suite: 8637 passed, 2 skipped.**

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_