### PR TITLE
Add claude GitHub actions 1780178034288

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+


### PR DESCRIPTION
<!--
Vorlage für Pull Requests im Wien-ÖPNV-Feed-Repository. Die Checkliste
bündelt die Mindestanforderungen aus den fortlaufenden Audits. Nicht
zutreffende Punkte bitte in der Beschreibung kurz begründen.
-->

## Beschreibung der Änderung
<!-- Was wurde geändert? Warum ist diese Änderung notwendig? -->

## Ticket-Referenz
<!-- Falls vorhanden, bitte Issue-Nummer verlinken (z. B. #123) -->

## Bewusst ausgeklammert
<!--
Optional. Was wurde bei der Arbeit auffällig, aber bewusst nicht
mitbehoben? Hilft Reviewer:innen, bekannte Baustellen nicht erneut
aufzudecken. Beispiele:
- „C901 für _foo weiterhin 51 — Refactor in eigenem PR"
- „wl_fetch-Tests mocken noch auf falscher Ebene — separater Cleanup"
-->

---

## Review-Checkliste

Diese Checkliste fasst die wiederkehrenden Audit-Schwerpunkte des
Projekts zusammen. Bitte jeden Punkt abhaken **oder** in der
Beschreibung begründen, warum er auf diesen PR nicht zutrifft.

### Sicherheit
- [ ] Kein neuer HTTP-Aufruf umgeht `request_safe` (`src/utils/http.py`).
- [ ] Keine neue `# nosec`-Markierung verdeckt eine echte Schwachstelle
      (Markierungen ausschließlich an Call-Sites mit vertrauenswürdigem
      Input – siehe `docs/architecture.md` §2).
- [ ] Keine neue SSRF-, Redirect- oder DNS-Rebinding-Angriffsfläche.
- [ ] Wenn ein neuer externer Host angesprochen wird: Allowlist
      aktualisiert und Response-`Content-Type` validiert.

### Performance
- [ ] Keine `copy.deepcopy(items)` oder unnötigen Defensiv-Kopien auf
      Hot-Paths der Datenpipeline.
- [ ] Kein neuer O(n²)-Regex-Reparse in paarweisen Schleifen; bei
      mehrfach gelesener Projektion: cachen.
- [ ] Keine `wait()`-gemockten Test-Loops ohne kleinen
      `feed_config.PROVIDER_TIMEOUT`-Patch.

### Statische Analyse
- [ ] `ruff check src/ tests/` ist sauber.
- [ ] `python3 -m mypy --no-pretty src tests` (CI-pinnung 1.10.1) ist sauber.
- [ ] Keine neuen `# type: ignore` / `# noqa`, die eine strukturelle
      Schwäche verbergen.
- [ ] Keine neuen Mypy-Allowlist-Einträge, sofern nicht dokumentiert.

### Komplexität
- [ ] Keine neue Funktion übersteigt **C901 = 15** (durch
      `scripts/check_complexity.py` durchgesetzt).
- [ ] Falls ein Refactor eine Baseline-Funktion unter den Threshold
      bringt, wurde `.c901-baseline.txt` regeneriert
      (`bash scripts/regen_c901_baseline.sh`).
- [ ] Extrahierte Helfer sind nach Möglichkeit reine Funktionen mit
      klar benennbarer Einzelverantwortung.

### `request_safe`-Berührungen
- [ ] Wenn `request_safe` oder einer seiner Helfer angepasst wurde:
      jede betroffene Security-Gate hat eigene Test-Abdeckung (keine
      implizite „der bestehende Test fängt das" -Annahme).
- [ ] Neue Security-Helfer beginnen den Docstring mit
      `Mitigates: <Angriffsvektor>`.

### Resilienz
- [ ] Pfade für hostile Payloads liefern `{}` / `[]` / `None`
      (fail-closed) und brechen den Cron-Job nicht ab.
- [ ] Für neue Payload-Parser werden `RecursionError`,
      `JSONDecodeError` und `ET.ParseError` gemeinsam abgefangen.
- [ ] Neue Provider nutzen `CircuitBreaker` (`src/utils/circuit_breaker.py`)
      oder begründen explizit, warum nicht.
- [ ] Provider-Bulkhead bleibt erhalten: eine Provider-Exception nimmt
      die Items der anderen Provider nicht mit in den Abgrund.

### Dokumentation
- [ ] Neue öffentliche Funktionen / Klassen tragen PEP-257-Docstrings
      mit `Args`, `Returns`, `Raises`.
- [ ] Architektur-relevante Änderungen aktualisieren
      `docs/architecture.md` (samt zugehörigem Mermaid-Diagramm,
      sofern betroffen).

---

## Lokale Verifikation

Vor dem Push bitte ausführen — spiegelt die CI exakt:

```bash
pre-commit run --all-files            # ruff + mypy + bandit + scan_secrets
python scripts/run_static_checks.py   # vollständiger CI-Parity-Check
python scripts/check_complexity.py    # C901-Gate gegen Baseline
python -m pytest --timeout=120        # vollständige Test-Suite
```
