### PR TITLE
fix: station-directory data-loss floor + secret-scanner bare-* footgun

### DIFF
--- a/scripts/update_station_directory.py
+++ b/scripts/update_station_directory.py
@@ -2499,6 +2499,34 @@ def write_json(stations_list: list[dict[str, object]], output_path: Path) -> Non
     logger.info("Wrote [path-sha256=%s]", _path_fingerprint(output_path))
 
 
+# Refuse to overwrite a populated station directory with a drastically smaller
+# ÖBB set (truncated/corrupt workbook). 0.5 → block when the new ÖBB count drops
+# below half the existing; ÖBB station counts are very stable, so the false-
+# abort risk is negligible while a manual-only / near-empty result is caught.
+STATION_DIRECTORY_FLOOR_RATIO = 0.5
+
+
+def _station_directory_floor_violation(*, new_oebb: int, existing_oebb: int) -> str | None:
+    """Return a reason string when writing would lose ÖBB station data, else None.
+
+    A truncated or corrupt ÖBB workbook yields zero or very few ÖBB stations;
+    overwriting a populated ``data/stations.json`` with that set silently drops
+    the entire ÖBB layer (only the preserved manual entries survive). Mirrors
+    the ``write_cache`` degradation guard. A fresh/empty existing directory
+    (``existing_oebb == 0``) writes through — there is nothing to lose — but a
+    zero-ÖBB result is always rejected because a valid workbook always yields
+    stations.
+    """
+    if new_oebb == 0:
+        return "extract_stations produced 0 ÖBB stations (truncated/corrupt workbook?)"
+    if existing_oebb and new_oebb < existing_oebb * STATION_DIRECTORY_FLOOR_RATIO:
+        return (
+            f"{new_oebb} ÖBB stations is below {STATION_DIRECTORY_FLOOR_RATIO:.0%} "
+            f"of the existing {existing_oebb} (truncated/corrupt workbook?)"
+        )
+    return None
+
+
 def main() -> None:
     args = parse_args()
     configure_logging(args.verbose)
@@ -2646,6 +2674,19 @@ def main() -> None:
 
     final_stations = [station.as_dict() for station in stations]
     final_stations.extend(manual_stations)
+
+    # Data-loss floor: never replace a populated directory with a truncated ÖBB
+    # set (see _station_directory_floor_violation). Fails closed — the pinned
+    # committed file stays intact and the cron run surfaces a non-zero exit.
+    floor_violation = _station_directory_floor_violation(
+        new_oebb=len(stations), existing_oebb=len(existing_entries)
+    )
+    if floor_violation:
+        raise SystemExit(
+            "Refusing to overwrite station directory "
+            f"[path-sha256={_path_fingerprint(args.output)}]: {floor_violation}"
+        )
+
     write_json(final_stations, args.output)
 
 

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -231,7 +231,6 @@ _INVISIBLE_DANGEROUS_RE = re.compile(
     r"\U0001d173-\U0001d17a"
     r"\U000e0000-\U000e007f\U000e0100-\U000e01ef]"
 )
-_LOG_INJECTION_RE = re.compile(r"[\n\r\t]")
 # ANSI escape codes: comprehensive matching for CSI, OSC, Fe, and 2-byte sequences
 # Matches:
 # 1. CSI: ESC [ ...

--- a/src/utils/secret_scanner.py
+++ b/src/utils/secret_scanner.py
@@ -2947,10 +2947,10 @@ def _should_ignore(path: Path, patterns: Sequence[str], base_dir: Path) -> bool:
       (``src/leak.py`` matches only that file).
     * A pattern without ``/`` matches the basename (``*.env`` matches
       every ``.env`` at any depth, in line with operator expectation).
-    * Bare ``*`` no longer matches everything because ``fnmatch``'s
-      ``*`` does NOT cross ``/`` boundaries when applied to the full
-      path, and at the basename layer it only matches files in the
-      repo root with no dot in the name.
+    * A bare ``*`` / ``**`` pattern (only asterisks, optionally wrapped in
+      whitespace) is explicitly REFUSED: it would match every basename and
+      silently disable the entire scanner — the precise ignore-list footgun
+      this matcher guards against. Such a pattern is skipped, never honoured.
 
     The behaviour is closer to ``gitignore`` than the previous
     ``PurePath.match`` and never silently drops the scanner's coverage.
@@ -2962,6 +2962,11 @@ def _should_ignore(path: Path, patterns: Sequence[str], base_dir: Path) -> bool:
     rel_str = relative.as_posix()
     rel_name = relative.name
     for pattern in patterns:
+        # Security: refuse a bare "*"/"**" (only asterisks, possibly wrapped in
+        # whitespace). fnmatch("*") matches every basename, so honouring it
+        # would silently disable the whole scanner — the ignore-list footgun.
+        if not pattern.strip().strip("*"):
+            continue
         if "/" in pattern:
             if fnmatch.fnmatch(rel_str, pattern):
                 return True

