### PR TITLE
fix(wl): reject phantom single-letter lines in body-scan extraction

### DIFF
--- a/src/providers/wl_lines.py
+++ b/src/providers/wl_lines.py
@@ -46,7 +46,12 @@ def _display_line(s: str) -> str:
 #      bug when the original digit-only gate rejected ``D`` so
 #      ``_ensure_line_prefix`` couldn't strip the existing ``D:``
 #      prefix and ended up prepending another ``D:`` from
-#      ``relatedLines``.
+#      ``relatedLines``. The over-permissiveness (accepting any letter,
+#      not just ``D`` / ``O``) is bounded here by the colon-line-prefix
+#      shape ``LINE_PREFIX_STRIP_RE`` requires; the body-scanner gate
+#      ``LINE_CODE_RE`` below tightens to ``[DO]`` because that surface
+#      is unanchored and a sentence-start ``S`` in ``S-Bahn-Verkehr``
+#      otherwise matches via ``\b[A-Z]\b`` as a phantom line.
 #
 # Multi-letter words without digits (``ACHTUNG``, ``INFORMATION``,
 # ``HINWEIS``, ``LINIE``) still fail both shapes, so the original
@@ -233,8 +238,24 @@ def _ensure_line_prefix(title: str, lines_disp: list[str]) -> str:
 # canonically upper-cased (``U6``, ``S40``, ``41E``, ``D``), so
 # requiring uppercase rejects the false positive without missing any
 # legitimate token.
+#
+# Single-letter alternative is ``[DO]`` (not ``[A-Z]``): ``D`` (Wien
+# Hauptbahnhof — Nußdorf) and ``O`` (Praterstern — Raxstraße) are the
+# ONLY single-letter line codes in the entire WL/ÖBB/VOR network. Pre-
+# fix the unconstrained ``[A-Z]`` alternative extracted any standalone
+# uppercase letter as a phantom line — real example title ``Information
+# zu S-Bahn-Verkehr in Wien`` yielded ``[('S', 'S')]`` because ``\bS\b``
+# matches the ``S`` in ``S-Bahn`` (``-`` is a non-word boundary). The
+# phantom line then flowed into ``_wl_identity`` (wrong bucket /
+# first_seen key) AND into the rendered title via ``_ensure_line_prefix``
+# (``S: Information zu S-Bahn-Verkehr…``). Same bug for ``A`` in ``A bis
+# Karlsplatz`` (sentence-start preposition). Tightening to ``[DO]``
+# preserves both real single-letter tram lines while rejecting every
+# other standalone uppercase letter. Multi-character tokens (``U6``,
+# ``S40``, ``41E``, ``REX7``) are unaffected — they match the
+# digit-bearing alternatives.
 LINE_CODE_RE = re.compile(
-    r"\b(?:U\d{1,2}|S\d{1,2}|N\d{1,3}|[0-9]{1,3}[A-Z]?|[A-Z])\b",
+    r"\b(?:U\d{1,2}|S\d{1,2}|N\d{1,3}|[0-9]{1,3}[A-Z]?|[DO])\b",
 )
 RUF_BUS_RE = re.compile(r"Rufbus\s+([A-Za-z0-9]+)", re.IGNORECASE)
 DATE_FULL_RE = re.compile(r"\b\d{1,2}\.\d{1,2}\.(?:\d{2}|\d{4})\b")

