### PR TITLE
fix: line-by-line audit — 18 verified defect fixes

### DIFF
--- a/.github/workflows/test-vor-api.yml
+++ b/.github/workflows/test-vor-api.yml
@@ -14,13 +14,14 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    # Defense-in-depth ceiling: the VOR API smoke test does a single
-    # /departureBoard probe with the usual VOR/VAO retry budget. Healthy
-    # runs are under a minute. 10 min gives generous headroom while
-    # catching hangs (stuck retry loop, unresponsive upstream) quickly.
-    # Without the cap the workflow inherits GitHub's 360-min default.
-    # Mirrors the canonical defence shape established in update-cycle.yml.
-    timeout-minutes: 10
+    # Defense-in-depth ceiling. The VOR /location.name smoke test itself is
+    # under a minute, but the final ``pytest -q`` step re-runs the FULL suite
+    # (~8000 tests) with the VOR secrets present, which — like the "Run test
+    # suite" job in test.yml — takes well over 10 min on a GH runner and was
+    # being cancelled at the cap. Match test.yml's 20-min budget (the per-test
+    # pytest-timeout of 60 s still catches genuine hangs). Without the cap the
+    # workflow inherits GitHub's 360-min default.
+    timeout-minutes: 20
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       PYTHONPATH: src

--- a/scripts/check_vor_auth.py
+++ b/scripts/check_vor_auth.py
@@ -80,18 +80,23 @@ def main(argv: Sequence[str] | None = None) -> int:
     session = requests.Session()
     vor_module.apply_authentication(session)
 
-    if session.auth is None:
-        LOGGER.error(
-            "apply_authentication() did not configure session.auth — credentials "
-            "would not be injected on outgoing requests."
-        )
-        return 1
-
+    # Check the plain-HTTP case FIRST: apply_authentication() fails closed on
+    # an http:// base URL (it returns WITHOUT setting session.auth), so the
+    # session.auth-is-None branch below would otherwise fire first with a
+    # misleading "internal bug" message for what is really the insecure-URL
+    # condition — leaving this accurate diagnostic unreachable (dead code).
     if base_url.lower().startswith("http://"):
         LOGGER.error(
             "VOR base URL is plain HTTP (%s) while credentials are configured — "
             "secrets would leak over the wire. Refusing to report success.",
             base_url,
+        )
+        return 1
+
+    if session.auth is None:
+        LOGGER.error(
+            "apply_authentication() did not configure session.auth — credentials "
+            "would not be injected on outgoing requests."
         )
         return 1
 

--- a/scripts/enrich_station_aliases.py
+++ b/scripts/enrich_station_aliases.py
@@ -358,11 +358,24 @@ def _load_vor_names(path: Path) -> dict[str, str]:
         return {}
     names: dict[str, str] = {}
     reader = csv.DictReader(io.StringIO(content), delimiter=";")
-    for row in reader:
-        vor_id = (row.get("StopPointId") or "").strip()
-        name = (row.get("StopPointName") or "").strip()
-        if vor_id and name:
-            names[vor_id] = name
+    try:
+        for row in reader:
+            vor_id = (row.get("StopPointId") or "").strip()
+            name = (row.get("StopPointName") or "").strip()
+            if vor_id and name:
+                names[vor_id] = name
+    except csv.Error:
+        # read_capped_text enforces only the byte cap, not CSV well-formedness.
+        # A single field larger than csv.field_size_limit (default 131072) —
+        # still well under MAX_ALIAS_CSV_BYTES — raises csv.Error (NOT an
+        # OSError) during iteration. Degrade gracefully (skip enrichment)
+        # instead of crashing the cron pipeline, mirroring the size/depth
+        # fallbacks in the sibling loaders.
+        log.warning(
+            "Malformed VOR stops CSV [path-sha256=%s]; skipping alias enrichment.",
+            _path_fingerprint(path),
+        )
+        return {}
     log.info("Loaded %d VOR stop names", len(names))
     return names
 
@@ -442,13 +455,24 @@ def _load_gtfs_index(path: Path) -> dict[str, set[str]]:
         return {}
     index: dict[str, set[str]] = defaultdict(set)
     reader = csv.DictReader(io.StringIO(content))
-    for row in reader:
-        name = (row.get("stop_name") or "").strip()
-        if not name:
-            continue
-        key = _normalize_key(name)
-        if key:
-            index[key].add(name)
+    try:
+        for row in reader:
+            name = (row.get("stop_name") or "").strip()
+            if not name:
+                continue
+            key = _normalize_key(name)
+            if key:
+                index[key].add(name)
+    except csv.Error:
+        # See _load_vor_names: a field larger than csv.field_size_limit
+        # (default 131072, well under MAX_ALIAS_CSV_BYTES) raises csv.Error
+        # (NOT an OSError) during iteration. Degrade gracefully with whatever
+        # rows parsed cleanly instead of crashing the cron pipeline.
+        log.warning(
+            "Malformed GTFS stops CSV [path-sha256=%s]; using %d variants "
+            "parsed before the error.",
+            _path_fingerprint(path), len(index),
+        )
     log.info("Indexed %d GTFS stop name variants", len(index))
     return index
 

--- a/scripts/extract_oebb_geonetz_stops.py
+++ b/scripts/extract_oebb_geonetz_stops.py
@@ -337,12 +337,15 @@ def main(argv: list[str] | None = None) -> int:
         handle.write(
             json.dumps(serialisable, ensure_ascii=False, indent=2, allow_nan=False) + "\n"
         )
-    size_kib = args.output.stat().st_size / 1024
+    # Use the resolved out_path (atomic_write wrote there). args.output may be
+    # an unexpanded "~/..." that Path.stat() looks up literally, raising a
+    # spurious FileNotFoundError AFTER a successful write.
+    size_kib = out_path.stat().st_size / 1024
     logger.info(
         "Wrote %d stops (%.0f KiB) to %s — fahrplanperiode %s..%s",
         len(payload["stops"]),
         size_kib,
-        args.output,
+        out_path,
         payload.get("fahrplanperiode", {}).get("from", "?"),
         payload.get("fahrplanperiode", {}).get("to", "?"),
     )

--- a/scripts/update_all_stations.py
+++ b/scripts/update_all_stations.py
@@ -765,17 +765,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             start = time.monotonic()
             try:
                 run_script(args.python, script_path, args.verbose, output_flag, tmp_stations_path)
