### PR TITLE
fix(wl): three correctness fixes in the Wiener Linien provider

### DIFF
--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -127,10 +127,24 @@ WL_SESSION_HEADERS = {"Accept": "application/json"}
 
 # ---------------- Zeit & Utils ----------------
 
-def _iso(s: str | None) -> datetime | None:
-    """Parst ISO (inkl. 'Z' / TZ ohne Doppelpunkt) robust zu aware datetime."""
+def _iso(s: object) -> datetime | None:
+    """Parst ISO (inkl. 'Z' / TZ ohne Doppelpunkt) robust zu aware datetime.
 
-    if not s:
+    Accepts ``object`` rather than ``str | None`` because every call site
+    passes a raw ``dict.get(...)`` value (typed ``Any``) straight from the
+    upstream JSON — see ``_best_ts`` (``time.start`` / ``updated`` / …) and
+    the two item loops in ``fetch_events``. A *truthy non-string* value (a
+    numeric epoch like ``1700000000``, a list, a dict) would otherwise reach
+    ``s.replace(...)`` below and raise ``AttributeError`` — which the
+    ``(ValueError, OverflowError)`` guard around ``isoparse`` does NOT catch.
+    That exception then propagates out of the unguarded ``fetch_events`` item
+    loop and disables the entire WL cache refresh for the cycle
+    (``update_wl_cache.py`` swallows it via a broad ``except Exception``).
+    Type-guarding here upholds the documented "one bad timestamp must not
+    abort the fetch" contract below.
+    """
+
+    if not isinstance(s, str) or not s:
         return None
     s = s.replace("Z", "+00:00")
     if len(s) >= 5 and (s[-5] in "+-") and s[-3] != ":":
@@ -189,6 +203,59 @@ def _best_ts(obj: dict[str, Any]) -> datetime | None:
         if cand:
             return cand
     return None
+
+
+# Status values (``status`` / ``state`` on the POI or its ``attributes``)
+# that mark a disruption finished / inactive — such items are dropped.
+# Matched on WORD BOUNDARIES, not bare substrings: the German *active*
+# statuses ``laufende`` (ongoing) and ``ausstehende`` (pending) — and the
+# noun ``Wochenende`` (weekend) — all contain the substring ``ende`` and were
+# wrongly dropped by the prior ``"ende" in blob`` membership test, silently
+# discarding valid live disruptions. All keywords are ASCII, so ``\b`` is safe.
+_INACTIVE_STATUS_RE = re.compile(
+    r"\b(?:finished|inactive|inaktiv|done|closed|nicht aktiv|ended|ende|"
+    r"abgeschlossen|beendet|geschlossen)\b"
+)
+
+
+def _is_inactive_status(*values: object) -> bool:
+    """True when any status/state *value* marks the item finished/inactive."""
+    blob = " ".join(str(v or "") for v in values).lower()
+    return _INACTIVE_STATUS_RE.search(blob) is not None
+
+
+def _wl_identity(
+    prefix: str,
+    line_pairs: list[tuple[str, str]],
+    real_start: datetime | None,
+    topic_key: str,
+) -> str:
+    """Build a stable, collision-resistant ``_identity`` for a WL item.
+
+    The base key is line-set + start-day, kept deliberately title-/
+    description-insensitive so a disruption's identity (and thus its
+    ``first_seen`` age) stays stable across builds as upstream edits its
+    wording. But that base key is too weak when an item has NO parseable
+    line set OR no start date: two genuinely distinct line-less Hinweise, or
+    two distinct date-less Störungen sharing a line set, then collapse to the
+    same key and ``_dedupe_items`` (which keys on ``_identity`` first —
+    build_feed.py) silently drops one. In those weak cases fold the
+    normalized ``topic_key`` into the key — mirroring the line-less
+    title/hash discriminator the central ``_identity_for_item`` already
+    applies — so distinct topics stay distinct (and true duplicates, which
+    share a topic_key, still dedup). The common lines+date case is left
+    byte-identical, so existing identities (and their first_seen) don't churn.
+    """
+    id_lines = ",".join(sorted(_line_tokens_from_pairs(line_pairs)))
+    id_day = (
+        real_start.date().isoformat()
+        if isinstance(real_start, datetime)
+        else "None"
+    )
+    identity = f"wl|{prefix}|L={id_lines}|D={id_day}"
+    if not id_lines or id_day == "None":
+        identity = f"{identity}|TK={topic_key}"
+    return identity
 
 
 def _is_active(start: datetime | None, end: datetime | None, now: datetime) -> bool:
