### PR TITLE
fix: zweiter Line-by-Line-Audit — 32 Fixes (Logik, Security, Performance, Doku)

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install bandit[sarif]
+          pip install "bandit[sarif]>=1.9.4,<2.0"
 
       - name: Run Bandit Security Scan
         run: bandit -r src/ -f sarif -o bandit-results.sarif

--- a/.github/workflows/build-feed.yml
+++ b/.github/workflows/build-feed.yml
@@ -101,7 +101,7 @@ jobs:
           echo "month=$(date -u +'%Y-%m')" >> "$GITHUB_OUTPUT"
 
       - name: Cache Hugging Face hub
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/huggingface
           key: huggingface-${{ runner.os }}-${{ steps.hf-cache-key.outputs.month }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/test-vor-api.yml
+++ b/.github/workflows/test-vor-api.yml
@@ -42,28 +42,37 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Validate required secrets
+        id: secrets
         shell: bash
         run: |
           set -euo pipefail
+          # ``exit 78`` does NOT produce a neutral/skipped status for a shell
+          # ``run:`` step (that code only signalled "neutral" for the legacy
+          # container/JS Action mechanism); any non-zero exit hard-FAILS the
+          # job. Emit a flag instead and gate the downstream steps on it so a
+          # secrets-less run (e.g. a fork) skips cleanly with a green job.
           if [[ -z "${VOR_ACCESS_ID:-}" || -z "${VOR_BASE_URL:-}" ]]; then
-            echo "VOR_ACCESS_ID oder VOR_BASE_URL fehlt -> Tests werden übersprungen." >&2
-            echo "Hinweis: In PRs aus Forks stehen Secrets nicht zur Verfügung." >&2
-            exit 78
+            echo "VOR_ACCESS_ID oder VOR_BASE_URL fehlt -> Tests werden übersprungen."
+            echo "Hinweis: Ohne konfigurierte Secrets (z. B. in Forks) stehen diese Werte nicht zur Verfügung."
+            echo "have_secrets=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_secrets=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up Python
-        if: ${{ success() }}
+        if: steps.secrets.outputs.have_secrets == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 
       - name: Install dependencies
+        if: steps.secrets.outputs.have_secrets == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
       - name: Smoke test VOR endpoint
-        if: ${{ success() }}
+        if: steps.secrets.outputs.have_secrets == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -85,5 +94,5 @@ jobs:
           retention-days: 1
 
       - name: Run pytest
-        if: ${{ success() }}
+        if: steps.secrets.outputs.have_secrets == 'true'
         run: pytest -q

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -404,7 +404,7 @@ flowchart LR
   Restmenge — und **nur** diese — wird an
   `_enrich_with_google_places(..., missing_subset=...)` übergeben.
   Stationen, die von OSM oder HAFAS aufgelöst wurden, werden auch
-  dann nicht neu verschlüsselt, wenn ein Google-Place zufällig
+  dann nicht erneut geokodiert, wenn ein Google-Place zufällig
   denselben Namen trägt.
 - Wenn OSM und HAFAS alle Stationen mit Koordinaten abdecken, wird
   der Google-Places-Call vollständig übersprungen. Das Freikontingent
@@ -647,19 +647,28 @@ gewinnt.
 | **Wann** bündeln sich Disruption-Events? | „Störungen" — per-Provider-Tabelle plus Wochentag- und Stunden-Verteilung |
 
 `extract_location_name` ist weiterhin Teil der Producer-Pipeline (siehe
-`src/utils/stats.py` und `src/build_feed.py:2041`) und persistiert die
+`src/utils/stats.py` und `src/build_feed.py`) und persistiert die
 abgeleitete Location pro Disruption-Zeile in
 `data/stats/stoerungen_<YYYY>.csv`. Die aktuelle Dashboard-Renderung
 aggregiert die Daten allerdings nur nach `provider`, `weekday` und
 `hour` (siehe `aggregate_stoerungen` in
-`scripts/generate_markdown_stats.py:416`) — eine frühere „Top-5
+`scripts/generate_markdown_stats.py`) — eine frühere „Top-5
 Hotspots mit Stundenprofil"-Sektion wurde entfernt, die Roh-Daten in
 der CSV bleiben aber für Ad-hoc-Analysen erhalten. Die Heuristik selbst
-versucht — in dieser Reihenfolge — `zwischen X und Y` (Capture Group 1),
-dann `Wien <Name>`, dann das erste mehrteilige Token außerhalb einer
-kleinen Stoppwortliste (`Bauarbeiten`, `Verspätung`, `Linie`, …). Als
-Fallback bleibt `"unbekannt"`, damit das Dashboard auch bei
-adversarial Provider-Input noch rendert.
+ist katalog-zentriert: Ein Kandidat wird nur zurückgegeben, wenn er
+über die kuratierte Verzeichnisdatei `data/stations.json` (`station_info`)
+auflösbar ist. In dieser Reihenfolge versucht sie — (1)
+`| Haltestelle:` (WL-`relatedStops`, erster Eintrag, verbatim
+akzeptiert), (2) `| Station:` / `| Location:` (WL-Extras), (3)
+`in Richtung X` (Stammstrecke-Renderer), (4) `zwischen X und Y`
+(ÖBB-Phrasierung, Capture Group 1), (5) `Wien <Stadtteil>`, (6) einen
+Sliding-Window-Verzeichnis-Scan über Titel + Beschreibung. Einziger
+Fallback ist `"unbekannt"`; einen Freitext-/Token-Fallback samt
+Stoppwortliste gibt es bewusst **nicht** mehr (die Freitext-Regex-
+Matches wurden 2026-05-09 entfernt, weil deutsche Substantive durchweg
+großgeschrieben sind und Störungstypen wie `Demonstration Linie`
+fälschlich als Haltestellen akzeptiert wurden). So rendert das Dashboard
+auch bei adversarial Provider-Input noch.
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -428,22 +428,23 @@ Die GitHub Action `.github/workflows/update-stations.yml` aktualisiert
      Ein leerer Bericht bestätigt den No-Change-Lauf (Heartbeat-Funktion).
 5. **Validation-Report regenerieren** – `python -m src.cli stations validate
    --output docs/stations_validation_report.md` schreibt die Markdown-
-   Variante des Validation-Reports (alle 8 Kategorien) für Review-Zwecke.
+   Variante des Validation-Reports (alle 10 Kategorien) für Review-Zwecke.
 
 #### Automatisierte Qualitätsberichte
 
 `python -m src.cli stations validate` erzeugt einen Markdown-Bericht mit
