### PR TITLE
fix(stammstrecke): persist episode start; guard double-finalise + midnight rollover

### DIFF
--- a/scripts/update_stammstrecke_status.py
+++ b/scripts/update_stammstrecke_status.py
@@ -1214,10 +1214,29 @@ def _leg_departure_delay_minutes(leg: Mapping[str, Any]) -> float | None:
     if not rt_time:
         return None
 
-    rt_date = origin.get("rtDate") or origin.get("rtDepDate") or sched_date
+    # ``rt_date_explicit`` captures whether VAO ITSELF supplied a real-
+    # time date (vs the ``sched_date`` fallback). The midnight-rollover
+    # heuristic below is only applied when it did NOT — otherwise the
+    # explicit date is authoritative and a same-day early departure is a
+    # legitimate small-magnitude negative delay we must record verbatim.
+    rt_date_explicit = origin.get("rtDate") or origin.get("rtDepDate")
+    rt_date = rt_date_explicit or sched_date
     actual = _parse_vao_dt(rt_date, rt_time)
     if actual is None:
         return None
+
+    # Midnight-rollover heuristic ported from the sibling
+    # :func:`update_stammstrecke_hbf._departure_delay_minutes`. Without
+    # an explicit ``rtDate``, ``actual`` defaults to ``sched_date``; a
+    # scheduled-at-23:55 leg with ``rtTime="00:05"`` therefore yields a
+    # same-day 00:05 ``actual`` and a meaningless ≈ −23h50m "delay"
+    # which then propagates verbatim into ``latest_delay_minutes`` and
+    # the downstream Stammstrecke aggregator. Bumping ``actual`` by one
+    # day when the computed delay is < −12 h reflects the true wall-
+    # clock difference. 12 h cleanly separates a legitimate small
+    # negative early departure from a midnight wrap.
+    if rt_date_explicit is None and (scheduled - actual) > timedelta(hours=12):
+        actual = actual + timedelta(days=1)
 
     return (actual - scheduled).total_seconds() / 60.0
 
