### PR TITLE
fix(stations): route real ÖBB workbook stations that lost their bare "oebb" token to mapping

### DIFF
--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -57,6 +57,7 @@ try:  # pragma: no cover - convenience for module execution
     from src.utils.http import fetch_content_safe, session_with_retries
     from src.utils.serialize import scrub_trojan_source_primitives
     from src.utils.stations import is_in_vienna as _is_point_in_vienna
+    from src.utils.stations_validation import is_synthetic_vor_id
 except ModuleNotFoundError:  # pragma: no cover - fallback when installed as package
     from utils.files import (  # type: ignore[no-redef]
         atomic_write,
@@ -73,6 +74,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback when installed as pac
     from utils.http import fetch_content_safe, session_with_retries  # type: ignore[no-redef]
     from utils.serialize import scrub_trojan_source_primitives  # type: ignore[no-redef]
     from utils.stations import is_in_vienna as _is_point_in_vienna  # type: ignore[no-redef]
+    from utils.stations_validation import is_synthetic_vor_id  # type: ignore[no-redef]
 
 # Security cap against wide-but-flat JSON size-bomb attacks. Mirrors the
 # canonical ``MAX_*_FILE_BYTES`` contract from ``src/utils/cache.py`` /
@@ -762,7 +764,36 @@ def _load_existing_station_entries(
                         # post-mortem (the file fix there did not address
                         # the underlying classifier bug).
                         tokens = {t.strip() for t in stripped.split(",") if t.strip()}
-                        is_manual = "oebb" not in tokens
+                        if "oebb" in tokens:
+                            is_manual = False
+                        else:
+                            # No bare ``oebb`` token. Route to the ÖBB-Excel
+                            # ``mapping`` (so the re-pull merges into the entry)
+                            # ONLY when it carries a real Betriebsstellen
+                            # ``bst_code``. Two non-workbook shapes stay manual:
+                            #   * synthetic VOR stops, whose ``bst_code`` is a
+                            #     9xxxx placeholder the live workbook never
+                            #     emits (e.g. ``Wien Hauptbahnhof`` 900100) —
+                            #     the case the token check originally fixed; and
+                            #   * WL-/VOR-only haltestellen, which carry no
+                            #     ``bst_code`` at all (e.g. ``source="wl,vor"``).
+                            # The pre-fix ``"oebb" not in tokens`` shortcut
+                            # mis-filed a real workbook station that had merely
+                            # lost its bare ``oebb`` token (``Siebenhirten``,
+                            # bst_id=1371, source="oebb_geonetz,osm") as manual,
+                            # duplicating it against the fresh extract (same
+                            # bst_id in both lists, no dedup at the combine
+                            # step) and tripping ``validate_stations``. Keying
+                            # off a real (non-synthetic) ``bst_code`` keeps the
+                            # synthetic / WL-only entries manual while letting a
+                            # genuine Betriebsstelle round-trip through mapping.
+                            bst_code = entry.get("bst_code")
+                            has_real_oebb_code = (
+                                isinstance(bst_code, str)
+                                and bool(bst_code.strip())
+                                and not is_synthetic_vor_id(bst_code.strip())
+                            )
+                            is_manual = not has_real_oebb_code
                     else:
                         # Backward-compat: entries written before the
                         # ``as_dict`` source-default fix lack a source

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -843,6 +843,28 @@ _UNSAFE_CHARS_RE = re.compile(
 _VOR_ID_PATTERN = re.compile(r"9\d{4,5}")
 
 
+def is_synthetic_vor_id(value: object) -> bool:
+    """Return ``True`` when *value* is a synthetic VOR station id.
+
+    Synthetic ids occupy the ``9xxxx`` / ``9xxxxx`` range
+    (:data:`_VOR_ID_PATTERN`) assigned to VOR-sourced departure-board
+    stops — e.g. ``900100``–``900112`` for the Wien U-Bahn stops, plus
+    the tolerated legacy 5-digit form such as ``93010``. The live ÖBB
+    ``Verzeichnis der Verkehrsstationen`` workbook never carries these,
+    so an entry keyed by one cannot round-trip through an Excel re-pull
+    and must be preserved verbatim rather than rebuilt. Real ÖBB
+    Betriebsstellen ids (e.g. ``1371``) and non-string values return
+    ``False``.
+
+    Single source of truth for the synthetic-id test, shared by the VOR
+    provider validation below and the directory builder's manual/ÖBB
+    classifier (``scripts/update_station_directory.py``) — keeping the
+    two in lock-step so a real workbook station can never be mistaken
+    for a synthetic one (or vice versa) by only one of them.
+    """
+    return isinstance(value, str) and _VOR_ID_PATTERN.fullmatch(value) is not None
+
+
 def _find_cross_station_id_conflicts(
     stations: Sequence[Mapping[str, object]]
 ) -> Iterator[CrossStationIDIssue]:
@@ -919,8 +941,13 @@ def _find_identity_field_conflicts(
     station — same ``eva_nr`` 8101934 — and slipped past the other four
     keys because their ``bst_code`` / ``bst_id`` differ.
 
-    Whitespace-stripped + lower-cased ``int`` / ``str`` values are
-    compared; ``None`` and empty strings are ignored.  Distinct from
+    Whitespace-stripped ``int`` / ``str`` values are compared
+    **case-sensitively** — ÖBB ``bst_code``s are case-significant
+    (``Aw`` and ``aw`` are distinct Betriebsstellen), so case-folding
+    here would manufacture false-positive collisions; the alias-shadow
+    sibling :func:`_find_cross_station_id_conflicts` *does* casefold via
+    :func:`_normalize_token` because it matches free-text aliases.
+    ``None`` and empty strings are ignored.  Distinct from
     :func:`_find_cross_station_id_conflicts`, which fires only when an
     *alias* on one station shadows an *identity* field on a different
     station — this function fires on raw identity collisions.
@@ -1003,7 +1030,7 @@ def _find_provider_issues(
         name = str(entry.get("name", "")).strip() or "<unknown>"
         for key in ("bst_id", "bst_code"):
             value = entry.get(key)
-            if not isinstance(value, str) or not _VOR_ID_PATTERN.fullmatch(value):
+            if not is_synthetic_vor_id(value):
                 yield ProviderIssue(
                     identifier=identifier,
                     name=name,

--- a/tests/test_stations_validation_provider.py
+++ b/tests/test_stations_validation_provider.py
@@ -9,7 +9,33 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from src.utils.stations_validation import validate_stations
+from src.utils.stations_validation import is_synthetic_vor_id, validate_stations
+
+
+def test_is_synthetic_vor_id_matches_only_the_synthetic_range() -> None:
+    """The shared synthetic-id test: 9xxxx / 9xxxxx strings, nothing else.
+
+    This predicate is the single source of truth used by both the VOR
+    provider validation and the directory builder's manual/ÖBB
+    classifier, so a drift here would silently re-open either the
+    dropped-synthetic-entry bug or the duplicate-real-bst_id bug.
+    """
+    # Synthetic VOR ids (Wien U-Bahn departure-board stops + legacy form).
+    assert is_synthetic_vor_id("900100") is True
+    assert is_synthetic_vor_id("900112") is True
+    assert is_synthetic_vor_id("93010") is True  # tolerated legacy 5-digit form
+    # Real ÖBB Betriebsstellen ids and codes are NOT synthetic.
+    assert is_synthetic_vor_id("1371") is False  # Siebenhirten
+    assert is_synthetic_vor_id("100") is False
+    assert is_synthetic_vor_id("Mb  H2H") is False
+    # fullmatch, not search: a synthetic substring inside a longer id
+    # must not register as synthetic.
+    assert is_synthetic_vor_id("8900100") is False
+    assert is_synthetic_vor_id("900100x") is False
+    # Non-string values (int ids, None) return False — callers that hold
+    # an int normalise via ``str(...)`` first.
+    assert is_synthetic_vor_id(900100) is False
+    assert is_synthetic_vor_id(None) is False
 
 
 def _write(path: Path, entries: list[dict[str, object]]) -> None:

--- a/tests/test_update_station_directory_classification.py
+++ b/tests/test_update_station_directory_classification.py
@@ -142,6 +142,44 @@ def test_real_oebb_entry_with_extras_stays_in_mapping(tmp_path: Path) -> None:
     assert not any(e.get("name") == "Wiener Neustadt Hauptbahnhof" for e in manual)
 
 
+def test_real_oebb_entry_without_bare_oebb_token_stays_in_mapping(tmp_path: Path) -> None:
+    """A real workbook station that lost its bare ``oebb`` source token → mapping.
+
+    Regression for the duplicate-``bst_id`` bug. ``Siebenhirten`` is a
+    real ÖBB Betriebsstelle (``bst_id=1371``) the Excel workbook
+    re-emits, but its committed ``source`` is ``"oebb_geonetz,osm"`` —
+    the bare ``oebb`` token was lost across enrichment cycles. The
+    pre-fix token check classified it ``manual``, so the rebuild
+    appended it verbatim *alongside* the fresh Excel extract's own
+    ``bst_id=1371`` row → two entries sharing one ``bst_id`` → a
+    ``validate_stations`` identity-conflict failure. Because ``1371`` is
+    NOT in the synthetic VOR range, it must land in ``mapping`` so the
+    fresh extract merges into it instead of duplicating it.
+    """
+    path = tmp_path / "stations.json"
+    _write_stations(
+        path,
+        [
+            {
+                "bst_id": 1371,
+                "bst_code": "Mb  H2H",
+                "name": "Siebenhirten",
+                "source": "oebb_geonetz,osm",
+                "eva_nr": "8101523",
+            }
+        ],
+    )
+
+    mapping, manual = _load_existing_station_entries(path)
+
+    assert "1371" in mapping, (
+        "A real ÖBB workbook station (non-synthetic bst_id) whose source "
+        "lost the bare ``oebb`` token must stay in mapping so the Excel "
+        "re-pull merges into it rather than emitting a duplicate."
+    )
+    assert not any(e.get("name") == "Siebenhirten" for e in manual)
+
+
 def test_bare_oebb_source_string_stays_in_mapping(tmp_path: Path) -> None:
     """The pre-PR-β canonical ÖBB source — ``source="oebb"`` exactly.
 
@@ -296,3 +334,27 @@ def test_real_stations_json_keeps_wien_hauptbahnhof_as_manual() -> None:
     manual_names = {e.get("name") for e in manual}
     assert "Wien Hauptbahnhof" in manual_names
     assert "Wien Kaiserebersdorf" in manual_names
+
+
+def test_real_stations_json_keeps_siebenhirten_in_mapping() -> None:
+    """End-to-end pin: committed Siebenhirten (real bst_id 1371) → mapping.
+
+    Sibling to :func:`test_real_stations_json_keeps_wien_hauptbahnhof_as_manual`
+    for the opposite failure mode. ``Siebenhirten`` carries
+    ``source="oebb_geonetz,osm"`` (no bare ``oebb`` token) but a real,
+    non-synthetic ``bst_id`` the live workbook re-emits. It must classify
+    into ``mapping`` — leaking it into ``manual_stations`` ships a
+    duplicate ``bst_id=1371`` that fails ``validate_stations`` in CI.
+    """
+    stations_path = Path("data/stations.json")
+    if not stations_path.exists():  # pragma: no cover - fresh clone
+        pytest.skip("data/stations.json not present in this checkout")
+
+    mapping, manual = _load_existing_station_entries(stations_path)
+
+    assert "1371" in mapping, (
+        "Regression: Siebenhirten (real bst_id 1371, source without a bare "
+        "``oebb`` token) must round-trip through the ÖBB-Excel mapping, not "
+        "leak into manual_stations and duplicate against the fresh extract."
+    )
+    assert not any(e.get("name") == "Siebenhirten" for e in manual)


### PR DESCRIPTION
## Summary

Bug-hunt round across `places/`, the station-directory scripts, and feed `providers.py` / `configuration_wizard.py`. **One genuine correctness bug** (station classifier) plus a stale docstring, fixed here. The `places/` and feed-provider/config-wizard audits came back clean (all behavior either correct or already test-pinned).

## The bug: duplicate `bst_id` from the manual/ÖBB classifier

`_load_existing_station_entries` (`scripts/update_station_directory.py`) classified an existing entry as `manual` (preserve verbatim) whenever its comma-separated `source` lacked the bare `oebb` token. That token check was added to keep **synthetic VOR stops** (900xxx `bst_id`s the ÖBB workbook never carries) in the manual list — but it also caught **real workbook stations** that merely lost their bare `oebb` token across enrichment cycles.

Concrete case in the committed data: **Siebenhirten** (`bst_id=1371`, `bst_code="Mb  H2H"`, `source="oebb_geonetz,osm"`). It was filed `manual`, so the rebuild appended it verbatim *alongside* the fresh Excel extract's own `bst_id=1371` row — the combine step does no `bst_id` dedup — producing **two entries with the same `bst_id`** that fail `validate_stations`'s identity-conflict gate in CI.

### Fix
For a no-`oebb`-token entry, route it to the ÖBB `mapping` (so the fresh extract merges into it) **only when it carries a real, non-synthetic Betriebsstellen `bst_code`**. Two non-workbook shapes stay `manual`:
- synthetic VOR stops — `bst_code` is a `9xxxx` placeholder the workbook never emits (e.g. `Wien Hauptbahnhof` 900100);
- WL/VOR-only haltestellen — no `bst_code` at all (e.g. `source="wl,vor"`).

Verified against committed `data/stations.json`: Siebenhirten → `mapping`; 900100/900105 → `manual`; **0** `mapping` entries lack a real `bst_code` (149 mapping / 2088 manual).

## Supporting changes
- **Shared `is_synthetic_vor_id()` helper** in `stations_validation.py` — single source of truth for the `9\d{4,5}` synthetic-id signature, reused by both the VOR provider validation (`_find_provider_issues`, refactored **behavior-preservingly** — identical truth table incl. the `None` → "Invalid…" case) and the directory classifier, so the two can't drift.
- **Stale docstring fix** on `_find_identity_field_conflicts`: it claimed values are compared "lower-cased", but the code is (correctly) **case-sensitive** — ÖBB `bst_code`s are case-significant (`Aw` ≠ `aw`), so case-folding would manufacture false-positive collisions. Docstring now matches the code and notes the contrast with the alias-shadow sibling that *does* casefold.

## Tests
- Classifier regression: a real workbook entry without a bare `oebb` token → `mapping` (tmp_path) + a committed-data pin (Siebenhirten → `mapping`).
- `is_synthetic_vor_id` unit coverage (synthetic 9xxxx/legacy → True; real ids/codes, substrings, ints, None → False).
- All eight pre-existing classifier cases still pass (incl. the WL/VOR-only-stays-manual case that pinned the `bst_code`-based discriminator).

## Verification
- `ruff` clean; `mypy --strict` clean on the changed files.
- 1033-test station/validation sweep green; full suite running locally as the final gate.

## Not in this PR (flagged, awaiting maintainer call)
`STAMMSTRECKE_ENABLE` is absent from the config wizard's `CONFIG_OPTIONS`, so the wizard can't toggle that provider (runtime still defaults it to `True`, so feed behavior is unaffected). Possibly intentional — Stammstrecke/VOR is operator-policy-scoped per the code comments — so left untouched pending a decision.

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_