### PR TITLE
fix(audit): close 8 correctness/security findings from line-by-line review

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ ignore = [
 "scripts/run_static_checks.py" = ["S603"]
 "scripts/update_all_stations.py" = ["S603"]
 "scripts/update_station_directory.py" = ["S603"]
+# Spawns a real ``git`` process to build throwaway repos for the sitemap
+# lastmod regression. Static ``["git", *args]`` arg list, never user input.
+# A file-specific ignore is version-robust (ruff 0.4.x vs newer anchor the
+# S603 range to different lines, so an inline ``# noqa`` cannot satisfy both).
+"tests/scripts/test_generate_sitemap_lastmod.py" = ["S603", "S607"]
 "tests/**/*.py" = [
   "S101", "S113", "S314", "S105", "S108", "S110", "S310", "F841",
   # bugbear rules deliberately allowed in tests:

--- a/scripts/fetch_google_places_stations.py
+++ b/scripts/fetch_google_places_stations.py
@@ -368,7 +368,11 @@ def _write_if_changed(path: Path, stations: Sequence[Mapping[str, object]]) -> N
             LOGGER.info("Stations file already up-to-date")
             return
     path.parent.mkdir(parents=True, exist_ok=True)
-    if not payload.strip():
+    if not serialisable:
+        # ``payload`` is always a non-empty JSON document (at minimum
+        # ``{"stations": []}``), so the previous ``payload.strip()`` guard
+        # could never fire. Check the actual station list instead so a
+        # genuinely empty result cannot clobber a previously committed file.
         LOGGER.warning("Refusing to write empty stations payload to %s", path)
         return
 

--- a/scripts/update_baustellen_cache.py
+++ b/scripts/update_baustellen_cache.py
@@ -34,7 +34,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from src.feed.logging_safe import setup_script_logging  # noqa: E402
 from src.providers.baustellen import is_transit_relevant, oepnv_lead  # noqa: E402
-from utils.cache import write_cache  # noqa: E402
+from utils.cache import DataDegradationError, write_cache  # noqa: E402
 from utils.files import loads_finite, read_capped_json  # noqa: E402
 from utils.http import fetch_content_safe, session_with_retries, validate_http_url  # noqa: E402
 from utils.ids import make_guid  # noqa: E402
@@ -903,7 +903,22 @@ def main() -> int:
             "Cache wird NICHT überschrieben, gepinnter Snapshot bleibt aktiv."
         )
         return 1
-    write_cache("baustellen", relevant)
+    try:
+        write_cache("baustellen", relevant)
+    except DataDegradationError:
+        # ``write_cache`` refuses not only *empty* but also *drastically
+        # smaller* payloads (< 20 % of the existing cache). The bundled
+        # fallback sample holds only a couple of features, so when the live
+        # WFS fetch fails against a populated production cache the write would
+        # raise — and this is exactly the scenario the fallback exists for.
+        # Treat it like the empty-payload guard above: keep the pinned
+        # snapshot, surface a non-zero exit, never crash the cron step.
+        LOGGER.warning(
+            "Baustellen: Schreiben würde den Cache drastisch degradieren "
+            "(%d Eintrag/Einträge) – gepinnter Snapshot bleibt aktiv.",
+            len(relevant),
+        )
+        return 1
     if used_fallback:
         # Exit 2 = "degraded": the cache was written from the bundled
         # fallback sample, NOT a live fetch. The cron wrapper maps any

--- a/src/feed/logging_safe.py
+++ b/src/feed/logging_safe.py
@@ -153,6 +153,13 @@ class SafeFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         record = logging.makeLogRecord(record.__dict__)
+        # Security: a foreign (non-Safe) handler on the same logger may have
+        # already formatted this record and cached an UNSANITISED traceback in
+        # ``record.exc_text``. ``logging.Formatter.format`` reuses that cache
+        # verbatim instead of calling our sanitising ``formatException``, so a
+        # copied-in ``exc_text`` would leak raw secrets straight to the sink.
+        # Drop the cache so ``formatException`` (which redacts) always re-runs.
+        record.exc_text = None
         original_msg = record.getMessage()
         sanitized_msg = sanitize_log_message(original_msg)
         record.msg = sanitized_msg
@@ -244,7 +251,15 @@ class SafeJSONFormatter(logging.Formatter):
         # logging framework wraps formatter exceptions in noisy stderr
         # output that would mask the original log call entirely.
         try:
-            dumped = json.dumps(safe_payload, ensure_ascii=False, allow_nan=False)
+            # ``default=str`` keeps the formatter's never-raise contract for
+            # non-JSON-serialisable ``extra`` values (e.g. ``datetime`` —
+            # extremely common). Without it ``json.dumps`` raises ``TypeError``
+            # (NOT caught by the ``except ValueError`` below), Python's logging
+            # framework swallows it via ``handleError`` and the whole record is
+            # silently dropped.
+            dumped = json.dumps(
+                safe_payload, ensure_ascii=False, allow_nan=False, default=str
+            )
         except ValueError:
             # Final fallback for the pathological-bypass case (custom
             # Mapping subclass / non-list iterable that the walker did
@@ -260,6 +275,7 @@ class SafeJSONFormatter(logging.Formatter):
                 ensure_ascii=False,
                 allow_nan=False,
                 cls=_FallbackJSONEncoder,
+                default=str,
             )
         sanitized = sanitize_log_message(dumped, strip_control_chars=False)
         return sanitized.replace("\n", "\\n").replace("\r", "\\r")

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -719,9 +719,13 @@ def load_request_count(bypass_cache: bool = False) -> tuple[str | None, int]:
     today_local = datetime.now(vienna_tz).strftime("%Y-%m-%d")
 
     if not bypass_cache and _QUOTA_CACHE["date"] == today_local:
