### PR TITLE
fix: fill empty grid column in Stammstrecke delay section

### DIFF
--- a/docs/site.html
+++ b/docs/site.html
@@ -274,7 +274,7 @@
           <h3 class="card__title" data-i18n="card-stammstrecke-weekday">Ø Verspätung nach Wochentag</h3>
           <div class="bars" id="stammstrecke-weekday" role="group" aria-label="Ø Verspätung je Wochentag" data-i18n-aria-label="aria-stammstrecke-weekday"></div>
         </article>
-        <article class="card card--wide">
+        <article class="card">
           <h3 class="card__title" data-i18n="card-stammstrecke-direction">Beobachtungen je Richtung</h3>
           <div class="bars" id="stammstrecke-direction" role="group" aria-label="Beobachtungen je Richtung" data-i18n-aria-label="aria-stammstrecke-direction"></div>
         </article>


### PR DESCRIPTION
## Problem
In der Sektion **„Stammstrecke – Verspätungen"** blieb auf breiten Viewports oben rechts eine leere Spalte im Chart-Grid (siehe Screenshot der Aufgabe). Ursache: Die Karte **„Beobachtungen je Richtung"** trug den Modifier `card--wide` (`grid-column: 1 / -1`) und rutschte dadurch in eine eigene, volle Zeile – die dritte Spalte der ersten Zeile blieb dadurch leer.

## Lösung
`card--wide` von der „Beobachtungen je Richtung"-Karte entfernt. Sie füllt jetzt die dritte Spalte neben „Ø Verspätung nach Tageszeit" und „Ø Verspätung nach Wochentag" und schließt damit die Lücke – analog zum Layout der Sektion „Störungs-Statistik", die ebenfalls drei gleichwertige Karten nebeneinander zeigt.

Reine Layout-Änderung (eine Zeile in `docs/site.html`); CSS/JS und die `?v=`-Cache-Bust-Tokens bleiben unverändert. Das `card--wide` der Ausfälle-Sektion („Nach Tageszeit") bleibt bewusst erhalten.

## Verifikation
- `python scripts/optimize_site_assets.py --check` → keine Drift (Asset-Hashes unverändert)
- `pytest test_site_html_structured_data test_site_html_seo_head test_i18n_coverage_gate` → 8 passed

https://claude.ai/code/session_01URPYmpT1JEJLnZErQMTJTh

---
_Generated by [Claude Code](https://claude.ai/code/session_01URPYmpT1JEJLnZErQMTJTh)_