### PR TITLE
fix(wl): close four phantom-line / topic-key / stop-name masking gaps

### DIFF
--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -307,7 +307,13 @@ def _stop_names_from_related(rel_stops: list[Any]) -> list[str]:
         if canonical:
             final = display_name(canonical)
         else:
-            final = re.sub(r"\s{2,}", " ", raw).strip()
+            # ``\s+`` (NOT ``\s{2,}``): the prior shape only collapsed runs
+            # of >=2 whitespace chars, so a single embedded ``\n`` or ``\t``
+            # in a relatedStops name survived into the RSS ``Haltestelle:``
+            # description line verbatim, breaking the single-line render
+            # downstream. Matches the canonical shape of the sibling
+            # ``_normalize_whitespace`` helper below.
+            final = re.sub(r"\s+", " ", raw).strip()
         if not final:
             continue
         key = final.casefold()

--- a/src/providers/wl_lines.py
+++ b/src/providers/wl_lines.py
@@ -260,7 +260,12 @@ LINE_CODE_RE = re.compile(
 RUF_BUS_RE = re.compile(r"Rufbus\s+([A-Za-z0-9]+)", re.IGNORECASE)
 DATE_FULL_RE = re.compile(r"\b\d{1,2}\.\d{1,2}\.(?:\d{2}|\d{4})\b")
 DATE_SHORT_RE = re.compile(r"\b\d{1,2}\.\d{1,2}\b")
-TIME_RE = re.compile(r"\b\d{1,2}:\d{2}\b")
+# ``(?::\d{2})?`` captures the optional seconds component. Pre-fix the
+# regex matched only ``HH:MM``; an ``HH:MM:SS`` timestamp left ``:SS``
+# behind, and the trailing 2-digit ``SS`` was then extracted as a phantom
+# WL line via the ``[0-9]{1,3}[A-Z]?`` branch of ``LINE_CODE_RE``
+# (``Sperre 17:30:45 Ausfall`` -> phantom line ``45``).
+TIME_RE = re.compile(r"\b\d{1,2}:\d{2}(?::\d{2})?\b")
 ADDRESS_NO_RE = re.compile(
     # Two shapes covered:
     #   1) Compound street names where the suffix is glued onto the prefix
@@ -284,8 +289,14 @@ ADDRESS_NO_RE = re.compile(
     r"\s+\d+(?:\s*[-–—/]\s*\d+)?[A-Za-z]?\b",
     re.IGNORECASE,
 )
+# ``[A-Za-z]?`` captures the optional alpha suffix on a house number.
+# Pre-fix the trailing ``\b`` required the number to end at a word boundary
+# WITHOUT a letter (``Stiege 12`` masked, ``Stiege 12A`` did NOT — the
+# ``12`` matched but ``A`` then escaped to ``LINE_CODE_RE`` and surfaced as
+# a phantom line ``12A``). Mirrors the alpha-suffix already supported by
+# the sibling ``ADDRESS_NO_RE`` numeric-tail above (``[A-Za-z]?\b``).
 ADDRESS_NO_PRE_RE = re.compile(
-    r"\b(?:ggü\.?|gegenüber|Nr\.?|Nummer|Hausnr\.?|Objekt|Stiege|Tür|Top)\s+\d+\b",
+    r"\b(?:ggü\.?|gegenüber|Nr\.?|Nummer|Hausnr\.?|Objekt|Stiege|Tür|Top)\s+\d+[A-Za-z]?\b",
     re.IGNORECASE,
 )
 

--- a/src/providers/wl_text.py
+++ b/src/providers/wl_text.py
@@ -268,9 +268,21 @@ TITLE_TOPIC_TOKENS = {
     "gesperrt",
 }
 
+# Pre-fix ``betrieb\s+ab.*`` (and the sibling ``betrieb\s+nur.*``) used a
+# greedy ``.*`` that swallowed every downstream token through to end-of-
+# string, eating legitimate topic tokens — ``Sperre Betrieb ab Karlsplatz
+# mit Unfall`` collapsed to ``sperre`` (the ``unfall`` topic token was
+# lost), so two unrelated incidents that happened to follow a "Betrieb
+# ab ..." preamble degenerated to the same ``topic_key`` and collided in
+# the WL identity / dedup pipeline. Replacing ``.*`` with
+# ``\s+\S+`` strips the canonical "Betrieb ab <Ort>" / "Betrieb nur
+# <Ort>" phrasing (one location word, matching what the upstream feed
+# actually emits — verified against current cache snapshots) and stops
+# at the next whitespace so downstream tokens survive for the topic-key
+# extractor at ``_topic_key_from_title``.
 _GENERIC_FILLER = re.compile(
     r"\b(fahrtbehinderung|verkehrsbehinderung|behinderung|störung|stoerung|hinweis|meldung|serviceinfo|service\-info|"
-    r"betrieb\s+ab.*|betrieb\s+nur.*)\b",
+    r"betrieb\s+ab\s+\S+|betrieb\s+nur\s+\S+)\b",
     re.IGNORECASE,
 )
 

--- a/tests/test_wl_masking_phantoms_and_topic_key.py
+++ b/tests/test_wl_masking_phantoms_and_topic_key.py
@@ -1,0 +1,153 @@
+"""Regression tests for four WL text/line-masking findings.
+
+Each of these slipped through the line-detection / topic-key / stop-name
+normalisation paths and surfaced as phantom WL line tokens, degraded dedup
+keys, or multi-line description rows in the RSS feed. All four reproduce
+deterministically before the fixes are applied.
+
+1. ``wl_lines.ADDRESS_NO_PRE_RE`` — required ``\\d+\\b`` so a house number
+   with an alpha suffix (``Stiege 12A``, ``Nr. 5B``) escaped the mask. The
+   trailing ``A``/``B`` was then picked up by ``LINE_CODE_RE``'s
+   ``[0-9]{1,3}[A-Z]?`` branch as a phantom WL bus line. Fix mirrors the
+   alpha-suffix already supported by sibling ``ADDRESS_NO_RE``.
+
+2. ``wl_lines.TIME_RE`` — matched only ``HH:MM``, so the ``:SS`` tail of an
+   ``HH:MM:SS`` timestamp survived; the trailing 2-digit ``SS`` was then
+   extracted as a phantom WL line. Fix: optional ``(?::\\d{2})?``.
+
+3. ``wl_text._GENERIC_FILLER`` — the ``betrieb\\s+ab.*`` alternation used a
+   greedy ``.*`` that swallowed every downstream token to end-of-string,
+   eating legitimate topic tokens. ``Sperre Betrieb ab Karlsplatz mit
+   Unfall`` collapsed to ``sperre`` (the ``unfall`` topic token was lost),
+   so two unrelated incidents that happen to share a "Betrieb ab ..."
+   preamble degenerated to the same ``topic_key`` and collided downstream
+   in the WL identity / dedup pipeline. Fix: ``\\s+\\S+`` (one location
+   word) instead of ``.*``.
+
+4. ``wl_fetch._stop_names_from_related`` (non-canonical fallback) used
+   ``\\s{2,}`` to collapse whitespace runs, so a single embedded ``\\n`` /
+   ``\\t`` in a relatedStops name survived into the RSS ``Haltestelle:``
+   description line verbatim, breaking the single-line render. Fix:
+   ``\\s+`` — matches the canonical shape of the sibling
+   ``_normalize_whitespace`` helper.
+"""
+
+from __future__ import annotations
+
+from src.providers.wl_fetch import _stop_names_from_related
+from src.providers.wl_lines import (
+    ADDRESS_NO_PRE_RE,
+    TIME_RE,
+    _detect_line_pairs_from_text,
+)
+from src.providers.wl_text import _topic_key_from_title
+
+
+# --------------------------------------------------------------------------
+# 1. ADDRESS_NO_PRE_RE — alpha suffix on the house number
+# --------------------------------------------------------------------------
+
+
+def test_address_pre_keyword_with_alpha_suffix_is_masked() -> None:
+    """``Stiege 12A``, ``Nr. 5B``, etc. must mask the WHOLE number+suffix."""
+    for raw in ("Stiege 12A", "Nr. 5B", "Tür 7", "Top 200a", "Hausnr. 3c"):
+        assert ADDRESS_NO_PRE_RE.search(raw), raw
+        # And ``_detect_line_pairs_from_text`` must not surface the suffix
+        # as a phantom WL line:
+        assert _detect_line_pairs_from_text(f"{raw} wegen Bauarbeiten") == [], raw
+
+
+def test_address_pre_bare_number_still_masked() -> None:
+    """The fix must not regress the original bare-number masking."""
+    for raw in ("Stiege 12", "Nr. 5", "Tür 7"):
+        assert _detect_line_pairs_from_text(f"{raw} wegen Bauarbeiten") == [], raw
+
+
+# --------------------------------------------------------------------------
+# 2. TIME_RE — optional seconds component
+# --------------------------------------------------------------------------
+
+
+def test_time_with_seconds_is_masked_fully() -> None:
+    """``HH:MM:SS`` must mask the WHOLE timestamp, not leave ``:SS``."""
+    masked = TIME_RE.sub(" ", "Sperre 17:30:45 Ausfall")
+    assert "45" not in masked, masked
+    assert _detect_line_pairs_from_text("Sperre 17:30:45 Ausfall") == []
+
+
+def test_time_without_seconds_still_masked() -> None:
+    """The fix must not regress the original ``HH:MM`` masking."""
+    assert _detect_line_pairs_from_text("Sperre 17:30 Ausfall") == []
+    assert _detect_line_pairs_from_text("U6 12:00 Verspätung") == [("U6", "U6")]
+
+
+def test_real_line_codes_after_time_still_detected() -> None:
+    """A real line code in a title with a timestamp must still extract."""
+    pairs = _detect_line_pairs_from_text("U6 verspätet ab 17:30:00 wegen Sperre")
+    assert ("U6", "U6") in pairs
+
+
+# --------------------------------------------------------------------------
+# 3. _GENERIC_FILLER — non-greedy 'Betrieb ab <Ort>' / 'Betrieb nur <Ort>'
+# --------------------------------------------------------------------------
+
+
+def test_topic_key_preserves_token_after_betrieb_ab() -> None:
+    """``Sperre Betrieb ab Karlsplatz mit Unfall`` -> ``sperre unfall``.
+
+    Pre-fix the greedy ``.*`` swallowed everything past "Betrieb ab" so
+    ``unfall`` was lost and the key collapsed to ``sperre``.
+    """
+    assert _topic_key_from_title(
+        "Sperre Betrieb ab Karlsplatz mit Unfall"
+    ) == "sperre unfall"
+
+
+def test_topic_key_preserves_token_after_betrieb_nur() -> None:
+    """Same fix for the sibling ``betrieb nur <Ort>`` alternation."""
+    assert _topic_key_from_title(
+        "Sperre Betrieb nur Karlsplatz mit Unfall"
+    ) == "sperre unfall"
+
+
+def test_topic_key_two_unrelated_betrieb_ab_titles_dont_collide() -> None:
+    """Two incidents sharing only a "Betrieb ab ..." preamble must produce
+    DIFFERENT topic keys (the pre-fix collision-cause)."""
+    k1 = _topic_key_from_title("Sperre Betrieb ab Karlsplatz mit Unfall")
+    k2 = _topic_key_from_title(
+        "Sperre Betrieb ab Karlsplatz wegen Demonstration"
+    )
+    assert k1 != k2, (
+        f"Two unrelated incidents collapsed to the same topic_key {k1!r} — "
+        f"would collide in the WL dedup / identity pipeline."
+    )
+
+
+def test_topic_key_without_betrieb_ab_is_unaffected() -> None:
+    """The fix must not change keys for titles that don't carry the phrase."""
+    assert _topic_key_from_title("Sperre wegen Unfall") == "sperre unfall"
+
+
+# --------------------------------------------------------------------------
+# 4. _stop_names_from_related — single-char whitespace runs
+# --------------------------------------------------------------------------
+
+
+def test_stop_name_with_embedded_newline_collapses_to_single_line() -> None:
+    """A lone ``\\n`` in a relatedStops name must collapse, not survive."""
+    nl = chr(10)
+    result = _stop_names_from_related([{"name": f"Karls{nl}platz"}])
+    assert result == ["Karls platz"], result
+
+
+def test_stop_name_with_embedded_tab_collapses_to_single_line() -> None:
+    """Same for a lone ``\\t``."""
+    tab = chr(9)
+    result = _stop_names_from_related([{"name": f"Stephans{tab}platz"}])
+    assert result == ["Stephans platz"], result
+
+
+def test_stop_name_with_normal_double_space_still_collapses() -> None:
+    """The original behaviour (collapse runs of >= 2 ws chars) must hold."""
+    result = _stop_names_from_related([{"name": "Karlsplatz  bei  Oper"}])
+    assert result == ["Karlsplatz bei Oper"], result


### PR DESCRIPTION
## Summary

Four narrow but real masking gaps in the WL text/line-detection paths, each surfacing as phantom line tokens, degraded dedup keys, or multi-line description rows in the rendered RSS feed. Each reproduced concretely before fixing. **PR 3 of the 6-PR audit series** (follows #1704 and #1705).

### 1. `src/providers/wl_lines.py` — `ADDRESS_NO_PRE_RE` alpha suffix  🟠 MED

The regex required `\d+\b`, so a house number with a letter suffix (`Stiege 12A`, `Nr. 5B`, `Top 200a`) escaped the address mask. The trailing alphanumeric was then picked up by `LINE_CODE_RE`'s `[0-9]{1,3}[A-Z]?` branch and surfaced as a phantom WL bus line.

```python
>>> _detect_line_pairs_from_text("Stiege 12A wegen Lift-Bauarbeiten")
[('12A', '12A')]   # phantom line — should be []
```

**Fix:** added optional `[A-Za-z]?`, mirroring the alpha-suffix already supported by the sibling `ADDRESS_NO_RE` numeric tail.

### 2. `src/providers/wl_lines.py` — `TIME_RE` seconds component  🟠 MED

The regex matched only `HH:MM`, so the `:SS` tail of an `HH:MM:SS` timestamp survived; the trailing 2-digit `SS` was then extracted as a phantom WL line.

```python
>>> _detect_line_pairs_from_text("Sperre 17:30:45 Ausfall")
[('45', '45')]   # phantom line from seconds — should be []
```

**Fix:** added optional `(?::\d{2})?` for the seconds component.

### 3. `src/providers/wl_text.py` — `_GENERIC_FILLER` greedy `betrieb ab.*`  🟠 MED

The `betrieb\s+ab.*` alternation (and sibling `betrieb\s+nur.*`) used a greedy `.*` that swallowed every downstream token to end-of-string, eating legitimate topic tokens. Two unrelated incidents sharing a "Betrieb ab ..." preamble degenerated to the **same** `topic_key` and collided downstream in the WL identity / dedup pipeline.

```python
>>> _topic_key_from_title("Sperre Betrieb ab Karlsplatz mit Unfall")
'sperre'   # the 'unfall' topic token was eaten — should be 'sperre unfall'
```

**Fix:** replaced `.*` with `\s+\S+` (one location word, matching what the upstream feed actually emits).

### 4. `src/providers/wl_fetch.py` — `_stop_names_from_related` whitespace  🟡 LOW

The non-canonical fallback at L310 used `\s{2,}` to collapse runs of whitespace, so a single embedded `\n`/`\t` in a relatedStops name survived into the RSS `Haltestelle:` description line verbatim and broke the single-line render.

```python
>>> _stop_names_from_related([{"name": "Karls\nplatz"}])
['Karls\nplatz']   # newline survives — should collapse to 'Karls platz'
```

**Fix:** switched to `\s+`, matching the canonical shape of the sibling `_normalize_whitespace` helper.

## Tests / verification

- New `tests/test_wl_masking_phantoms_and_topic_key.py` (**12 tests**) pins every fix, every legitimate case that must not regress (bare `HH:MM`, bare `Stiege 12`, real line codes after the masked region, topic keys without `Betrieb ab`), and the topic-key-collision invariant (two unrelated `Betrieb ab ...` incidents now produce different keys).
- **205 existing WL-related tests pass** (line/text/fetch/topic modules) — no regression.
- `ruff` + `mypy --strict` clean.
- No line-number shifts in `build_feed.py` / `hafas_client.py`, so the line-keyed sentinel allowlists are unaffected (PR2's bite won't repeat).

## Audit-series progress

- ✅ PR1 (#1704) — ReDoS hardening (2 HIGH) — merged
- ✅ PR2 (#1705) — renderer/cache guards (3 MED) — merged
- 🔄 PR3 (this) — WL text/line masking (3 MED + 1 LOW) — *open*
- ⏭️ PR4 — SSRF / places / stations · PR5 — Stammstrecke statemachine · PR6 — tooling + remaining lows

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_