### PR TITLE
fix(logic): correctness fixes across providers, stats, breaker, quota preflight

### DIFF
--- a/scripts/apply_station_overrides.py
+++ b/scripts/apply_station_overrides.py
@@ -176,7 +176,11 @@ def _alpha_insertion_index(stations: list[dict[str, Any]], target_name: str) -> 
 
 
 def _op_restore(stations: list[dict[str, Any]], override: dict[str, Any]) -> str:
-    diva = override["wl_diva"]
+    # Strip once (mirroring ``_op_patch_coords`` / ``_op_remove``) so the
+    # idempotency key used for ``_find_by_diva`` is identical to the value
+    # stored on the inserted record — otherwise a wl_diva with surrounding
+    # whitespace would miss the lookup and re-insert a duplicate every tick.
+    diva = str(override["wl_diva"]).strip()
     entry_template = override.get("entry")
     if not isinstance(entry_template, dict):
         raise OverrideError(

--- a/scripts/preflight_quota_check.py
+++ b/scripts/preflight_quota_check.py
@@ -158,8 +158,10 @@ def _configure_safe_logging(level: int = logging.INFO) -> None:
 VOR_DAILY_LIMIT: Final[int] = 100
 VOR_QUOTA_FILE: Final[Path] = REPO_ROOT / "data" / "vor_request_count.json"
 
-# Google Places monthly + daily caps. Mirror the env defaults used by
-# the OSM-first / Google-Places-fallback step in ``update-stations.yml``.
+# Google Places monthly cap. (This preflight gates only the monthly total;
+# the daily Places sub-cap is enforced in-script by ``MonthlyQuota``.) Mirror
+# the env defaults used by the OSM-first / Google-Places-fallback step in
+# ``update-stations.yml``.
 PLACES_QUOTA_FILE: Final[Path] = REPO_ROOT / "data" / "places_quota.json"
 PLACES_DEFAULT_MONTHLY: Final[int] = 4000
 
@@ -251,11 +253,15 @@ def _check_places(margin: int, limit: int) -> int:
     expensive workflow steps that run *before* the client is invoked).
     """
     state = _read_json_file(PLACES_QUOTA_FILE)
-    # Cross-month boundary → counter resets to 0.
+    # Cross-month boundary → counter resets to 0. The stored ``month`` is
+    # written by ``MonthlyQuota.current_month_key`` in Europe/Vienna, so the
+    # comparison month MUST also be Vienna-local — using UTC here would, in the
+    # ~1–2 h month-end window where Vienna has rolled over but UTC has not,
+    # falsely treat the counter as freshly reset and pass a near-cap run.
     from datetime import datetime
     from zoneinfo import ZoneInfo
 
-    current_month = datetime.now(ZoneInfo("UTC")).strftime("%Y-%m")
+    current_month = datetime.now(ZoneInfo("Europe/Vienna")).strftime("%Y-%m")
     stored_month = state.get("month")
     if stored_month != current_month:
         return margin

--- a/scripts/update_wl_stations.py
+++ b/scripts/update_wl_stations.py
@@ -926,6 +926,14 @@ def build_wl_entries(
                 ):
                     latitude = round(float(lat_val), 6)
                     longitude = round(float(lon_val), 6)
+                    # The flags above were derived from the unreliable name
+                    # lookup because aggregate coords were missing. Now that the
+                    # VOR mapping's coordinates have been adopted, re-derive
+                    # ``in_vienna`` from them (mirroring the aggregate-coord and
+                    # co-located-merge branches) so the persisted flag stays
+                    # consistent with the persisted coordinates — the invariant
+                    # ``test_coordinates_match_in_vienna_flag`` checks.
+                    in_vienna = is_in_vienna(latitude, longitude)
         aliases.update(_alias_variants(station.name, canonical, resolved_name or None))
         # Mirror the legacy WL-auto-promote heuristic from
         # ``update_station_directory._annotate_station_flags`` (a WL-sourced
@@ -1086,8 +1094,6 @@ def _merge_colocated_duplicates(
 def _haversine_m(
     lat1: float, lon1: float, lat2: float, lon2: float
 ) -> float:
-    import math
-
     radius = 6_371_000.0
     p1, p2 = math.radians(lat1), math.radians(lat2)
     dp = math.radians(lat2 - lat1)

--- a/src/feed/reporting.py
+++ b/src/feed/reporting.py
@@ -420,7 +420,11 @@ class RunReport:
     def record_exception(self, exc: Exception) -> None:
         message = f"{exc.__class__.__name__}: {exc}"
         self.exception_message = clean_message(message)
-        self.add_error_message(f"Ausnahme: {message}")
+        # Don't also push an "Ausnahme: …" entry into the error list: every
+        # rendering sink already appends ``exception_message`` to its error
+        # output (guarded by ``not in errors``), and the prefixed copy would
+        # never match that guard — so the exception was being listed twice.
+        # The structured "**Ausnahme:**" field still carries the label.
 
     def prune_logs(self) -> None:
         now = self.started_at

--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -545,17 +545,12 @@ _STRECKE_PLAIN_RE = re.compile(
     re.IGNORECASE | re.DOTALL,
 )
 
-# Suffixes that should be stripped before looking up a station name.
-_BAHNHOF_TRAILING_RE = re.compile(
-    r"\s*\b(?:Hauptbahnhof|Bahnhof|Bahnhst|Hbf|Bhf|Bf)\b\.?",
-    re.IGNORECASE,
-)
-# Variant that anchors at end-of-string AND rejects a leading hyphen so
-# compound proper nouns like ``Wien Franz-Josefs-Bahnhof`` keep the
-# trailing ``-Bahnhof`` intact. Stripping it produced a dangling
-# ``Wien Franz-Josefs-`` that leaked into dedup keys (and into visible
-# titles whenever the alias resolution in :func:`station_info` failed to
-# bridge the truncation).
+# Suffix stripped before looking up a station name. Anchored at end-of-string
+# AND rejects a leading hyphen so compound proper nouns like
+# ``Wien Franz-Josefs-Bahnhof`` keep the trailing ``-Bahnhof`` intact.
+# Stripping it produced a dangling ``Wien Franz-Josefs-`` that leaked into
+# dedup keys (and into visible titles whenever the alias resolution in
+# :func:`station_info` failed to bridge the truncation).
 _BAHNHOF_TRAILING_END_RE = re.compile(
     r"(?<![\-‐-―])\s+\b(?:Hauptbahnhof|Bahnhof|Bahnhst|Hbf|Bhf|Bf)\b\.?\s*$",
     re.IGNORECASE,
@@ -1411,7 +1406,7 @@ def _is_poor_title(t: str) -> bool:
 # imaginary prefix onto such titles, mangling the downstream rebuild. The
 # companion :data:`_LEADING_LINE_PREFIX_RE` already requires the colon.
 _LINE_PREFIX_RE = re.compile(
-    r"^\s*((?:REX|RJX|RJ|EC|ICE|IC|WB|NJ|CJX|S-Bahn|S|U|R|D)\s*\d+[A-Za-z]?)\s*:\s*",
+    r"^\s*((?:REX|RJX|RJ|EC|ICE|IC|WB|NJ|CJX|S-Bahn|S|U-Bahn|U|R|D)\s*\d+[A-Za-z]?)\s*:\s*",
     re.IGNORECASE,
 )
 

--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -35,6 +35,7 @@ from .wl_lines import (
 from .wl_text import (
     KW_EXCLUDE,
     KW_RESTRICTION,
+    _VIENNA_TZ,
     _is_facility_only,
     _tidy_title_wl,
     _title_core,
@@ -662,7 +663,11 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
                 # If we found a date in the title, we prioritize it if:
                 # 1. We don't have a start date from API.
                 # 2. Or the title date is later than the API start date (suggesting future event published early).
-                if not start or title_date.date() > start.date():
+                # ``title_date`` is anchored to Europe/Vienna midnight, so the
+                # API ``start`` (UTC-aware) must be projected to Vienna before
+                # comparing calendar days — otherwise the day-boundary decision
+                # drifts by one near midnight UTC.
+                if not start or title_date.date() > start.astimezone(_VIENNA_TZ).date():
                     real_start = title_date
 
             # We check activity based on the API start time (publication/validity start),
@@ -747,7 +752,11 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
 
             real_start = start
             if title_date:
-                if not start or title_date.date() > start.date():
+                # ``title_date`` is anchored to Europe/Vienna midnight, so the
+                # API ``start`` (UTC-aware) must be projected to Vienna before
+                # comparing calendar days — otherwise the day-boundary decision
+                # drifts by one near midnight UTC.
+                if not start or title_date.date() > start.astimezone(_VIENNA_TZ).date():
                     real_start = title_date
 
             if not _is_active(start, end, now):

--- a/src/utils/circuit_breaker.py
+++ b/src/utils/circuit_breaker.py
@@ -337,6 +337,16 @@ class CircuitBreaker:
         except Exception:
             self.record_failure()
             raise
+        except BaseException:
+            # A non-Exception BaseException (KeyboardInterrupt, SystemExit,
+            # GeneratorExit) escaping the probe must still release the
+            # HALF_OPEN single-flight slot — otherwise the breaker stays
+            # wedged forever (the state never leaves HALF_OPEN, so the lazy
+            # recovery timer never re-fires and every later call is refused).
+            # It is deliberately NOT counted as an upstream failure.
+            with self._lock:
+                self._probe_in_flight = False
+            raise
         else:
             self.record_success()
             return result

--- a/src/utils/stations.py
+++ b/src/utils/stations.py
@@ -901,7 +901,6 @@ def is_in_vienna(lat: object, lon: object | None = None) -> bool:
             info = station_info(lat)
             if info:
                 return bool(info.in_vienna)
-            import os
             # _normalize_token casefolds and strips noise — apply the same
             # normalisation to the env-derived city token so a deployer
             # setting WIEN_TOKEN="Wien" (or any cased variant) still
@@ -934,7 +933,8 @@ def is_pendler(name: str) -> bool:
 def vor_station_ids() -> tuple[str, ...]:
     """Return the configured VOR station IDs from ``stations.json``.
 