--- a/tests/test_wl_lines_phantom_single_letter.py
+++ b/tests/test_wl_lines_phantom_single_letter.py
@@ -1,0 +1,112 @@
+"""Regression test: ``LINE_CODE_RE`` must not extract a standalone
+non-D/non-O uppercase letter as a phantom line from a body scan.
+
+Pre-fix ``LINE_CODE_RE`` carried a bare ``[A-Z]`` alternative — added
+to support WL's real letters-only tram lines ``D`` (Wien Hauptbahnhof
+— Nußdorf) and ``O`` (Praterstern — Raxstraße) — but the alternative
+was unconstrained. Any standalone uppercase letter at a word boundary
+matched, so realistic title shapes produced phantom line pairs that
+poisoned the downstream identity bucket AND the rendered title prefix:
+
+* ``"Information zu S-Bahn-Verkehr in Wien"`` →
+  ``[('S', 'S')]``. ``\\bS\\b`` matches the ``S`` in ``S-Bahn`` because
+  ``-`` is a non-word boundary.
+* ``"A bis Karlsplatz"`` → ``[('A', 'A')]``. Sentence-start
+  preposition ``"A"`` matched as a bus / tram letter.
+
+The phantom then flowed into ``_wl_identity`` (wrong bucket / wrong
+``first_seen`` key) AND into the rendered title via
+``_ensure_line_prefix`` (``"S: Information zu S-Bahn-Verkehr…"``).
+
+Scope of the fix
+================
+Only the BODY-SCANNER regex ``LINE_CODE_RE`` is tightened to ``[DO]``.
+``_STRICT_LINE_TOKEN_RE`` (the prefix-strip gate) keeps the broader
+``[A-Z]`` alternative because ``_extract_prefix_lines`` is anchored on
+the colon-line-prefix shape ``LINE_PREFIX_STRIP_RE`` and the existing
+``test_single_letter_line_codes.py`` pins acceptance of ``J``/``O``/``A``
+as a defensive "future-proof for hypothetical lines" surface. The
+concrete repro is body-scan only.
+"""
+
+from __future__ import annotations
+
+from src.providers.wl_lines import (
+    LINE_CODE_RE,
+    _detect_line_pairs_from_text,
+)
+
+
+# ---- 1. Phantom single-letter extraction is rejected --------------------
+
+
+def test_s_in_s_bahn_compound_is_not_a_phantom_line() -> None:
+    """``"S-Bahn"`` must not yield ``('S', 'S')`` as a phantom line pair."""
+    pairs = _detect_line_pairs_from_text("Information zu S-Bahn-Verkehr in Wien")
+    assert pairs == [], (
+        f"Phantom ``S`` extracted from ``S-Bahn`` compound: {pairs}"
+    )
+
+
+def test_sentence_start_uppercase_letter_is_not_a_phantom_line() -> None:
+    """Standalone non-D/non-O uppercase letters are not WL line codes."""
+    for title in (
+        "A bis Karlsplatz",
+        "B zum Hauptbahnhof",
+        "X-Mal verspätet",
+        "E wegen Bauarbeiten",
+        "I am Stephansplatz",
+    ):
+        pairs = _detect_line_pairs_from_text(title)
+        assert pairs == [], (
+            f"Phantom single-letter extracted from {title!r}: {pairs}"
+        )
+
+
+def test_line_code_regex_rejects_non_do_single_letter() -> None:
+    """Direct ``LINE_CODE_RE`` regression: ``\\bX\\b`` must not match."""
+    # Realistic compound-word context.
+    assert LINE_CODE_RE.findall("Verkehr in S-Bahn-Zonen") == []
+    assert LINE_CODE_RE.findall("A bis Karlsplatz") == []
+    # Multiple phantoms in one title.
+    assert LINE_CODE_RE.findall("X und Y unbekannt") == []
+
+
+# ---- 2. Real single-letter tram lines D and O still extract -------------
+
+
+def test_tram_d_is_still_extracted() -> None:
+    """``D`` is a real WL tram line — must still be detected."""
+    pairs = _detect_line_pairs_from_text("Linie D im Bauarbeiten-Modus")
+    extracted = [tok for tok, _ in pairs]
+    assert "D" in extracted, (
+        "Real WL tram line ``D`` (Wien Hbf — Nußdorf) must still extract"
+    )
+    # Direct regex check too.
+    assert "D" in LINE_CODE_RE.findall("Linie D im Bauarbeiten-Modus")
+
+
+def test_tram_o_is_still_extracted() -> None:
+    """``O`` is a real WL tram line — must still be detected."""
+    pairs = _detect_line_pairs_from_text("O: Demonstration Praterstern")
+    extracted = [tok for tok, _ in pairs]
+    assert "O" in extracted, "Real WL tram line ``O`` must still extract"
+
+
+# ---- 3. Multi-character lines are unaffected by the tightening ----------
+
+
+def test_multi_character_line_codes_still_extract() -> None:
+    """Tightening ``[A-Z]`` → ``[DO]`` must not regress digit-bearing codes."""
+    for text, must_contain in (
+        ("U6: Sperre", "U6"),
+        ("S40 verspätet", "S40"),
+        ("Bus 41E Umleitung", "41E"),
+        ("Linie 10A betroffen", "10A"),
+        ("Rufbus N20 Information", "N20"),
+    ):
+        pairs = _detect_line_pairs_from_text(text)
+        extracted = [tok for tok, _ in pairs]
+        assert must_contain in extracted, (
+            f"Real line {must_contain!r} dropped from {text!r}: {extracted}"
+        )