-        # If we have a cached value for today, it might be stale but it's a lower bound.
-        # However, for accurate reading we fall through to file.
-        return (today_local, _QUOTA_CACHE["count"])
+        # Return the full in-memory usage. ``count`` only holds the last
+        # *flushed* total; live reservations accumulate in ``unsaved_delta``
+        # between batch flushes. Every other read site (the disk path below
+        # and ``save_request_count``) sums both, so the cache-hit path must
+        # too — otherwise it under-reports usage by up to one flush batch and
+        # defeats the ``_charge_one_request`` pre-flight quota check.
+        return (today_local, cast(int, _QUOTA_CACHE["count"] + _QUOTA_CACHE.get("unsaved_delta", 0)))
 
     # Security: ``read_capped_json`` enforces a TOCTOU-safe 1 MiB cap and
     # returns ``None`` for missing / oversized / depth-bombed / corrupt

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -302,7 +302,7 @@ def sanitize_log_message(
         # subject_assertion, jwt_assertion, etc.
         r"[a-z0-9_.\-]{0,64}assertion[a-z0-9_.\-]{0,64}|"
         r"saml[-_.\s]*request|saml[-_.\s]*response|"
-        r"[a-z0-9_.\-]{0,64}accessid[a-z0-9_.\-]{0,64}|id[-_.\s]*token|[a-z0-9_.\-]{0,64}session[-_.\s]*id[a-z0-9_.\-]{0,64}|session|cookie|[a-z0-9_.\-]{0,64}apikey[a-z0-9_.\-]{0,64}|[a-z0-9_.\-]{0,64}secret[a-z0-9_.\-]{0,64}|ticket|[a-z0-9_.\-]{0,64}token|code|key|sig|sid|"
+        r"[a-z0-9_.\-]{0,64}access[-_.\s]*id[a-z0-9_.\-]{0,64}|id[-_.\s]*token|[a-z0-9_.\-]{0,64}session[-_.\s]*id[a-z0-9_.\-]{0,64}|session|cookie|[a-z0-9_.\-]{0,64}apikey[a-z0-9_.\-]{0,64}|[a-z0-9_.\-]{0,64}secret[a-z0-9_.\-]{0,64}|ticket|[a-z0-9_.\-]{0,64}token|code|key|sig|sid|"
         r"nonce|state|"
         # Security (sibling-drift closure of PR #1531's
         # ``_SENSITIVE_QUERY_KEYS`` SAML/CSRF/WordPress round):
@@ -351,7 +351,7 @@ def sanitize_log_message(
         # alternations. Suffixed variants (``X-CSRF-Token``,
         # ``X-XSRF-TOKEN``) are already covered via ``token``.
         r"samlart|csrf|xsrf|"
-        r"credential|client[-_.\s]*id|passphrase|access[-_.\s]*key|e[-_.\s]*mail"
+        r"credential|client[-_.\s]*id|passphrase|access[-_.\s]*key|access[-_.\s]*id|e[-_.\s]*mail"
     )
 
     # Common patterns for secrets in URLs/Headers

--- a/src/utils/stats.py
+++ b/src/utils/stats.py
@@ -728,6 +728,14 @@ def _parse_stammstrecke_row(row: dict[str, str]) -> StammstreckeObservation | No
         delay = float(raw_delay)
     except ValueError:
         return None
+    if not math.isfinite(delay):
+        # Reader-side non-finite floor — symmetric with the writer guard in
+        # ``append_stammstrecke_row``. ``float("nan")`` / ``float("inf")`` /
+        # ``float("1e400")`` parse without raising and would otherwise be
+        # re-accepted verbatim, silently poisoning every downstream
+        # mean/threshold aggregation (the exact threat the writer docstring
+        # warns about). Drop the row rather than propagate a poison value.
+        return None
     return StammstreckeObservation(
         timestamp=ts, direction=raw_dir, delay_minutes=delay
     )

--- a/tests/scripts/test_generate_sitemap_lastmod.py
+++ b/tests/scripts/test_generate_sitemap_lastmod.py
@@ -24,8 +24,8 @@ def _git(repo: Path, *args: str, committer_date: str | None = None) -> None:
     if committer_date is not None:
         env["GIT_COMMITTER_DATE"] = committer_date
         env["GIT_AUTHOR_DATE"] = committer_date
-    subprocess.run(
-        ["git", *args],  # noqa: S603, S607
+    subprocess.run(  # noqa: S603
+        ["git", *args],  # noqa: S607
         cwd=repo,
         check=True,
         capture_output=True,

--- a/tests/scripts/test_generate_sitemap_lastmod.py
+++ b/tests/scripts/test_generate_sitemap_lastmod.py
@@ -24,8 +24,8 @@ def _git(repo: Path, *args: str, committer_date: str | None = None) -> None:
     if committer_date is not None:
         env["GIT_COMMITTER_DATE"] = committer_date
         env["GIT_AUTHOR_DATE"] = committer_date
-    subprocess.run(  # noqa: S603
-        ["git", *args],  # noqa: S607
+    subprocess.run(
+        ["git", *args],
         cwd=repo,
         check=True,
         capture_output=True,

--- a/tests/test_audit_regression_fixes.py
+++ b/tests/test_audit_regression_fixes.py
@@ -65,7 +65,9 @@ def test_safe_json_formatter_handles_datetime_extra() -> None:
 
     formatter = logging_safe.SafeJSONFormatter()
     record = logging.LogRecord("t", logging.INFO, __file__, 1, "hello", (), None)
-    record.when = datetime(2026, 1, 1, 12, 0, 0)  # type: ignore[attr-defined]
+    # Inject a datetime ``extra`` the way the logging framework would; the
+    # formatter reads it back from ``record.__dict__``.
+    record.__dict__["when"] = datetime(2026, 1, 1, 12, 0, 0)
     out = formatter.format(record)
     payload = json.loads(out)
     assert payload["message"] == "hello"
@@ -160,13 +162,18 @@ def test_baustellen_main_survives_data_degradation(
 ) -> None:
     from scripts import update_baustellen_cache
 
+    # Import the original class definition from the SAME module the script
+    # uses (``utils.cache`` once the script has put ``src`` on sys.path).
+    # Under CI's ``PYTHONPATH=src`` ``utils.cache`` and ``src.utils.cache`` are
+    # distinct module objects with distinct ``DataDegradationError`` classes,
+    # so the raised type must match the one the script's ``except`` references.
+    from utils.cache import DataDegradationError
+
     def fake_fetch_remote(url: str, timeout: int) -> None:
         return None
 
     def degrading_write_cache(provider: str, items: list[dict[str, Any]]) -> None:
-        # Use the exact class the script's ``except`` clause references so the
-        # handler matches regardless of the src/ vs scripts/ import path.
-        raise update_baustellen_cache.DataDegradationError("degraded payload rejected")
+        raise DataDegradationError("degraded payload rejected")
 
     monkeypatch.setattr(update_baustellen_cache, "_fetch_remote", fake_fetch_remote)
     monkeypatch.setattr(update_baustellen_cache, "write_cache", degrading_write_cache)

--- a/tests/test_audit_regression_fixes.py
+++ b/tests/test_audit_regression_fixes.py
@@ -1,0 +1,187 @@
+"""Regression tests for bugs found during the line-by-line audit (2026-05-30).
+
+Each test pins one specific defect that was fixed in the same change set so a
+future refactor cannot silently reintroduce it. The fixes span four modules:
+
+* ``src/utils/stats.py``           — reader-side non-finite floor
+* ``src/feed/logging_safe.py``     — datetime ``extra`` + cached ``exc_text``
+* ``src/utils/logging.py``         — ``access_id`` / ``access-id`` masking
+* ``src/providers/vor.py``         — quota cache must include ``unsaved_delta``
+* ``scripts/update_baustellen_cache.py`` — degraded fallback must not crash
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pytest
+
+SAMPLE_PATH = (
+    Path(__file__).resolve().parents[1] / "data" / "samples" / "baustellen_sample.geojson"
+)
+
+
+# ---------------------------------------------------------------------------
+# src/utils/stats.py — CSV reader must reject non-finite delays, symmetric
+# with the writer's ``math.isfinite`` floor in ``append_stammstrecke_row``.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("token", ["nan", "inf", "-inf", "1e400", "Infinity", "NaN"])
+def test_parse_stammstrecke_row_rejects_non_finite(token: str) -> None:
+    from src.utils import stats
+
+    row = {
+        "timestamp": "2026-05-30T12:00:00+02:00",
+        "direction": "S1",
+        "delay_minutes": token,
+    }
+    assert stats._parse_stammstrecke_row(row) is None
+
+
+def test_parse_stammstrecke_row_accepts_finite() -> None:
+    from src.utils import stats
+
+    row = {
+        "timestamp": "2026-05-30T12:00:00+02:00",
+        "direction": "S1",
+        "delay_minutes": "3.5",
+    }
+    obs = stats._parse_stammstrecke_row(row)
+    assert obs is not None
+    assert obs.delay_minutes == 3.5
+
+
+# ---------------------------------------------------------------------------
+# src/feed/logging_safe.py — a ``datetime`` (or any non-JSON-serialisable
+# object) in ``extra`` must not raise / drop the record.
+# ---------------------------------------------------------------------------
+def test_safe_json_formatter_handles_datetime_extra() -> None:
+    from src.feed import logging_safe
+
+    formatter = logging_safe.SafeJSONFormatter()
+    record = logging.LogRecord("t", logging.INFO, __file__, 1, "hello", (), None)
+    record.when = datetime(2026, 1, 1, 12, 0, 0)  # type: ignore[attr-defined]
+    out = formatter.format(record)
+    payload = json.loads(out)
+    assert payload["message"] == "hello"
+    assert "2026-01-01" in payload["extra"]["when"]
+
+
+# ---------------------------------------------------------------------------
+# src/feed/logging_safe.py — a foreign handler that caches an unsanitised
+# traceback in ``record.exc_text`` must not leak it through SafeFormatter.
+# ---------------------------------------------------------------------------
+def test_safe_formatter_does_not_leak_cached_exc_text() -> None:
+    from src.feed import logging_safe
+
+    secret = "ghp_ABCDEFGHIJKLMNOP1234567890abcdefXX"
+    log = logging.getLogger("audit_regression_exc_text")
+    log.setLevel(logging.ERROR)
+    log.handlers.clear()
+    log.propagate = False
+
+    plain_buf = io.StringIO()
+    plain = logging.StreamHandler(plain_buf)
+    plain.setFormatter(logging.Formatter("%(message)s"))
+
+    safe_buf = io.StringIO()
+    safe = logging.StreamHandler(safe_buf)
+    safe.setFormatter(logging_safe.SafeFormatter("%(message)s"))
+
+    # Order matters: the plain handler formats first and caches the raw
+    # traceback on the shared record; the Safe handler runs afterwards.
+    log.addHandler(plain)
+    log.addHandler(safe)
+    try:
+        try:
+            raise ValueError(f"token={secret}")
+        except ValueError:
+            log.error("boom", exc_info=True)
+        assert secret not in safe_buf.getvalue()
+    finally:
+        log.handlers.clear()
+
+
+# ---------------------------------------------------------------------------
+# src/utils/logging.py — the project's own VOR credential key name
+# (``access_id`` / ``access-id``) must be masked, not just camelCase
+# ``accessid`` / ``accessId``.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "line",
+    [
+        "access_id=SUPERSECRETVALUE123",
+        "access-id=SUPERSECRETVALUE123",
+        "accessid=SUPERSECRETVALUE123",
+        "access_id: SUPERSECRETVALUE123",
+    ],
+)
+def test_sanitize_masks_access_id_variants(line: str) -> None:
+    from src.utils import logging as ul
+
+    assert "SUPERSECRETVALUE123" not in ul.sanitize_log_message(line)
+
+
+# ---------------------------------------------------------------------------
+# src/providers/vor.py — the cache-hit read path must add the live
+# ``unsaved_delta`` to the flushed ``count`` (matches the disk path and
+# ``save_request_count``), otherwise it under-reports usage by up to one
+# flush batch and defeats the ``_charge_one_request`` pre-flight check.
+# ---------------------------------------------------------------------------
+def test_load_request_count_cache_includes_unsaved_delta(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.providers import vor
+
+    today = datetime.now(ZoneInfo("Europe/Vienna")).strftime("%Y-%m-%d")
+    monkeypatch.setitem(vor._QUOTA_CACHE, "date", today)
+    monkeypatch.setitem(vor._QUOTA_CACHE, "count", 5)
+    monkeypatch.setitem(vor._QUOTA_CACHE, "unsaved_delta", 3)
+
+    stored_date, count = vor.load_request_count()
+
+    assert stored_date == today
+    assert count == 8  # 5 flushed + 3 pending — not 5
+
+
+# ---------------------------------------------------------------------------
+# scripts/update_baustellen_cache.py — when the fallback payload is
+# drastically smaller than the existing cache, ``write_cache`` raises
+# ``DataDegradationError``; ``main()`` must catch it (keep the pinned
+# snapshot, exit non-zero) instead of crashing the cron step.
+# ---------------------------------------------------------------------------
+def test_baustellen_main_survives_data_degradation(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    from scripts import update_baustellen_cache
+
+    def fake_fetch_remote(url: str, timeout: int) -> None:
+        return None
+
+    def degrading_write_cache(provider: str, items: list[dict[str, Any]]) -> None:
+        # Use the exact class the script's ``except`` clause references so the
+        # handler matches regardless of the src/ vs scripts/ import path.
+        raise update_baustellen_cache.DataDegradationError("degraded payload rejected")
+
+    monkeypatch.setattr(update_baustellen_cache, "_fetch_remote", fake_fetch_remote)
+    monkeypatch.setattr(update_baustellen_cache, "write_cache", degrading_write_cache)
+    monkeypatch.setattr(
+        update_baustellen_cache, "_log_endpoint_diagnostic", lambda *a, **k: None
+    )
+    monkeypatch.setenv("BAUSTELLEN_FALLBACK_PATH", str(SAMPLE_PATH))
+    caplog.set_level(logging.WARNING, logger="update_baustellen_cache")
+
+    # Must return 1 (degraded, snapshot kept) rather than raising.
+    exit_code = update_baustellen_cache.main()
+
+    assert exit_code == 1
+    assert any(
+        "degrad" in record.getMessage().lower()
+        for record in caplog.records
+        if record.name == "update_baustellen_cache"
+    )

--- a/tests/test_sentinel_trojan_source_audit_walker.py
+++ b/tests/test_sentinel_trojan_source_audit_walker.py
@@ -134,8 +134,8 @@ ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
         # strip_control_chars=False)`` always strips the canonical
         # attack-byte union via ``_INVISIBLE_DANGEROUS_RE.sub("",
         # sanitized)`` post-serialisation.
-        ("src/feed/logging_safe.py", 247),
-        ("src/feed/logging_safe.py", 258),
+        ("src/feed/logging_safe.py", 260),
+        ("src/feed/logging_safe.py", 273),
     }
 )
 
@@ -636,7 +636,7 @@ def test_allowlist_is_minimal_and_documented() -> None:
         {
             ("src/places/hafas_client.py", 289),
             ("src/feed/reporting.py", 846),
-            ("src/feed/logging_safe.py", 247),
-            ("src/feed/logging_safe.py", 258),
+            ("src/feed/logging_safe.py", 260),
+            ("src/feed/logging_safe.py", 273),
         }
     )


### PR DESCRIPTION
## Was ist das?

Ergebnis eines **zeilenweisen Audits** von `src/` (~31.6 kLOC) und `scripts/` (~17.9 kLOC) durch 18 parallele Review-Agents. Jeder Fund wurde anschließend von Hand am echten Code (teils empirisch durch Ausführung) verifiziert. Dieser PR behebt die **8 klaren, risikoarmen, hochwertigen** Funde; jeder ist durch einen Regressionstest in `tests/test_audit_regression_fixes.py` abgedeckt.

**Tests:** komplette Suite grün — `8737 passed, 2 skipped`. `ruff check` (ganzes Repo) ist jetzt grün (war vorher **rot**, s. #8).

## Behobene Funde

| # | Sev | Datei | Bug | Verifikation |
|---|-----|-------|-----|--------------|
| 1 | High | `src/utils/stats.py` | `_parse_stammstrecke_row` akzeptierte `nan`/`inf`/`1e400` (`float()` wirft dort kein `ValueError`) → vergiftete jeden nachgelagerten Mittelwert/Schwellenwert. Writer hatte den `math.isfinite`-Schutz, der Reader nicht. | Reader gibt jetzt `None` für nicht-finite Werte zurück (symmetrisch zum Writer) |
| 2 | High | `src/feed/logging_safe.py` | `SafeFormatter` reichte gecachtes `record.exc_text` durch → ein fremder (Nicht-Safe) Handler konnte einen **unmaskierten Traceback** cachen, den `logging.Formatter` 1:1 wiederverwendet → Secret-Leak. | **Empirisch bestätigt** (roher `ghp_…`-Token im Output); Fix: `record.exc_text = None` |
| 3 | High | `scripts/update_baustellen_cache.py` | Ungefangener `DataDegradationError` um `write_cache`. `write_cache` lehnt drastisch kleinere Payloads ab (<20 %); das Fallback-Sample hat nur 2 Features → genau das WFS-Ausfall-Szenario, für das der Fallback existiert, **crasht den Cron-Step**. | Wird nun gefangen → exit 1, gepinnter Snapshot bleibt |
| 4 | Med | `src/feed/logging_safe.py` | `SafeJSONFormatter` fing nur `ValueError`; ein `datetime` in `extra={}` wirft aber `TypeError` → ganzer Log-Record verworfen. | **Empirisch bestätigt**; Fix: `default=str` |
| 5 | Med | `src/utils/logging.py` | `access_id` / `access-id` (die snake/kebab-Schreibweise der VOR/VAO-Credential) wurde **nicht** maskiert — nur das zusammenhängende `accessid`/`accessId`. | **Empirisch bestätigt**; Regex `accessid` → `access[-_.\s]*id`, plus Header-Keys |
| 6 | Med | `src/providers/vor.py` | `load_request_count` Cache-Hit gab `count` **ohne** `unsaved_delta` zurück — inkonsistent zum Platten-Pfad und `save_request_count`. Unterzählung bis zu einer Flush-Batch, hebelt die `_charge_one_request`-Vorprüfung aus. | Cache-Read summiert jetzt `count + unsaved_delta` |
| 7 | Med | `scripts/fetch_google_places_stations.py` | Toter Leer-Guard: `payload.strip()` ist nie leer (mind. `{"stations": []}`), der Anti-Clobber-Schutz konnte nie greifen. | Prüft jetzt die echte Stationsliste |
| 8 | Low | `tests/scripts/test_generate_sitemap_lastmod.py` | Falsch platziertes `# noqa` (auf der Args-Zeile; S603 verankert an der `subprocess.run`-Zeile) → `ruff check` über das ganze Repo war **rot** (pre-commit/Lint-Gate). | `ruff check` jetzt grün |

## Bewusst **nicht** als Bug gewertet (False Positives, Genauigkeit vor Masse)

- **8 mypy-Fehler in `src/utils/http.py`** (`Class cannot subclass … has type Any`): Sandbox-Artefakt — `reveal_type` zeigt, dass urllib3-Typen hier nicht aufgelöst werden, obwohl `py.typed` vorhanden ist. CI committet eine **leere** `.mypy-baseline.txt` via `regen_mypy_baseline.sh` ⇒ in CI 0 Fehler. Kein Code-Bug.
- **`config.py resolve_env_path` Fallback** gibt relativen `default` zurück, env-Pfad absoluten: durch `tests/test_resolve_env_path.py` **explizit gepinntes** by-design-Verhalten.

## Weitere Funde (gemeldet, hier **nicht** gefixt)

Diese erfordern Produkt-/Policy-Entscheidungen oder sind größere Eingriffe — bewusst aus diesem fokussierten PR herausgehalten. Auf Wunsch in Folge-PRs:

**Daten-Integrität (Skripte):**
- `update_station_directory.py` / `update_wl_stations.py`: kein Mindest-Stations-Floor vor `write_json` → trunkierter ÖBB-Workbook / leere/oversized CSV / unlesbare `stations.json` kann **stillschweigend alle Stationen löschen**.
- `apply_station_overrides.py`: Koordinaten-Overrides werden nicht typgeprüft (String-Koordinaten landen in `stations.json`); `wl_diva`-Remove entfernt nur den ersten Treffer.

**Logik / Semantik:**
- `src/feed/merge.py:550`: `"vor" in p1` matcht auch `"vor/vao"` (Stammstrecke-Quelle) → eine ÖBB-**Echtzeit**-Meldung kann von einem Stammstrecke-**Statistik**-Aggregat überschrieben werden. Seit der VOR-Konsolidierung gibt es keinen eigenen VOR-Provider mehr — **Prioritäts-Entscheidung nötig** (soll Stammstrecke Vorrang vor ÖBB haben?).
- `src/providers/wl_lines.py`: „Rufbus N…"-Token (`_tok`) divergiert vom Display (`_display_line`) → bricht Dedup-Bucket; `LINES_COMPLEX_PREFIX_RE` deckt „A, Rufbus B:" nicht ab → gestapeltes Titel-Präfix.
- `src/providers/wl_fetch.py`: `_INACTIVE_STATUS_RE` enthält bare `ende` → kann aktive Items mit „…am Ende…" verwerfen.

**Pfad-/Schreib-Sicherheit (Operator-Tools):**
- `configure_feed.py:198`: `--env-file` mit absolutem oder `..`-Pfad umgeht die Repo-Eingrenzung → beliebiger Datei-Write.
- `scaffold_provider_plugin.py:64`: `write_text` statt `atomic_write` + keine `validate_path`.
- diverse `--output`/`--target`-Argumente ohne `validate_path` (cli.py, sync_hafas_profile, extract_oebb_geonetz_stops, …).

**Robustheit (utils / Fundament — dormant/Defense-in-Depth):**
- `files.py atomic_write`: kein Parent-Dir-`fsync` nach `os.replace` (POSIX-Durability bei Stromausfall).
- `locking.py`: `KeyboardInterrupt`-Fenster zwischen `acquire()` und `thread_lock_held = True` → `threading.Lock` bleibt gehalten → Deadlock (Multithread).
- `serialize.py serialize_for_cache`: lässt `nan`/`inf` durch (Vertragsbruch).
- `secret_scanner.py`: bare `*` in `.secret-scan-ignore` deaktiviert **den ganzen Scanner** (Docstring behauptet das Gegenteil).
- `generate_sitemap.py` / `generate_llms_txt.py`: `main() -> None` ohne Exception-Handling → SEO-Guard-Workflow crasht hart.
- `stammstrecke`-Skripte: Quota-Erschöpfung (`_QuotaExceeded`) verschmutzt den Circuit-Breaker-Failure-Counter.
- `places/client.py`: `GooglePlacesConfig.radius_m` / `max_result_count` werden ignoriert (tote Config-Felder).
- `stations_validation.py`: Self-Collision-False-Positive für Einträge mit Quelle `oebb,vor`.
- `text.py`: HTML-Truncation kann Grapheme-Cluster zerschneiden; Entity-Zählung/Tag-Closing-Edge.

> Hinweis: viele Module wurden **als sauber bestätigt** (`build_feed.py`, `http.py` SSRF-Kern, `circuit_breaker.py`, `places/*` Geo/Quota, die `stammstrecke`-Producer u. a.).

https://claude.ai/code/session_0156MPgicCwNN2QRqL7nKQoj

---
_Generated by [Claude Code](https://claude.ai/code/session_0156MPgicCwNN2QRqL7nKQoj)_