### PR TITLE
fix(stations): WL data-loss floor + VOR/ÖBB self-collision false positive

### DIFF
--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -1615,19 +1615,6 @@ def merge_into_stations(
     *,
     reconcile: Callable[[list[dict[str, object]]], None] | None = None,
 ) -> None:
-    # Data-loss floor: with no WL entries the merge below strips every
-    # existing ``source == "wl"`` station and writes the remainder back,
-    # silently deleting the entire Wiener-Linien layer from stations.json.
-    # An empty set only happens when the OGD CSVs failed to load/parse
-    # (oversized → ``read_capped_text`` returned ``None``, download error,
-    # format change). Refuse and keep the committed file untouched.
-    if not wl_entries:
-        log.error(
-            "merge_into_stations called with no WL entries — refusing to "
-            "overwrite stations [path-sha256=%s] (would delete every WL station).",
-            _path_fingerprint(stations_path),
-        )
-        return
     # Security: ``read_capped_json`` enforces both the depth-bomb catch
     # tuple and the byte-size cap (see MAX_JSON_FILE_BYTES). The
     # depth-bomb-only catch missed ``MemoryError`` (a ``BaseException``
@@ -1704,6 +1691,22 @@ def merge_into_stations(
                 wl_diva_index[key] = entry
 
     log.info("Keeping %d existing non-WL stations", len(filtered))
+
+    # Data-loss floor: with no WL entries to re-add, writing ``filtered``
+    # back would permanently drop every existing ``source == "wl"`` station.
+    # An empty set only happens when the OGD CSV load failed (oversized →
+    # ``read_capped_text`` returned ``None``, download/format error), so
+    # refuse and keep the committed file. A genuinely empty or unreadable
+    # existing file has no WL rows to lose (``len(filtered) == len(existing)``),
+    # so the depth-bomb / fresh-start path still writes through.
+    if not wl_entries and len(filtered) < len(existing):
+        log.error(
+            "No WL entries to merge but %d existing WL station(s) would be "
+            "deleted — refusing to overwrite stations [path-sha256=%s].",
+            len(existing) - len(filtered),
+            _path_fingerprint(stations_path),
+        )
+        return
 
     unmatched: list[dict[str, object]] = []
     for payload in wl_entries:

--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -1615,6 +1615,19 @@ def merge_into_stations(
     *,
     reconcile: Callable[[list[dict[str, object]]], None] | None = None,
 ) -> None:
+    # Data-loss floor: with no WL entries the merge below strips every
+    # existing ``source == "wl"`` station and writes the remainder back,
+    # silently deleting the entire Wiener-Linien layer from stations.json.
+    # An empty set only happens when the OGD CSVs failed to load/parse
+    # (oversized → ``read_capped_text`` returned ``None``, download error,
+    # format change). Refuse and keep the committed file untouched.
+    if not wl_entries:
+        log.error(
+            "merge_into_stations called with no WL entries — refusing to "
+            "overwrite stations [path-sha256=%s] (would delete every WL station).",
+            _path_fingerprint(stations_path),
+        )
+        return
     # Security: ``read_capped_json`` enforces both the depth-bomb catch
     # tuple and the byte-size cap (see MAX_JSON_FILE_BYTES). The
     # depth-bomb-only catch missed ``MemoryError`` (a ``BaseException``
@@ -1801,6 +1814,17 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     wl_entries = build_wl_entries(haltestellen, haltepunkte, vor_mapping)
     log.info("Prepared %d WL station entries", len(wl_entries))
+
+    # Abort before the costly reconcile + merge if the OGD load produced
+    # nothing — merge_into_stations would otherwise wipe the WL layer.
+    if not wl_entries:
+        log.error(
+            "No WL station entries were built (haltestellen=%d, haltepunkte=%d) — "
+            "aborting to protect data/stations.json from WL-layer deletion.",
+            len(haltestellen),
+            len(haltepunkte),
+        )
+        return 1
 
     # Drop mislabelled stop names that resolve to a far-away station (an
     # upstream WL DIVA-grouping artefact). Without this a stop sitting at

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -1048,6 +1048,12 @@ def _find_provider_issues(
                 )
 
     for entry in vor_entries:
+        # A station sourced from BOTH ``oebb`` and ``vor`` already contributed
+        # its own ``bst_code`` to ``oebb_codes`` above, so an ``in oebb_codes``
+        # test would flag it as colliding with itself. It IS the OEBB entry,
+        # not a distinct VOR-only station, so skip the cross-provider check.
+        if "oebb" in _extract_source_tokens(entry.get("source")):
+            continue
         bst_code = entry.get("bst_code")
         # Same type-guard as the OEBB-side ``oebb_codes.add`` above: a
         # malformed list / dict ``bst_code`` would otherwise raise

--- a/tests/test_stations_validation_provider.py
+++ b/tests/test_stations_validation_provider.py
@@ -162,6 +162,24 @@ def test_vor_bst_code_collides_with_oebb(tmp_path: Path) -> None:
     assert "VOR bst_code collides with OEBB" in reasons
 
 
+def test_dual_source_oebb_vor_entry_does_not_self_collide(tmp_path: Path) -> None:
+    """A station sourced from BOTH ``oebb`` and ``vor`` must not be flagged as
+    colliding with itself.
+
+    Such an entry contributes its own ``bst_code`` to the OEBB code set, so the
+    cross-provider collision check would otherwise match it against itself and
+    emit a spurious ``VOR bst_code collides with OEBB`` issue.
+    """
+    path = tmp_path / "stations.json"
+    dual = _vor_entry("900100", "Dual")
+    dual["source"] = "oebb,vor"
+    _write(path, [dual, _vor_entry("900200", "VOR-only", lat=48.3)])
+    report = validate_stations(path)
+    reasons = [issue.reason for issue in report.provider_issues]
+    assert "VOR bst_code collides with OEBB" not in reasons
+    assert report.provider_issues == ()
+
+
 def test_source_string_with_spaces_is_parsed(tmp_path: Path) -> None:
     """`source: 'google_places, vor, wl'` (with whitespace after commas) must be recognised as VOR.
 

--- a/tests/test_update_wl_stations_merge.py
+++ b/tests/test_update_wl_stations_merge.py
@@ -270,6 +270,32 @@ def _read_entries(path: Path) -> list[dict[str, object]]:
     return cast(list[dict[str, object]], data)
 
 
+def test_merge_into_stations_refuses_to_delete_wl_on_empty_entries(
+    stations_path: Path,
+) -> None:
+    """Empty ``wl_entries`` must NOT strip existing WL stations (data-loss floor).
+
+    An empty entry set only happens when the OGD CSV load failed; the merge
+    must keep the committed file rather than silently wipe the WL layer.
+    """
+    stations_path.write_text(
+        json.dumps(
+            [
+                {"name": "Karlsplatz", "wl_diva": "60201076", "source": "wl"},
+                {"name": "Wien Hbf", "bst_id": "900100", "source": "oebb"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    update_wl_stations.merge_into_stations(stations_path, [])
+
+    merged = _read_entries(stations_path)
+    # Both entries preserved — the WL station was not deleted.
+    assert len(merged) == 2
+    assert {e.get("source") for e in merged} == {"wl", "oebb"}
+
+
 def test_merge_wl_data_into_existing_vor_entry(stations_path: Path) -> None:
     stations_path.write_text(
         json.dumps(


### PR DESCRIPTION
## Was ist das?

Folge-PR zum zeilenweisen Audit (#1710). Zwei weitere **genuine** Funde auf dem Stations-Datenintegritäts-Pfad — verifiziert mit den **CI-exakten** Tool-Versionen (ruff 0.4.10, mypy 1.10, pytest unter `PYTHONPATH=src`).

## Fixes

### 1. `update_wl_stations.py` — stiller WL-Datenverlust [High]
`merge_into_stations` filtert erst alle bestehenden `source == "wl"`-Stationen heraus und hängt dann `wl_entries` an. Bei **leeren** `wl_entries` (OGD-CSV-Load fehlgeschlagen: oversized → `read_capped_text` → `None`, Download-/Formatfehler) wird der Rest zurückgeschrieben — **die gesamte Wiener-Linien-Schicht aus `data/stations.json` verschwindet lautlos**, ohne Exception, ohne Fehler-Exit.

**Fix:** Guard in `merge_into_stations` (Datenschutz für alle Aufrufer — schreibt nicht, behält die committe Datei) **und** in `main()` (Fehler-Exit `1` + spart den teuren Reconcile-Schritt).

### 2. `stations_validation.py` — Self-Collision-False-Positive [Medium]
Ein Eintrag mit `source = "oebb,vor"` landet in `vor_entries` **und** fügt seinen eigenen `bst_code` zu `oebb_codes` hinzu → die Cross-Provider-Kollisionsprüfung matcht ihn gegen sich selbst → falsche Meldung `VOR bst_code collides with OEBB`. Dormant auf aktuellen Daten, aber das Quell-Vokabular enthält bereits `oebb` und `vor`, und 6-Token-Merges existieren.

**Fix:** Einträge, die **auch** `oebb`-Quelle sind, in der Kollisionsschleife überspringen (sie *sind* der OEBB-Eintrag, keine separate kollidierende VOR-only-Station).

## Verifikation (CI-exakt)
- `ruff 0.4.10` (CI-Pin) — All checks passed
- `mypy 1.10.1` (CI-Pin) `src tests` — 0 Fehler
- pytest unter `PYTHONPATH=src`: 80 Tests (Orchestrator + alle Stations-/Validierungs-Tests) grün, inkl. zwei neuer Regressionstests. Echte Cross-Station-Kollisionen und das reale `data/stations.json` validieren weiterhin sauber.

## Bewusst NICHT aufgenommen (verifiziert)
Beim Durchgehen weiterer Audit-Funde stellten sich einige als **Edge-Cases / bewusste Trade-offs** heraus (keine Bugs):
- `wl_fetch.py` `\bende\b` — der Wortgrenzen-Match ist **absichtlich** so (matcht Status-Wert „ende", nicht `laufende`/`Wochenende`); test-gepinnt.
- `locking.py` KI-Race — der naheliegende Einzeiler schließt das CALL→STORE-Bytecode-Fenster nicht vollständig; echte Lösung wäre invasiver, Wert gering.
- `serialize_for_cache` Non-Finite — verschiebt nur einen ohnehin auftretenden Crash (kein Datenverlust, da `allow_nan=False` greift).

## Noch offen (Folge-Arbeit / Entscheidungen)
- **`update_station_directory.py`** — gleiche Datenverlust-Klasse (kein ÖBB-Floor vor `write_json`); braucht ein **relatives** Floor-Design + Orchestrator-Test-Verifikation. Kandidat für den nächsten PR.
- **`merge.py:550`** — `"vor" in p1` matcht `"vor/vao"` (Stammstrecke); ob Stammstrecke Vorrang vor ÖBB-Echtzeit haben soll, ist eine **Produktentscheidung**.
- **Pfad-Policy** für Operator-Tools (`configure_feed --env-file`, `--output`-Args) — bewusste Design-Entscheidung nötig (Operator-Tools dürfen evtl. legitim beliebige Pfade schreiben).
- Diverse weitere Lows (secret_scanner bare-`*`-Footgun, WL-Rufbus-Parsing, atomic_write dir-fsync, …) — sammelbar in einem „lows"-Batch.

https://claude.ai/code/session_0156MPgicCwNN2QRqL7nKQoj

---
_Generated by [Claude Code](https://claude.ai/code/session_0156MPgicCwNN2QRqL7nKQoj)_