-            except subprocess.CalledProcessError as exc:  # pragma: no cover - thin wrapper
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:  # pragma: no cover - thin wrapper
                 duration = time.monotonic() - start
+                # TimeoutExpired is a sibling of CalledProcessError (NOT a
+                # subclass) and carries no ``returncode``: a sub-script that
+                # actually exceeds the 600 s budget — the exact hang the
+                # timeout guards — would otherwise escape this handler and
+                # crash the orchestrator with a traceback, bypassing the
+                # structured failure record. Record it like any other failure.
+                exit_code = getattr(exc, "returncode", None) or 1
                 sub_script_results.append({
                     "name": script_name,
-                    "exit_code": exc.returncode or 1,
+                    "exit_code": exit_code,
                     "duration_s": round(duration, 2),
                 })
                 logging.error(
-                    "Script %s failed with exit code %s", script_path.name, exc.returncode
+                    "Script %s failed with exit code %s", script_path.name, exit_code
                 )
-                return exc.returncode or 1
+                return exit_code
             duration = time.monotonic() - start
             sub_script_results.append({
                 "name": script_name,

--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -1655,6 +1655,16 @@ def merge_into_stations(
     else:
         raise ValueError("stations.json must contain a JSON array or a dict with a 'stations' array")
 
+    # Drop non-dict elements before the merge loop below calls ``entry.get(...)``.
+    # read_capped_json validates only the TOP-LEVEL type, so a structurally
+    # valid but malformed file (``[1, 2, "x"]`` / ``{"stations": ["foo"]}`` — a
+    # corrupted previous run or a parallel atomic state swap, the documented
+    # threat model) would otherwise raise an uncaught AttributeError and abort
+    # the cron pipeline (the orchestrator runs this via ``subprocess(check=True)``).
+    # Mirrors update_all_stations._load_stations and the sibling NaN/size/depth
+    # defences in this file, which degrade gracefully instead of crashing.
+    existing = [entry for entry in existing if isinstance(entry, dict)]
+
     filtered: list[dict[str, object]] = []
     vor_index: dict[str, dict[str, object]] = {}
     bst_index: dict[str, dict[str, object]] = {}
@@ -1810,15 +1820,27 @@ def main(argv: Sequence[str] | None = None) -> int:
         "Reading haltestellen: [path-sha256=%s]",
         _path_fingerprint(args.haltestellen),
     )
-    haltestellen = load_haltestellen(args.haltestellen)
-    log.info("Found %d haltestellen", len(haltestellen))
+    try:
+        haltestellen = load_haltestellen(args.haltestellen)
+        log.info("Found %d haltestellen", len(haltestellen))
 
-    log.info(
-        "Reading haltepunkte: [path-sha256=%s]",
-        _path_fingerprint(args.haltepunkte),
-    )
-    haltepunkte = load_haltepunkte(args.haltepunkte)
-    log.info("Found %d haltepunkte", len(haltepunkte))
+        log.info(
+            "Reading haltepunkte: [path-sha256=%s]",
+            _path_fingerprint(args.haltepunkte),
+        )
+        haltepunkte = load_haltepunkte(args.haltepunkte)
+        log.info("Found %d haltepunkte", len(haltepunkte))
+    except FileNotFoundError:
+        # A required CSV is missing (e.g. --download enabled but the fetch
+        # failed and no local fallback file exists): _dict_reader raises
+        # FileNotFoundError. Abort cleanly with return 1 — matching the
+        # empty-wl_entries path below — instead of an unhandled traceback
+        # that aborts the cron pipeline (subprocess check=True). Path is not
+        # logged raw to avoid leaking it.
+        log.error(
+            "A required Wiener-Linien OGD CSV is missing; aborting (return 1)."
+        )
+        return 1
 
     vor_mapping = load_vor_mapping(args.vor_mapping)
     if vor_mapping:

--- a/src/config/defaults.py
+++ b/src/config/defaults.py
@@ -47,7 +47,15 @@ DEFAULT_CACHE_MAX_AGE_HOURS = 24
 DEFAULT_PROVIDER_TIMEOUT = 25
 DEFAULT_PROVIDER_MAX_WORKERS = 0
 DEFAULT_STATE_PATH = Path("data/first_seen.json")
-DEFAULT_STATE_RETENTION_DAYS = 60
+# Must stay >= DEFAULT_ABSOLUTE_MAX_ITEM_AGE_DAYS so a long-running disruption's
+# first_seen is retained for the item's whole feed lifetime. With a shorter
+# window (the prior default was 60 << 540), _load_state dropped a still-produced
+# item's state once its first_seen crossed the window; _update_item_state then
+# reset first_seen to "now", so the item re-published (fresh pubDate), jumped to
+# the top of the recency sort, could never reach the age cutoff, and was
+# re-counted in the stats. 600 = 540 (the absolute age cap) + 60 days margin so
+# the age machinery retires the item before its state is pruned.
+DEFAULT_STATE_RETENTION_DAYS = 600
 DEFAULT_PROVIDER_FLAGS = {
     "WL_ENABLE": True,
     "OEBB_ENABLE": True,

--- a/src/feed/logging.py
+++ b/src/feed/logging.py
@@ -245,7 +245,12 @@ def prune_log_file(path: Path, *, now: datetime, keep_days: int = 7) -> None:
         # Security: Modify in-place to preserve file handle for RotatingFileHandler.
         # atomic_write would replace the inode, causing the active logger to write to a stale handle.
         # Use r+ to read/write without replacing inode.
-        with path.open("r+", encoding="utf-8") as handle:
+        # newline="" disables universal-newline translation on write: the read
+        # side (read_capped_text -> bytes.decode + splitlines(keepends=True)) is
+        # byte-exact, so without this a record already ending in "\r\n" would be
+        # rewritten as "\r\r\n" on a platform where os.linesep == "\r\n"
+        # (Windows), corrupting the log and shifting offsets vs the live handler.
+        with path.open("r+", encoding="utf-8", newline="") as handle:
             handle.seek(0)
             handle.write("".join(filtered))
             handle.truncate()

--- a/src/feed/stammstrecke.py
+++ b/src/feed/stammstrecke.py
@@ -381,6 +381,27 @@ def _has_consecutive_exceedance(
     return False
 
 
+def _has_recent_exceedance(
+    observations: list[StammstreckeObservation], now: datetime
+) -> bool:
+    """Return ``True`` when an above-threshold observation lies within
+    :data:`EPISODE_GAP_TOLERANCE` of *now* — i.e. the episode is still
+    bridging a brief dip rather than having genuinely ended.
+
+    Used to gate the persisted-start CLEAR in
+    :func:`compute_stammstrecke_events` with the SAME gap tolerance
+    :func:`_episode_start` applies to the wider lookback window, so a single
+    recovered cron tick (a sub-threshold sample between two highs) that makes
+    the narrow ``feed_window`` trigger gate fail does NOT wipe the persisted
+    ``first_seen`` / GUID of a still-running disruption.
+    """
+    cutoff = now - EPISODE_GAP_TOLERANCE
+    return any(
+        obs.delay_minutes > DELAY_THRESHOLD_MINUTES and obs.timestamp >= cutoff
+        for obs in observations
+    )
+
+
 def _build_event(
     *,
     direction: _Direction,
@@ -505,12 +526,19 @@ def compute_stammstrecke_events(
         # in-window observations (easier for end users to interpret).
         # See module docstring "Window lengths".
         if not recent or not _has_consecutive_exceedance(recent):
-            # Trigger no longer fires for this direction → the episode
-            # has ended. Drop any persisted start so the NEXT episode
-            # (after EPISODE_GAP_TOLERANCE has elapsed and a fresh trigger
-            # fires) starts with a fresh ``first_seen`` / GUID instead of
-            # inheriting the previous disruption's identity.
-            persisted_starts.pop(direction.target_label, None)
+            # The narrow 1 h feed_window trigger gate is not firing this cycle.
+            # Only FORGET the episode identity once the episode has GENUINELY
+            # ended — i.e. no above-threshold observation remains within
+            # EPISODE_GAP_TOLERANCE of ``current``. A single recovered cron
+            # tick (a brief sub-threshold dip between two highs) makes this
+            # gate fail while ``_episode_start`` still bridges the dip over the
+            # wider episode_lookback window; clearing the persisted start here
+            # would wipe the true ``first_seen``, change the GUID, and
+            # re-publish the ongoing disruption as brand-new (jumping the
+            # rendered ``[Seit DD.MM.YYYY]`` date). Gate the clear on the SAME
+            # gap tolerance ``_episode_start`` uses so the two windows agree.
+            if not _has_recent_exceedance(direction_obs, current):
+                persisted_starts.pop(direction.target_label, None)
             continue
         avg_delay = mean([obs.delay_minutes for obs in recent])
         computed_start = _episode_start(direction_obs=direction_obs, now=current)

--- a/src/places/merge.py
+++ b/src/places/merge.py
@@ -276,7 +276,16 @@ def _find_matching_station(
     for station in stations:
         lat = station.get("latitude")
         lng = station.get("longitude")
-        if not (isinstance(lat, float | int) and isinstance(lng, float | int)):
+        # ``bool`` is a subclass of ``int``, so a JSON boolean coordinate
+        # (``true``/``false``) would pass the ``float | int`` gate and coerce to
+        # ``1.0``/``0.0``. Reject it first, mirroring every sibling coordinate
+        # parser (client._parse_place, osm_client._coerce_float,
+        # tiling._coerce_coordinate, hafas_client) which all drop bool.
+        if (
+            isinstance(lat, bool)
+            or isinstance(lng, bool)
+            or not (isinstance(lat, float | int) and isinstance(lng, float | int))
+        ):
             continue
         # Defence-in-depth (Coordinate finite/range drift — disk-read side):
         # ``load_stations`` already rejects non-finite literals

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -605,6 +605,22 @@ def _normalize_endpoint_name(name: str) -> str:
     return cleaned
 
 
+# German weekday / month names (and a few temporal words). The temporal
+# phrasings ``von <Tag> bis <Tag>`` / ``zwischen <Tag> und <Tag>`` are matched
+# by _VON_NACH_PLAIN_RE / _ZWISCHEN_PLAIN_RE, whose endpoints are validated only
+# by _looks_like_station_name — which otherwise accepts a weekday/month word as
+# a "station". The resulting bogus route (e.g. ("Montag", "Freitag …")), being
+# the only route extracted, makes _is_relevant return False and silently drop an
+# otherwise Wien-relevant single-station message. These tokens are never station
+# endpoints, so reject them up-front.
+_CALENDAR_WORDS = frozenset({
+    "montag", "dienstag", "mittwoch", "donnerstag", "freitag", "samstag",
+    "sonntag", "feiertag", "feiertage", "feiertagen", "werktag", "werktags",
+    "jänner", "januar", "februar", "feber", "märz", "april", "mai", "juni",
+    "juli", "august", "september", "oktober", "november", "dezember",
+})
+
+
 def _looks_like_station_name(text: str) -> bool:
     """Reject pure dates/numbers and date/time fragments.
 
@@ -632,6 +648,11 @@ def _looks_like_station_name(text: str) -> bool:
     # Defence in depth: reject if the entire string is dates / numbers
     # interleaved with punctuation.
     if re.fullmatch(r"[\d.\-/\s]+", text):
+        return False
+    # Reject endpoints whose first word is a German weekday / month name: the
+    # temporal "von X bis Y" / "zwischen X und Y" phrasings capture these as
+    # fake route endpoints (e.g. "Montag", "Freitag verkehren Busse").
+    if text.casefold().split()[0] in _CALENDAR_WORDS:
         return False
     return True
 

--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -641,7 +641,13 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
             desc_raw = str(ti.get("description") or "").strip()
             # Do NOT strip HTML here, we need to preserve links (Task 3)
             desc = desc_raw
-            if _is_facility_only(title_raw, desc_raw):
+            # Facility check is TITLE-driven (mirrors the ÖBB sibling
+            # _is_facility_or_weather_only, which inspects only the title): a
+            # facility word in the free-text DESCRIPTION is a side-mention and
+            # must NOT drop a genuine line disruption (e.g. "U4: Streckensperre"
+            # whose description also notes an out-of-service lift). Only a
+            # facility-only TITLE drops the item.
+            if _is_facility_only(title_raw):
                 continue
 
             tinfo = _coerce_dict(ti.get("time"))
@@ -726,9 +732,10 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
             desc_raw = str(poi.get("description") or "").strip()
             # Do NOT strip HTML here, we need to preserve links (Task 3)
             desc = desc_raw
-            if _is_facility_only(
-                title_raw, desc_raw, str(poi.get("subtitle") or "")
-            ):
+            # Title-driven facility check (see the trafficInfo branch above):
+            # a facility word in the description / subtitle is only a
+            # side-mention and must not drop a genuine line disruption.
+            if _is_facility_only(title_raw):
                 continue
 
             tinfo = _coerce_dict(poi.get("time"))
@@ -943,19 +950,26 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
             }
         )
 
-    # E) Sammel-vs.-Einzel: Aggregat entfernen, wenn *alle* Linien als Einzel vorliegen
-    single_line_coverage: dict[str, int] = {}
+    # E) Sammel-vs.-Einzel: Aggregat entfernen, wenn *alle* Linien als Einzel
+    #    vorliegen — aber nur innerhalb DERSELBEN Kategorie. Ohne den
+    #    Kategorie-Schlüssel löscht z. B. ein Hinweis-Einzelitem (U1) + ein
+    #    Hinweis-Einzelitem (U2) ein echtes Störungs-Aggregat {U1,U2}, obwohl
+    #    keine Einzel-*Störung* diese Linien abdeckt — die Störungsmeldung
+    #    verschwände still aus dem Feed. Spiegelt die Kategorie-Prüfung in F).
+    single_line_coverage: dict[tuple[Any, str], int] = {}
     for it in items:
         ls = it.get("_lines_set") or set()
         if len(ls) == 1:
             ln = next(iter(ls))
-            single_line_coverage[ln] = single_line_coverage.get(ln, 0) + 1
+            cov_key = (it.get("category"), ln)
+            single_line_coverage[cov_key] = single_line_coverage.get(cov_key, 0) + 1
 
     filtered: list[dict[str, Any]] = []
     for it in items:
         ls = it.get("_lines_set") or set()
-        if len(ls) >= 2 and all(single_line_coverage.get(ln, 0) > 0 for ln in ls):
-            continue  # Aggregat raus
+        cat = it.get("category")
+        if len(ls) >= 2 and all(single_line_coverage.get((cat, ln), 0) > 0 for ln in ls):
+            continue  # Aggregat raus (nur bei gleicher Kategorie)
         filtered.append(it)
 
     # F) Subset-Bereinigung: Eintrag entfernen, wenn ein anderer Eintrag eine Obermenge der Linien abdeckt

--- a/src/providers/wl_text.py
+++ b/src/providers/wl_text.py
@@ -148,7 +148,13 @@ _MONTHS_DE: dict[str, int] = {
 # ``ab DD.MM.[YYYY]`` — numeric form (trailing dot after the month is
 # mandatory, matching the legacy pattern).
 _DATE_NUMERIC_RE = re.compile(
-    r"ab\s+(\d{1,2})\.(\d{1,2})\.(\d{4})?",
+    # The 4-digit alternative is tried BEFORE the 2-digit one (ordered
+    # alternation) so "2026" captures all four digits. A 2-digit year like
+    # "26" is now accepted and expanded to 2026 in _extract_day_month_year,
+    # instead of being captured as None and routed through the
+    # nearest-occurrence year heuristic (which can resolve to the wrong year
+    # when the title's "ab" date lies in the past relative to the API start).
+    r"ab\s+(\d{1,2})\.(\d{1,2})\.(\d{4}|\d{2})?",
     re.IGNORECASE,
 )
 # ``ab DD. <Monat> [YYYY]`` — spelled-out form WL uses for advance
@@ -163,6 +169,20 @@ _DATE_MONTHNAME_RE = re.compile(
 )
 
 
+def _expand_two_digit_year(year_str: str | None) -> int | None:
+    """Expand an optional captured year.
+
+    A 2-digit year (``"26"``) becomes ``2026``; a 4-digit year passes
+    through unchanged; ``None`` (no year captured) stays ``None``.
+    """
+    if not year_str:
+        return None
+    year = int(year_str)
+    if len(year_str) == 2:
+        year += 2000
+    return year
+
+
 def _extract_day_month_year(title: str) -> tuple[int, int, int | None] | None:
     """Return ``(day, month, year_or_None)`` from the first ``ab`` date.
 
@@ -173,7 +193,7 @@ def _extract_day_month_year(title: str) -> tuple[int, int, int | None] | None:
     match = _DATE_NUMERIC_RE.search(title)
     if match:
         day_str, month_str, year_str = match.groups()
-        return int(day_str), int(month_str), int(year_str) if year_str else None
+        return int(day_str), int(month_str), _expand_two_digit_year(year_str)
     match = _DATE_MONTHNAME_RE.search(title)
     if match:
         day_str, month_word, year_str = match.groups()

--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -276,7 +276,29 @@ def read_cache(provider: str) -> list[Any]:
             # marks regardless of how the on-disk bytes got there. See
             # ``src/utils/serialize.py:scrub_trojan_source_primitives``
             # for the canonical attack-byte union.
-            scrubbed = scrub_trojan_source_primitives(payload)
+            try:
+                scrubbed = scrub_trojan_source_primitives(payload)
+            except RecursionError:
+                # ``scrub_trojan_source_primitives`` enforces its OWN nesting
+                # cap (max_depth=50) and raises ``RecursionError``. ``json.loads``
+                # above parses far deeper (CPython ~1000), so a moderately-deep
+                # (51..~990 levels) poisoned cache parses cleanly — entering this
+                # ``else`` block — and only trips the scrubber HERE, OUTSIDE the
+                # ``try`` whose ``except (... RecursionError ...)`` handler was
+                # meant to neutralise depth bombs. Without this guard the error
+                # escapes ``read_cache`` and is reclassified by the orchestrator's
+                # generic ``except`` as a fetch failure, losing the dedicated
+                # cache-corruption alert and the documented return-[] contract.
+                log.warning(
+                    "Cache for provider '%s' at %s exceeds the safe nesting "
+                    "depth; treating as corrupt and skipping.",
+                    provider,
+                    cache_file,
+                )
+                _emit_cache_alert(
+                    provider, "Cache-Verschachtelung zu tief (Depth-Bomb)"
+                )
+                return []
             if isinstance(scrubbed, list):
                 return scrubbed
             return []

--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -23,7 +23,7 @@ from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from typing import Any, TypeGuard, cast
 from collections.abc import Container, Mapping, MutableMapping
-from urllib.parse import parse_qsl, urlencode, urljoin, urlparse
+from urllib.parse import ParseResult, parse_qsl, urlencode, urljoin, urlparse
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -1298,6 +1298,20 @@ def _rebuild_netloc(normalized_hostname: str, port: int | None) -> str:
     return final_hostname
 
 
+def _has_embedded_credentials(parsed: ParseResult) -> bool:
+    """True if the URL carries userinfo (``user[:pass]@host``).
+
+    Used both before AND after NFKC hostname normalization. NFKC can map
+    fullwidth / compatibility characters to an ASCII ``@`` (e.g. U+FF20
+    FULLWIDTH COMMERCIAL AT -> ``@``); because ``urlparse`` only splits
+    userinfo at an ASCII ``@``, such a character survives the pre-normalization
+    check as part of the hostname and only becomes a real ``@`` after
+    normalization, re-partitioning the authority and re-introducing userinfo.
+    Extracted so :func:`validate_http_url` stays at/below its C901 baseline.
+    """
+    return bool(parsed.username or parsed.password)
+
+
 def validate_http_url(
     url: str | None, check_dns: bool = True, allowed_ports: Container[int] = (80, 443)
 ) -> str | None:
@@ -1339,7 +1353,7 @@ def validate_http_url(
 
         # Disallow embedded credentials to avoid leaking secrets via logs or proxies.
         # Check this BEFORE normalization to ensure we don't accidentally strip them when reconstructing netloc.
-        if parsed.username or parsed.password:
+        if _has_embedded_credentials(parsed):
             return None
 
         # Security: Normalize only hostname to NFKC to prevent IDNA bypasses and homograph confusion
@@ -1369,6 +1383,19 @@ def validate_http_url(
              # the invariant ``_UNSAFE_URL_CHARS`` is meant to guarantee for URLs
              # that land in the published feed ``<link>``.
              if _UNSAFE_URL_CHARS.search(candidate):
+                 return None
+
+             # NFKC can also map fullwidth / compatibility characters to an
+             # ASCII '@' (e.g. U+FF20 FULLWIDTH COMMERCIAL AT -> '@'). Such a
+             # character is part of the hostname before normalization (urlparse
+             # only splits userinfo at an ASCII '@'), so the pre-normalization
+             # credentials check above cannot see it; after normalization it
+             # re-partitions the authority and re-introduces userinfo. '@' is
+             # intentionally NOT in _UNSAFE_URL_CHARS, so re-validate embedded
+             # credentials on the reconstructed parse result to preserve the
+             # no-credentials invariant (and avoid host-spoofing display
+             # confusion in the published feed <link>).
+             if _has_embedded_credentials(parsed):
                  return None
 
         hostname = parsed.hostname

--- a/src/utils/secret_scanner.py
+++ b/src/utils/secret_scanner.py
@@ -2950,8 +2950,10 @@ def _should_ignore(path: Path, patterns: Sequence[str], base_dir: Path) -> bool:
     sub-tree configs. Neither aligns with the gitignore intuition the
     one-line comment at the call site implies.
 
-    Post-fix the match uses ``fnmatch.fnmatch`` against the FULL forward-
-    slash-normalised relative path AND the basename, so:
+    Post-fix the match uses ``fnmatch.fnmatchcase`` against the FULL forward-
+    slash-normalised relative path AND the basename (``fnmatchcase`` is
+    case-sensitive on every platform, unlike ``fnmatch`` which case-folds on
+    Windows via ``os.path.normcase``), so:
 
     * A pattern with ``/`` is anchored against the full path
       (``src/leak.py`` matches only that file).
@@ -2977,11 +2979,18 @@ def _should_ignore(path: Path, patterns: Sequence[str], base_dir: Path) -> bool:
         # would silently disable the whole scanner — the ignore-list footgun.
         if not pattern.strip().strip("*"):
             continue
+        # Use fnmatchcase, NOT fnmatch: fnmatch routes both the name and the
+        # pattern through os.path.normcase, which lowercases on Windows — making
+        # the ignore list case-INsensitive there but case-sensitive on Linux,
+        # i.e. platform-dependent coverage for a security gate (a Windows-side
+        # over-broad match could silently skip a file holding a planted secret).
+        # fnmatchcase is case-sensitive on every platform, matching git's
+        # default case-sensitive path semantics the docstring describes.
         if "/" in pattern:
-            if fnmatch.fnmatch(rel_str, pattern):
+            if fnmatch.fnmatchcase(rel_str, pattern):
                 return True
         else:
-            if fnmatch.fnmatch(rel_name, pattern):
+            if fnmatch.fnmatchcase(rel_name, pattern):
                 return True
     return False
 

--- a/src/utils/text.py
+++ b/src/utils/text.py
@@ -439,7 +439,17 @@ def normalise_markdown_text(text: str, *, max_len: int = 200) -> str:
 
 def escape_markdown(text: str) -> str:
     """Escape HTML and Markdown characters to prevent injection/XSS."""
-    text = html.escape(text)
+    # Order matters: backslash-escape the Markdown metacharacters FIRST, then
+    # HTML-escape LAST (see the trailing ``html.escape`` call). Doing
+    # ``html.escape`` first was a bug — it rewrites an apostrophe to the numeric
+    # entity ``&#x27;``, and the ``#`` step of the per-char loop then escaped the
+    # ``#`` *inside* that entity (``&\\#x27;``), which CommonMark / GFM render as
+    # the literal text ``&#x27;`` instead of an apostrophe, silently corrupting
+    # every apostrophe in operator-facing reports (``KeyError: 'station'``,
+    # station names like ``O'Brien``). Escaping the metacharacters first keeps
+    # the loop's ``#`` away from the numeric entity emitted later, with every
+    # injection defence below still intact.
+    #
     # Security (backslash-precedence-bypass round): escape ``\\``
     # itself FIRST, before the per-char loop below. CommonMark 2.4
     # consumes ``\\\\`` left-to-right as a single literal ``\\``, so
@@ -460,7 +470,13 @@ def escape_markdown(text: str) -> str:
     # single literal ``\\``.
     text = text.replace("\\", "\\\\")
     # Escape Markdown characters that could create links or formatting.
-    # We backslash-escape: [ ] ( ) * _ ` @ < > # ~
+    # We backslash-escape: [ ] ( ) * _ ` @ # ~
+    #
+    # ``<`` and ``>`` are intentionally NOT backslash-escaped here: the trailing
+    # ``html.escape`` turns them into ``&lt;`` / ``&gt;`` (rendered as literal
+    # ``<`` / ``>``, unable to form an HTML tag, autolink, or blockquote marker).
+    # Backslash-escaping them would instead yield ``\\&lt;``, which renders as
+    # the literal text ``&lt;``.
     #
     # Security: ``#`` was missing pre-Sentinel ``escape_markdown`` ATX-
     # heading-injection round. Callers in :mod:`src.feed.reporting`
@@ -504,8 +520,13 @@ def escape_markdown(text: str) -> str:
     # 2.4, so backslash escapes apply), so legitimate text
     # ("~/foo" path abbreviations, "~5 minutes" approximation
     # symbols) is visually unchanged on the rendered page.
-    for char in "[]()*_`@<>#~":
+    for char in "[]()*_`@#~":
         text = text.replace(char, f"\\{char}")
+    # HTML-escape LAST: ``& < > " '`` -> entities so the result is safe both as
+    # Markdown and as inline HTML (GFM interprets raw HTML). Running this after
+    # the loop keeps the numeric entity ``&#x27;`` it emits for an apostrophe
+    # intact — the loop's ``#`` step can no longer reach inside it.
+    text = html.escape(text)
     return text
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -38,6 +38,27 @@ def test_read_cache_warns_on_non_list(
     assert "does not contain a JSON array" in caplog.text
 
 
+def test_read_cache_skips_moderately_deep_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A poisoned cache nested deeper than the Trojan-Source scrubber's
+    ``max_depth`` (50) but shallower than ``json.loads``' ~1000 limit parses
+    cleanly, enters the ``else`` block, then trips ``scrub_trojan_source_
+    primitives`` with ``RecursionError``. That call sits OUTSIDE the read
+    ``try``/``except``, so without the dedicated guard the error escapes
+    ``read_cache``. The guard must treat it as a corrupt cache (skip + alert)."""
+    cache_file = _prepare_cache(tmp_path, monkeypatch, "provider")
+    depth = 100
+    cache_file.write_text("[" * depth + "]" * depth, encoding="utf-8")
+
+    caplog.set_level(logging.WARNING, logger="src.utils.cache")
+
+    assert cache.read_cache("provider") == []
+    assert "nesting depth" in caplog.text
+
+
 @pytest.mark.parametrize("pretty", [False, True])
 def test_write_cache_explicit_pretty_flag(
     tmp_path: Path,

--- a/tests/test_http_validation.py
+++ b/tests/test_http_validation.py
@@ -32,6 +32,18 @@ def test_validate_http_url_rejects_userinfo() -> None:
     assert validate_http_url("http://user@example.com") is None
 
 
+def test_validate_http_url_rejects_nfkc_userinfo() -> None:
+    # NFKC maps U+FF20 FULLWIDTH COMMERCIAL AT to an ASCII '@'. urlparse does
+    # not split userinfo at the fullwidth form, so the whole authority is the
+    # hostname and the pre-normalization credentials check passes; after
+    # hostname normalization the '@' re-partitions the authority and
+    # re-introduces userinfo (host becomes "evil.com", userinfo "trusted.com").
+    # The post-normalization re-check must reject it. check_dns=False isolates
+    # the syntax/credentials gate from DNS.
+    assert validate_http_url("http://trusted.com＠evil.com/", check_dns=False) is None
+    assert validate_http_url("https://a.example＠b.example", check_dns=False) is None
+
+
 def test_validate_http_url_rejects_excessive_length() -> None:
     long_url = "https://example.com/" + ("a" * 5000)
     assert validate_http_url(long_url) is None

--- a/tests/test_multi_zwischen.py
+++ b/tests/test_multi_zwischen.py
@@ -88,3 +88,28 @@ class TestMultiRouteUndZwischen:
             )
             is False
         )
+
+
+def test_von_bis_weekday_phrase_is_not_a_route() -> None:
+    # "von Montag bis Freitag" is a validity period, not a route. Pre-fix it
+    # was extracted as a bogus ("Montag", "Freitag …") route which, being the
+    # only route, made _is_relevant drop an otherwise Wien-relevant message.
+    assert _extract_routes(
+        "Wien Praterstern",
+        "Bahnsteigsanierung. Von Montag bis Freitag verkehren Busse.",
+    ) == []
+
+
+def test_zwischen_weekday_phrase_is_not_a_route() -> None:
+    assert _extract_routes(
+        "Bauarbeiten", "zwischen Montag und Freitag fahren keine Züge."
+    ) == []
+
+
+def test_weekday_temporal_phrase_keeps_wien_station_relevant() -> None:
+    # End-to-end: the Vienna single-station message survives despite the
+    # validity-period phrasing that previously fabricated a route.
+    assert _is_relevant(
+        "Wien Praterstern",
+        "Bahnsteigsanierung. Von Montag bis Freitag verkehren Busse.",
+    ) is True

--- a/tests/test_stammstrecke_statemachine.py
+++ b/tests/test_stammstrecke_statemachine.py
@@ -179,6 +179,56 @@ def test_persisted_start_is_cleared_when_episode_ends(tmp_path: Path) -> None:
     assert "Praterstern" not in sm._load_episode_starts(starts_path)
 
 
+def test_single_recovered_tick_does_not_reset_episode_identity(
+    tmp_path: Path,
+) -> None:
+    """A brief sub-threshold dip between two highs (one recovered cron tick)
+    makes the 1 h feed_window trigger gate fail for a cycle, but the episode is
+    still bridged by ``_episode_start`` over the 6 h window. Pre-fix the
+    persisted start was wiped on that gate miss, so the next firing cycle
+    re-derived the start from the slid 6 h window edge and re-published the
+    disruption as brand-new. Post-fix the identity stays stable across the dip.
+    """
+    base = datetime(2026, 5, 30, 0, 0, tzinfo=VIENNA_TZ)
+    dip_ts = base + timedelta(hours=7, minutes=30)
+    starts_path = tmp_path / "episode_starts.json"
+
+    def run(hour: int, minute: int) -> list[dict[str, Any]]:
+        # Rewrite the ledger with only the rows that exist UP TO this cycle's
+        # ``now`` (the reader does not cap future rows, and the real cron writes
+        # rows as time progresses). 12.0 min every 30 min, except a 5.0 dip at
+        # 07:30.
+        now = datetime(2026, 5, 30, hour, minute, tzinfo=VIENNA_TZ)
+        rows: list[tuple[datetime, str, float]] = []
+        i = 0
+        while (ts := base + timedelta(minutes=30 * i)) <= now:
+            rows.append((ts, "Praterstern", 5.0 if ts == dip_ts else 12.0))
+            i += 1
+        _write_obs_ledger(tmp_path, year=2026, rows=rows)
+        return _patched_compute(now=now, stats_dir=tmp_path, starts_path=starts_path)
+
+    # Establish the persisted start while 00:00 is still inside the 6 h lookback.
+    early = run(3, 0)
+    assert len(early) == 1
+    true_first_seen = early[0]["first_seen"]
+    true_guid = early[0]["guid"]
+
+    # Dip cycle at 08:00: the 07:30 sub-threshold sample sits between the only
+    # two in-feed-window highs (07:00, 08:00), breaking the consecutive gate so
+    # no event fires — but the persisted start must NOT be wiped, because a high
+    # remains within EPISODE_GAP_TOLERANCE of now.
+    dip = run(8, 0)
+    assert dip == []
+    assert "Praterstern" in sm._load_episode_starts(starts_path)
+
+    # Recovery cycle at 08:30: the gate fires again. The identity must match the
+    # original 00:00 start, not the slid 6 h-window edge (02:30).
+    recovered = run(8, 30)
+    assert len(recovered) == 1
+    assert recovered[0]["first_seen"] == true_first_seen
+    assert recovered[0]["guid"] == true_guid
+
+
 def test_load_save_round_trip_preserves_timezone(tmp_path: Path) -> None:
     """A persisted aware datetime must round-trip without losing its offset."""
     path = tmp_path / "episode_starts.json"

--- a/tests/test_state_retention_default_covers_item_age.py
+++ b/tests/test_state_retention_default_covers_item_age.py
@@ -1,0 +1,27 @@
+"""Regression: the default first_seen state-retention window must cover the
+maximum age an item can live in the feed.
+
+If ``DEFAULT_STATE_RETENTION_DAYS`` is shorter than the age caps, ``_load_state``
+drops a still-produced long-running item's state once its ``first_seen`` crosses
+the retention window; ``_update_item_state`` then resets ``first_seen`` to "now",
+so the item re-publishes (fresh pubDate), jumps to the top of the recency sort,
+can never reach the age cutoff, and is re-counted in the stats. The shipped
+default therefore MUST satisfy retention >= absolute / max item age (the prior
+default was 60 << 540).
+"""
+
+from __future__ import annotations
+
+from src.config.defaults import (
+    DEFAULT_ABSOLUTE_MAX_ITEM_AGE_DAYS,
+    DEFAULT_MAX_ITEM_AGE_DAYS,
+    DEFAULT_STATE_RETENTION_DAYS,
+)
+
+
+def test_default_state_retention_covers_item_lifetime() -> None:
+    assert DEFAULT_STATE_RETENTION_DAYS >= DEFAULT_ABSOLUTE_MAX_ITEM_AGE_DAYS, (
+        "State retention must outlast the absolute item-age cap, otherwise a "
+        "long-running item's first_seen is pruned before it ages out."
+    )
+    assert DEFAULT_STATE_RETENTION_DAYS >= DEFAULT_MAX_ITEM_AGE_DAYS

--- a/tests/test_text_markdown_helpers.py
+++ b/tests/test_text_markdown_helpers.py
@@ -112,3 +112,20 @@ def test_escape_markdown_strips_dangerous_markdown_meta_chars() -> None:
     assert escape_markdown("**bold**") == r"\*\*bold\*\*"
     assert escape_markdown("`code`") == r"\`code\`"
     assert escape_markdown("@here") == r"\@here"
+
+
+def test_escape_markdown_apostrophe_not_corrupted() -> None:
+    """Regression: ``html.escape`` emits the numeric entity ``&#x27;`` for an
+    apostrophe. Pre-fix, ``html.escape`` ran first and the ``#`` step of the
+    per-char loop then backslash-escaped the ``#`` *inside* that entity
+    (``&\\#x27;``), which GFM renders as the literal text ``&#x27;`` instead of
+    an apostrophe. With ``html.escape`` running LAST the entity stays intact.
+    """
+    assert escape_markdown("O'Brien") == "O&#x27;Brien"
+    assert escape_markdown("KeyError: 'station'") == "KeyError: &#x27;station&#x27;"
+    # The apostrophe entity must NOT carry a backslash before its '#'.
+    assert "&\\#x27;" not in escape_markdown("don't")
+    # Double quotes stay a clean entity too (they never contained a '#').
+    assert escape_markdown('say "hi"') == "say &quot;hi&quot;"
+    # '<' / '>' are still neutralised — via html.escape, not the backslash loop.
+    assert escape_markdown("<b>") == "&lt;b&gt;"

--- a/tests/test_wl_aggregate_removal.py
+++ b/tests/test_wl_aggregate_removal.py
@@ -67,3 +67,48 @@ def test_aggregate_retained_when_single_missing(monkeypatch: pytest.MonkeyPatch)
     # Single1 is removed because it is a subset of Aggregate
     assert "U1: Single1" not in titles
     assert len(items) == 1
+
+
+def _make_news(title: str, lines: list[str]) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    start = (now - timedelta(hours=1)).isoformat()
+    end = (now + timedelta(hours=1)).isoformat()
+    return {
+        "title": title,
+        "description": "",
+        "time": {"start": start, "end": end},
+        "relatedLines": lines,
+        "relatedStops": [],
+        "attributes": {},
+    }
+
+
+def test_aggregate_retained_when_only_other_category_singles_cover_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A multi-line Störung aggregate must NOT be dropped just because
+    single-line items of a DIFFERENT category (Hinweis) cover its lines:
+    no single-line *Störung* actually covers them, so the disruption alert
+    must survive. Section E is category-aware, mirroring section F."""
+    aggregate = _make_event("Signalstörung Innenstadt", ["U1", "U2"])
+    hinweis1 = _make_news("U1: Umleitung wegen Veranstaltung", ["U1"])
+    hinweis2 = _make_news("U2: Umleitung wegen Veranstaltung", ["U2"])
+
+    monkeypatch.setattr(
+        wl_fetch,
+        "_fetch_traffic_infos",
+        lambda timeout=20, session=None: [aggregate],
+    )
+    monkeypatch.setattr(
+        wl_fetch,
+        "_fetch_news",
+        lambda timeout=20, session=None: [hinweis1, hinweis2],
+    )
+
+    items = wl_fetch.fetch_events()
+    categories = [it["category"] for it in items]
+
+    # The Störung aggregate survives (cross-category singles do not cover it).
+    assert "Störung" in categories, categories
+    assert categories.count("Hinweis") == 2
+    assert len(items) == 3

--- a/tests/test_wl_extract_date_from_title.py
+++ b/tests/test_wl_extract_date_from_title.py
@@ -38,6 +38,24 @@ def test_numeric_missing_year_january_reference_keeps_previous_december() -> Non
     assert got == datetime(2025, 12, 28, tzinfo=VIENNA)
 
 
+def test_numeric_two_digit_year_is_honoured() -> None:
+    # Pre-fix the 2-digit year "26" was captured as None and routed through
+    # the nearest-occurrence heuristic; now it is expanded to 2026.
+    got = extract_date_from_title("Linie 4A: Verlegung ab 12.01.26")
+    assert got == datetime(2026, 1, 12, tzinfo=VIENNA)
+
+
+def test_numeric_two_digit_year_overrides_nearest_occurrence() -> None:
+    # The harmful case: an "ab" date in the past relative to a late API
+    # reference. With only a 4-digit pattern, "ab 1.5.26" was treated as
+    # missing-year and the heuristic resolved it to 2027 (nearest to the
+    # reference). Honouring the explicit 2-digit year keeps it at 2026.
+    got = extract_date_from_title(
+        "Umleitung ab 1.5.26", reference_date=_ref(2026, 12, 20)
+    )
+    assert got == datetime(2026, 5, 1, tzinfo=VIENNA)
+
+
 def test_monthname_explicit_year() -> None:
     got = extract_date_from_title(
         "56A/58A: Bauarbeiten Maxingstraße ab 07. April 2026"


### PR DESCRIPTION
Line-by-line audit of the whole `src/` + `scripts/` tree (multi-pass review, each finding adversarially verified). 18 confirmed defects fixed across 16 commits, each with a focused regression test where the behaviour is unit-testable. False positives (Windows-only portability nits, already-guarded paths, etc.) were filtered out.

All fixes were validated locally on Python 3.11: `ruff check` clean, the C901 complexity gate passes (no new/increased violations — `validate_http_url` stays at its baseline of 34 via an extracted helper), `mypy --strict` clean for the changed code, and the affected unit tests pass. The only local test failures were environment-specific and do **not** occur on the Linux CI: POSIX-only `os.fchmod` (writes) and the sandbox blocking DNS to `api.github.com` (the GitHub-issue submission path).

## High
- **`src/utils/http.py` — NFKC re-introduces userinfo `@`.** The embedded-credentials guard ran only *before* NFKC hostname normalization. NFKC maps fullwidth `＠` (U+FF20) to ASCII `@`; `urlparse` does not split userinfo at the fullwidth form, so `validate_http_url("http://trusted.com＠evil.com/")` passed the pre-check, then after normalization returned `http://trusted.com@evil.com/` — silently breaking the documented no-credentials invariant (host-spoofing in the published feed `<link>` + logs). Re-validate userinfo after normalization.
- **`src/feed/stammstrecke.py` — a single recovered cron tick wiped the persisted episode start.** The clear keyed on the narrow 1 h `feed_window` gate, but `_episode_start` bridges brief dips over the 6 h window via `EPISODE_GAP_TOLERANCE` (70 min). One sub-threshold sample between two highs wiped the persisted start; the next firing cycle re-derived it from the slid window edge, changing the GUID/`first_seen` and re-publishing the ongoing disruption as brand-new. Gate the clear on the same tolerance.

## Medium
- **`src/config/defaults.py` — state retention shorter than item lifetime.** `STATE_RETENTION_DAYS=60` << `ABSOLUTE_MAX_AGE_DAYS=540`, so `_load_state` dropped a long-running item's `first_seen` past 60 days → periodic re-publish, recency-sort displacement, unreachable age retirement, stats double-count. Raise the shipped default to 600 (≥ the absolute cap + margin).
- **`src/providers/oebb.py` — "von Montag bis Freitag" extracted as a bogus route** and silently dropped Wien-relevant single-station messages. Reject weekday/month tokens as route endpoints.
- **`src/providers/wl_fetch.py` — two fixes:** the facility-only check scanned the description (a side-mention dropped a valid line disruption → make it title-driven, like the ÖBB sibling); the aggregate-vs-single removal ignored category (a different-category single could delete a real multi-line disruption aggregate → key coverage by `(category, line)`).
- **`src/utils/text.py` — `escape_markdown` corrupted every apostrophe** (`&\#x27;` rendered literally) — reorder so `html.escape` runs last.
- **`scripts/update_wl_stations.py` — two fixes:** a non-dict element in `stations.json` crashed the merge (filter to dicts); a missing CSV raised an uncaught `FileNotFoundError` (return 1 cleanly).
- **`scripts/update_all_stations.py` — `subprocess.TimeoutExpired` not caught** (sibling of `CalledProcessError`, no `returncode`) crashed the orchestrator on a hung sub-script.

## Low
- `src/utils/cache.py` — depth-bomb `RecursionError` from the Trojan-Source scrub escaped `read_cache` (guard it).
- `src/providers/wl_text.py` — explicit 2-digit years (`ab 1.5.26`) were treated as missing-year.
- `src/places/merge.py` — JSON boolean coordinates accepted (`bool ⊂ int`).
- `src/utils/secret_scanner.py` — `fnmatch` (OS-dependent case-fold) → `fnmatchcase`.
- `src/feed/logging.py` — `prune_log_file` rewrote without `newline=""` (`\r\n`→`\r\r\n` risk).
- `scripts/enrich_station_aliases.py` — `csv.Error` from an oversized field aborted the cron pipeline.
- `scripts/extract_oebb_geonetz_stops.py` — post-write `stat()` used the unexpanded `--output` path.
- `scripts/check_vor_auth.py` — misleading diagnostic order for plain-HTTP + credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)