@@ -1467,10 +1486,27 @@ def _finalize_departed(
     Mutates *state* (and, when supplied, *recently_finalised*) in place.
     """
 
+    # ``key not in recently_finalised`` guard: if the previous tick
+    # successfully wrote the recently-finalised ledger but then CRASHED
+    # before ``_save_pending_trips`` rewrote ``pending_trips.json``, the
+    # next load sees both files out of sync — the entry is already
+    # finalised on disk but still present in ``state``. Pre-fix we
+    # finalised it a SECOND time, producing a duplicate CSV row (and a
+    # second tally in the daily ``ausfaelle_*.csv``). The
+    # ``_observe_legs`` re-emission guard at the read path only protects
+    # against API-side re-emissions; it has no effect on entries already
+    # loaded from the un-updated ``pending_trips.json`` after a crash
+    # between the two ``atomic_write`` calls. Skipping here is the
+    # complete fix and matches the spirit of the docstring's "exactly
+    # once per trip" contract.
     finalize_keys = [
         key
         for key, trip in state.items()
-        if trip.direction == direction and trip.scheduled <= now
+        if (
+            trip.direction == direction
+            and trip.scheduled <= now
+            and (recently_finalised is None or key not in recently_finalised)
+        )
     ]
     finalize_keys.sort(key=lambda k: state[k].scheduled)
     finalised: list[_PendingTrip] = []

--- a/src/feed/stammstrecke.py
+++ b/src/feed/stammstrecke.py
@@ -32,15 +32,20 @@ Operational notes:
 """
 from __future__ import annotations
 
+import json as _json_lib
 import logging
 from collections import defaultdict
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from pathlib import Path
 from statistics import mean
 from typing import Any, Final
 from zoneinfo import ZoneInfo
 
+from src.utils.files import atomic_write, loads_finite, read_capped_text
 from src.utils.ids import make_guid
+from src.utils.logging import sanitize_log_arg
 from src.utils.stats import (
     StammstreckeObservation,
     read_recent_stammstrecke_observations,
@@ -49,6 +54,11 @@ from src.utils.stats import (
 LOGGER = logging.getLogger("feed.stammstrecke")
 
 VIENNA_TZ: Final = ZoneInfo("Europe/Vienna")
+
+# Repository root — for resolving the on-disk
+# ``cache/stammstrecke/episode_starts.json`` ledger. ``parents[2]``
+# walks ``stammstrecke.py`` → ``feed/`` → ``src/`` → repo root.
+_REPO_ROOT: Final = Path(__file__).resolve().parents[2]
 
 # Threshold and event-shape constants. Single source of truth — the
 # cron script no longer carries its own copy of these (it writes raw
@@ -103,6 +113,37 @@ FEED_WINDOW: Final = timedelta(hours=1)
 EPISODE_LOOKBACK: Final = timedelta(hours=6)
 EPISODE_GAP_TOLERANCE: Final = timedelta(minutes=70)
 
+# Path to the persisted episode-start ledger. One entry per direction
+# with a currently-active episode (``{direction.target_label: ISO
+# datetime}``). Wiped per-direction when the trigger gate no longer
+# fires for that direction (the episode has ended).
+#
+# Why this exists: ``_episode_start`` walks an at-most ``EPISODE_LOOKBACK``-
+# wide observation window backwards through above-threshold rows. For an
+# episode that has lasted longer than the lookback (6 h), the oldest row
+# still inside the window is the window edge — NOT the true episode start.
+# As the lookback window slides forward each build cycle the returned
+# ``episode_start`` advances with it, which in turn drifts the derived
+# ``first_seen`` / ``guid`` / ``_identity`` (all derived from
+# ``iso_first_seen`` in ``_build_event``), so every cycle the build-feed
+# state lookup misses the prior entry, ``first_seen`` is reset to ``now``,
+# and the disruption re-publishes as brand-new (FIFO retirement on age can
+# never fire either). Persisting the FIRST observed episode start across
+# cycles pins ``iso_first_seen`` regardless of how much later the lookback
+# window slides — exactly the same first-observation-wins semantics
+# ``build_feed`` already uses for ``data/first_seen.json``.
+EPISODE_STARTS_PATH: Final = (
+    _REPO_ROOT / "cache" / "stammstrecke" / "episode_starts.json"
+)
+
+# Defence-in-depth byte cap on the persisted episode-start ledger. The
+# canonical happy-path payload is two ISO-8601 timestamps keyed by short
+# direction labels (~200 bytes); 256 KiB is ~1000× that, generous for any
+# future schema widening yet small enough to bound a planted / corrupt
+# file. Matches the size-cap convention of the sibling
+# ``RECENTLY_FINALISED_MAX_BYTES`` in the cron script.
+EPISODE_STARTS_MAX_BYTES: Final = 256 * 1024
+
 
 @dataclass(frozen=True)
 class _Direction:
@@ -149,6 +190,113 @@ DIRECTIONS_BY_LABEL: Final[dict[str, _Direction]] = {
         for legacy_label, canonical_label in _LEGACY_DIRECTION_ALIAS.items()
     },
 }
+
+
+def _coerce_aware(value: datetime) -> datetime:
+    """Force *value* to be timezone-aware in :data:`VIENNA_TZ`.
+
+    Mirrors the helper of the same name in the cron script: naive
+    datetimes can appear when a hand-edited state file omits the offset;
+    rather than rejecting the entry we localise it defensively so the
+    rest of the persisted state survives.
+    """
+    if value.tzinfo is None:
+        return value.replace(tzinfo=VIENNA_TZ)
+    return value
+
+
+def _load_episode_starts(path: Path) -> dict[str, datetime]:
+    """Read the persisted-episode-start ledger from *path*.
+
+    Schema: ``{direction.target_label: iso-8601-timestamp}``. Returns an
+    empty dict on missing / oversize / unparseable input — the WARNING log
+    line distinguishes a silent fresh-start (no file yet, e.g. first run
+    after deploy) from a corrupt-file recovery.
+
+    Mirrors the read-side defence shape of ``_load_recently_finalised`` in
+    ``scripts/update_stammstrecke_status.py`` (Round 1503 sibling): a
+    poisoned ``cache/stammstrecke/episode_starts.json`` would otherwise
+    land ``float('nan')`` in a timestamp slot and silently round-trip back
+    through the writer.
+    """
+    raw = read_capped_text(
+        path,
+        max_bytes=EPISODE_STARTS_MAX_BYTES,
+        label="episode starts",
+        logger=LOGGER,
+    )
+    if raw is None or not raw.strip():
+        return {}
+    try:
+        payload = loads_finite(raw)
+    except (ValueError, RecursionError) as exc:
+        LOGGER.warning(
+            "Episode-Starts-Ledger korrupt (%s) — starte mit leerem Set.",
+            sanitize_log_arg(str(exc)),
+        )
+        return {}
+    if not isinstance(payload, Mapping):
+        LOGGER.warning(
+            "Episode-Starts-Ledger hat unerwartetes Top-Level-Format — "
+            "starte mit leerem Set."
+        )
+        return {}
+    out: dict[str, datetime] = {}
+    for key, value in payload.items():
+        if not isinstance(value, str):
+            continue
+        try:
+            ts = datetime.fromisoformat(value)
+        except ValueError:
+            continue
+        out[str(key)] = _coerce_aware(ts)
+    return out
+
+
+def _save_episode_starts(path: Path, starts: Mapping[str, datetime]) -> bool:
+    """Persist *starts* atomically; best-effort.
+
+    Returns ``True`` on success, ``False`` if the write failed (and was
+    logged at WARNING). Losing one cycle's update is safe — the affected
+    directions keep their previous persisted start on next load, which is
+    the desired fallback shape (one drifted ``first_seen`` value on a
+    rare crash beats every value drifting every cycle).
+
+    Security: same Trojan-Source / Non-Finite-Literal threat model as the
+    sibling ``_save_pending_trips`` / ``_save_recently_finalised`` in the
+    cron script — committed to ``main`` via ``update-cycle.yml``'s
+    auto-commit step, rendered through ``cat`` / ``less`` / the GitHub
+    web UI. Keys are short hardcoded direction labels (ASCII), but the
+    ``ensure_ascii=True`` pin keeps the file shape uniform with its
+    siblings so a future schema widening cannot regress half of the
+    round-trip invariant. ``allow_nan=False`` is the writer-side dual of
+    the ``loads_finite`` hook in ``_load_episode_starts`` above.
+    """
+    payload = {key: ts.isoformat() for key, ts in starts.items()}
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with atomic_write(
+            path,
+            mode="w",
+            encoding="utf-8",
+            permissions=0o644,
+        ) as fh:
+            _json_lib.dump(
+                payload,
+                fh,
+                indent=2,
+                sort_keys=True,
+                ensure_ascii=True,
+                allow_nan=False,
+            )
+            fh.write("\n")
+        return True
+    except OSError as exc:
+        LOGGER.warning(
+            "Episode-Starts-Ledger konnte nicht geschrieben werden: %s",
+            sanitize_log_arg(str(exc)),
+        )
+        return False
 
 
 def _format_minutes(value: float) -> str:
@@ -271,6 +419,7 @@ def compute_stammstrecke_events(
     now: datetime | None = None,
     feed_window: timedelta = FEED_WINDOW,
     episode_lookback: timedelta = EPISODE_LOOKBACK,
+    episode_starts_path: Path | None = None,
 ) -> list[dict[str, Any]]:
     """Read the CSV ledger, fold it into 0..N feed events.
 
@@ -285,14 +434,34 @@ def compute_stammstrecke_events(
     item is the *mean* of all in-window observations — see the module-
     level note on the trigger / display split.
 
+    ``episode_start`` persistence: the per-direction start is loaded
+    from / persisted to *episode_starts_path* (default
+    :data:`EPISODE_STARTS_PATH`). The persisted value pins the
+    rendered ``[Seit DD.MM.YYYY]`` label, the GUID and the
+    ``_identity`` across feed builds so an episode lasting longer than
+    :data:`EPISODE_LOOKBACK` does not drift its identity every cycle —
+    pre-fix the sliding lookback window advanced the returned start
+    once an episode aged past 6 h, making the build-feed state lookup
+    miss the prior entry every cycle and re-publishing the disruption
+    as brand-new. When the trigger gate STOPS firing for a direction
+    the persisted entry is cleared (episode ended). Pass a custom
+    *episode_starts_path* in tests.
+
     Used by :func:`src.feed.providers.read_cache_stammstrecke` as the
     canonical entry point.
     """
     current = now if now is not None else datetime.now(VIENNA_TZ)
+    starts_path = episode_starts_path or EPISODE_STARTS_PATH
+    persisted_starts = _load_episode_starts(starts_path)
     observations = read_recent_stammstrecke_observations(
         now=current, window=episode_lookback
     )
     if not observations:
+        # No data at all → keep the persisted state untouched. A silent
+        # window with no rows is NOT evidence that an active episode has
+        # ended (it may just mean the cron hasn't written yet); clearing
+        # here would forfeit the persisted ``first_seen`` for every
+        # currently-active episode on every empty cycle.
         return []
     # Bucket observations by their *canonical* direction label so a CSV
     # row that still carries the legacy ``"Floridsdorf"`` value (from a
@@ -318,12 +487,15 @@ def compute_stammstrecke_events(
     # Process directions in registry order so two simultaneous events
     # surface in a stable order across feed builds.
     for direction in DIRECTIONS:
-        direction_obs = by_direction.get(direction.target_label)
-        if not direction_obs:
-            continue
-        recent = [obs for obs in direction_obs if obs.timestamp >= feed_window_start]
-        if not recent:
-            continue
+        # ``direction_obs`` defaults to ``[]`` so the trigger-gate-failed
+        # branch below treats "direction has no observations at all"
+        # identically to "direction has rows older than feed_window" —
+        # both signal the episode is not currently active and the
+        # persisted entry should be cleared.
+        direction_obs = by_direction.get(direction.target_label, [])
+        recent = [
+            obs for obs in direction_obs if obs.timestamp >= feed_window_start
+        ]
         # Trigger gate: an episode may only start when
         # ``TRIGGER_CONSECUTIVE_COUNT`` (2) *consecutive* in-window
         # observations each carry a delay strictly greater than the
@@ -332,17 +504,38 @@ def compute_stammstrecke_events(
         # does not fire. The displayed value is the *mean* of all
         # in-window observations (easier for end users to interpret).
         # See module docstring "Window lengths".
-        if not _has_consecutive_exceedance(recent):
+        if not recent or not _has_consecutive_exceedance(recent):
+            # Trigger no longer fires for this direction → the episode
+            # has ended. Drop any persisted start so the NEXT episode
+            # (after EPISODE_GAP_TOLERANCE has elapsed and a fresh trigger
+            # fires) starts with a fresh ``first_seen`` / GUID instead of
+            # inheriting the previous disruption's identity.
+            persisted_starts.pop(direction.target_label, None)
             continue
         avg_delay = mean([obs.delay_minutes for obs in recent])
-        episode_start = _episode_start(direction_obs=direction_obs, now=current)
-        if episode_start is None:
+        computed_start = _episode_start(direction_obs=direction_obs, now=current)
+        if computed_start is None:
             # Degenerate case: ``_episode_start`` returned None despite
             # the threshold gate firing. Should be unreachable (the recent
             # subset feeds the same threshold gate), but rather than
             # raise we fall back to the earliest row in *recent* —
             # which is at most ``feed_window`` old.
-            episode_start = min(obs.timestamp for obs in recent)
+            computed_start = min(obs.timestamp for obs in recent)
+        # Persisted-start state machine: a value persisted on a prior
+        # cycle wins as long as it's still EARLIER than what the current
+        # 6 h lookback yields — that's exactly the case the window-drift
+        # bug fires (episode older than EPISODE_LOOKBACK → ``computed_start``
+        # has advanced past the persisted true start). If the persisted
+        # value is somehow LATER than the computed (out-of-order ledger
+        # writes, hand edit) we trust the earlier of the two. The first
+        # cycle of a fresh episode has no persisted entry and just pins
+        # ``computed_start``.
+        persisted = persisted_starts.get(direction.target_label)
+        if persisted is not None and persisted <= computed_start:
+            episode_start = persisted
+        else:
+            episode_start = computed_start
+            persisted_starts[direction.target_label] = episode_start
         events.append(
             _build_event(
                 direction=direction,
@@ -351,6 +544,12 @@ def compute_stammstrecke_events(
                 episode_start=episode_start,
             )
         )
+    # Best-effort persistence: failure is logged inside ``_save_episode_starts``
+    # and falls through silently — losing one cycle's update means the
+    # affected directions keep their previous persisted start on next load,
+    # which is the desired fallback shape (one drifted ``first_seen`` value
+    # on a rare crash beats every value drifting every cycle).
+    _save_episode_starts(starts_path, persisted_starts)
     return events
 
 

--- a/tests/test_stammstrecke_statemachine.py
+++ b/tests/test_stammstrecke_statemachine.py
@@ -1,0 +1,302 @@
+"""Regression tests for the Stammstrecke statemachine PR (PR5).
+
+Three findings in one themed PR:
+
+1. HIGH — ``src/feed/stammstrecke.py::_episode_start`` 6h-window-drift:
+   ``compute_stammstrecke_events`` reads observations with
+   ``window=episode_lookback`` (6h); for an episode older than that, the
+   oldest in-window above-threshold row IS the window edge, NOT the true
+   start. As the window slides each build cycle the returned
+   ``episode_start`` advances → ``iso_first_seen`` / GUID / ``_identity``
+   drift → ``data/first_seen.json`` lookup misses every cycle →
+   ``first_seen`` reset to ``now`` and the disruption republishes as
+   brand-new (FIFO retirement on age never fires either).
+
+   Fix: persist the per-direction episode start to
+   ``cache/stammstrecke/episode_starts.json``; on subsequent cycles the
+   persisted value pins the rendered identity. Cleared per-direction when
+   the trigger gate no longer fires (the episode ended). The first cycle
+   after deploy still uses the window-edge value (no historical state to
+   recover); subsequent cycles are stable.
+
+2. MED — ``scripts/update_stammstrecke_status.py::_finalize_departed``
+   double-finalise after crash. Reachable LIVE via
+   ``update_stammstrecke_hbf`` which imports and calls this helper. If a
+   prior tick wrote ``recently_finalised.json`` but crashed before
+   ``_save_pending_trips``, the next load finalises the entry a SECOND
+   time, producing a duplicate CSV row. Fix: skip entries that are
+   already in ``recently_finalised``.
+
+3. LOW — ``scripts/update_stammstrecke_status.py::_leg_departure_delay_minutes``
+   midnight-rollover. Without an explicit ``rtDate``, an ``rtTime`` that
+   crosses midnight relative to ``schedule`` (sched 23:55, rtTime 00:05)
+   produced ≈ −1430 minutes. Fix ports the heuristic already in the
+   sibling ``update_stammstrecke_hbf._departure_delay_minutes``.
+"""
+
+from __future__ import annotations
+
+import csv
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from scripts.update_stammstrecke_status import (
+    _PendingTrip,
+    _finalize_departed,
+    _leg_departure_delay_minutes,
+)
+from src.feed import stammstrecke as sm
+from src.utils.stats import (
+    STAMMSTRECKE_HEADER,
+    read_recent_stammstrecke_observations,
+    stats_path,
+)
+
+VIENNA_TZ = ZoneInfo("Europe/Vienna")
+
+
+# ---------------------------------------------------------------------------
+# 1. HIGH — persisted episode-start state machine
+# ---------------------------------------------------------------------------
+
+
+def _write_obs_ledger(
+    tmp_dir: Path,
+    *,
+    year: int,
+    rows: list[tuple[datetime, str, float]],
+) -> None:
+    """Seed a stammstrecke CSV with (timestamp, direction, delay) rows."""
+    ledger = stats_path("stammstrecke", year, base_dir=tmp_dir)
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    with ledger.open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=STAMMSTRECKE_HEADER)
+        writer.writeheader()
+        for ts, direction, delay in rows:
+            writer.writerow(
+                {
+                    "timestamp": ts.isoformat(),
+                    "weekday": "Sa",
+                    "hour": ts.hour,
+                    "direction": direction,
+                    "delay_minutes": f"{delay:.1f}",
+                }
+            )
+
+
+def _patched_compute(
+    *, now: datetime, stats_dir: Path, starts_path: Path
+) -> list[dict[str, Any]]:
+    """Run ``compute_stammstrecke_events`` reading observations from *stats_dir*."""
+
+    def reader(*, now: datetime, window: timedelta) -> list[Any]:
+        return read_recent_stammstrecke_observations(
+            now=now, window=window, stats_dir=stats_dir
+        )
+
+    with patch.object(sm, "read_recent_stammstrecke_observations", reader):
+        return sm.compute_stammstrecke_events(
+            now=now, episode_starts_path=starts_path
+        )
+
+
+def test_episode_identity_stays_stable_when_lookback_window_slides_past_start(
+    tmp_path: Path,
+) -> None:
+    """The HIGH bug: 9 h of continuous above-threshold observations, 3 build
+    cycles 1 h apart. Pre-fix the GUID/first_seen drifted with the sliding
+    lookback. Post-fix they MUST be byte-identical across the three cycles.
+    """
+    base = datetime(2026, 5, 30, 2, 0, tzinfo=VIENNA_TZ)
+    rows = [
+        (base + timedelta(minutes=30 * i), "Praterstern", 10.0) for i in range(18)
+    ]
+    _write_obs_ledger(tmp_path, year=2026, rows=rows)
+    starts_path = tmp_path / "episode_starts.json"
+
+    cycles = []
+    for hour in (9, 10, 11):
+        cycles.append(
+            _patched_compute(
+                now=datetime(2026, 5, 30, hour, 0, tzinfo=VIENNA_TZ),
+                stats_dir=tmp_path,
+                starts_path=starts_path,
+            )
+        )
+
+    assert all(len(c) == 1 for c in cycles), "trigger gate must fire each cycle"
+    guids = [c[0]["guid"] for c in cycles]
+    first_seens = [c[0]["first_seen"] for c in cycles]
+    assert guids[0] == guids[1] == guids[2], f"GUID drifted: {guids}"
+    assert first_seens[0] == first_seens[1] == first_seens[2], (
+        f"first_seen drifted: {first_seens}"
+    )
+
+    # And the persisted ledger has captured the start so the NEXT process
+    # restart still finds it.
+    assert starts_path.exists()
+    loaded = sm._load_episode_starts(starts_path)
+    assert "Praterstern" in loaded
+
+
+def test_persisted_start_is_cleared_when_episode_ends(tmp_path: Path) -> None:
+    """Trigger gate stops firing → the persisted entry must be wiped so the
+    NEXT episode (after EPISODE_GAP_TOLERANCE) gets a fresh first_seen."""
+    # Two old above-threshold rows, then NOTHING in the feed window.
+    base = datetime(2026, 5, 30, 2, 0, tzinfo=VIENNA_TZ)
+    _write_obs_ledger(
+        tmp_path,
+        year=2026,
+        rows=[
+            (base, "Praterstern", 10.0),
+            (base + timedelta(minutes=30), "Praterstern", 10.0),
+        ],
+    )
+    starts_path = tmp_path / "episode_starts.json"
+
+    # Cycle 1 at 03:00: both rows are in the 1h feed window, gate fires.
+    cycle1 = _patched_compute(
+        now=datetime(2026, 5, 30, 3, 0, tzinfo=VIENNA_TZ),
+        stats_dir=tmp_path,
+        starts_path=starts_path,
+    )
+    assert len(cycle1) == 1
+    assert "Praterstern" in sm._load_episode_starts(starts_path)
+
+    # Cycle 2 at 05:00: rows fall outside the 1h feed window, gate fails →
+    # persisted entry must be cleared.
+    cycle2 = _patched_compute(
+        now=datetime(2026, 5, 30, 5, 0, tzinfo=VIENNA_TZ),
+        stats_dir=tmp_path,
+        starts_path=starts_path,
+    )
+    assert cycle2 == []
+    assert "Praterstern" not in sm._load_episode_starts(starts_path)
+
+
+def test_load_save_round_trip_preserves_timezone(tmp_path: Path) -> None:
+    """A persisted aware datetime must round-trip without losing its offset."""
+    path = tmp_path / "episode_starts.json"
+    original = {"Praterstern": datetime(2026, 5, 28, 21, 0, tzinfo=VIENNA_TZ)}
+    sm._save_episode_starts(path, original)
+    loaded = sm._load_episode_starts(path)
+    assert loaded["Praterstern"] == original["Praterstern"]
+    assert loaded["Praterstern"].tzinfo is not None
+
+
+def test_load_returns_empty_for_missing_or_corrupt_file(tmp_path: Path) -> None:
+    """Missing / unparseable / wrong-shape input must yield ``{}`` (safe restart)."""
+    missing = tmp_path / "nope.json"
+    assert sm._load_episode_starts(missing) == {}
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{not json")
+    assert sm._load_episode_starts(corrupt) == {}
+    wrong_shape = tmp_path / "wrong.json"
+    wrong_shape.write_text('[1, 2, 3]')
+    assert sm._load_episode_starts(wrong_shape) == {}
+
+
+# ---------------------------------------------------------------------------
+# 2. MED — _finalize_departed double-finalise guard
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_departed_skips_entry_already_in_recently_finalised() -> None:
+    """A previously-finalised entry must NOT be re-finalised (the crash-
+    between-saves trap)."""
+    now = datetime(2026, 5, 30, 10, 5, tzinfo=VIENNA_TZ)
+    sched = datetime(2026, 5, 30, 10, 0, tzinfo=VIENNA_TZ)
+    key = "Meidling|S2|2026-05-30T10:00:00+02:00"
+    state = {key: _PendingTrip("Meidling", "S2", sched, 3.0, sched)}
+    recently_finalised = {key: sched}  # ledger from a prior crashed tick
+
+    result = _finalize_departed(
+        state,
+        direction="Meidling",
+        now=now,
+        recently_finalised=recently_finalised,
+    )
+    assert result == [], (
+        "Entry was finalised twice — would produce a duplicate CSV row."
+    )
+
+
+def test_finalize_departed_still_finalises_fresh_trips() -> None:
+    """The new guard must not over-suppress: a fresh trip still finalises."""
+    now = datetime(2026, 5, 30, 10, 5, tzinfo=VIENNA_TZ)
+    sched = datetime(2026, 5, 30, 10, 0, tzinfo=VIENNA_TZ)
+    key = "Meidling|S2|2026-05-30T10:00:00+02:00"
+    state = {key: _PendingTrip("Meidling", "S2", sched, 3.0, sched)}
+    recently_finalised: dict[str, datetime] = {}
+
+    result = _finalize_departed(
+        state,
+        direction="Meidling",
+        now=now,
+        recently_finalised=recently_finalised,
+    )
+    assert len(result) == 1
+    # And the ledger was updated.
+    assert key in recently_finalised
+
+
+def test_finalize_departed_no_ledger_argument_is_unchanged() -> None:
+    """When called without a ``recently_finalised`` arg, behaviour is unchanged."""
+    now = datetime(2026, 5, 30, 10, 5, tzinfo=VIENNA_TZ)
+    sched = datetime(2026, 5, 30, 10, 0, tzinfo=VIENNA_TZ)
+    key = "Meidling|S2|2026-05-30T10:00:00+02:00"
+    state = {key: _PendingTrip("Meidling", "S2", sched, 3.0, sched)}
+    result = _finalize_departed(state, direction="Meidling", now=now)
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. LOW — _leg_departure_delay_minutes midnight rollover
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "leg, expected_minutes",
+    [
+        # Without an explicit rtDate, an rtTime that crosses midnight is
+        # the bug — pre-fix yielded ≈ -1430.0 (same-day arithmetic).
+        (
+            {"Origin": {"date": "2026-01-01", "time": "23:55", "rtTime": "00:05"}},
+            10.0,
+        ),
+        # Earlier-than-scheduled by a few minutes, NO explicit rtDate:
+        # legitimate negative delay, must NOT trigger the heuristic.
+        (
+            {"Origin": {"date": "2026-01-01", "time": "12:00", "rtTime": "11:55"}},
+            -5.0,
+        ),
+        # Explicit rtDate matches sched_date → authoritative, even a -23h59
+        # "delay" must be recorded verbatim (operator data, not a wrap).
+        (
+            {
+                "Origin": {
+                    "date": "2026-01-01",
+                    "time": "23:55",
+                    "rtDate": "2026-01-01",
+                    "rtTime": "00:05",
+                }
+            },
+            -23 * 60 - 50.0,
+        ),
+        # On-time same-day, sanity baseline.
+        (
+            {"Origin": {"date": "2026-01-01", "time": "12:00", "rtTime": "12:00"}},
+            0.0,
+        ),
+    ],
+)
+def test_leg_departure_delay_minutes_midnight_heuristic(
+    leg: dict[str, Any], expected_minutes: float
+) -> None:
+    actual = _leg_departure_delay_minutes(leg)
+    assert actual == pytest.approx(expected_minutes)


### PR DESCRIPTION
## Summary

Three findings in the Stammstrecke statemachine, one themed PR. **PR 5 of the audit series** (follows #1704/#1705/#1706/#1707). This is the architecturally significant one — it adds a persisted state ledger.

### 1. 🔴 HIGH — `src/feed/stammstrecke.py`: episode-start drift → `first_seen` churn

`compute_stammstrecke_events` reads observations in an `EPISODE_LOOKBACK` (6 h) window, and `_episode_start` walks that window backwards to find the episode start. **For an episode older than 6 h, the oldest in-window above-threshold row *is* the window edge, not the true start.** As the window slides forward each ~30–60 min build cycle, the returned start advances with it → `iso_first_seen` / `guid` / `_identity` (all derived from it in `_build_event`) drift every cycle. `build_feed`'s `first_seen` state lookup then misses the prior entry every cycle → `first_seen` reset to `now` → the disruption **re-publishes as brand-new every cycle** and the age-based FIFO retirement can never fire. Same `first_seen`-churn class as #1703, in the Stammstrecke episode logic — and it bites exactly the *sustained major disruptions* the feed matters most for.

**Verified end-to-end** (pre-fix → post-fix): 9 h of continuous above-threshold observations, 3 build cycles 1 h apart. Post-fix the GUID and `first_seen` are **byte-identical** across the 2 h window-slide (pre-fix they all differed).

**Fix (persisted episode start — the chosen design):** a new `cache/stammstrecke/episode_starts.json` ledger (`{direction: ISO start}`) pins the *first observed* start across cycles — first-observation-wins, the same semantics `build_feed` already uses for `data/first_seen.json`. The persisted value wins while it's `<=` the window-computed start (the drift case); it's **cleared per-direction the moment the trigger gate stops firing** (episode ended), so the next episode gets a fresh identity. New `_load_episode_starts` / `_save_episode_starts` mirror the canonical state-sink shape of the sibling `_save_recently_finalised` (`atomic_write`, `ensure_ascii=True`, `allow_nan=False`, `loads_finite` read-side, byte-cap, naive→Vienna coercion). An empty observation cycle leaves the ledger untouched (a silent window is not evidence an episode ended).

**One-time migration:** the first build after deploy has no persisted ledger, so each currently-active episode pins its start at whatever the 6 h window yields that cycle (a one-time `first_seen` refresh for any episode already older than 6 h). Every subsequent cycle is stable.

### 2. 🟠 MED — `scripts/update_stammstrecke_status.py`: `_finalize_departed` double-finalise

Reachable **live** (`update_stammstrecke_hbf` imports and calls it). If a tick wrote `recently_finalised.json` but crashed before `_save_pending_trips`, the next load finalises the entry a **second time** → duplicate CSV row (and double tally in `ausfaelle_*.csv`). Fix: skip entries already in `recently_finalised`.

### 3. 🟡 LOW — `_leg_departure_delay_minutes` midnight rollover

Without an explicit `rtDate`, an `rtTime` crossing midnight vs the schedule (sched `23:55`, rtTime `00:05`) produced ≈ −1430 min. Ported the +1-day heuristic already present in the sibling `hbf._departure_delay_minutes`. (status.py is no longer the live cron path, but the fix keeps the two delay calculators consistent.)

## Tests / verification

- New `tests/test_stammstrecke_statemachine.py` (**11 tests**): the end-to-end 3-cycle / 2 h-window-slide proof (guid + `first_seen` byte-identical), episode-end clear, load/save round-trip + corrupt-file recovery, the double-finalise guard (+ fresh-trip / no-ledger control cases), and the midnight heuristic parametrisation (incl. the explicit-`rtDate`-is-authoritative case).
- **Full suite: 8706 passed, 2 skipped, 0 failed.**
- `ruff` + `mypy --strict` clean.
- The `allow_nan` writer-audit sentinel stays green — the new `_save_episode_starts` pins `allow_nan=False`.

https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEzxhKAm6YGy8RTnuAVuhJ)_