### PR TITLE
feat(security): hybrid path policy — CI lockdown + operator guardrails

### DIFF
--- a/scripts/configure_feed.py
+++ b/scripts/configure_feed.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import re
 import sys
 import textwrap
@@ -14,6 +15,8 @@ BASE_DIR = Path(__file__).resolve().parents[1]
 SRC_DIR = BASE_DIR / "src"
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
+
+LOGGER = logging.getLogger("configure_feed")
 
 try:  # pragma: no cover - allow execution via package and script
     from utils.configuration_wizard import (
@@ -26,6 +29,7 @@ try:  # pragma: no cover - allow execution via package and script
         mask_value,
         normalize_existing_values,
     )
+    from feed.config import warn_if_outside_allowed_roots
     from utils.env import load_env_file
     from utils.files import atomic_write
 except ImportError:  # pragma: no cover - allow python scripts/configure_feed.py
@@ -39,6 +43,7 @@ except ImportError:  # pragma: no cover - allow python scripts/configure_feed.py
         mask_value,
         normalize_existing_values,
     )
+    from src.feed.config import warn_if_outside_allowed_roots  # type: ignore
     from src.utils.env import load_env_file  # type: ignore
     from src.utils.files import atomic_write  # type: ignore
 
@@ -195,9 +200,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    env_path = Path(args.env_file)
-    if not env_path.is_absolute():
-        env_path = (BASE_DIR / env_path).resolve()
+    raw_env_path = Path(args.env_file).expanduser()
+    env_path = raw_env_path if raw_env_path.is_absolute() else (BASE_DIR / raw_env_path)
+    # Operator guardrail: --env-file may legitimately point outside the repo
+    # (e.g. ~/.config/feed.env), but warn on out-of-tree / ``..`` paths. This
+    # also fixes the former absolute-path bypass that skipped resolution.
+    env_path = warn_if_outside_allowed_roots(env_path, logger=LOGGER, label="--env-file")
 
     overrides = _parse_overrides(list(args.set))
     existing_env = _load_existing(env_path)

--- a/scripts/extract_oebb_geonetz_stops.py
+++ b/scripts/extract_oebb_geonetz_stops.py
@@ -49,10 +49,12 @@ if str(_ROOT) not in sys.path:
 
 try:  # pragma: no cover - convenience for module execution
     from src.feed.logging_safe import setup_script_logging
+    from src.feed.config import warn_if_outside_allowed_roots
     from src.utils.files import atomic_write, loads_finite, read_capped_bytes
     from src.utils.serialize import scrub_trojan_source_primitives
 except ModuleNotFoundError:  # pragma: no cover - fallback when installed as package
     from feed.logging_safe import setup_script_logging  # type: ignore[no-redef]
+    from feed.config import warn_if_outside_allowed_roots  # type: ignore[no-redef]
     from utils.files import atomic_write, loads_finite, read_capped_bytes  # type: ignore[no-redef]
     from utils.serialize import scrub_trojan_source_primitives  # type: ignore[no-redef]
 
@@ -276,7 +278,10 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     payload = extract(args.raw, args.source_url)
-    args.output.parent.mkdir(parents=True, exist_ok=True)
+    # Operator guardrail: --output may target a path outside the repo; warn but
+    # still write there.
+    out_path = warn_if_outside_allowed_roots(args.output, logger=logger, label="--output")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
     # Security (Trojan-Source / BiDi-Mark Drift, ingestion-boundary
     # defence): strip the canonical CVE-2021-42574 attack-byte union
     # (BiDi formatting controls, BiDi isolates, zero-width primitives +
@@ -319,7 +324,7 @@ def main(argv: list[str] | None = None) -> int:
     # rather than silently landing non-standard ``NaN`` / ``Infinity``
     # literals (invalid per RFC 8259) in the committed
     # ``data/oebb_geonetz_stops.json`` sidecar.
-    with atomic_write(args.output, mode="w", encoding="utf-8") as handle:
+    with atomic_write(out_path, mode="w", encoding="utf-8") as handle:
         handle.write(
             json.dumps(serialisable, ensure_ascii=False, indent=2, allow_nan=False) + "\n"
         )

--- a/scripts/fetch_google_places_stations.py
+++ b/scripts/fetch_google_places_stations.py
@@ -49,7 +49,7 @@ from src.utils.env import load_default_env_files
 from src.utils.files import atomic_write, loads_finite, read_capped_text
 from src.utils.logging import sanitize_log_arg
 from src.utils.serialize import scrub_trojan_source_primitives
