### PR TITLE
fix(security): close CGNAT SSRF bypass, bound PEM ReDoS, harden file writes

### DIFF
--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -186,6 +186,22 @@ def atomic_write(
             except FileExistsError as exc:
                 raise FileExistsError(f"File {target} already exists") from exc
 
+        # Durability: the file's data blocks were fsync'd above, but the
+        # directory entry created by the rename/link is a separate metadata
+        # write that can be lost on power loss / kernel crash. fsync the parent
+        # directory so the appearance of ``target`` is itself durable. Best
+        # effort: platforms without directory file descriptors (e.g. Windows)
+        # raise ``OSError`` on ``os.open`` of a directory and degrade to a
+        # no-op, matching the os.fchmod handling above.
+        try:
+            dir_fd = os.open(target.parent, os.O_RDONLY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+        except OSError:
+            pass
+
     except Exception:
         _close_and_cleanup_failed_write(f, fd, tmp_path)
         raise
@@ -648,10 +664,15 @@ def validate_zip_archive_safe(
         )
     total_declared = 0
     for info in infos:
-        if len(info.filename) > max_filename_length:
+        # Measure the encoded byte length: ``zipfile`` decodes entry names to a
+        # ``str``, so ``len()`` would count code points and let a multibyte
+        # (CJK/emoji) name reach ~4x the cap on disk / in a log line — the very
+        # filename-bomb shape this guard defends against.
+        filename_bytes = len(info.filename.encode("utf-8", "surrogatepass"))
+        if filename_bytes > max_filename_length:
             raise ValueError(
                 f"{label} archive entry filename length exceeds threshold: "
-                f"{len(info.filename)} > {max_filename_length} bytes"
+                f"{filename_bytes} > {max_filename_length} bytes"
             )
         if info.file_size > max_per_entry_uncompressed:
             raise ValueError(

--- a/src/utils/http.py
+++ b/src/utils/http.py
@@ -1196,6 +1196,19 @@ def is_ip_safe(
         else:
             return False
 
+        # Normalize IPv4-mapped IPv6 addresses (``::ffff:a.b.c.d``) to their
+        # embedded IPv4 form so every property and range check below — most
+        # importantly the explicit RFC 6598 Shared-Address-Space (CGNAT) block
+        # — runs against the real IPv4. On Python 3.11 the mapped form reports
+        # ``is_global=True``/``is_private=False`` for the 100.64.0.0/10 range,
+        # so without this unwrap ``http://[::ffff:100.64.0.1]/`` or an
+        # attacker-controlled AAAA record pointing there would slip past the
+        # IPv4-only CGNAT guard. (3.13 already delegates these properties, but
+        # the project targets 3.11.)
+        mapped = getattr(ip, "ipv4_mapped", None)
+        if mapped is not None:
+            ip = mapped
+
         # Block unspecified addresses (0.0.0.0, ::)
         if ip.is_unspecified:
             return False

--- a/src/utils/secret_scanner.py
+++ b/src/utils/secret_scanner.py
@@ -477,9 +477,9 @@ _HOBA_RE = re.compile(
 # token-shaped body sits inside one of those headers. The
 # ``is_covered`` check in ``_scan_content`` anchors the first matching
 # reason at each span. New auth-scheme detectors (e.g. RFC 7616
-# Digest, RFC 8120 Mutual, RFC 4559 AWS4-HMAC-SHA256)
-# follow the same shape and inherit the ``(?i)`` case-insensitivity
-# invariant pinned per RFC 7235 §2.1.
+# Digest, RFC 8120 Mutual, AWS SigV4 ``AWS4-HMAC-SHA256`` — a vendor
+# scheme with no IETF RFC) follow the same shape and inherit the
+# ``(?i)`` case-insensitivity invariant pinned per RFC 7235 §2.1.
 _AUTH_SCHEME_DETECTORS: tuple[tuple[re.Pattern[str], str], ...] = (
     (_BEARER_RE, "Bearer-Token wirkt echt"),
     (_BASIC_AUTH_RE, "HTTP Basic Authentication Credential gefunden"),
@@ -489,7 +489,13 @@ _AUTH_SCHEME_DETECTORS: tuple[tuple[re.Pattern[str], str], ...] = (
     (_TOKEN_SCHEME_RE, "HTTP Token-Scheme Authentication Credential gefunden"),
 )
 
-_PEM_RE = re.compile(r"(-----BEGIN [A-Z ]*PRIVATE KEY-----)(?:.|\n)*?(-----END [A-Z ]*PRIVATE KEY-----)")
+# Security: the inter-anchor gap is bounded (``{0,8192}?`` — well above any
+# real PEM body, an RSA-4096 key is ~3.2 KiB) instead of the unbounded
+# ``(?:.|\n)*?``. An unbounded lazy quantifier makes ``finditer`` restart at
+# every ``BEGIN`` marker and scan to EOF when no ``END`` follows, which is
+# O(markers x filesize) — a crafted file (hostile-PR threat model) could hang
+# the secret-scan gate. The bound caps per-start-position work to a constant.
+_PEM_RE = re.compile(r"(-----BEGIN [A-Z ]*PRIVATE KEY-----)(?:.|\n){0,8192}?(-----END [A-Z ]*PRIVATE KEY-----)")
 
 # Known high-value token patterns to detect specifically
 # These bypass the generic entropy checks and provide specific descriptions
@@ -2786,8 +2792,9 @@ def _scan_auth_scheme_credentials(
 ) -> list[tuple[int, str, str]]:
     """Scan *content* for HTTP-auth-scheme-prefixed credential leaks.
 
-    Iterates over :data:`_AUTH_SCHEME_DETECTORS` (currently
-    ``_BEARER_RE`` + ``_BASIC_AUTH_RE``) and emits one finding per match
+    Iterates over :data:`_AUTH_SCHEME_DETECTORS` (Bearer, Basic,
+    Negotiate, NTLM, HOBA and the generic Token scheme) and emits one
+    finding per match
     that passes ``_looks_like_secret(candidate, is_assignment=True)`` and
     does not overlap an already-covered range. Mutates
     ``covered_ranges`` in place so subsequent detector loops in
@@ -2796,10 +2803,9 @@ def _scan_auth_scheme_credentials(
     Extracted from :func:`_scan_content` to keep the latter at its C901
     complexity baseline while still extending coverage to additional
     auth-scheme literals from the HTTP authentication family (RFC 7235
-    §2.1 case-insensitive auth-scheme contract). Future detectors (RFC
-    7616 Digest, RFC 4559 SPNEGO, RFC 7486 HOBA) extend
-    ``_AUTH_SCHEME_DETECTORS`` without changing this helper or the
-    caller.
+    §2.1 case-insensitive auth-scheme contract). Future detectors (e.g.
+    RFC 7616 Digest) extend ``_AUTH_SCHEME_DETECTORS`` without changing
+    this helper or the caller.
     """
     findings: list[tuple[int, str, str]] = []
     for regex, reason in _AUTH_SCHEME_DETECTORS:

--- a/tests/test_secret_scanner_pem.py
+++ b/tests/test_secret_scanner_pem.py
@@ -31,5 +31,29 @@ iAMfQyuvBjM9OiMIIEpQIBAAKCAQEA3Tz2mr7SZiAMfQyuvBjM9OiMIIEpQIBAAK
         self.assertIn("Private Key (PEM) gefunden", reasons)
         self.assertEqual(len(findings), 1, "Should be deduplicated")
 
+    def test_pem_unterminated_markers_do_not_blow_up(self) -> None:
+        # Regression guard for the quadratic ReDoS in _PEM_RE: many BEGIN
+        # markers with no matching END must not drive finditer to scan to EOF
+        # at every start position. The bounded inter-anchor quantifier keeps
+        # this near-linear, so it completes well within the suite timeout and
+        # (correctly) reports no PEM finding.
+        content = ("-----BEGIN RSA PRIVATE KEY-----\n" + "A" * 40 + "\n") * 3000
+        findings = _scan_content(content)
+        reasons = [f[2] for f in findings]
+        self.assertNotIn("Private Key (PEM) gefunden", reasons)
+
+    def test_pem_large_body_within_bound_detected(self) -> None:
+        # A realistic large key body (well under the 8192-char bound, an
+        # RSA-4096 PEM is ~3.2 KiB) is still detected after bounding _PEM_RE.
+        body = "A" * 4000
+        pem_content = (
+            "-----BEGIN RSA PRIVATE KEY-----\n"
+            f"{body}\n"
+            "-----END RSA PRIVATE KEY-----"
+        )
+        findings = _scan_content(pem_content)
+        reasons = [f[2] for f in findings]
+        self.assertIn("Private Key (PEM) gefunden", reasons)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ssrf_ipv6_bypass.py
+++ b/tests/test_ssrf_ipv6_bypass.py
@@ -38,3 +38,20 @@ def test_other_translation_prefixes() -> None:
 def test_ipv4_mapped() -> None:
     # IPv4-mapped (::ffff:0:0/96) - Should be blocked
     assert is_ip_safe(ipaddress.ip_address("::ffff:127.0.0.1")) is False
+
+
+def test_ipv4_mapped_cgnat_blocked() -> None:
+    # IPv4-mapped Shared Address Space / CGNAT (RFC 6598, ::ffff:100.64.0.0/10).
+    # On Python 3.11 the mapped form reports is_global=True / is_private=False,
+    # so without the ipv4_mapped unwrap in is_ip_safe it would slip past the
+    # IPv4-only 100.64.0.0/10 block (reachable via an attacker-controlled AAAA
+    # record or an ``http://[::ffff:100.64.0.1]/`` URL literal).
+    assert is_ip_safe(ipaddress.ip_address("100.64.0.1")) is False
+    assert is_ip_safe(ipaddress.ip_address("::ffff:100.64.0.1")) is False
+
+
+def test_ipv4_mapped_public_still_allowed() -> None:
+    # The unwrap must not over-block: a genuinely public mapped address stays
+    # reachable (parity with its bare IPv4 form).
+    assert is_ip_safe(ipaddress.ip_address("8.8.8.8")) is True
+    assert is_ip_safe(ipaddress.ip_address("::ffff:8.8.8.8")) is True


### PR DESCRIPTION
Third deep audit — **security & robustness** group. Each item was adversarially verified against the real code before fixing.

## Changes
| File | Fix | Severity |
|------|-----|----------|
| `src/utils/http.py` | Unwrap IPv4-mapped IPv6 in `is_ip_safe` so `::ffff:100.64.0.0/10` (CGNAT) can no longer bypass the IPv4-only RFC 6598 block on Python 3.11 | **high** (SSRF) |
| `src/utils/secret_scanner.py` | Bound `_PEM_RE` inter-anchor gap (`{0,8192}?`) — kills the O(n^2) ReDoS that a hostile-PR file could use to hang the secret-scan gate | **high** (DoS) |
| `src/utils/files.py` | `validate_zip_archive_safe`: measure filename cap in UTF-8 **bytes** (matching the docstring/error) | low |
| `src/utils/files.py` | `atomic_write`: fsync the parent directory after rename/link for crash durability (best-effort, no-ops without dir fds) | low |
| `src/utils/secret_scanner.py` | 3 stale docstring/comment corrections (detector inventory; SPNEGO/HOBA already implemented; AWS4-HMAC-SHA256 is a vendor scheme, not RFC 4559) | low (docs) |

## Tests
* New: `test_ipv4_mapped_cgnat_blocked`, `test_ipv4_mapped_public_still_allowed` (SSRF), `test_pem_unterminated_markers_do_not_blow_up`, `test_pem_large_body_within_bound_detected`.
* Verified locally: ruff clean, mypy --strict introduces no new errors (only the known Windows-only fcntl/os.fchmod baseline), targeted SSRF/PEM/zip/files suites green.

Generated with Claude Code