### PR DESCRIPTION
## Summary

`LINE_CODE_RE` in `src/providers/wl_lines.py` carried a bare `[A-Z]` single-letter alternative — added to support the only two real WL letters-only tram lines `D` (Wien Hbf — Nußdorf) and `O` (Praterstern — Raxstraße). The alternative was unconstrained, so `\bX\b` matched **any** standalone uppercase letter at a word boundary. Two realistic title shapes produced phantom line pairs:

```python
>>> from src.providers.wl_lines import _detect_line_pairs_from_text
>>> _detect_line_pairs_from_text("Information zu S-Bahn-Verkehr in Wien")
[('S', 'S')]   # phantom — \bS\b matches the S in S-Bahn (- is a non-word boundary)
>>> _detect_line_pairs_from_text("A bis Karlsplatz")
[('A', 'A')]   # phantom — sentence-start preposition matched as a tram letter
```

`_detect_line_pairs_from_text` is the **body-scan fallback** invoked by `wl_fetch.py:670` / `:758` when WL's API ships no `relatedLines`. The phantom then flowed into:

1. `_wl_identity` — wrong bucket / wrong `first_seen` key (distinct items collapse onto `wl|hinweis|L=S|D=…`)
2. The rendered title via `_ensure_line_prefix` — `"S: Information zu S-Bahn-Verkehr in Wien"`

## Fix

Tighten the single-letter alternative in `LINE_CODE_RE` from `[A-Z]` to `[DO]` — the actual WL tram lines. Every other alternative is byte-identical, so multi-character codes (`U6`, `S40`, `41E`, `REX7`, …) and the legitimate `D` / `O` extractions are unchanged.

## Scope decision: only `LINE_CODE_RE`, not `_STRICT_LINE_TOKEN_RE`

The confirmed concrete bug is body-scan only. `_STRICT_LINE_TOKEN_RE` (the prefix-strip gate at `_extract_prefix_lines`) keeps its broader `[A-Z]` alternative because:

1. It is bounded by the colon-line-prefix anchor `LINE_PREFIX_STRIP_RE` — phantom prefix matches require a title shape like `"A: foo"` which doesn't appear in real WL data.
2. `tests/test_single_letter_line_codes.py::test_other_single_letter_codes` explicitly pins `J` / `O` / `A` as accepted prefix-line codes for a defensive "future-proof for hypothetical lines" surface. Loosening it now would contest an existing intentional decision without evidence.

## Tests / verification

- New `tests/test_wl_lines_phantom_single_letter.py` (5 tests): pins the four phantom inputs above, the two real `D` / `O` extractions, and the unaffected `U6` / `S40` / `41E` / `10A` / `N20` regressions.
- `tests/test_single_letter_line_codes.py` continues to pass (prefix gate untouched).
- Full WL / line / merge / cache / dedup test set: **1343 tests pass**.
- `ruff` clean on changed files. `mypy --strict` clean (the 8 pre-existing errors in `src/utils/http.py` are unrelated transitive-import findings).

## Context: how PR #2 was scoped

Following the `feed/merge.py` follow-up note from PR #1701, a fresh evidence-first re-audit of `src/build_feed.py` (4555 lines, comprehensive pass by a separate audit run), `src/utils/cache.py`, and `src/providers/wl_lines.py` was run looking for any remaining correctness bugs. Result: **zero** verified bugs in `build_feed.py` (clean — the recent fix bundles `edc56d0` / `eba6160` / `dcafaae` / `d181839` closed the readily-reachable surface), **zero** verified bugs in `cache.py`, and **one** in `wl_lines.py` — this PR.

## Next

`feed/merge.py` first_seen / GUID state-machine hardening (order-independent `deduplicate_fuzzy` + peer-merge GUID rehash resetting `first_seen`) — the architecturally significant change PR #1701 explicitly flagged — lands as a separate PR after this one, with the documented one-time churn surface in its body.

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_