@@ -558,28 +625,8 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
         # A) TrafficInfos (Störungen)
         for ti in _fetch_traffic_infos(timeout=timeout, session=session):
             attrs = _coerce_dict(ti.get("attributes"))
-            status_blob = " ".join(
-                [
-                    str(ti.get("status") or ""),
-                    str(attrs.get("status") or ""),
-                    str(attrs.get("state") or ""),
-                ]
-            ).lower()
-            if any(
-                x in status_blob
-                for x in (
-                    "finished",
-                    "inactive",
-                    "inaktiv",
-                    "done",
-                    "closed",
-                    "nicht aktiv",
-                    "ended",
-                    "ende",
-                    "abgeschlossen",
-                    "beendet",
-                    "geschlossen",
-                )
+            if _is_inactive_status(
+                ti.get("status"), attrs.get("status"), attrs.get("state")
             ):
                 continue
 
@@ -633,9 +680,8 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
                     extras.append(f"{k.capitalize()}: {str(attrs[k]).strip()}")
 
             # stabile Identity für first_seen
-            id_lines = ",".join(sorted(_line_tokens_from_pairs(line_pairs)))
-            id_day = real_start.date().isoformat() if isinstance(real_start, datetime) else "None"
-            identity = f"wl|störung|L={id_lines}|D={id_day}"
+            topic_key = _topic_key_from_title(title_raw)
+            identity = _wl_identity("störung", line_pairs, real_start, topic_key)
 
             raw.append(
                 {
@@ -643,7 +689,7 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
                     "category": "Störung",
                     "title": title,
                     "title_core": _title_core(title_raw),
-                    "topic_key": _topic_key_from_title(title_raw),
+                    "topic_key": topic_key,
                     "desc": desc,
                     "extras": extras,
                     "lines_pairs": line_pairs,  # [(tok, disp), …]
@@ -658,28 +704,8 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
         # B) News/Hinweise
         for poi in _fetch_news(timeout=timeout, session=session):
             attrs = _coerce_dict(poi.get("attributes"))
-            status_blob = " ".join(
-                [
-                    str(poi.get("status") or ""),
-                    str(attrs.get("status") or ""),
-                    str(attrs.get("state") or ""),
-                ]
-            ).lower()
-            if any(
-                x in status_blob
-                for x in (
-                    "finished",
-                    "inactive",
-                    "inaktiv",
-                    "done",
-                    "closed",
-                    "nicht aktiv",
-                    "ended",
-                    "ende",
-                    "abgeschlossen",
-                    "beendet",
-                    "geschlossen",
-                )
+            if _is_inactive_status(
+                poi.get("status"), attrs.get("status"), attrs.get("state")
             ):
                 continue
 
@@ -741,9 +767,8 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
                 if attrs.get(k):
                     extras.append(f"{k.capitalize()}: {str(attrs[k]).strip()}")
 
-            id_lines = ",".join(sorted(_line_tokens_from_pairs(line_pairs)))
-            id_day = real_start.date().isoformat() if isinstance(real_start, datetime) else "None"
-            identity = f"wl|hinweis|L={id_lines}|D={id_day}"
+            topic_key = _topic_key_from_title(title_raw)
+            identity = _wl_identity("hinweis", line_pairs, real_start, topic_key)
 
             raw.append(
                 {
@@ -751,7 +776,7 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
                     "category": "Hinweis",
                     "title": title,
                     "title_core": _title_core(title_raw),
-                    "topic_key": _topic_key_from_title(title_raw),
+                    "topic_key": topic_key,
                     "desc": desc,
                     "extras": extras,
                     "lines_pairs": line_pairs,  # [(tok, disp), …]

--- a/tests/test_wl_fetch_correctness.py
+++ b/tests/test_wl_fetch_correctness.py
@@ -1,0 +1,130 @@
+"""Regression tests for three WL-provider correctness fixes in ``wl_fetch``.
+
+1. ``_iso`` must not raise on a truthy non-string timestamp (numeric epoch,
+   list, dict). The previous ``s.replace(...)`` after only a falsy check
+   raised ``AttributeError`` — uncaught by the ``isoparse`` guard — which
+   propagated out of the unguarded ``fetch_events`` item loop and disabled
+   the whole WL cache refresh for the cycle.
+2. The finished/inactive status filter must match on WORD BOUNDARIES, not
+   bare substrings: the active German statuses ``laufende`` (ongoing) and
+   ``ausstehende`` (pending) — and the noun ``Wochenende`` — contain the
+   substring ``ende`` and were wrongly dropped, discarding live disruptions.
+3. ``_wl_identity`` must not collide for two genuinely distinct items that
+   share a (possibly empty) line set AND lack a parseable date. The base
+   ``L=…|D=…`` key is the authoritative dedup key (``_dedupe_items`` keys on
+   ``_identity`` first), so a collision silently drops a valid disruption.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, UTC
+
+from src.providers.wl_fetch import (
+    _best_ts,
+    _is_inactive_status,
+    _iso,
+    _wl_identity,
+)
+
+
+# ---- 1. _iso / _best_ts robustness against non-string timestamps --------
+
+
+def test_iso_returns_none_for_truthy_non_string_values() -> None:
+    """A numeric epoch / list / dict must yield ``None``, never raise."""
+    assert _iso(1700000000) is None
+    assert _iso(1700000000.0) is None
+    assert _iso([2026, 1, 1]) is None
+    assert _iso({"start": "2026-01-01"}) is None
+    assert _iso(True) is None
+
+
+def test_iso_still_parses_valid_strings() -> None:
+    """The fix must not regress normal string parsing (incl. trailing Z)."""
+    parsed = _iso("2026-01-01T00:00:00Z")
+    assert parsed == datetime(2026, 1, 1, tzinfo=UTC)
+    assert _iso("") is None
+    assert _iso(None) is None
+
+
+def test_best_ts_survives_numeric_start_and_falls_through() -> None:
+    """A numeric ``time.start`` must not abort; a later valid field wins.
+
+    Pre-fix ``_best_ts({"time": {"start": 1700000000}, ...})`` raised
+    ``AttributeError`` on the very first candidate, aborting ``fetch_events``.
+    """
+    ts = _best_ts(
+        {"time": {"start": 1700000000}, "updated": "2026-01-01T00:00:00Z"}
+    )
+    assert ts == datetime(2026, 1, 1, tzinfo=UTC)
+    # All candidates non-string → None, still no raise.
+    assert _best_ts({"time": {"start": [1, 2]}, "updated": 42}) is None
+
+
+# ---- 2. status filter: word boundaries, not bare substrings -------------
+
+
+def test_active_statuses_with_ende_substring_are_not_inactive() -> None:
+    """``laufende`` / ``ausstehende`` / ``Wochenende`` must NOT be dropped."""
+    assert _is_inactive_status("laufende") is False
+    assert _is_inactive_status("ausstehende") is False
+    assert _is_inactive_status("Wochenende") is False
+    assert _is_inactive_status("aktiv", "laufend") is False
+    # Across multiple fields (status / attrs.status / attrs.state).
+    assert _is_inactive_status("", "laufende", "") is False
+
+
+def test_genuinely_inactive_statuses_are_still_dropped() -> None:
+    """The real finished/inactive keywords must still match (any field)."""
+    for s in (
+        "finished",
+        "inactive",
+        "inaktiv",
+        "done",
+        "closed",
+        "nicht aktiv",
+        "ended",
+        "Ende",
+        "abgeschlossen",
+        "beendet",
+        "geschlossen",
+    ):
+        assert _is_inactive_status(s) is True, s
+    assert _is_inactive_status("", "", "beendet") is True
+    assert _is_inactive_status(None, 0, "FINISHED") is True  # case-insensitive
+
+
+# ---- 3. _wl_identity: no collision for weak (line-less / date-less) keys -
+
+
+def test_weak_identity_discriminates_distinct_topics() -> None:
+    """Two distinct line-less, date-less items must get distinct identities."""
+    a = _wl_identity("hinweis", [], None, "umleitung_innere_stadt")
+    b = _wl_identity("hinweis", [], None, "ersatzverkehr_donaustadt")
+    assert a != b
+    assert a.endswith("|TK=umleitung_innere_stadt")
+    # Same line set (U6) but no date — still must not collide.
+    c = _wl_identity("störung", [("U6", "U6")], None, "aufzug")
+    d = _wl_identity("störung", [("U6", "U6")], None, "weichenstoerung")
+    assert c != d
+    assert "|D=None|TK=" in c
+
+
+def test_strong_identity_is_unchanged_so_first_seen_does_not_churn() -> None:
+    """Lines + date present → byte-identical to the pre-fix format (no TK)."""
+    ident = _wl_identity(
+        "störung", [("U6", "U6")], datetime(2026, 1, 1, tzinfo=UTC), "anything"
+    )
+    assert ident == "wl|störung|L=U6|D=2026-01-01"
+    assert "TK=" not in ident
+
+
+def test_identical_weak_items_still_dedupe() -> None:
+    """Same topic + same (empty) lines + same date-status → same identity.
+
+    The discriminator must not over-split: genuine duplicates (which share a
+    topic_key) must still collapse so ``_dedupe_items`` keeps exactly one.
+    """
+    a = _wl_identity("hinweis", [], None, "same_topic")
+    b = _wl_identity("hinweis", [], None, "same_topic")
+    assert a == b


### PR DESCRIPTION
## Summary

A deep, line-by-line audit of the Wiener Linien provider (`src/providers/wl_fetch.py`) surfaced three genuine correctness bugs, each reproduced and now fixed with regression tests. (Companion audits of `oebb.py`, the VOR/Stammstrecke pipeline, and the two `places/` clients found no High/Med bugs.)

### 1. `_iso` crashed the **entire** WL fetch on a non-string timestamp
`_iso(s)` did `s.replace(...)` after only a falsy check, so a *truthy non-string* value from the upstream JSON (a numeric epoch `1700000000`, a list, a dict — reached via `_best_ts` on `time.start`/`updated`/`lastUpdate`/…) raised `AttributeError`. That's **not** caught by the `(ValueError, OverflowError)` guard around `isoparse`, so it propagated out of the unguarded `fetch_events` item loop and disabled the whole WL cache refresh for the cycle (`update_wl_cache.py` swallows it via a broad `except Exception`), silently serving the stale cache.
**Fix:** type-guard — non-`str` → `None` (the function's own docstring already promised "one bad timestamp must not abort the fetch").

### 2. The finished/inactive status filter dropped **active** disruptions
The drop keywords were matched as bare substrings, and `"ende"` is a substring of the active German statuses `"laufende"` (ongoing) and `"ausstehende"` (pending) — and of `"Wochenende"`. So live disruptions carrying those statuses were silently discarded.
**Fix:** match on **word boundaries** via a shared `_is_inactive_status` helper (`\bende\b` no longer matches `laufende`).

### 3. Weak `_identity` collided → valid disruptions dropped in dedup
`_identity = "wl|{störung,hinweis}|L={lines}|D={day}"` is the authoritative dedup key (`_dedupe_items` keys on `_identity` first), but it has no title/topic discriminator. Two genuinely distinct items that share a (possibly empty) line set **and** lack a parseable date collapse to the same key — e.g. two line-less Hinweise → `"…|L=|D=None"` — so `_dedupe_items` drops one.
**Fix:** only in those weak cases (no lines **or** no date), fold the normalized `topic_key` into the key via a shared `_wl_identity` helper — mirroring the central `_identity_for_item` line-less discriminator. The common `lines+date` case is **byte-identical**, so existing identities and their `first_seen` don't churn.

## Refactor
Extracted the duplicated status-filter and identity logic from the two near-identical TrafficInfo/News item loops into the shared `_is_inactive_status` / `_wl_identity` helpers.

## Tests / verification
- New `tests/test_wl_fetch_correctness.py` (8 tests) pins all three fixes incl. the strong-identity no-churn invariant and "true duplicates still dedup".
- ruff + mypy --strict clean on `wl_fetch.py`; 730 WL/dedup/identity/merge tests pass; full local suite run as the final gate.

## Not in this PR (flagged for follow-up)
A `feed/merge.py` audit found two genuine findings in the `first_seen`/GUID state machine (order-dependent `deduplicate_fuzzy` grouping; peer-merge GUID rehash resetting `first_seen`). Those are architecturally significant and risk one-time churn, so they're held for a separate, deliberate change.

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_