--- a/tests/test_tooling_and_remaining_lows.py
+++ b/tests/test_tooling_and_remaining_lows.py
@@ -156,6 +156,21 @@ def test_should_ignore_with_basename_pattern_matches_at_any_depth(
     assert _should_ignore(nested, ["*.env"], tmp_path)
 
 
+def test_should_ignore_refuses_bare_star(tmp_path: Path) -> None:
+    """A bare ``*`` / ``**`` must NOT disable the whole scanner (ignore footgun)."""
+    from src.utils.secret_scanner import _should_ignore
+
+    nested = tmp_path / "src" / "config" / ".env"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("x")
+    # Bare asterisk patterns (optionally whitespace-wrapped) are refused...
+    assert not _should_ignore(nested, ["*"], tmp_path)
+    assert not _should_ignore(nested, ["**"], tmp_path)
+    assert not _should_ignore(nested, [" * "], tmp_path)
+    # ...while a real glob in the same list still applies.
+    assert _should_ignore(nested, ["*", "*.env"], tmp_path)
+
+
 def test_should_ignore_returns_false_for_outside_base_dir(tmp_path: Path) -> None:
     from src.utils.secret_scanner import _should_ignore
 

--- a/tests/test_update_station_directory_floor.py
+++ b/tests/test_update_station_directory_floor.py
@@ -1,0 +1,40 @@
+"""Data-loss floor for the ÖBB station-directory rebuild.
+
+A truncated / corrupt ÖBB workbook yields zero or very few ÖBB stations, which
+would otherwise silently overwrite the populated ``data/stations.json`` with a
+manual-only (or near-empty) set. The floor refuses such a write and keeps the
+pinned committed file.
+"""
+from __future__ import annotations
+
+from scripts import update_station_directory
+
+
+def test_zero_oebb_stations_is_always_rejected() -> None:
+    # 0 ÖBB stations is always a failure — even on a fresh run with no existing
+    # directory to protect (a valid workbook always yields stations).
+    fv = update_station_directory._station_directory_floor_violation
+    assert fv(new_oebb=0, existing_oebb=2237) is not None
+    assert fv(new_oebb=0, existing_oebb=0) is not None
+
+
+def test_drastic_shrink_against_populated_directory_is_rejected() -> None:
+    # Manual-only fallback (~296) replacing a populated directory (~2237).
+    fv = update_station_directory._station_directory_floor_violation
+    assert fv(new_oebb=296, existing_oebb=2237) is not None
+
+
+def test_normal_run_writes_through() -> None:
+    fv = update_station_directory._station_directory_floor_violation
+    assert fv(new_oebb=2200, existing_oebb=2237) is None
+    # The floor uses a strict ``<`` comparison, so exactly at the ratio passes.
+    ratio = update_station_directory.STATION_DIRECTORY_FLOOR_RATIO
+    boundary = int(2237 * ratio)
+    assert fv(new_oebb=boundary + 1, existing_oebb=2237) is None
+
+
+def test_fresh_directory_writes_through() -> None:
+    # No existing directory (existing_oebb == 0) and a non-empty result →
+    # nothing to lose, so the write proceeds.
+    fv = update_station_directory._station_directory_floor_violation
+    assert fv(new_oebb=1500, existing_oebb=0) is None


### PR DESCRIPTION
## Was ist das?

Folge-PR (#1710/#1711/#1712) — drei weitere Audit-Funde („Batch A"), CI-exakt verifiziert (ruff 0.4.10, mypy 1.10, `PYTHONPATH=src`).

## Fixes

### 1. `update_station_directory.py` — stiller Datenverlust [High]
Ein truncated/korruptes ÖBB-Workbook lässt `extract_stations` 0 (oder sehr wenige) Stationen liefern. `write_json` würde dann `data/stations.json` **lautlos** mit einem manual-only (bzw. fast leeren) Satz überschreiben — die **gesamte ÖBB-Schicht verschwindet**, ohne Exception.

**Fix:** Datenverlust-Floor (analog zur `write_cache`-Degradation-Guard) — verweigert das Schreiben, wenn die neue ÖBB-Anzahl **0** ist oder **unter 50 %** der bestehenden ÖBB-Anzahl liegt. **Fail-closed** (`SystemExit`) → die gepinnte committe Datei bleibt erhalten, der Cron-Lauf surfaced einen non-zero Exit. Ein frisches/leeres Verzeichnis schreibt durch.

### 2. `secret_scanner._should_ignore` — bare-`*`-Footgun [Medium, Security]
Ein bare `"*"`/`"**"` in `.secret-scan-ignore` matchte via `fnmatch` **jeden** Basenamen → **der gesamte Scanner war deaktiviert**. Genau der Footgun, den der Matcher laut Docstring (fälschlich) verhindern sollte.

**Fix:** bare Asterisk-only-Patterns (auch whitespace-umschlossen) werden explizit **verweigert/übersprungen**; echte Globs (`*.env`, `src/*`) bleiben unberührt. Docstring korrigiert.

### 3. `logging.py` — toter `_LOG_INJECTION_RE` entfernt [Low]
Nie referenziert (kein Treffer in `src/` oder `tests/`).

## Tests
- Neue `tests/test_update_station_directory_floor.py` (alle Floor-Branches: zero/drastic-shrink/normal/fresh).
- bare-`*`-Test in `tests/test_tooling_and_remaining_lows.py` (refused, aber normale Globs greifen weiter).
- Alle bestehenden secret-scanner-Sentinel-Tests bleiben grün.

## Verifikation (CI-exakt)
- `ruff 0.4.10` ✓ · `mypy 1.10.1` (`src tests`) = 0 ✓ · `bandit` ✓ · `scan_secrets` (Keine Secrets) ✓ · `C901` (0 neue) ✓ · `i18n` ✓ · `pip-audit` ✓
- volle pytest-Suite `PYTHONPATH=src`: **8745 passed, 0 failed** (echter Exit-Code geprüft).

https://claude.ai/code/session_0156MPgicCwNN2QRqL7nKQoj

---
_Generated by [Claude Code](https://claude.ai/code/session_0156MPgicCwNN2QRqL7nKQoj)_