### PR TITLE
fix(merge): VOR/VAO (Stammstrecke) darf ÖBB-Meldungen nicht überschreiben

### DIFF
--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -542,14 +542,19 @@ def deduplicate_fuzzy(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 if _has_significant_overlap_cached(
                     norm_name, ex_norm_name, tokens, ex_tokens
                 ):
-                    # Provider Priority Logic
-                    # VOR > ÖBB. If one is VOR and other is ÖBB, we prioritize VOR.
+                    # Provider priority logic — legacy VOR disruption provider only.
+                    # The standalone VOR disruption provider (source == "vor") was
+                    # removed 2026-05-11. The only remaining "vor"-ish source is the
+                    # Stammstrecke delay monitor (source "VOR/VAO"): an INDIRECT,
+                    # derived signal that must NOT override real ÖBB / WL disruptions.
+                    # Match the provider name EXACTLY so "vor/vao" is excluded from
+                    # this priority and merges as a normal peer (ÖBB stays master).
                     p1 = (existing.get("provider") or existing.get("source") or "").lower()
                     p2 = (item.get("provider") or item.get("source") or "").lower()
 
-                    is_vor_existing = "vor" in p1
+                    is_vor_existing = p1 == "vor"
                     is_oebb_existing = "oebb" in p1 or "öbb" in p1
-                    is_vor_item = "vor" in p2
+                    is_vor_item = p2 == "vor"
                     is_oebb_item = "oebb" in p2 or "öbb" in p2
 
                     # Case 1: Existing is VOR, Item is ÖBB -> Keep Existing, merge ÖBB desc if useful

--- a/tests/test_fuzzy_merge_stopwords.py
+++ b/tests/test_fuzzy_merge_stopwords.py
@@ -92,5 +92,51 @@ def test_dedupe_fuzzy_still_merges_same_topic() -> None:
     ]
     result = deduplicate_fuzzy(items)
     assert len(result) == 1
-    # VOR record wins as master; ÖBB description appended only when substantive.
-    assert result[0].get("source") == "VOR/VAO"
+    # ÖBB (a real disruption) stays master. "VOR/VAO" is the Stammstrecke delay
+    # monitor — an INDIRECT, derived signal that must NOT override ÖBB / WL. It
+    # merges as a normal peer, so the ÖBB record wins and the VOR description is
+    # appended. (The legacy "VOR wins" rule applied only to the removed VOR
+    # disruption provider with source == "vor", never to "VOR/VAO".)
+    assert result[0].get("source") == "ÖBB"
+
+
+def test_stammstrecke_event_does_not_override_oebb() -> None:
+    """The Stammstrecke delay event must never override an ÖBB disruption.
+
+    Its fixed title ("S-Bahn Stammstrecke Verspätungen") carries no line prefix,
+    so it never reaches the line-overlap merge and stays a separate feed item.
+    Even a synthetic line-bearing "VOR/VAO" item merges as a peer with ÖBB as
+    master — it can no longer replace the ÖBB record (legacy footgun closed).
+    """
+    # 1) Realistic Stammstrecke event (no line tokens) + ÖBB → stay separate.
+    realistic = deduplicate_fuzzy(
+        [
+            {
+                "guid": "oebb-1", "_identity": "oebb|1", "source": "ÖBB",
+                "title": "S1, S2, S3: Störung Wien Mitte", "description": "ÖBB-Störung.",
+            },
+            {
+                "guid": "vor-1", "_identity": "vor|1", "source": "VOR/VAO",
+                "title": "S-Bahn Stammstrecke Verspätungen",
+                "description": "Durchschnittliche Verspätung von 11 Minuten.",
+            },
+        ]
+    )
+    assert len(realistic) == 2
+    assert {i.get("source") for i in realistic} == {"ÖBB", "VOR/VAO"}
+
+    # 2) Even a synthetic line-bearing VOR/VAO item does not replace ÖBB.
+    overlap = deduplicate_fuzzy(
+        [
+            {
+                "guid": "oebb-2", "_identity": "oebb|2", "source": "ÖBB",
+                "title": "S1: Signalstörung Floridsdorf", "description": "ÖBB-Meldung.",
+            },
+            {
+                "guid": "vor-2", "_identity": "vor|2", "source": "VOR/VAO",
+                "title": "S1: Signalstörung Floridsdorf", "description": "VOR-Detail.",
+            },
+        ]
+    )
+    assert len(overlap) == 1
+    assert overlap[0].get("source") == "ÖBB"  # ÖBB master — not overridden by VOR/VAO