-    The function collects all entries that provide a ``vor_id`` and returns a
+    The function collects entries that lie inside Vienna or in the commuter
+    belt (``in_vienna`` or ``pendler``) and provide a ``vor_id``, returning a
     sorted tuple of distinct identifiers. Numeric aliases are also included to
     preserve legacy identifiers that may still be referenced externally. This
     centralizes the list of
@@ -975,7 +975,8 @@ def _non_vienna_stations_regex() -> re.Pattern[str] | None:
         if name and not name.isdigit() and len(name) >= 4:
             non_vienna.add(name)
 
-        for alias in entry.get("aliases", []):
+        aliases = entry.get("aliases")
+        for alias in aliases if isinstance(aliases, list) else []:
             if alias:
                 alias_str = str(alias).strip()
                 if alias_str and not alias_str.isdigit() and len(alias_str) >= 4:
@@ -1013,7 +1014,8 @@ def _vienna_stations_regex() -> re.Pattern[str]:
             name = str(entry.get("name", "")).strip().lower()
             if name:
                 vienna.add(name)
-            for alias in entry.get("aliases", []):
+            aliases = entry.get("aliases")
+            for alias in aliases if isinstance(aliases, list) else []:
                 if alias:
                     vienna.add(str(alias).strip().lower())
 

