### PR TITLE
fix(merge): order-independent dedup + preserve survivor identity across peer-merge

### DIFF
--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -1,4 +1,3 @@
-import hashlib
 import re
 from typing import Any
 
@@ -491,6 +490,27 @@ def deduplicate_fuzzy(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     # work is touched.
     merged_cache: list[tuple[set[str], str, str, set[str]]] = []
 
+    # Stable, input-order-independent iteration. ``deduplicate_fuzzy``
+    # uses first-match-wins on the inner loop (``break`` after the merge),
+    # so the SURVIVOR of any merge group is whichever item arrives in
+    # ``items`` first. Without this sort the result depends on the
+    # arbitrary upstream concatenation order — three items with a
+    # transitive overlap graph (``A↔C``, ``B↔C``, but no direct ``A↔B``)
+    # produce ``[AC, B]`` from ``[A, B, C]`` and ``[BC, A]`` from
+    # ``[B, A, C]`` because ``C`` merges with whichever of ``A`` / ``B``
+    # the iteration encountered first. Sorting by the per-item stable
+    # identity tuple makes survivor selection deterministic across
+    # runs, so the merged item's preserved ``_identity`` / ``guid``
+    # (see the peer-merge branch below) stays the same cycle to cycle.
+    items = sorted(
+        items,
+        key=lambda it: (
+            str(it.get("_identity") or ""),
+            str(it.get("guid") or ""),
+            str(it.get("title") or ""),
+        ),
+    )
+
     for item in items:
         merged = False
         title = item.get("title", "")
@@ -682,11 +702,25 @@ def deduplicate_fuzzy(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
                     _promote_newer_dates(existing_copy, item)
 
-                    # 4. Update GUID
-                    # We create a new deterministic GUID based on the new title.
-                    # This ensures clients see it as a new/updated item.
-                    existing_copy["guid"] = hashlib.sha256(new_title.encode("utf-8")).hexdigest()
-                    existing_copy["_identity"] = existing_copy["guid"]
+                    # 4. Preserve survivor's GUID and ``_identity``.
+                    # Pre-fix the peer-merge rehashed ``guid = sha256(new_title)``
+                    # and set ``_identity = guid`` to "signal clients see a new
+                    # / updated item". That broke ``first_seen`` tracking: the
+                    # build-time state lookup keys on the guid (preferred by
+                    # ``_state_key_for_item``) with a legacy fallback to
+                    # ``_identity_for_item``. Both keys came from the same
+                    # ``sha256(new_title)``, so every cycle in which the
+                    # merge grouping or the combined title shifted produced
+                    # a fresh hash → fresh state key → fresh ``first_seen``,
+                    # and the merged disruption was perpetually treated as
+                    # brand-new (re-published via the fresh-pubDate window,
+                    # FIFO retirement could never fire). Survivor selection
+                    # is now deterministic via the top-of-function sort, so
+                    # the survivor's ``guid`` and ``_identity`` (carried
+                    # forward by the ``dict(existing)`` copy above) stay
+                    # stable across cycles. Updates flow through ``title``
+                    # / ``description`` / ``pubDate`` — the channels RSS
+                    # clients actually use to detect updates.
                     existing_copy.pop("_calculated_identity", None)
 
                     merged_items[idx] = existing_copy

--- a/tests/test_feed_merge.py
+++ b/tests/test_feed_merge.py
@@ -33,9 +33,14 @@ def test_fuzzy_merge_silvester() -> None:
     assert "Details about Lauf." in item["description"]
     assert "Details about Pfad." in item["description"]
 
-    # Check GUID updated
-    assert item["guid"] != "guid1"
-    assert item["guid"] != "guid2"
+    # Check GUID: the survivor's guid is preserved across the peer-merge
+    # so RSS clients keep tracking the same item across cycles, and the
+    # server-side ``first_seen`` lookup (which keys on the guid) survives
+    # the merge instead of resetting every cycle the combined title
+    # shifts. Survivor selection is deterministic via the top-of-function
+    # sort by ``(_identity, guid, title)``; neither item carries
+    # ``_identity`` here, so the lower ``guid`` wins → ``guid1``.
+    assert item["guid"] == "guid1"
 
 def test_fuzzy_merge_pubdate_update() -> None:
     items = [

--- a/tests/test_feed_merge_order_independence.py
+++ b/tests/test_feed_merge_order_independence.py
@@ -1,0 +1,126 @@
+"""Regression test: ``deduplicate_fuzzy`` must be order-independent.
+
+Pre-fix the merge iterated ``items`` in arrival order and used
+first-match-wins on the inner loop (``break`` after the merge). Three
+items with a transitive overlap graph — ``A`` overlaps ``C``,
+``B`` overlaps ``C``, but ``A`` and ``B`` do NOT directly overlap —
+produced different groupings depending on the upstream concatenation
+order::
+
+    order [A, B, C] → [AC, B]   # C merged with A (the first existing item it saw)
+    order [B, A, C] → [BC, A]   # C merged with B (the first existing item it saw)
+
+Why this matters: cache loaders feed ``deduplicate_fuzzy`` after a
+``_dedupe_items`` pass that may itself reshuffle items by dedup key.
+Upstream provider order is also incidental (network race, plugin
+registration order). The merge result therefore drifted between
+runs / between deployments, taking the survivor's ``guid`` and
+``_identity`` (post-fix preserved by the peer-merge branch) along with
+it — every drift event reset ``first_seen`` for the affected merged
+disruption.
+
+Fix sorts ``items`` at the top of ``deduplicate_fuzzy`` by the per-item
+stable identity tuple ``(_identity, guid, title)``, so survivor
+selection is deterministic across runs regardless of input order.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from src.feed.merge import deduplicate_fuzzy
+
+
+def _signature(items: list[dict[str, Any]]) -> list[tuple[str, str, str]]:
+    """Return an order-insensitive equality signature for a merge result."""
+    return sorted(
+        (
+            str(it.get("title") or ""),
+            str(it.get("_identity") or ""),
+            str(it.get("guid") or ""),
+        )
+        for it in items
+    )
+
+
+def test_three_items_transitive_overlap_is_order_independent() -> None:
+    """A↔C, B↔C, but NOT A↔B — pre-fix the result swapped with input order."""
+    items_base = [
+        {
+            "title": "U1/U2: ottakring umleitung",
+            "guid": "g_A",
+            "_identity": "wl|hinweis|L=U1,U2|D=2026-05-29",
+        },
+        {
+            "title": "U3/U4: ottakring umleitung",
+            "guid": "g_B",
+            "_identity": "wl|hinweis|L=U3,U4|D=2026-05-29",
+        },
+        {
+            "title": "U1/U3: ottakring umleitung",
+            "guid": "g_C",
+            "_identity": "wl|hinweis|L=U1,U3|D=2026-05-29",
+        },
+    ]
+
+    results: list[list[tuple[str, str, str]]] = []
+    for permutation in ([0, 1, 2], [1, 0, 2], [2, 1, 0], [2, 0, 1], [0, 2, 1]):
+        inp = [copy.deepcopy(items_base[i]) for i in permutation]
+        results.append(_signature(deduplicate_fuzzy(inp)))
+
+    for idx, sig in enumerate(results[1:], start=1):
+        assert sig == results[0], (
+            f"Permutation #{idx} produced a different merge result than "
+            f"the canonical one:\n  canonical: {results[0]}\n  this run:  {sig}"
+        )
+
+
+def test_vor_oebb_priority_already_order_independent_still_holds() -> None:
+    """Independence guarantee must hold for the VOR/ÖBB branches too."""
+    vor = {
+        "title": "S1/S2: Weichenstörung",
+        "description": "Short VOR text.",
+        "guid": "vor_guid_1",
+        "provider": "vor",
+        "source": "vor",
+    }
+    oebb = {
+        "title": "S1/S2: Weichenstörung",
+        "description": "Details from ÖBB.",
+        "guid": "oebb_guid_1",
+        "provider": "oebb",
+        "source": "oebb",
+    }
+    a = deduplicate_fuzzy([copy.deepcopy(vor), copy.deepcopy(oebb)])
+    b = deduplicate_fuzzy([copy.deepcopy(oebb), copy.deepcopy(vor)])
+    # Both orderings collapse to the same merged item; VOR wins.
+    assert _signature(a) == _signature(b)
+    assert a[0]["guid"] == "vor_guid_1"
+
+
+def test_repeat_runs_on_identical_input_produce_byte_identical_output() -> None:
+    """Same input twice must produce the same ``_identity`` / ``guid``.
+
+    The repeat-run invariant is what makes ``first_seen`` survive
+    upstream re-publishes of the same disruption: every cycle the
+    deduped + merged item must collapse to the same persistent key.
+    """
+    items = [
+        {
+            "title": "U6/U4: stoerung praterstern",
+            "guid": "wl_aaa",
+            "_identity": "wl|hinweis|L=U4,U6|D=2026-05-29",
+        },
+        {
+            "title": "U6: stoerung praterstern",
+            "guid": "wl_bbb",
+            "_identity": "wl|hinweis|L=U6|D=2026-05-29",
+        },
+    ]
+    a = deduplicate_fuzzy(copy.deepcopy(items))
+    b = deduplicate_fuzzy(copy.deepcopy(items))
+    assert len(a) == 1
+    assert len(b) == 1
+    assert a[0]["_identity"] == b[0]["_identity"]
+    assert a[0]["guid"] == b[0]["guid"]

--- a/tests/test_feed_merge_priority.py
+++ b/tests/test_feed_merge_priority.py
@@ -85,7 +85,10 @@ def test_fuzzy_merge_provider_priority_vor_wins_reverse_order() -> None:
 
 def test_fuzzy_merge_provider_priority_no_provider_field() -> None:
     """
-    Ensure no crash if 'provider' field is missing, falls back to normal merge.
+    Ensure no crash if 'provider' field is missing — falls back to the
+    standard peer-merge branch, which now PRESERVES the survivor's guid
+    (the pre-fix code rehashed it to ``sha256(new_title)`` and reset
+    first_seen; see ``test_fuzzy_merge_identity.py`` for the rationale).
     """
     items = [
         {
@@ -104,8 +107,10 @@ def test_fuzzy_merge_provider_priority_no_provider_field() -> None:
 
     merged = deduplicate_fuzzy(items)
     assert len(merged) == 1
-    # Should use normal logic (merge descriptions, generate new GUID)
-    assert merged[0]["guid"] != "g1"
-    assert merged[0]["guid"] != "g2"
+    # Peer-merge preserves the survivor's guid. Survivor selection is
+    # deterministic via the top-of-function sort by
+    # ``(_identity, guid, title)``; neither item carries ``_identity``
+    # so the lower ``guid`` wins → ``g1``.
+    assert merged[0]["guid"] == "g1"
     assert "Desc 1" in merged[0]["description"]
     assert "Desc 2" in merged[0]["description"]

--- a/tests/test_fuzzy_merge_identity.py
+++ b/tests/test_fuzzy_merge_identity.py
@@ -1,34 +1,97 @@
+"""Pin the post-fix peer-merge identity preservation behaviour.
+
+Pre-fix ``deduplicate_fuzzy``'s peer-merge branch rewrote the merged
+item's ``guid`` to ``sha256(new_title)`` and aliased
+``_identity = guid``. The intent (per the now-deleted comment) was to
+"ensure clients see it as a new/updated item", but it conflated two
+keys with different responsibilities:
+
+* ``_identity`` is the *server-side* dedup / ``first_seen`` key. It
+  must stay STABLE across cycles or every cycle in which the merge
+  grouping or the combined title shifts triggers a fresh ``first_seen``,
+  and the merged disruption is perpetually republished as brand-new
+  (FIFO retirement on age can never fire either).
+* ``guid`` is the *client-side* identifier RSS readers use to track
+  "is this the same item I've already seen?". Stable guid → stable
+  user-side history. Updates flow through ``pubDate`` / ``title`` /
+  ``description``, the channels clients actually use to detect updates.
+
+Post-fix both fields are PRESERVED from the survivor item across a
+peer-merge. Survivor selection is now deterministic via the
+top-of-function sort by ``(_identity, guid, title)``, so the survivor
+is the same item cycle to cycle and the merged item's identity stays
+byte-identical.
+"""
+
 from src.feed.merge import deduplicate_fuzzy
 
-def test_fuzzy_merge_identity() -> None:
-    # Two items with significant overlap
+
+def test_peer_merge_preserves_survivor_identity_and_guid() -> None:
+    """Survivor's ``_identity`` AND ``guid`` carry forward unchanged."""
     items = [
         {
             "title": "U1: Störung Event",
             "description": "desc1",
             "guid": "guid1",
             "_calculated_identity": "calc_ident1",
-            "_identity": "ident1"
+            "_identity": "ident1",
         },
         {
             "title": "U1: Störung Event",
             "description": "desc2",
             "guid": "guid2",
             "_calculated_identity": "calc_ident2",
-            "_identity": "ident2"
-        }
+            "_identity": "ident2",
+        },
     ]
 
     merged = deduplicate_fuzzy(items)
-
-    # Should be merged into 1 item
     assert len(merged) == 1
-
-    # Check that identity matches guid and _calculated_identity is gone
     merged_item = merged[0]
-    assert "_calculated_identity" not in merged_item
-    assert merged_item["guid"] == merged_item["_identity"]
 
-    # guid should be deterministic from new title
+    # Survivor selection is deterministic via the top-of-function sort by
+    # ``(_identity, guid, title)``. Both items share the same title and
+    # ``_identity`` orders first → item 1 (``ident1`` / ``guid1``) wins.
+    assert merged_item["_identity"] == "ident1", (
+        "Survivor's pre-merge _identity must be preserved (not replaced by "
+        "a sha256(new_title) rehash) so first_seen survives the merge."
+    )
+    assert merged_item["guid"] == "guid1", (
+        "Survivor's pre-merge guid must be preserved so RSS clients keep "
+        "the item as the same entry across cycles."
+    )
+
+    # Defensive cleanup of the stale ``_calculated_identity`` cache slot
+    # is unchanged from the pre-fix code.
+    assert "_calculated_identity" not in merged_item
+
+
+def test_peer_merge_does_not_introduce_sha256_rehash() -> None:
+    """The merged guid must not be ``sha256(new_title)`` — that was the bug."""
     import hashlib
-    assert merged_item["guid"] == hashlib.sha256(merged_item["title"].encode("utf-8")).hexdigest()
+
+    items = [
+        {
+            "title": "U1/U2: foo bar quux",
+            "guid": "alpha",
+            "_identity": "id_alpha",
+        },
+        {
+            "title": "U1: foo bar baz",
+            "guid": "beta",
+            "_identity": "id_beta",
+        },
+    ]
+
+    merged = deduplicate_fuzzy(items)
+    assert len(merged) == 1
+    merged_item = merged[0]
+
+    new_title = merged_item["title"]
+    pre_fix_rehash = hashlib.sha256(new_title.encode("utf-8")).hexdigest()
+    assert merged_item["guid"] != pre_fix_rehash, (
+        "Pre-fix peer-merge rehashed guid to sha256(new_title), resetting "
+        "first_seen every cycle the combined title shifted. Post-fix the "
+        "survivor's guid is preserved."
+    )
+    assert merged_item["guid"] in ("alpha", "beta")


### PR DESCRIPTION
## Summary

`src/feed/merge.py:deduplicate_fuzzy` had two architectural bugs in the `first_seen` / GUID state machine — both flagged for follow-up in PR #1701's "Not in this PR" section. Reproduced concretely, fixed, and pinned with regression tests.

### 1. Order-dependent grouping

The merge iterated `items` in arrival order and used **first-match-wins** on the inner loop (`break` after the merge). Three items with a transitive overlap graph — `A↔C`, `B↔C`, but no direct `A↔B` — produced different groupings depending on the upstream concatenation order:

```python
>>> from src.feed.merge import deduplicate_fuzzy
>>> # A, B, C all share name "ottakring umleitung". Lines: A={U1,U2}, B={U3,U4}, C={U1,U3}.
>>> # A↔C overlap = 1/3 > 0.3, B↔C overlap = 1/3 > 0.3, A↔B overlap = 0.
>>> deduplicate_fuzzy([A, B, C])
[merged(A, C), B]   # C merged with A — the first existing item it saw
>>> deduplicate_fuzzy([B, A, C])
[merged(B, C), A]   # C merged with B — the first existing item it saw
```

Cache loaders feed `deduplicate_fuzzy` after a `_dedupe_items` pass that may reshuffle items by dedup key. Provider plugin registration order is also incidental. The merge result therefore drifted between runs / between deployments, taking the survivor's `guid` and `_identity` along with it.

### 2. Peer-merge identity rehash

The peer-merge branch rewrote `existing_copy["guid"] = sha256(new_title)` and aliased `_identity = guid` to (per the now-deleted comment) "ensure clients see it as a new / updated item". That conflated two keys with different responsibilities:

- **`_identity`** is the *server-side* `first_seen` key. It must stay STABLE across cycles or every shift triggers a fresh `first_seen`.
- **`guid`** is the *client-side* identifier RSS readers use to track "is this the same item I've seen?". Stable guid → stable user-side history. Updates flow through `pubDate` / `title` / `description`, the channels clients actually use to detect updates.

The state lookup keys on the guid (preferred by `build_feed._state_key_for_item`) with a legacy fallback to `_identity_for_item` — both came from the same `sha256(new_title)`, so every cycle in which the merge grouping or combined title shifted produced a fresh hash, missing the historic state key and resetting `first_seen`. The merged disruption was perpetually republished as brand-new and the FIFO age-based retirement gate could never fire.

```python
>>> import hashlib
>>> r = deduplicate_fuzzy([
...     {'title': 'U1: stoerung praterstern', 'guid': 'g_old', '_identity': 'id_old'},
...     {'title': 'U1/U2: stoerung praterstern', 'guid': 'g_new', '_identity': 'id_new'},
... ])
>>> r[0]['_identity'] == hashlib.sha256(r[0]['title'].encode()).hexdigest()
True   # pre-fix: survivor's identity discarded, replaced with sha256 rehash
```

## Fix

- **Sort `items`** at the top of `deduplicate_fuzzy` by the stable identity tuple `(_identity, guid, title)` so survivor selection is deterministic across runs regardless of input order.
- **Peer-merge branch**: remove the guid rehash and `_identity = guid` assignment. The survivor's `guid` and `_identity` (already in `existing_copy` via `dict(existing)`) stay byte-identical.
- `hashlib` import dropped (no remaining consumers).

The VOR/ÖBB priority branches were already not affected — they explicitly preserve the master's guid as `_identity`.

## One-time churn

The first build after deploy refreshes `first_seen` for every existing peer-merged item. On-disk `data/first_seen.json` keys generated by the pre-fix `sha256(new_title)` no longer match the post-fix survivor's guid. Of the 1549 current state entries, 469 are sha256-shaped (a superset of peer-merge rehashes — most are legitimate provider guids); the actual refresh surface is bounded by however many of those are peer-merged. Subsequent cycles are stable.

This is the documented "architecturally significant change with one-time churn" surface PR #1701 flagged. It's the price of moving from broken to correct first_seen tracking.

## Tests

- New `tests/test_feed_merge_order_independence.py` (3 tests) pins:
  - Transitive-overlap independence across 5 input permutations
  - VOR/ÖBB priority independence still holds
  - Repeat-runs on identical input produce byte-identical `_identity` / `guid` (the invariant `first_seen` actually needs)
- `tests/test_fuzzy_merge_identity.py` rewritten — was pinning the rehash bug; now pins preserved-survivor behavior.
- `tests/test_feed_merge.py::test_fuzzy_merge_silvester` and `tests/test_feed_merge_priority.py::test_fuzzy_merge_provider_priority_no_provider_field` updated similarly.

## Verification

- Full test suite: **8658 passed, 0 failed**.
- `ruff` clean, `mypy --strict` clean.
- McCabe gate on `deduplicate_fuzzy` unchanged at 21 (the fix is +1 sort line / −2 assignment lines, no new branches).

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_