--- a/tests/test_oebb_filter_audit.py
+++ b/tests/test_oebb_filter_audit.py
@@ -174,5 +174,8 @@ class TestLinePrefixWithSpace:
         ]
         result = deduplicate_fuzzy(items)
         assert len(result) == 1
-        # VOR wins as master per provider priority logic.
-        assert result[0]["source"] == "VOR/VAO"
+        # ÖBB (a real disruption) stays master. "VOR/VAO" (the Stammstrecke
+        # delay monitor) is an indirect signal that no longer overrides ÖBB —
+        # it merges as a normal peer. (The "VOR wins" rule applied only to the
+        # removed VOR disruption provider with source == "vor".)
+        assert result[0]["source"] == "ÖBB"


### PR DESCRIPTION
## Kontext

Architektur-Klarstellung: **VOR dient nur dem Stammstrecken-Monitoring** (Verspätungen/Ausfälle). **WL/ÖBB bilden den Feed**; VOR fließt **nur indirekt** über die Verspätungsregel (2 Züge >9 min in 1 h) als eigenes Item ein. Es darf reale ÖBB/WL-Meldungen **nicht überschreiben**.

## Problem

Die Merge-Prioritätslogik „VOR > ÖBB" matchte jede Quelle, die `"vor"` als **Substring** enthält — also auch die Stammstrecke-Quelle `"VOR/VAO"`. Der eigenständige VOR-Störungs-Provider wurde am 2026-05-11 entfernt; die einzige verbliebene „vor"-Quelle ist der Stammstrecke-Verspätungs-Monitor. Die Alt-Regel ließ damit ein abgeleitetes Verspätungs-Aggregat eine echte ÖBB-Meldung **ersetzen** (Case 2) — entgegen der Architektur.

## Fix

```diff
- is_vor_existing = "vor" in p1
- is_vor_item     = "vor" in p2
+ is_vor_existing = p1 == "vor"   # exakt → "vor/vao" ausgeschlossen
+ is_vor_item     = p2 == "vor"
```

`"VOR/VAO"` triggert die VOR-Priorität nicht mehr → bei Überlappung **Peer-Merge mit ÖBB als Master**. Der Legacy-`source=="vor"`-Provider (exakter Match) bleibt unverändert.

## Produktion bleibt unverändert

Das echte Stammstrecke-Event hat den **festen Titel** „S-Bahn Stammstrecke Verspätungen" **ohne Linien-Präfix** → es erreicht den Linien-Overlap-Merge nie und bleibt **immer ein eigenständiges Feed-Item** (empirisch bestätigt). Der Fix schließt nur den latenten Footgun (würde der Titel je ein Linien-Präfix bekommen, hätte Stammstrecke sonst ÖBB überschrieben).

## Tests
- Zwei Tests, die das obsolete „VOR gewinnt"-Verhalten festschrieben, auf **ÖBB-Master** aktualisiert (`test_dedupe_fuzzy_still_merges_same_topic`, `test_cross_provider_merge_works_with_space_prefix`).
- Regressionstest ergänzt: realer Stammstrecke-Titel bleibt **getrennt** von ÖBB; synthetischer Linien-Titel → **ÖBB-Master** (überschreibt nicht).
- Legacy-`vor`-Provider-Prioritätstests unverändert grün.

## Verifikation (CI-exakt)
- `ruff 0.4.10` ✓ · `mypy 1.10.1` (`src tests`) = 0 Fehler ✓
- volle pytest-Suite unter `PYTHONPATH=src`: grün (der einzige durch die Test-Updates betroffene Fall ist gefixt).

https://claude.ai/code/session_0156MPgicCwNN2QRqL7nKQoj

---
_Generated by [Claude Code](https://claude.ai/code/session_0156MPgicCwNN2QRqL7nKQoj)_