--- a/src/utils/stats.py
+++ b/src/utils/stats.py
@@ -803,13 +803,26 @@ def read_recent_stammstrecke_observations(
         if text is None:
             continue
         reader = csv.DictReader(io.StringIO(text))
-        for row in reader:
-            parsed = _parse_stammstrecke_row(row)
-            if parsed is None:
-                continue
-            if parsed.timestamp < cutoff:
-                continue
-            observations.append(parsed)
+        try:
+            for row in reader:
+                parsed = _parse_stammstrecke_row(row)
+                if parsed is None:
+                    continue
+                if parsed.timestamp < cutoff:
+                    continue
+                observations.append(parsed)
+        except csv.Error as exc:
+            # ``csv`` can raise (e.g. a quoted field exceeding
+            # ``csv.field_size_limit`` still fits under the byte cap) only
+            # while iterating — after ``read_capped_text`` already returned.
+            # Honour the documented best-effort contract: keep the rows read
+            # so far (incl. earlier year-files) instead of propagating.
+            LOGGER.warning(
+                "Stammstrecke ledger %s konnte nicht vollständig gelesen werden: %s",
+                sanitize_log_arg(str(path)),
+                sanitize_log_arg(str(exc)),
+            )
+            continue
     observations.sort(key=lambda obs: obs.timestamp)
     return observations
 

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -203,6 +203,31 @@ def test_call_half_open_admits_exactly_one_probe() -> None:
     assert_state(breaker, CircuitState.CLOSED)
 
 
+def test_call_half_open_releases_probe_slot_on_base_exception() -> None:
+    # A non-Exception BaseException (KeyboardInterrupt/SystemExit/GeneratorExit)
+    # escaping the probe must still release the HALF_OPEN single-flight slot,
+    # or the breaker wedges forever: state never leaves HALF_OPEN (the lazy
+    # recovery timer only re-fires from OPEN) and every later call is refused.
+    clock = FakeClock()
+    breaker = CircuitBreaker(
+        "test", failure_threshold=1, recovery_timeout=1.0, clock=clock
+    )
+    breaker.record_failure()  # OPEN
+    clock.advance(1.5)  # → HALF_OPEN
+
+    def probe_interrupted() -> str:
+        raise KeyboardInterrupt("probe interrupted")
+
+    with pytest.raises(KeyboardInterrupt):
+        breaker.call(probe_interrupted)
+
+    # The slot was released, so the next probe is admitted (not refused with
+    # CircuitBreakerOpen) and can recover the breaker.
+    assert_state(breaker, CircuitState.HALF_OPEN)
+    breaker.call(lambda: "ok")
+    assert_state(breaker, CircuitState.CLOSED)
+
+
 # ---------- reset() ----------
 
 def test_reset_returns_to_closed() -> None:

--- a/tests/test_sentinel_trojan_source_audit_walker.py
+++ b/tests/test_sentinel_trojan_source_audit_walker.py
@@ -126,10 +126,10 @@ ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
         # not committed to any operator-facing sidecar.
         ("src/places/hafas_client.py", 289),
         # Feed-health JSON sink; per-field ``_CONTROL_CHARS_RE.sub("",
-        # ...)`` calls at lines 726 / 729 / 777 strip the canonical
+        # ...)`` calls at lines 730 / 733 / 781 strip the canonical
         # attack-byte union from every user-controlled string field
         # before ``json.dump``.
-        ("src/feed/reporting.py", 846),
+        ("src/feed/reporting.py", 850),
         # JSON log formatter; ``sanitize_log_message(dumped,
         # strip_control_chars=False)`` always strips the canonical
         # attack-byte union via ``_INVISIBLE_DANGEROUS_RE.sub("",
@@ -635,7 +635,7 @@ def test_allowlist_is_minimal_and_documented() -> None:
     assert ALLOWLIST == frozenset(
         {
             ("src/places/hafas_client.py", 289),
-            ("src/feed/reporting.py", 846),
+            ("src/feed/reporting.py", 850),
             ("src/feed/logging_safe.py", 260),
             ("src/feed/logging_safe.py", 273),
         }

--- a/tests/test_utils_stats.py
+++ b/tests/test_utils_stats.py
@@ -159,6 +159,35 @@ def test_read_recent_reads_intermediate_years(tmp_path: Path) -> None:
     assert {obs.timestamp.year for obs in result} == {2024, 2025, 2026}
 
 
+def test_read_recent_degrades_on_csv_error_keeping_prior_rows(tmp_path: Path) -> None:
+    """A corrupted ledger that makes ``csv`` raise mid-iteration must not sink
+    the whole read: the best-effort contract requires keeping the rows already
+    parsed from healthy year-files instead of propagating the exception."""
+    # Healthy 2025 ledger — one valid observation.
+    stats_utils.append_stammstrecke_row(
+        timestamp=datetime(2025, 6, 1, 12, 0, tzinfo=VIENNA_TZ),
+        direction="Meidling",
+        delay_minutes=10.0,
+        stats_dir=tmp_path,
+    )
+    # Corrupted 2026 ledger — a single quoted field larger than
+    # ``csv.field_size_limit()`` (still well under the byte cap) makes
+    # ``csv.DictReader`` raise ``csv.Error`` while iterating.
+    oversized = "x" * (csv.field_size_limit() + 1000)
+    (tmp_path / "stammstrecke_2026.csv").write_text(
+        "timestamp,direction,delay_minutes\n" + f'"{oversized}",Meidling,5\n',
+        encoding="utf-8",
+    )
+
+    # Must not raise — and the healthy 2025 observation survives.
+    result = stats_utils.read_recent_stammstrecke_observations(
+        now=datetime(2026, 6, 2, 12, 0, tzinfo=VIENNA_TZ),
+        window=timedelta(days=900),
+        stats_dir=tmp_path,
+    )
+    assert {obs.timestamp.year for obs in result} == {2025}
+
+
 # ---- Disruption writer ----------------------------------------------------
 
 


### PR DESCRIPTION
Third deep audit — **logic & correctness** group. Files are disjoint from the security PR so the two can run in parallel. Each item was adversarially verified against the real code.

## Highlights
| Area | Fix |
|------|-----|
| `circuit_breaker` | Release the HALF_OPEN single-flight probe slot on a non-Exception `BaseException` — otherwise the breaker wedges forever. **+test** |
| `stats` | `read_recent_stammstrecke_observations` now wraps the csv iteration so a `csv.Error` degrades to the rows already read (best-effort contract). **+test** |
| `preflight_quota_check` | Compare the Places quota month in **Europe/Vienna** (it is stored Vienna-local) — UTC compare falsely reported a reset in the month-end window. |
| `reporting` | `record_exception` no longer double-lists the exception (prefix-drift defeated the dedup guard). |
| `wl_fetch` | Title-date vs API-start day comparison done in Vienna, not UTC (one-day drift near midnight). |
| `oebb` | `_LINE_PREFIX_RE` gains `U-Bahn` so a verbose "U-Bahn N:" prefix is not dropped. |
| `update_wl_stations` | Re-derive `in_vienna` from adopted VOR coords so flag/coords stay consistent. |
| `apply_station_overrides` | `_op_restore` strips `wl_diva` (idempotency) like its siblings. |

Plus null-`aliases` `isinstance` guards in both station regex builders, a dead `_BAHNHOF_TRAILING_RE` removal, a redundant `import os`, and two docstring/comment accuracy fixes.

## Validation
* ruff clean; mypy --strict adds **no** new errors (only the known Windows `fcntl`/`os.fchmod` baseline).
* Targeted suites green: circuit_breaker, stats, oebb line-prefix/title, wl date, vienna-connection, apply_station_overrides, vienna flags, update_wl_stations (~480 tests). The 14 GitHub-issue reporting failures locally are the known DNS-sandbox artifact (confirmed identical on baseline); they pass on CI.

Generated with Claude Code