-neun Issue-Kategorien: **geographic duplicates**, **alias issues**,
+zehn Issue-Kategorien: **geographic duplicates**, **alias issues**,
 **coordinate anomalies**, **GTFS mismatches**, **security warnings**,
 **provider issues** (VOR-/OEBB-Konsistenz), **cross-station ID
 collisions**, **identity field conflicts** (raw `wl_diva`/`bst_id`/
 `vor_id`/`bst_code`-Kollisionen zwischen Stationen, ergänzt 2026-05-16
-in PR #1539) und **naming issues** (no-space-Source-Format +
+in PR #1539), **naming issues** (no-space-Source-Format +
 Vienna/Pendler Mutual-Exclusivity; die pre-2026-05-12 vorhandene
 kanonische Namens-Eindeutigkeits-Prüfung wurde entfernt, weil
 `name` ein operator-facing Display-Label ist, dessen
 strukturelle Eindeutigkeit von `wl_diva`/`bst_id`/`vor_id`/
-`bst_code` getragen wird).
+`bst_code` getragen wird) und **cross-name alias collisions**
+(Namens-Alias-Kollisionen zwischen Stationen).
 Über `--output docs/stations_validation_report.md` wird der Bericht
 persistiert; mit `--fail-on-issues` bricht die CLI bei jedem Befund mit
 einem Fehlercode ab. In CI läuft der Validator als Pflicht-Gate (siehe

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ Weitere Details findest du in der [ausführlichen Projektdokumentation](../READM
 | Datenquelle | Inhalt | Abruf-Cadence |
 |-------------|--------|---------------|
 | Wiener Linien (WL) | Störungs- und Echtzeitmeldungen für U-Bahn, Straßenbahn und Bus | ~alle 30 Min (IFTTT-getriggert) |
-| ÖBB | Bundesweite Bahnmeldungen mit strikten Wien-Filter | ~alle 30 Min (IFTTT-getriggert) |
+| ÖBB | Bundesweite Bahnmeldungen mit striktem Wien-Filter | ~alle 30 Min (IFTTT-getriggert) |
 | Verkehrsverbund Ost-Region (VOR) | VOR/VAO ReST API, seit 2026-05-11 **ausschließlich** für den S-Bahn-Stammstrecken-Verspätungs- und Ausfall-Monitor genutzt | ~alle 30 Min (IFTTT-getriggert) |
 | Stadt Wien (OGD) | Offizielle Baustellendaten (Bezirk, Zeitraum, Geo-Infos) | ~alle 30 Min (IFTTT-getriggert) |
 

--- a/scripts/apply_station_overrides.py
+++ b/scripts/apply_station_overrides.py
@@ -186,6 +186,12 @@ def _op_restore(stations: list[dict[str, Any]], override: dict[str, Any]) -> str
     if existing is not None:
         return "skip (already present)"
     new_entry = dict(entry_template)
+    # Force the inserted record's identity field to equal the idempotency
+    # key. Otherwise, if a curated ``entry`` template ever carried a
+    # different (or missing) ``wl_diva``, the next run's
+    # ``_find_by_diva(stations, diva)`` would not match the inserted
+    # record and restore would re-insert a duplicate on every cron tick.
+    new_entry["wl_diva"] = diva
     name = new_entry.get("name", "<unknown>")
     insert_at = _alpha_insertion_index(stations, name if isinstance(name, str) else "")
     stations.insert(insert_at, new_entry)

--- a/scripts/sync_hafas_profile.py
+++ b/scripts/sync_hafas_profile.py
@@ -97,20 +97,58 @@ _AID_RE: Final[re.Pattern[str]] = re.compile(
     r"""\baid\s*:\s*['"]([0-9A-Za-z.\-_]{1,128})['"]""",
 )
 
-# Strip ``/* … */`` block comments and ``// …`` line comments before the
-# credential regexes scan: a stale doc-comment containing the literal
-# ``ver: '1.30', aid: 'Old...'`` would otherwise be the FIRST occurrence
-# ``re.search`` matches (see ``_extract_profile``). The two pre-fix
-# substitutions don't need to understand JS lexer rules — string
-# literals can in principle contain ``//`` sequences, but the upstream
-# HAFAS sources never embed comment markers inside a credential string.
-_JS_BLOCK_COMMENT_RE: Final[re.Pattern[str]] = re.compile(r"/\*[\s\S]*?\*/")
-_JS_LINE_COMMENT_RE: Final[re.Pattern[str]] = re.compile(r"//[^\n]*")
-
-
 def _strip_js_comments(source: str) -> str:
-    """Return *source* with ``/* … */`` and ``// …`` comments removed."""
-    return _JS_LINE_COMMENT_RE.sub("", _JS_BLOCK_COMMENT_RE.sub("", source))
+    """Return *source* with ``/* … */`` and ``// …`` comments removed.
+
+    Stripping comments before the credential regexes scan prevents a stale
+    doc-comment containing a literal ``ver: '1.30', aid: 'Old...'`` from
+    being the FIRST occurrence ``re.search`` matches (see
+    ``_extract_profile``).
+
+    The scan is **string-literal aware**: a ``//`` or ``/*`` sequence that
+    lives inside a ``'…'`` / ``"…"`` / ``` `…` ``` literal is NOT treated as
+    a comment. A naive regex strip (the pre-fix implementation) deleted
+    everything after the ``//`` of a URL such as
+    ``endpoint: 'https://fahrplan.oebb.at/...'``, which would silently erase
+    a credential that ever shared the same physical line as a URL.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(source)
+    quote: str | None = None
+    while i < n:
+        ch = source[i]
+        if quote is not None:
+            out.append(ch)
+            if ch == "\\" and i + 1 < n:
+                # Preserve the escaped character verbatim.
+                out.append(source[i + 1])
+                i += 2
+                continue
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in "'\"`":
+            quote = ch
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "/" and i + 1 < n:
+            nxt = source[i + 1]
+            if nxt == "/":
+                newline = source.find("\n", i + 2)
+                if newline == -1:
+                    break
+                i = newline
+                continue
+            if nxt == "*":
+                end = source.find("*/", i + 2)
+                i = n if end == -1 else end + 2
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
 
 
 # Tight wall-clock cap. The fetch happens at the very start of the

--- a/scripts/update_all_stations.py
+++ b/scripts/update_all_stations.py
@@ -159,6 +159,17 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "failure (default: data/quarantine.json under the repository root)."
         ),
     )
+    parser.add_argument(
+        "--polygon",
+        type=Path,
+        default=_DEFAULT_POLYGON_PATH,
+        help=(
+            "Path to the Vienna boundary polygon whose vertex count is "
+            "recorded in the heartbeat (default: data/LANDESGRENZEOGD.json "
+            "under the repository root). Exposed so a relocated run reads a "
+            "relocated polygon instead of the production data dir."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -740,6 +751,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     heartbeat_path: Path = args.heartbeat
     diff_report_path: Path = args.diff_report
     quarantine_path: Path = args.quarantine
+    polygon_path: Path = args.polygon
 
     sub_script_results: list[dict[str, Any]] = []
 
@@ -873,7 +885,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         # before atomic copy-back so the heartbeat reflects what is about to land.
         after_snapshot = _load_stations(tmp_stations_path)
         diff = _compute_diff(before_snapshot, after_snapshot)
-        polygon_vertices = _count_polygon_vertices(_DEFAULT_POLYGON_PATH)
+        polygon_vertices = _count_polygon_vertices(polygon_path)
         heartbeat = _build_heartbeat(
             report=report,
             diff=diff,

--- a/scripts/update_oebb_cache.py
+++ b/scripts/update_oebb_cache.py
@@ -16,7 +16,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from src.feed.logging_safe import setup_script_logging  # noqa: E402
 from src.providers.oebb import fetch_events  # noqa: E402  (import after path setup)
-from src.utils.cache import write_cache  # noqa: E402
+from src.utils.cache import DataDegradationError, write_cache  # noqa: E402
 from src.utils.serialize import serialize_for_cache  # noqa: E402
 
 
@@ -64,7 +64,19 @@ def main() -> int:
         return 1
 
     serialized_items = [serialize_for_cache(item) for item in items]
-    write_cache("oebb", serialized_items)
+    try:
+        write_cache("oebb", serialized_items)
+    except DataDegradationError:
+        # ``write_cache`` refuses not only an empty payload but also a
+        # drastically smaller one (< 20 % of the existing cache) to avoid
+        # overwriting a healthy cache during a partial upstream outage.
+        # Keep the existing cache and exit non-zero instead of crashing
+        # the cron step (mirrors scripts/update_baustellen_cache.py).
+        logger.warning(
+            "Degraded ÖBB payload (%d events); keeping existing cache.",
+            len(serialized_items),
+        )
+        return 1
     logger.info("Updated ÖBB cache with %d events.", len(serialized_items))
     return 0
 

--- a/scripts/update_stammstrecke_hbf.py
+++ b/scripts/update_stammstrecke_hbf.py
@@ -703,6 +703,13 @@ def _departure_delay_minutes(dep: Mapping[str, Any]) -> float | None:
     # departure from a midnight wrap.
     if rt_date_explicit is None and (scheduled - actual) > timedelta(hours=12):
         actual = actual + timedelta(days=1)
+    # Symmetric wrap: a leg scheduled just AFTER midnight (e.g. 00:05)
+    # that departs a few minutes early (rtTime "23:54", i.e. the previous
+    # day) yields a same-day 23:54 ``actual`` and a bogus ≈ +23h49m
+    # "delay". Pull ``actual`` back one day so the recorded delay is the
+    # true small negative value (≈ −11 min) instead of ~+1429 min.
+    elif rt_date_explicit is None and (actual - scheduled) > timedelta(hours=12):
+        actual = actual - timedelta(days=1)
 
     return (actual - scheduled).total_seconds() / 60.0
 

--- a/scripts/update_stammstrecke_status.py
+++ b/scripts/update_stammstrecke_status.py
@@ -1235,6 +1235,12 @@ def _leg_departure_delay_minutes(leg: Mapping[str, Any]) -> float | None:
     # negative early departure from a midnight wrap.
     if rt_date_explicit is None and (scheduled - actual) > timedelta(hours=12):
         actual = actual + timedelta(days=1)
+    # Symmetric wrap: a leg scheduled just AFTER midnight (e.g. 00:05)
+    # departing a few minutes early (rtTime "23:54", i.e. the previous
+    # day) would otherwise yield a bogus ≈ +23h49m delay; pull ``actual``
+    # back one day so it becomes the true small negative value.
+    elif rt_date_explicit is None and (actual - scheduled) > timedelta(hours=12):
+        actual = actual - timedelta(days=1)
 
     return (actual - scheduled).total_seconds() / 60.0
 

--- a/scripts/update_wl_cache.py
+++ b/scripts/update_wl_cache.py
@@ -14,7 +14,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from src.feed.logging_safe import setup_script_logging  # noqa: E402
 from src.providers.wiener_linien import fetch_events  # noqa: E402  (import after path setup)
-from src.utils.cache import write_cache  # noqa: E402
+from src.utils.cache import DataDegradationError, write_cache  # noqa: E402
 from src.utils.serialize import serialize_for_cache  # noqa: E402
 
 
@@ -56,7 +56,19 @@ def main() -> int:
         return 1
 
     serialized_items = [serialize_for_cache(item) for item in items]
-    write_cache("wl", serialized_items)
+    try:
+        write_cache("wl", serialized_items)
+    except DataDegradationError:
+        # ``write_cache`` refuses not only an empty payload but also a
+        # drastically smaller one (< 20 % of the existing cache) to avoid
+        # overwriting a healthy cache during a partial upstream outage.
+        # Keep the existing cache and exit non-zero instead of crashing
+        # the cron step (mirrors scripts/update_baustellen_cache.py).
+        logger.warning(
+            "Degraded WL payload (%d events); keeping existing cache.",
+            len(serialized_items),
+        )
+        return 1
     logger.info("Updated Wiener Linien cache with %d events.", len(serialized_items))
     return 0
 

--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -235,7 +235,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=True,
         help=(
             "Download the latest WL OGD haltestellen/haltepunkte CSVs from "
-            "data.wien.gv.at before merging (default: enabled). On failure, "
+            "www.wienerlinien.at before merging (default: enabled). On failure, "
             "the existing local files are used as a fallback."
         ),
     )
@@ -584,31 +584,6 @@ def _canonical_name(raw: str) -> str:
     return base
 
 
-def _derive_bst_id(identifier: str | None) -> int | None:
-    if not identifier:
-        return None
-    digits = re.sub(r"\D", "", identifier)
-    if not digits:
-        return None
-    trimmed = digits[-8:]
-    return int(f"9{trimmed.zfill(8)}")
-
-
-def _derive_bst_code(name: str, identifier: str | None) -> str | None:
-    cleaned = re.sub(r"\(WL\)", "", name).strip()
-    cleaned = re.sub(r"(?i)^wien\s+", "", cleaned).strip()
-    tokens = [token for token in re.split(r"[^A-Za-z0-9ÄÖÜäöüß]+", cleaned) if token]
-    if tokens:
-        primary = tokens[0][:3]
-        if primary:
-            return f"WL-{primary.upper()}"
-    if identifier:
-        digits = re.sub(r"\D", "", identifier)
-        if digits:
-            return f"WL-{digits[-3:]}"
-    return None
-
-
 # Haltestelle PlatformText values that carry no location information
 # on their own and are routinely shared across far-apart stops in the
 # OGD-Echtzeit data (e.g. ``Lokalbahn`` × 4 across 5.6 km of greater
@@ -934,7 +909,21 @@ def build_wl_entries(
             if latitude is None or longitude is None:
                 lat_val = vor_entry.get("latitude")
                 lon_val = vor_entry.get("longitude")
-                if isinstance(lat_val, int | float) and isinstance(lon_val, int | float):
+                # Mirror the finiteness + WGS84 range gate every other
+                # coordinate-ingestion point enforces (``_coerce_float``,
+                # ``_wl_coord_index``, ``extract_oebb_geonetz_stops``); a
+                # planted out-of-range value (e.g. latitude 999.0) in the
+                # VOR mapping must not flow through as a "valid" coordinate.
+                if (
+                    isinstance(lat_val, int | float)
+                    and isinstance(lon_val, int | float)
+                    and not isinstance(lat_val, bool)
+                    and not isinstance(lon_val, bool)
+                    and math.isfinite(lat_val)
+                    and math.isfinite(lon_val)
+                    and -90.0 <= lat_val <= 90.0
+                    and -180.0 <= lon_val <= 180.0
+                ):
                     latitude = round(float(lat_val), 6)
                     longitude = round(float(lon_val), 6)
         aliases.update(_alias_variants(station.name, canonical, resolved_name or None))
@@ -970,8 +959,8 @@ def build_wl_entries(
         #   (a) ``_find_cross_station_id_conflicts`` flagged
         #       ``alias DIVA`` collisions against synthetic
         #       ``bst_id = 9{DIVA}`` on other entries.
-        #   (b) ``_derive_bst_code`` truncated names to the first
-        #       three letters, producing hundreds of duplicates
+        #   (b) name-based truncation to the first three letters
+        #       produced hundreds of duplicates
         #       (``WL-ABS`` for both Absbergbrücke and Absberggasse,
         #       ``WL-ADA`` for Ada-Christen-Gasse and four others, …).
         #

--- a/scripts/validate_vor_mapping.py
+++ b/scripts/validate_vor_mapping.py
@@ -43,8 +43,12 @@ def main() -> int:
 
     # HAFAS ID pattern: typically 7 to 9 digits (e.g. 430471000, 8100002)
     # The requirement says "usually 7-9 digits, often starting with 81 or 43".
-    # We will flag anything that is NOT 7-9 digits.
-    pattern = re.compile(r"^\d{7,9}$")
+    # We will flag anything that is NOT 7-9 digits. ``[0-9]`` (not ``\d``)
+    # restricts to ASCII digits — the Unicode-aware ``\d`` would accept
+    # Arabic-Indic/Devanagari/full-width digits — and the match is applied
+    # via ``fullmatch`` so a trailing newline (which bare ``$`` tolerates)
+    # is rejected too.
+    pattern = re.compile(r"[0-9]{7,9}")
 
     errors = 0
     for i, entry in enumerate(data):
@@ -81,7 +85,7 @@ def main() -> int:
             # Try to cast int to str
             vor_id = str(vor_id)
 
-        if not pattern.match(vor_id):
+        if not pattern.fullmatch(vor_id):
             print(f"Invalid VOR ID format for '{name}': {vor_id} (expected 7-9 digits)", file=sys.stderr)
             errors += 1
 

--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -322,9 +322,13 @@ def _collapse_common_prefix(
 
     * Substantial overlap — at least ``min_prefix`` shared characters,
       ending at a word boundary (space) so we never split mid-word.
-    * Short suffixes — each remainder must be ≤ ``max_suffix`` chars.
-      Joining two long sentences with a comma is harder to read than
-      the explicit ``&`` join the existing logic produces.
+    * Short new suffix — only the *incoming* remainder
+      (``name_remainder``) must be ≤ ``max_suffix`` chars. Joining two
+      long sentences with a comma is harder to read than the explicit
+      ``&`` join the existing logic produces. The existing remainder
+      (``ex_remainder``) is intentionally **not** capped because it
+      accumulates previously-collapsed comma-separated parts (e.g. a
+      growing date list) across successive merges.
     * No directional arrow — ÖBB chain routes carrying ``↔`` use that
       character as a chain joiner (``A ↔ B ↔ C``), not a separator,
       so collapsing them by common prefix would mangle the route.

--- a/src/feed/stammstrecke.py
+++ b/src/feed/stammstrecke.py
@@ -308,7 +308,6 @@ def _format_minutes(value: float) -> str:
 def _episode_start(
     *,
     direction_obs: list[StammstreckeObservation],
-    now: datetime,
 ) -> datetime | None:
     """Find the start timestamp of the current above-threshold episode.
 
@@ -541,7 +540,7 @@ def compute_stammstrecke_events(
                 persisted_starts.pop(direction.target_label, None)
             continue
         avg_delay = mean([obs.delay_minutes for obs in recent])
-        computed_start = _episode_start(direction_obs=direction_obs, now=current)
+        computed_start = _episode_start(direction_obs=direction_obs)
         if computed_start is None:
             # Degenerate case: ``_episode_start`` returned None despite
             # the threshold gate firing. Should be unreachable (the recent

--- a/src/places/client.py
+++ b/src/places/client.py
@@ -203,15 +203,44 @@ class GooglePlacesConfig:
         # may pass a smaller value (tests use 1.0–5.0s) but never raise
         # above ``MAX_TIMEOUT_S``. ``object.__setattr__`` is required
         # because the dataclass is frozen.
-        if self.timeout_s > MAX_TIMEOUT_S:
+        #
+        # Robustness: a non-positive ``timeout_s`` (e.g. a ``REQUEST_TIMEOUT_S``
+        # env typo like ``0`` / ``-1``) is invalid — ``requests`` would raise a
+        # bare ``ValueError`` mid-request and abort the whole enrichment pass.
+        # Fall back to the safe default (``MAX_TIMEOUT_S`` equals the documented
+        # 25 s default) instead of crashing, so the Places tier degrades rather
+        # than hard-fails.
+        if self.timeout_s <= 0 or self.timeout_s > MAX_TIMEOUT_S:
             object.__setattr__(self, "timeout_s", MAX_TIMEOUT_S)
         # Security: enforce the retry ceiling described in the
         # ``MAX_REQUEST_RETRIES`` block above. Same TIGHTEN-only contract
         # as ``timeout_s``: tests use 0–3, default is 4, the cap only
         # truncates oversized env overrides that would otherwise stall
         # the cron job and exhaust the monthly Places quota.
+        #
+        # Robustness: floor a negative ``max_retries`` at 0. A value like
+        # ``-1`` makes the ``while attempt <= max_retries`` loop in ``_post``
+        # never run, so NO request is issued and every tile hard-fails with a
+        # bare ``GooglePlacesError`` — silently disabling the whole Places
+        # fallback tier on a one-character env typo. Floor-clamping to 0 runs
+        # the request exactly once (no retries).
+        if self.max_retries < 0:
+            object.__setattr__(self, "max_retries", 0)
         if self.max_retries > MAX_REQUEST_RETRIES:
             object.__setattr__(self, "max_retries", MAX_REQUEST_RETRIES)
+        # Google Places ``searchNearby`` requires ``maxResultCount`` in [1, 20]
+        # and a positive ``radius`` (≤ 50 000 m). Clamp here so a misconfigured
+        # caller value is corrected at the single source of truth (the config)
+        # rather than silently rejected by the API or, for ``0``, diverging
+        # from the module-global default the client used to read.
+        if self.max_result_count < 1:
+            object.__setattr__(self, "max_result_count", 1)
+        elif self.max_result_count > 20:
+            object.__setattr__(self, "max_result_count", 20)
+        if self.radius_m < 1:
+            object.__setattr__(self, "radius_m", 1)
+        elif self.radius_m > 50000:
+            object.__setattr__(self, "radius_m", 50000)
 
 
 class GooglePlacesClient:
@@ -242,8 +271,13 @@ class GooglePlacesClient:
         self._enforce_quota = enforce_quota
         self._quota_skipped_kinds: set[str] = set()
         self._included_types = self._sanitize_included_types(config.included_types)
-        self._radius_m = RADIUS_M
-        self._max_result_count = MAX_RESULTS
+        # Read per-call geometry from the injected config (the single source
+        # of truth, already range-clamped in ``GooglePlacesConfig.__post_init__``)
+        # instead of the import-time module globals, so caller-supplied
+        # ``radius_m`` / ``max_result_count`` actually reach the request body.
+        # ``RANK_PREF`` stays a module global — the config carries no rank field.
+        self._radius_m = config.radius_m
+        self._max_result_count = config.max_result_count
         self._rank_preference = RANK_PREF
 
     def __enter__(self) -> GooglePlacesClient:
@@ -459,6 +493,13 @@ class GooglePlacesClient:
 
         while attempt <= self._config.max_retries:
             attempt += 1
+            # Breaker state for THIS attempt. When it is HALF_OPEN this request
+            # is the single recovery probe and MUST resolve the breaker: a 429
+            # or a connection-level error — neither of which records a failure
+            # on the normal CLOSED path — would otherwise leave the breaker
+            # stuck HALF_OPEN and admit an unbounded series of probes, each
+            # re-debiting Places quota up-front.
+            probe_state = _BREAKER.state
             # The 429 / 5xx branch below sets ``last_error`` to a
             # ``GooglePlacesError`` (NOT a ``requests.RequestException``), so
             # the legacy extraction from ``last_error.response.headers`` would
@@ -557,7 +598,11 @@ class GooglePlacesClient:
                         return cast(dict[str, object], payload)
 
                     if response.status_code in {429, 500, 502, 503, 504}:
-                        if response.status_code != 429:
+                        # A 429 is deliberately NOT a breaker failure on the
+                        # normal (CLOSED) path — but during a HALF_OPEN probe it
+                        # must still resolve the breaker (re-open it), otherwise
+                        # the probe never completes.
+                        if response.status_code != 429 or probe_state is CircuitState.HALF_OPEN:
                             _BREAKER.record_failure()
 
                         detail = _sanitize_error_detail(response.text, secrets=[self._config.api_key])
@@ -583,13 +628,22 @@ class GooglePlacesClient:
             except requests.RequestException as exc:
                 last_error = exc
 
+                resolved = False
                 if exc.response is not None:
                     if exc.response.status_code >= 500:
                         _BREAKER.record_failure()
+                        resolved = True
                     # Connection-level RequestException occasionally carries a
                     # response (e.g. a chunked-encoding error mid-body). Honour
                     # Retry-After from there too so the two paths converge.
                     retry_after_header = exc.response.headers.get("Retry-After")
+                if not resolved and probe_state is CircuitState.HALF_OPEN:
+                    # The recovery probe hit a connection-level error (no
+                    # response — the common reset/timeout case — or a <500
+                    # attached response). Re-open the breaker so it does not
+                    # remain HALF_OPEN and keep admitting a fresh probe (and a
+                    # fresh quota debit) on every subsequent call.
+                    _BREAKER.record_failure()
 
                 LOGGER.warning(
                     "Request error (attempt %s/%s): %s",

--- a/src/places/merge.py
+++ b/src/places/merge.py
@@ -339,27 +339,40 @@ def _update_station(
             changed = True
 
     existing_place_id = station.get("_google_place_id")
-    if existing_place_id != place.place_id and (
-        existing_place_id is None or matched_by_name or not isinstance(existing_place_id, str)
-    ):
+    # Whether this place is trusted to "own" the station. A distance-only
+    # match (matched_by_name=False) against a station that already carries a
+    # DIFFERENT valid Google place_id is NOT trusted: the place_id guard
+    # below already refuses to adopt the new id in that case, and the
+    # coordinate/type/address writes must be gated on the SAME predicate —
+    # otherwise a neighbouring, distinct place falling within max_distance_m
+    # would keep id X but silently relocate the station onto Y's coordinates
+    # (state corruption in dense areas where several stops share the radius).
+    place_owns_station = (
+        matched_by_name
+        or existing_place_id is None
+        or not isinstance(existing_place_id, str)
+        or existing_place_id == place.place_id
+    )
+    if existing_place_id != place.place_id and place_owns_station:
         station["_google_place_id"] = place.place_id
         changed = True
 
-    if station.get("latitude") != place.latitude:
-        station["latitude"] = place.latitude
-        changed = True
-    if station.get("longitude") != place.longitude:
-        station["longitude"] = place.longitude
-        changed = True
+    if place_owns_station:
+        if station.get("latitude") != place.latitude:
+            station["latitude"] = place.latitude
+            changed = True
+        if station.get("longitude") != place.longitude:
+            station["longitude"] = place.longitude
+            changed = True
 
-    if place.types:
-        if station.get("_types") != place.types:
-            station["_types"] = list(place.types)
-            changed = True
-    if place.formatted_address:
-        if station.get("_formatted_address") != place.formatted_address:
-            station["_formatted_address"] = place.formatted_address
-            changed = True
+        if place.types:
+            if station.get("_types") != place.types:
+                station["_types"] = list(place.types)
+                changed = True
+        if place.formatted_address:
+            if station.get("_formatted_address") != place.formatted_address:
+                station["_formatted_address"] = place.formatted_address
+                changed = True
 
     if "in_vienna" not in station:
         station["in_vienna"] = _infer_in_vienna(place, config.bounding_box)

--- a/src/places/quota.py
+++ b/src/places/quota.py
@@ -68,7 +68,7 @@ class QuotaConfig:
 
 @dataclass
 class MonthlyQuota:
-    """Persisted request counters scoped to the current UTC month."""
+    """Persisted request counters scoped to the current Europe/Vienna month."""
 
     month_key: str
     counts: dict[str, int] = field(default_factory=_empty_counts)
@@ -79,8 +79,14 @@ class MonthlyQuota:
 
     @staticmethod
     def current_month_key(now: datetime | None = None) -> str:
+        # Convert to Europe/Vienna before forming the key so the monthly
+        # counter resets on the SAME calendar boundary as ``current_daily_key``
+        # (and the operator's local mental model). Keying off raw UTC made the
+        # two counters reset on different boundaries for the ~1–2 h each month
+        # where Vienna has crossed into the new month but UTC has not.
         reference = now or _utc_now()
-        return f"{reference.year:04d}-{reference.month:02d}"
+        local_ref = reference.astimezone(ZoneInfo("Europe/Vienna"))
+        return f"{local_ref.year:04d}-{local_ref.month:02d}"
 
     @staticmethod
     def current_daily_key(now: datetime | None = None) -> str:

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -76,7 +76,12 @@ _OEBB_TRUSTED_HOSTS = frozenset({"fahrplan.oebb.at"})
 
 
 def _validated_oebb_url(raw: str) -> str | None:
-    safe = validate_http_url(raw)
+    # ``check_dns=False``: the host is pinned to a single trusted allow-list
+    # value below, so the DNS-rebinding/SSRF resolution adds nothing here. It
+    # would, however, run a blocking DNS lookup at module-import time (this is
+    # called at import) and — worse — silently DROP a legitimate override on a
+    # transient resolver hiccup. The https-scheme + exact-host pins remain.
+    safe = validate_http_url(raw, check_dns=False)
     if not safe:
         return None
     parsed = urlparse(safe)
@@ -147,6 +152,11 @@ ARROW_ANY_RE    = re.compile(
     r"(?:<=>|<->|<>|→|↔|=>|->|<-|=|–|—|\s-\s)"
     r"(?:\s*(?:>|&gt;|&amp;gt;|&#62;|&#x3E;)+)?\s*"
 )
+# Tokens that can never be part of a station name (arrow/separator
+# glyphs). Hoisted to module scope to match every other regex here and
+# the identical constant in ``src/utils/stats.py``; previously this was
+# recompiled on each ``_find_stations_in_text`` call.
+_NOISE_TOKEN_RE = re.compile(r"^[↔→←↗↘↙↖<>=–—\-«»‹›]+$")
 DESC_CLEANUP_RE = re.compile(
     r"(?:(?:<|&lt;|&amp;lt;|&#60;|&#x3C;)+\s*)"
     r"(?:<=>|<->|<>|→|↔|=>|->|<-)"
@@ -1286,7 +1296,6 @@ def _find_stations_in_text(blob: str) -> list[str]:
     # characters appear in route titles ("A ↔ B"), and including them in
     # sliding-window chunks let canonical_name silently expand "Hbf ↔"
     # into "Wien Hauptbahnhof" via the directory's alias-expansion rules.
-    _NOISE_TOKEN_RE = re.compile(r"^[↔→←↗↘↙↖<>=–—\-«»‹›]+$")
     tokens = [t for t in tokens if not _NOISE_TOKEN_RE.match(t)]
     if not tokens:
         return []

--- a/src/providers/vor.py
+++ b/src/providers/vor.py
@@ -447,7 +447,13 @@ _VOR_TRUSTED_HOSTS = frozenset({"routenplaner.verkehrsauskunft.at"})
 
 
 def _validated_vor_base_url(raw: str) -> str | None:
-    safe = validate_http_url(raw)
+    # ``check_dns=False``: the host is pinned to a single trusted allow-list
+    # value below, so the DNS-rebinding/SSRF resolution adds nothing here. It
+    # would, however, run a blocking DNS lookup at module-import time
+    # (``refresh_base_configuration`` runs at import) and silently DROP a
+    # legitimate override on a transient resolver hiccup. The https-scheme +
+    # exact-host pins remain the real checks.
+    safe = validate_http_url(raw, check_dns=False)
     if not safe:
         return None
     parsed = urlparse(safe)
@@ -779,11 +785,17 @@ def load_request_count(bypass_cache: bool = False) -> tuple[str | None, int]:
     return (None, 0)
 
 
-def _persist_quota_to_disk() -> int:
+def _persist_quota_to_disk(force_date: str | None = None) -> int:
     """Persist any pending ``unsaved_delta`` to disk; **does not increment**.
 
     Caller MUST hold :data:`_QUOTA_LOCK`. Returns the new on-disk total
     (or the unchanged in-memory total when there was nothing to flush).
+
+    *force_date* overrides the day the delta is booked under. It is used
+    by :func:`save_request_count` to flush a still-pending prior-day delta
+    under the PRIOR day's date when a long-lived process crosses the Vienna
+    midnight boundary — otherwise the default (current Vienna day) would
+    mis-credit those requests to the new day and zero the prior ledger.
 
     Split off from :func:`save_request_count` 2026-05-15 to fix a
     quota-inflation bug: the previous :func:`_flush_quota_cache` invoked
@@ -810,9 +822,12 @@ def _persist_quota_to_disk() -> int:
     if _QUOTA_CACHE.get("unsaved_delta", 0) <= 0:
         return cast(int, _QUOTA_CACHE.get("count", 0))
 
-    vienna_tz = ZoneInfo("Europe/Vienna")
-    now_local = datetime.now(vienna_tz)
-    date_iso = now_local.strftime("%Y-%m-%d")
+    if force_date is not None:
+        date_iso = force_date
+    else:
+        vienna_tz = ZoneInfo("Europe/Vienna")
+        now_local = datetime.now(vienna_tz)
+        date_iso = now_local.strftime("%Y-%m-%d")
 
     # Ensure the parent directory exists before attempting to open the lock file.
     # This prevents FileNotFoundError if the directory structure is missing.
@@ -906,6 +921,14 @@ def save_request_count(now_ignored: datetime | None = None) -> int:
 
         # Fast path: update memory cache and defer file writes to reduce I/O bottleneck
         if _QUOTA_CACHE["date"] != date_iso:
+            # Flush any pending prior-day delta BEFORE resetting, booking it
+            # under the prior day's date. A long-lived process that crosses
+            # the Vienna midnight boundary would otherwise silently discard
+            # up to QUOTA_FLUSH_BATCH_SIZE-1 reserved-but-unflushed requests,
+            # under-counting the prior day's on-disk ledger.
+            prior_date = _QUOTA_CACHE["date"]
+            if prior_date and _QUOTA_CACHE.get("unsaved_delta", 0) > 0:
+                _persist_quota_to_disk(force_date=cast(str, prior_date))
             _QUOTA_CACHE["date"] = date_iso
             _QUOTA_CACHE["count"] = 0
             _QUOTA_CACHE["unsaved_delta"] = 0

--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -951,25 +951,35 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
         )
 
     # E) Sammel-vs.-Einzel: Aggregat entfernen, wenn *alle* Linien als Einzel
-    #    vorliegen — aber nur innerhalb DERSELBEN Kategorie. Ohne den
-    #    Kategorie-Schlüssel löscht z. B. ein Hinweis-Einzelitem (U1) + ein
-    #    Hinweis-Einzelitem (U2) ein echtes Störungs-Aggregat {U1,U2}, obwohl
-    #    keine Einzel-*Störung* diese Linien abdeckt — die Störungsmeldung
-    #    verschwände still aus dem Feed. Spiegelt die Kategorie-Prüfung in F).
-    single_line_coverage: dict[tuple[Any, str], int] = {}
+    #    vorliegen — aber nur innerhalb DERSELBEN Kategorie UND nur, wenn das
+    #    Einzelitem zeitlich überlappt. Ohne den Kategorie-Schlüssel löscht
+    #    z. B. ein Hinweis-Einzelitem (U1) + ein Hinweis-Einzelitem (U2) ein
+    #    echtes Störungs-Aggregat {U1,U2}, obwohl keine Einzel-*Störung* diese
+    #    Linien abdeckt. Ohne die Zeitprüfung löschen zeitlich DISJUNKTE,
+    #    unverwandte Einzelmeldungen (U1 für Zeitraum P1, U2 für P2) ein echtes
+    #    Aggregat für einen dritten Zeitraum P3 — die Störungsmeldung verschwände
+    #    still aus dem Feed. Spiegelt die Kategorie- *und* Zeit-Prüfung in F).
+    single_line_intervals: dict[tuple[Any, str], list[tuple[Any, Any]]] = {}
     for it in items:
         ls = it.get("_lines_set") or set()
         if len(ls) == 1:
             ln = next(iter(ls))
-            cov_key = (it.get("category"), ln)
-            single_line_coverage[cov_key] = single_line_coverage.get(cov_key, 0) + 1
+            single_line_intervals.setdefault((it.get("category"), ln), []).append(
+                (it.get("starts_at"), it.get("ends_at"))
+            )
 
     filtered: list[dict[str, Any]] = []
     for it in items:
         ls = it.get("_lines_set") or set()
         cat = it.get("category")
-        if len(ls) >= 2 and all(single_line_coverage.get((cat, ln), 0) > 0 for ln in ls):
-            continue  # Aggregat raus (nur bei gleicher Kategorie)
+        if len(ls) >= 2 and all(
+            any(
+                _intervals_overlap(it.get("starts_at"), it.get("ends_at"), s, e)
+                for (s, e) in single_line_intervals.get((cat, ln), [])
+            )
+            for ln in ls
+        ):
+            continue  # Aggregat raus (gleiche Kategorie + Zeitüberlappung)
         filtered.append(it)
 
     # F) Subset-Bereinigung: Eintrag entfernen, wenn ein anderer Eintrag eine Obermenge der Linien abdeckt

--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -1006,7 +1006,11 @@ def _find_provider_issues(
        OEBB-sourced station.
     """
     vor_entries: list[Mapping[str, object]] = []
-    oebb_codes: set[object] = set()
+    # Normalise to ``str`` so an OEBB code serialised as int 900100 and a
+    # VOR code serialised as the string "900100" collide correctly (a set
+    # treats ``int`` and ``str`` members as distinct), mirroring the
+    # ``str(...)`` normalisation used by the sibling identity finders.
+    oebb_codes: set[str] = set()
 
     for entry in stations:
         sources = _extract_source_tokens(entry.get("source"))
@@ -1025,7 +1029,7 @@ def _find_provider_issues(
             # raise and propagate out of the public ``validate_stations``
             # entry point.
             if isinstance(bst_code, str | int) and bst_code:
-                oebb_codes.add(bst_code)
+                oebb_codes.add(str(bst_code))
 
     if len(vor_entries) < 2:
         yield ProviderIssue(
@@ -1062,7 +1066,7 @@ def _find_provider_issues(
         # cannot in principle collide with the (string / int) OEBB
         # entries that were admitted above, so skipping it here is
         # semantically correct as well as crash-safe.
-        if isinstance(bst_code, str | int) and bst_code in oebb_codes:
+        if isinstance(bst_code, str | int) and str(bst_code) in oebb_codes:
             yield ProviderIssue(
                 identifier=_format_identifier(entry),
                 name=str(entry.get("name", "")).strip() or "<unknown>",

--- a/src/utils/stats.py
+++ b/src/utils/stats.py
@@ -250,8 +250,10 @@ def _sanitize_csv_text_field(value: str) -> str:
 # :func:`station_info` recognises it — so a poisoned upstream string can
 # never silently land as a "location" cell on the dashboard.
 #
-# All upper bounds are explicit (``{1,80}``) to keep the regex engine
-# bounded on adversarial inputs (ReDoS hardening).
+# All upper bounds are explicit (``{1,200}`` for the labelled-segment
+# captures, ``{1,80}`` for the free-text scans) to keep the regex engine
+# bounded on adversarial inputs (ReDoS hardening); the captured value is
+# later clamped to 80 chars in :func:`_normalise_location`.
 _HALTESTELLE_RE: Final = re.compile(
     r"\|\s*Haltestelle:\s*([^|]{1,200})",
     re.IGNORECASE,

--- a/tests/places/test_client_circuit_breaker.py
+++ b/tests/places/test_client_circuit_breaker.py
@@ -138,3 +138,75 @@ def test_success_resets_failure_streak(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result == {"places": []}
     assert _BREAKER.state is CircuitState.CLOSED
     assert session.post.call_count == 5
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+def _install_half_open_breaker(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Install a fresh single-failure breaker (with an injected clock) as the
+    module-level ``_BREAKER`` and drive it to HALF_OPEN."""
+    from src.utils.circuit_breaker import CircuitBreaker
+
+    clock = _FakeClock()
+    breaker = CircuitBreaker(
+        "places-half-open-test",
+        failure_threshold=1,
+        recovery_timeout=5.0,
+        clock=clock,
+    )
+    monkeypatch.setattr("src.places.client._BREAKER", breaker)
+    breaker.record_failure()  # threshold=1 → OPEN
+    assert breaker.state is CircuitState.OPEN
+    clock.advance(6.0)  # recovery elapsed → next state read transitions to HALF_OPEN
+    return breaker
+
+
+def test_half_open_probe_429_reopens_breaker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 429 during the HALF_OPEN recovery probe must RE-OPEN the breaker.
+
+    Pre-fix a 429 skipped ``record_failure`` unconditionally, so the probe
+    left the breaker stuck HALF_OPEN — every subsequent call then issued
+    another probe (re-debiting quota) instead of holding OPEN.
+    """
+    monkeypatch.setattr("src.places.client.time.sleep", lambda _s: None)
+    breaker = _install_half_open_breaker(monkeypatch)
+    session = MagicMock(spec=requests.Session)
+    session.post.return_value = _MockResponse(429)
+    client = GooglePlacesClient(_CONFIG, session=session)
+
+    with pytest.raises(GooglePlacesError):
+        client._post("places:searchNearby", {}, quota_kind="nearby")
+
+    # The probe resolved the breaker (re-opened it) and stopped after one
+    # request instead of looping on further probes.
+    assert breaker.state is CircuitState.OPEN
+    assert session.post.call_count == 1
+
+
+def test_half_open_probe_connection_error_reopens_breaker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connection-level error (no attached response — the common reset /
+    timeout case) during the HALF_OPEN probe must also re-open the breaker
+    rather than leave it stuck HALF_OPEN.
+    """
+    monkeypatch.setattr("src.places.client.time.sleep", lambda _s: None)
+    breaker = _install_half_open_breaker(monkeypatch)
+    session = MagicMock(spec=requests.Session)
+    session.post.side_effect = requests.ConnectionError("connection reset")
+    client = GooglePlacesClient(_CONFIG, session=session)
+
+    with pytest.raises(GooglePlacesError):
+        client._post("places:searchNearby", {}, quota_kind="nearby")
+
+    assert breaker.state is CircuitState.OPEN
+    assert session.post.call_count == 1

--- a/tests/providers/data/stations_expected.json
+++ b/tests/providers/data/stations_expected.json
@@ -23,10 +23,11 @@
   {
     "_formatted_address": "Landstraße, 1030 Wien",
     "_google_place_id": "place-wien-mitte",
-    "latitude": 48.2066,
-    "longitude": 16.3844,
+    "latitude": 48.207,
+    "longitude": 16.3845,
     "_types": [
-      "train_station"
+      "train_station",
+      "bus_station"
     ],
     "aliases": [
       "Landstraße"

--- a/tests/scripts/test_update_stammstrecke_hbf.py
+++ b/tests/scripts/test_update_stammstrecke_hbf.py
@@ -271,6 +271,25 @@ def test_departure_delay_minutes_small_early_departure_not_treated_as_rollover()
     assert script._departure_delay_minutes(dep) == -2.0
 
 
+def test_departure_delay_minutes_handles_early_across_midnight_rollover() -> None:
+    """Symmetric to the late-across-midnight case: a leg scheduled just
+    AFTER midnight that departs a few minutes EARLY (rtTime on the previous
+    day) must NOT produce a bogus ~+24 h delay.
+
+    Pre-fix only the forward wrap (``scheduled − actual > 12 h``) was
+    corrected; a leg scheduled ``00:05`` with rtTime ``23:54`` (no rtDate)
+    computed actual = same-day 23:54 → +1429 min instead of the true
+    −11 min, massively skewing the per-direction mean for that tick.
+    """
+    dep = {
+        "date": "2026-05-15",
+        "time": "00:05:00",
+        # rtDate omitted; rtTime is 11 min EARLY, landing on the prior day.
+        "rtTime": "23:54:00",
+    }
+    assert script._departure_delay_minutes(dep) == -11.0
+
+
 # ---- _collect_hbf_observations --------------------------------------------
 
 

--- a/tests/scripts/test_update_stammstrecke_status.py
+++ b/tests/scripts/test_update_stammstrecke_status.py
@@ -398,6 +398,26 @@ def test_leg_departure_delay_skips_cancelled_leg() -> None:
     assert script._leg_departure_delay_minutes(leg) is None
 
 
+def test_leg_departure_delay_handles_early_across_midnight_rollover() -> None:
+    """Symmetric midnight wrap: a leg scheduled just AFTER midnight that
+    departs a few minutes EARLY (rtTime on the prior day, no rtDate) must
+    yield the true small negative delay (≈ −11 min), not a bogus ~+24 h
+    that would skew the per-direction mean.
+    """
+
+    leg = {
+        "type": "JNY",
+        "name": "S 1",
+        "category": "S",
+        "Origin": {
+            "date": "2026-05-09",
+            "time": "00:05:00",
+            "rtTime": "23:54:00",  # 11 min early, lands on the previous day.
+        },
+    }
+    assert script._leg_departure_delay_minutes(leg) == -11.0
+
+
 def test_leg_departure_delay_skips_unparseable_schedule() -> None:
     """When the scheduled timestamp is malformed we cannot compute a
     delta — return ``None`` rather than risk a misleading 0.

--- a/tests/test_audit_round2_regressions.py
+++ b/tests/test_audit_round2_regressions.py
@@ -1,0 +1,139 @@
+"""Regression tests for the round-2 line-by-line audit (2026-05).
+
+Each test pins a behavioural fix so a future refactor that reintroduces the
+defect fails loudly. The companion fixes for the midnight-rollover heuristic,
+the Places circuit-breaker HALF_OPEN probe and the ``_make_rss`` mock contract
+live next to their existing siblings (``tests/scripts/test_update_stammstrecke_*``,
+``tests/places/test_client_circuit_breaker.py``, ``tests/test_build_feed_mutation.py``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import MagicMock
+
+import requests
+
+from src.places.client import (
+    MAX_REQUEST_RETRIES,
+    MAX_TIMEOUT_S,
+    GooglePlacesClient,
+    GooglePlacesConfig,
+    Place,
+)
+from src.places.merge import MergeConfig, StationEntry, merge_places
+from src.places.quota import MonthlyQuota
+
+
+def _cfg(**overrides: Any) -> GooglePlacesConfig:
+    base: dict[str, Any] = dict(
+        api_key="k",
+        included_types=["bus_station"],
+        language="de",
+        region="AT",
+        radius_m=1000,
+        timeout_s=5.0,
+        max_retries=2,
+        max_result_count=20,
+    )
+    base.update(overrides)
+    return GooglePlacesConfig(**base)
+
+
+# --- #1: GooglePlacesConfig floor/range clamps -----------------------------
+
+
+def test_config_floors_negative_retries_to_zero() -> None:
+    # A negative ``max_retries`` made ``while attempt <= max_retries`` never
+    # run → every tile hard-failed and the whole Places tier silently died.
+    assert _cfg(max_retries=-1).max_retries == 0
+    assert _cfg(max_retries=-99).max_retries == 0
+
+
+def test_config_clamps_nonpositive_timeout_to_default() -> None:
+    # A non-positive timeout would make ``requests`` raise a bare ValueError
+    # mid-request and abort the enrichment pass; fall back to the safe default.
+    assert _cfg(timeout_s=0).timeout_s == MAX_TIMEOUT_S
+    assert _cfg(timeout_s=-3.0).timeout_s == MAX_TIMEOUT_S
+
+
+def test_config_still_caps_oversized_timeout_and_retries() -> None:
+    assert _cfg(timeout_s=99999.0).timeout_s == MAX_TIMEOUT_S
+    assert _cfg(max_retries=99999).max_retries == MAX_REQUEST_RETRIES
+
+
+def test_config_clamps_result_count_and_radius_to_api_range() -> None:
+    assert _cfg(max_result_count=0).max_result_count == 1
+    assert _cfg(max_result_count=99).max_result_count == 20
+    assert _cfg(radius_m=0).radius_m == 1
+    assert _cfg(radius_m=10**9).radius_m == 50000
+
+
+# --- #8: client consumes the config geometry, not the module globals -------
+
+
+def test_client_uses_config_geometry_not_module_globals() -> None:
+    cfg = _cfg(radius_m=1234, max_result_count=7)
+    client = GooglePlacesClient(cfg, session=MagicMock(spec=requests.Session))
+    assert client._radius_m == 1234
+    assert client._max_result_count == 7
+
+
+# --- #2: distance match must not relocate a station bound to another id ----
+
+
+def test_distance_match_preserves_station_bound_to_other_place_id() -> None:
+    """A distance-only match against a station that already carries a DIFFERENT
+    valid Google place_id must keep that id AND its coordinates/types/address —
+    it must not be silently relocated onto a neighbouring, distinct place."""
+    existing: list[StationEntry] = [
+        {
+            "name": "Established Stop",
+            "source": "oebb,google_places",
+            "_google_place_id": "place-X",
+            "aliases": [],
+            "latitude": 48.2060,
+            "longitude": 16.3840,
+            "_types": ["train_station"],
+            "_formatted_address": "Addr X",
+            "in_vienna": True,
+        }
+    ]
+    # A distinct place (different id, non-matching name) ~66 m away — within
+    # the 150 m radius, so it matches by distance, not by name.
+    places = [
+        Place(
+            place_id="place-Y",
+            name="Totally Different Name",
+            latitude=48.2065,
+            longitude=16.3845,
+            types=["bus_station"],
+            formatted_address="Addr Y",
+        )
+    ]
+    outcome = merge_places(
+        existing, places, MergeConfig(max_distance_m=150.0, bounding_box=None)
+    )
+    station = next(s for s in outcome.stations if s["name"] == "Established Stop")
+    assert station["_google_place_id"] == "place-X"
+    assert station["latitude"] == 48.2060
+    assert station["longitude"] == 16.3840
+    assert station["_types"] == ["train_station"]
+    assert station["_formatted_address"] == "Addr X"
+
+
+# --- #29: monthly quota key resets on the Vienna boundary, like the day key -
+
+
+def test_month_key_uses_vienna_not_utc_across_boundary() -> None:
+    # UTC 2026-01-31 23:30 == Vienna 2026-02-01 00:30 (CET, +1 h): the month
+    # and day keys must advance TOGETHER (both Europe/Vienna).
+    instant = datetime(2026, 1, 31, 23, 30, tzinfo=UTC)
+    assert MonthlyQuota.current_month_key(instant) == "2026-02"
+    assert MonthlyQuota.current_daily_key(instant) == "2026-02-01"
+
+
+def test_month_key_midday_utc_matches_vienna_month() -> None:
+    instant = datetime(2026, 3, 15, 10, 0, tzinfo=UTC)
+    assert MonthlyQuota.current_month_key(instant) == "2026-03"

--- a/tests/test_build_feed_mutation.py
+++ b/tests/test_build_feed_mutation.py
@@ -10,7 +10,7 @@ def test_build_feed_mutation() -> None:
          patch.object(bf, "_summarize_duplicates", return_value=[]), \
          patch.object(bf, "_dedupe_items", return_value=items), \
          patch.object(bf, "deduplicate_fuzzy", return_value=items), \
-         patch.object(bf, "_make_rss", return_value=("", set())), \
+         patch.object(bf, "_make_rss", return_value=""), \
          patch.object(bf, "_load_state", return_value={}), \
          patch.object(bf, "_save_state"), \
          patch.object(bf, "atomic_write", MagicMock()):

--- a/tests/test_path_guard.py
+++ b/tests/test_path_guard.py
@@ -33,7 +33,7 @@ def test_out_path_rejects_outside_whitelist(
     # Set env var so refresh_from_env picks it up and validation fails
     monkeypatch.setenv("OUT_PATH", "../evil.xml")
     monkeypatch.setattr(build_feed, "_collect_items", lambda: [])
-    monkeypatch.setattr(build_feed, "_make_rss", lambda items, now, state: ("", None))
+    monkeypatch.setattr(build_feed, "_make_rss", lambda items, now, state: "")
     monkeypatch.setattr(build_feed, "_load_state", lambda: {})
     monkeypatch.setattr(build_feed, "_save_state", lambda state: None)
 


### PR DESCRIPTION
## Zweiter Line-by-Line-Audit (2026-05)

Ein zweiter, umfassender Multi-Agent-Review des gesamten Projekts über sechs Dimensionen (Sicherheit, Logik, Code, Performance, Grammatik/Rechtschreibung, deutschsprachige Doku). 18 Finder-Agents fanden 50 Roh-Funde; jeder wurde adversariell verifiziert → **40 bestätigt** (5 medium, 35 low), 10 als False Positives verworfen.

Davon sind **32 gefixt** und **8 bewusst zurückgestellt** (Begründung unten; inkl. #4, das per PR technisch nicht anwendbar ist). Schwerpunkt: stille Daten-/Feed-Verluste, Fehlkonfig-Robustheit, CI-Supply-Chain-Härtung, deutschsprachige Doku-Drift.

### Behoben (32)

**Sicherheit / CI**
- `build-feed.yml`: `actions/cache` auf v4.3.0-SHA gepinnt (wie die Schwester-Steps); `bandit.yml`: `bandit[sarif]>=1.9.4,<2.0` gepinnt (Gleichlauf mit requirements-dev/pre-commit).
- `test-vor-api.yml`: `exit 78` ergibt für einen `run:`-Step **keinen** Neutral/Skip-Status, sondern hartes Job-Failure → durch ein `have_secrets`-Flag + gated Steps ersetzt (sauberer grüner Skip ohne Secrets).

> **Hinweis zu Finding #4 (Claude-Workflow-SHA-Pin):** Lässt sich **nicht** per PR anwenden. Die `anthropics/claude-code-action`-App verlangt, dass die aufrufende Workflow-Datei byte-identisch zur Default-Branch ist (Token-Exfiltrations-Schutz); jeder PR, der `claude-code-review.yml` ändert, lässt den `claude-review`-Check mit 401 rot werden („Workflow validation failed"). Der Pin müsste per Direkt-Push auf `main` durch den Maintainer erfolgen. Daher hier zurückgenommen, damit CI grün bleibt — das ist genau der Grund, warum diese zwei Vendor-Workflows die einzigen Floating-Tag-Ausnahmen im Repo sind.

**Logik / Korrektheit**
- `places/client.py`: `GooglePlacesConfig` clampt jetzt auch nach unten — negatives `max_retries→0` (verhinderte sonst jede Anfrage und legte die ganze Places-Stufe still lahm), nicht-positives `timeout_s→Default`, `max_result_count→[1,20]`, `radius_m→[1,50000]`. Der Client liest Radius/Result-Count nun aus der config statt aus Import-Zeit-Globals.
- `places/merge.py`: Eine reine Distanz-Übereinstimmung gegen eine Station mit **anderer** gültiger Google-`place_id` überschreibt nicht mehr deren Koordinaten/Typen/Adresse (verschob bislang etablierte Stationen auf einen Nachbar-Ort).
- `places/client.py`: Circuit-Breaker-HALF_OPEN-Probe löst jetzt immer auf — ein 429 oder Connection-Error während der Probe öffnet den Breaker wieder, statt ihn in HALF_OPEN festzuhängen (unbegrenzte Probes + Quota-Verbrauch).
- `places/quota.py`: Monatsschlüssel nutzt Europe/Vienna (wie der Tagesschlüssel) → beide Zähler setzen an derselben Grenze zurück.
- `providers/wl_fetch.py` (Section E): Aggregat-Entfernung verlangt jetzt eine **zeitlich überlappende** Einzelmeldung derselben Kategorie (Parität mit Section F) — zeitlich disjunkte Einzelmeldungen löschen kein echtes Aggregat mehr.
- `providers/vor.py`: ausstehender Vortags-Quota-Delta wird vor dem Mitternachts-Reset unter dem **Vortagsdatum** geflusht (kein stilles Unterzählen mehr).
- `update_stammstrecke_hbf.py` / `_status.py`: symmetrische Mitternachts-Rollover-Korrektur (früh-über-Mitternacht) → kein bogus ~+24 h-Delay mehr, der den Richtungs-Mittelwert verzerrt.
- `update_wl_stations.py`: VOR-Mapping-Koordinaten-Fallback prüft jetzt Finitheit + WGS84-Range (wie jeder andere Koordinaten-Eingang).
- `stations_validation.py`: `bst_code` wird beidseitig auf `str` normalisiert → int-vs-str-Serialisierung derselben Betriebsstelle kollidiert korrekt.
- `apply_station_overrides.py`: Restore erzwingt `wl_diva == Idempotenz-Schlüssel` (keine Duplikat-Wiedereinfügung bei divergentem Template).
- `validate_vor_mapping.py`: ASCII-Ziffern + `fullmatch` (lehnt Unicode-Ziffern & Trailing-Newline ab).

**Robustheit / Cron-Autarkie**
- `update_wl_cache.py` / `update_oebb_cache.py`: fangen `DataDegradationError` von `write_cache` ab (auch bei drastisch kleinerem Payload, nicht nur leer) → bestehender Cache bleibt, kein Crash der Cron-Stufe.
- `oebb.py` / `vor.py`: gepinnte-Host-Validatoren mit `check_dns=False` → kein blockierender Import-Zeit-DNS-Lookup und kein stilles Verwerfen eines gültigen Overrides bei DNS-Aussetzer.
- `sync_hafas_profile.py`: JS-Kommentar-Stripper ist nun string-literal-bewusst (`//` in einer URL/String wird nicht mehr als Zeilenkommentar fehlgedeutet).

**Performance / Aufräumen**
- `oebb.py`: `_NOISE_TOKEN_RE` auf Modulebene gehoben (kein Recompile pro Aufruf).
- `feed/stammstrecke.py`: toten `now`-Parameter entfernt; `update_wl_stations.py`: tote `_derive_bst_*`-Helfer entfernt; `update_all_stations.py`: `--polygon`-Arg.

**Doku & Grammatik (100% Deutsch)**
- `architecture.md`: veralteten `extract_location_name`-Absatz neu geschrieben (Freitext-/Stoppwort-Fallback gibt es seit 2026-05-09 nicht mehr); „verschlüsselt" → „geokodiert"; zwei driftende Zeilen-Anker entfernt.
- `index.md`: „mit strikten Wien-Filter" → „mit striktem Wien-Filter" (Dativ).
- `development.md`: Validierungsbericht hat 10 Kategorien (nicht widersprüchlich 8/9); fehlende „cross-name alias collisions" ergänzt.
- Diverse stale Docstrings/Kommentare korrigiert (`stats.py {1,80}`, `merge.py`-Suffix-Cap, `update_wl_stations` `--download`-Host).

### Bewusst zurückgestellt (8) — Begründung
Alle low/medium; jeweils mit klarer Begründung (Mikro-Optimierung/Risiko vs. Nutzen, bzw. technisch nicht per PR anwendbar):
- **Claude-Workflow-SHA-Pin (#4)** — siehe Hinweis oben: bricht zwangsläufig den `claude-review`-Check; nur per Maintainer-Direkt-Push auf `main` möglich.
- **HAFAS-Session-Reuse** — reale, aber minimale Perf-Optimierung (wöchentlicher Cron, ~Sekunden); Session durch Breaker-Call + beide Aufrufer zu fädeln birgt bei Best-Effort-Netzwerk-Code mehr Risiko als Nutzen.
- **`_strip_sensitive_params` Re-Encoding** — Bruch ist konstruiert/kontriviert; Änderung am Live-Redirect-Pfad riskanter als der Befund.
- **Preflight Places-Tageskontingent** — toter Pfad (kein Workflow ruft `--check places`); „keine Änderung für Korrektheit nötig".
- **EN-Feed-Doppelformatierung** — riskantes Refactoring in komplexitäts-gegateter 4600-Zeilen-Datei bei vernachlässigbarem Nutzen.
- **`_post_filter_oebb` doppeltes `_extract_routes`** — durch OEBB-Cache-Größe begrenzt, Station-Lookups bereits gecacht.
- **Quota-vor-Breaker-Reihenfolge** — Breaker ist prozesslokal und pro Cron-Tick CLOSED; bei einem `_process_tick` pro Prozess unerreichbar → reiner No-op.
- **`test_merge_mutation_order` settrace** — reine Test-Qualität; ein Rewrite riskiert einen falschen Test (Verifier warnte vor zu strenger Fassung).

### Validierung (lokal)
- `ruff` (src+scripts+tests): sauber.
- C901-Komplexitäts-Gate: bestanden (0 neue Verstöße).
- `mypy --strict` (src+tests): null neue Fehler (nur die bekannten Windows-only `fcntl`/`os.fchmod`-Zeilen, die auf Linux-CI mit leerer Baseline grün sind).
- Gezielte Tests über **alle** berührten Module: 531 grün; neue Regressionstests für die Medium-Fixes + den HALF_OPEN-Breaker + das Golden-File. (Die volle Suite ist lokal nicht fahrbar — einzelne Tests machen echtes DNS, das die Sandbox blockiert; CI ist die maßgebliche Instanz.)