-from src.feed.config import InvalidPathError, validate_path
+from src.feed.config import InvalidPathError, validate_path, warn_if_outside_allowed_roots
 
 LOGGER = logging.getLogger("places.cli")
 
@@ -292,6 +292,9 @@ def _dump_changes(
     new_entries: Sequence[Mapping[str, object]],
     updated_entries: Sequence[Mapping[str, object]],
 ) -> None:
+    # Operator guardrail: --dump-new may target a path outside the repo (a
+    # debug dump to /tmp is common); warn but still write there.
+    path = warn_if_outside_allowed_roots(path, logger=LOGGER, label="--dump-new")
     # Security (Trojan-Source / BiDi-Mark Drift Round 14, ingestion-boundary
     # defence): strip the canonical CVE-2021-42574 attack-byte union from
     # provider-fetched Google Places ``new`` / ``updated`` entries BEFORE

--- a/scripts/scaffold_provider_plugin.py
+++ b/scripts/scaffold_provider_plugin.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import sys
 import textwrap
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from src.utils.files import atomic_write  # noqa: E402
 
 TEMPLATE = textwrap.dedent(
     '''from __future__ import annotations
@@ -61,7 +68,10 @@ def main(argv: list[str] | None = None) -> int:
         parser.error(f"{target} exists – use --overwrite to replace it.")
 
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(TEMPLATE.strip() + "\n", encoding="utf-8")
+    # atomic_write (tempfile + os.replace) so a crash / SIGINT mid-write cannot
+    # leave a partially-written (corrupt) plugin skeleton at the target path.
+    with atomic_write(target, mode="w", encoding="utf-8") as handle:
+        handle.write(TEMPLATE.strip() + "\n")
     print(f"Provider plugin scaffold written to {target}")
     return 0
 

--- a/scripts/sync_hafas_profile.py
+++ b/scripts/sync_hafas_profile.py
@@ -58,6 +58,7 @@ import requests
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from src.feed.config import warn_if_outside_allowed_roots
 from src.feed.logging_safe import setup_script_logging
 from src.utils.files import atomic_write
 from src.utils.http import request_safe, session_with_retries
@@ -531,6 +532,9 @@ def _write_profile(profile: dict[str, object], output_path: Path) -> None:
     auth-bearing sidecars.
     """
     scrubbed = scrub_trojan_source_primitives(profile)
+    # Operator guardrail: --output may target a path outside the repo; warn but
+    # still write there (operators legitimately dump the profile elsewhere).
+    output_path = warn_if_outside_allowed_roots(output_path, logger=LOGGER, label="--output")
     output_path.parent.mkdir(parents=True, exist_ok=True)
     # Security (Coordinate finite/range drift, committed-writer
     # defence-in-depth): ``allow_nan=False`` mirrors the canonical

--- a/src/cli.py
+++ b/src/cli.py
@@ -12,10 +12,12 @@ from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from . import build_feed as build_feed_module
+    from .feed.config import InvalidPathError, validate_path
     from .utils.files import atomic_write
     from .utils.stations_validation import validate_stations
 else:
     from . import build_feed as build_feed_module
+    from .feed.config import InvalidPathError, validate_path
     from .utils.files import atomic_write
     from .utils.stations_validation import validate_stations
 
@@ -358,7 +360,13 @@ def _handle_stations_validate(args: argparse.Namespace) -> int:
     )
 
     if args.output:
-        output_path: Path = args.output
+        # CI lockdown: the validation-report path is restricted to the repo's
+        # allowed roots (docs/data/log). A path that resolves outside the
+        # repository fails loudly instead of writing an arbitrary file.
+        try:
+            output_path: Path = validate_path(args.output, "--output")
+        except InvalidPathError as exc:
+            raise CLIError(str(exc)) from exc
         output_path.parent.mkdir(parents=True, exist_ok=True)
         # ``atomic_write`` (tempfile + ``os.replace``) so a SIGINT
         # mid-write cannot leave a half-rendered Markdown report at

--- a/src/feed/config.py
+++ b/src/feed/config.py
@@ -32,6 +32,7 @@ from ..config.defaults import (
 )
 from ..utils.env import get_bool_env, get_int_env
 from ..utils.http import validate_public_feed_url
+from ..utils.logging import sanitize_log_arg
 
 ALLOWED_ROOTS = {"docs", "data", "log"}
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -222,6 +223,42 @@ def validate_path(path: Path, name: str) -> Path:
         if rel.parts and rel.parts[0] in ALLOWED_ROOTS:
             return resolved
     raise InvalidPathError(f"{name} outside allowed directories")
+
+
+def is_within_allowed_roots(path: Path) -> bool:
+    """Boolean companion to :func:`validate_path` (never raises).
+
+    Returns ``True`` when *path* resolves under one of the repository's
+    :data:`ALLOWED_ROOTS`. Used by operator-tool guardrails that warn — rather
+    than fail — on out-of-tree writes.
+    """
+    try:
+        validate_path(path, "path")
+    except InvalidPathError:
+        return False
+    return True
+
+
+def warn_if_outside_allowed_roots(
+    path: Path, *, logger: logging.Logger, label: str = "output path"
+) -> Path:
+    """Operator-tool guardrail: resolve *path*, warn (never fail) when it
+    escapes :data:`ALLOWED_ROOTS`, and return the resolved path to write to.
+
+    Operator tools may legitimately target paths outside the repository (e.g.
+    ``~/.config/feed.env``); this surfaces accidental ``..`` traversal without
+    breaking that workflow. CI / pipeline writers that must stay in-tree use
+    the raising :func:`validate_path` instead.
+    """
+    resolved = Path(path).expanduser().resolve()
+    if not is_within_allowed_roots(resolved):
+        logger.warning(
+            "%s %s is outside the repository's allowed roots (%s); writing there anyway.",
+            label,
+            sanitize_log_arg(str(resolved)),
+            ", ".join(sorted(ALLOWED_ROOTS)),
+        )
+    return resolved
 
 
 def resolve_env_path(env_name: str, default: str | Path, *, allow_fallback: bool = False) -> Path:

--- a/src/utils/configuration_wizard.py
+++ b/src/utils/configuration_wizard.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass
 from datetime import datetime, UTC
 from pathlib import Path
 from collections.abc import Mapping
+import logging
 import re
+
+from ..feed.config import warn_if_outside_allowed_roots
 
 from ..config.defaults import (
     DEFAULT_ABSOLUTE_MAX_ITEM_AGE_DAYS,
@@ -90,6 +93,14 @@ class ConfigOption:
                 f"{self.key} akzeptiert nur yes/no, true/false oder 1/0 (erhalten: {raw!r})."
             )
         if self.kind == "path":
+            # Operator guardrail: a path field (e.g. OUT_PATH) may legitimately
+            # point outside the repo; warn on out-of-tree targets but keep the
+            # value as typed (the feed builder resolves it via resolve_env_path).
+            warn_if_outside_allowed_roots(
+                Path(text).expanduser(),
+                logger=logging.getLogger(__name__),
+                label=self.key,
+            )
             return Path(text).as_posix()
         # secret/string fallthrough – trim outer whitespace only
         return text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,7 +69,11 @@ def test_cli_cache_update_rejects_mixed_all(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_cli_stations_validate_writes_report(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
-    output_path = tmp_path / "report.md"
+    # --output is locked to the repo's allowed roots (docs/data/log); chdir into
+    # tmp_path and write under a CWD-local data/ dir so validate_path accepts it.
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data").mkdir()
+    output_path = tmp_path / "data" / "report.md"
 
     class DummyReport:
         has_issues = True
@@ -115,6 +119,46 @@ def test_cli_stations_validate_writes_report(tmp_path: Path, monkeypatch: pytest
     assert "Report written to" in captured.out
     assert output_path.read_text(encoding="utf-8") == "dummy-report\n"
     assert exit_code == 1
+
+
+def test_cli_stations_validate_rejects_output_outside_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CI lockdown: an --output path outside the repo's allowed roots must fail."""
+
+    class DummyReport:
+        has_issues = False
+        total_stations = 1
+        duplicates: list[str] = []
+        alias_issues: list[str] = []
+        coordinate_issues: list[str] = []
+        gtfs_issues: list[str] = []
+        security_issues: list[str] = []
+        cross_station_id_issues: list[str] = []
+        identity_field_conflicts: list[str] = []
+        provider_issues: list[str] = []
+        naming_issues: list[str] = []
+        cross_name_alias_issues: list[str] = []
+
+        def to_markdown(self) -> str:
+            return "report\n"
+
+    monkeypatch.setattr(cli, "validate_stations", lambda *a, **k: DummyReport())
+
+    # tmp_path is outside the repository (CWD = repo root here) → rejected, and
+    # nothing is written.
+    outside = tmp_path / "evil.md"
+    with pytest.raises(SystemExit):
+        cli.main([
+            "stations",
+            "validate",
+            "--stations",
+            "stations.json",
+            "--output",
+            str(outside),
+        ])
+    assert not outside.exists()
+    assert "outside allowed directories" in capsys.readouterr().err
 
 
 def test_cli_checks_forwards_arguments(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_path_policy_guardrails.py
+++ b/tests/test_path_policy_guardrails.py
@@ -1,0 +1,140 @@
+"""Hybrid + CI-lockdown path policy for operator and CI tools.
+
+* CI tool (``src/cli.py stations validate --output``) is locked to the repo's
+  ALLOWED_ROOTS via ``validate_path`` — covered in ``tests/test_cli.py``.
+* Operator tools warn (but still write) when their output path escapes
+  ALLOWED_ROOTS, via ``warn_if_outside_allowed_roots``.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (src/feed/config.py) — the core every operator tool wires in.
+# ---------------------------------------------------------------------------
+def test_is_within_allowed_roots(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from src.feed.config import is_within_allowed_roots
+
+    monkeypatch.chdir(tmp_path)
+    assert is_within_allowed_roots(Path("data/x.json")) is True
+    assert is_within_allowed_roots(Path("docs/y.md")) is True
+    assert is_within_allowed_roots(Path("/etc/passwd")) is False
+    assert is_within_allowed_roots(tmp_path / "outside.json") is False
+
+
+def test_warn_if_outside_allowed_roots_warns_and_returns_resolved(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    from src.feed.config import warn_if_outside_allowed_roots
+
+    logger = logging.getLogger("test.guardrail.outside")
+    target = tmp_path / "x.json"
+    with caplog.at_level(logging.WARNING, logger="test.guardrail.outside"):
+        resolved = warn_if_outside_allowed_roots(target, logger=logger, label="--out")
+    # The write still proceeds: the resolved path is returned, not rejected.
+    assert resolved == target.resolve()
+    assert any("outside the repository" in r.getMessage() for r in caplog.records)
+
+
+def test_warn_if_outside_allowed_roots_silent_inside(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    from src.feed.config import warn_if_outside_allowed_roots
+
+    monkeypatch.chdir(tmp_path)
+    logger = logging.getLogger("test.guardrail.inside")
+    with caplog.at_level(logging.WARNING, logger="test.guardrail.inside"):
+        warn_if_outside_allowed_roots(Path("data/ok.json"), logger=logger, label="--out")
+    assert not any("outside the repository" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Operator tool: configuration wizard OUT_PATH (and any kind="path" field).
+# ---------------------------------------------------------------------------
+def test_config_option_path_warns_outside_but_keeps_value(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from src.utils.configuration_wizard import ConfigOption
+
+    option = ConfigOption(key="OUT_PATH", label="Output", help="...", kind="path")
+    with caplog.at_level(logging.WARNING, logger="src.utils.configuration_wizard"):
+        result = option.normalize("/tmp/outside.xml")
+    # Value preserved (operator flexibility) ...
+    assert result == "/tmp/outside.xml"
+    # ... but the out-of-tree target is surfaced, tagged with the field key.
+    assert any(
+        "OUT_PATH" in r.getMessage() and "outside" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_config_option_path_silent_for_in_tree(caplog: pytest.LogCaptureFixture) -> None:
+    from src.utils.configuration_wizard import ConfigOption
+
+    option = ConfigOption(key="OUT_PATH", label="Output", help="...", kind="path")
+    with caplog.at_level(logging.WARNING, logger="src.utils.configuration_wizard"):
+        result = option.normalize("data/feed.xml")
+    assert result == "data/feed.xml"
+    assert not any("outside" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Operator tool: sync_hafas_profile --output (via _write_profile).
+# ---------------------------------------------------------------------------
+def test_sync_hafas_write_profile_warns_outside_but_writes(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    from scripts import sync_hafas_profile
+
+    out = tmp_path / "profile.json"
+    with caplog.at_level(logging.WARNING, logger="places.hafas.sync"):
+        sync_hafas_profile._write_profile({"value": 1}, out)
+    assert out.exists()  # operator workflow preserved
+    assert any("outside the repository" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Operator tool: fetch_google_places_stations --dump-new (via _dump_changes).
+# ---------------------------------------------------------------------------
+def test_fetch_google_dump_changes_warns_outside_but_writes(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    from scripts import fetch_google_places_stations
+
+    out = tmp_path / "dump.json"
+    with caplog.at_level(logging.WARNING, logger="places.cli"):
+        fetch_google_places_stations._dump_changes(out, [], [])
+    assert out.exists()
+    assert any("outside the repository" in r.getMessage() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Operator tool: configure_feed --env-file (also fixes the absolute bypass).
+# ---------------------------------------------------------------------------
+def test_configure_feed_env_file_warns_outside_but_writes(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Load via spec_from_file_location (not ``from scripts import configure_feed``)
+    # so mypy does not statically follow into the module's pre-existing type debt.
+    import importlib.util
+    from typing import Any, cast
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "configure_feed.py"
+    spec = importlib.util.spec_from_file_location("configure_feed", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    outside = tmp_path / "feed.env"
+    with caplog.at_level(logging.WARNING, logger="configure_feed"):
+        rc = cast(Any, module).main(["--env-file", str(outside), "--accept-defaults"])
+    assert rc == 0
+    assert outside.exists()  # absolute out-of-tree path still written
+    assert any(
+        "--env-file" in r.getMessage() and "outside" in r.getMessage()
+        for r in caplog.records
+    )


### PR DESCRIPTION
## Was ist das?

Umsetzung der vereinbarten **„Hybrid + CI-Lockdown"**-Pfad-Policy für Operator- und CI-Tools — adressiert Arbitrary-Write/Path-Traversal-Risiken, ohne legitime Operator-Workflows zu brechen. CI-exakt verifiziert (ruff 0.4.10, mypy 1.10, `PYTHONPATH=src`).

## 1. Strict CI Lockdown
`src/cli.py` `stations validate --output` läuft jetzt durch **`validate_path`** → beschränkt auf `ALLOWED_ROOTS` (`docs/`, `data/`, `log/`). Ein Pfad außerhalb des Repos wirft eine saubere `CLIError` (Tool **schlägt fehl**, schreibt nichts).

## 2. Crash-Safety für Scaffold
`scripts/scaffold_provider_plugin.py` schreibt das Skeleton via **`atomic_write`** (tempfile + `os.replace`) statt bare `write_text` → kein korrupter Teilschreib bei Crash/SIGINT.

## 3. Operator-Guardrails (Hybrid)
Zwei neue **shared Helper** in `src/feed/config.py`:
- `is_within_allowed_roots(path) -> bool`
- `warn_if_outside_allowed_roots(path, *, logger, label) -> Path` — resolved den Pfad, **warnt** via `logger.warning` bei Pfaden außerhalb `ALLOWED_ROOTS`, **gibt den Pfad aber zurück → der Schreibvorgang läuft weiter**.

Eingebunden in:
| Tool | Argument |
|------|----------|
| `configure_feed.py` | `--env-file` (+ **Fix des absoluten-Pfad-Bypass**, der die Resolution übersprang) |
| `configuration_wizard.py` | `OUT_PATH` (jedes `kind="path"`-Feld) |
| `sync_hafas_profile.py` | `--output` |
| `extract_oebb_geonetz_stops.py` | `--output` |
| `fetch_google_places_stations.py` | `--dump-new` |

**Operator-Flexibilität bleibt:** `~/.config/feed.env`, `/tmp`-Dumps etc. werden weiterhin geschrieben — nur mit einer Warnung.

## Tests
- `test_cli.py`: akzeptiert in-tree `--output`, **lehnt out-of-tree ab** (neuer Reject-Test; bestehender Test auf einen erlaubten Root umgestellt).
- `test_path_policy_guardrails.py` (neu): die shared Helper + das **warn-but-write**-Verhalten von configuration_wizard, sync_hafas, fetch_google und configure_feed.

## Verifikation (CI-exakt)
- `ruff 0.4.10` ✓ · `mypy 1.10.1` (`src tests`) = 0 ✓ · `bandit`/`scan_secrets`/`C901`/`i18n`/`pip-audit` ✓ · kein Circular-Import ✓
- volle pytest-Suite `PYTHONPATH=src`: **8754 passed, 0 failed** (echter Exit-Code geprüft).

https://claude.ai/code/session_0156MPgicCwNN2QRqL7nKQoj

---
_Generated by [Claude Code](https://claude.ai/code/session_0156MPgicCwNN2QRqL7nKQoj)_