### PR TITLE
chore(bloat): remove dead code & redundant work across src

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -963,7 +963,7 @@ _TRANSLATION_CACHE_EPOCH = 3
 # Static lookup for German → English time-line prefixes used inside the
 # bracketed ``[…]`` timeframe (see ``format_local_times``). Translating
 # these via the ML model would be wasteful — every disruption shares
-# the same five prefixes — and slow (each translate call hits the
+# the same four prefixes — and slow (each translate call hits the
 # tokenizer). The dictionary mapping mirrors the prefixes emitted by
 # ``format_local_times`` in :mod:`src.build_feed`.
 _TIME_PREFIX_DE_TO_EN: dict[str, str] = {
@@ -4205,7 +4205,6 @@ def _make_rss(
     items: list[FeedItem],
     now: datetime,
     state: dict[str, dict[str, Any]],
-    deletions: set[str] | None = None,
     *,
     lang: str = "de",
 ) -> str:
@@ -4216,7 +4215,6 @@ def _make_rss(
         items: List of item dictionaries.
         now: Current timestamp.
         state: State dictionary for tracking items.
-        deletions: IDs to be removed from the state.
         lang: Target language for the output (``"de"`` or ``"en"``).
             Drives channel metadata, ``<language>``, the atom self
             ``href`` (``feed.xml`` vs ``feed.en.xml``) and the per-item
@@ -4225,9 +4223,6 @@ def _make_rss(
     Returns:
         The generated RSS XML string with CDATA sections.
     """
-    if deletions is None:
-        deletions = set()
-
     rss = ET.Element("rss", version="2.0")
     channel = ET.SubElement(rss, "channel")
 
@@ -4276,15 +4271,13 @@ def _make_rss(
     ET.SubElement(channel, "ttl").text = str(feed_config.FEED_TTL)
 
     item_replacements: dict[str, str] = {}
-    identities_in_feed: list[str] = []
     emitted = 0
     for it in items:
         if emitted >= feed_config.MAX_ITEMS:
             break
-        ident, elem, repl = _emit_item(it, now, state, lang=lang)
+        _ident, elem, repl = _emit_item(it, now, state, lang=lang)
         channel.append(elem)
         item_replacements.update(repl)
-        identities_in_feed.append(ident)
         emitted += 1
 
     # Pretty print the tree
@@ -4564,7 +4557,7 @@ def main() -> int:
         # is always refreshed regardless of any translation-pipeline
         # issues encountered for the EN variant.
         rss_start = perf_counter()
-        rss_de = _make_rss(items, now, state, deletions=dropped_ids, lang="de")
+        rss_de = _make_rss(items, now, state, lang="de")
         rss_duration = perf_counter() - rss_start
 
         out_path = validate_path(Path(feed_config.OUT_PATH), "OUT_PATH")
@@ -4582,7 +4575,7 @@ def main() -> int:
         en_out_path = validate_path(en_path, "OUT_PATH")
         try:
             rss_en = _make_rss(
-                items, now, state, deletions=dropped_ids, lang="en"
+                items, now, state, lang="en"
             )
             with atomic_write(
                 en_out_path, mode="w", encoding="utf-8", permissions=0o644

--- a/src/feed_types.py
+++ b/src/feed_types.py
@@ -37,33 +37,3 @@ class Provider(Protocol):
     """Protocol for disruption providers."""
     def fetch_events(self, *args: Any, **kwargs: Any) -> list[FeedItem]:
         ...
-
-
-class VorMessage(TypedDict):
-    """Raw message structure from VOR API."""
-    head: NotRequired[str]
-    text: NotRequired[str]
-    description: NotRequired[str]
-    name: NotRequired[str]
-
-    sDate: NotRequired[str]
-    sTime: NotRequired[str]
-    eDate: NotRequired[str]
-    eTime: NotRequired[str]
-
-    products: NotRequired[dict[str, Any] | list[Any]]
-    id: NotRequired[str]
-    act: NotRequired[str | bool]
-
-
-class VorDeparture(TypedDict):
-    """Departure structure from VOR API."""
-    name: NotRequired[str]
-    direction: NotRequired[str]
-    date: NotRequired[str]
-    time: NotRequired[str]
-    cancelled: NotRequired[bool | str]
-    Product: NotRequired[Any]
-    rtMessages: NotRequired[Any]
-    warnings: NotRequired[Any]
-    infos: NotRequired[Any]

--- a/src/places/diagnostics.py
+++ b/src/places/diagnostics.py
@@ -11,7 +11,7 @@ def permission_hint(details: str) -> str | None:
 
     message = details.lower()
 
-    if "are blocked" in message or "blocked" in message:
+    if "blocked" in message:
         return (
             "Check the Google Cloud project: enable Places API (New) and allow the API key to call "
             "https://places.googleapis.com in its API restrictions."

--- a/src/places/merge.py
+++ b/src/places/merge.py
@@ -213,8 +213,21 @@ def merge_places(
         if "aliases" not in station:
             station["aliases"] = []
 
+    # Precompute each station's normalized name once (O(n)) so the name-match
+    # phase is O(m+n), not O(m*n): otherwise normalize_name (NFKD + regex) runs
+    # for every station on every incoming place. Kept in lockstep with
+    # ``stations`` — ``_update_station`` never touches ``name``, and a newly
+    # created station appends its normalized name so later places still dedupe
+    # against it.
+    norm_names: list[str | None] = []
+    for station in stations:
+        name = station.get("name")
+        norm_names.append(normalize_name(name) if isinstance(name, str) else None)
+
     for place in places:
-        result = _find_matching_station(stations, place, config.max_distance_m)
+        result = _find_matching_station(
+            stations, norm_names, place, config.max_distance_m
+        )
         if result is not None:
             station, matched_by_name = result
             if _update_station(station, place, config, matched_by_name):
@@ -225,6 +238,10 @@ def merge_places(
         new_station = _create_station(place, config)
         stations.append(new_station)
         new_entries.append(new_station)
+        new_name = new_station.get("name")
+        norm_names.append(
+            normalize_name(new_name) if isinstance(new_name, str) else None
+        )
 
     stations = _sorted_stations(stations)
     return MergeOutcome(
@@ -255,13 +272,13 @@ def _sorted_stations(stations: Sequence[StationEntry]) -> list[StationEntry]:
 
 def _find_matching_station(
     stations: Sequence[StationEntry],
+    norm_names: Sequence[str | None],
     place: Place,
     max_distance_m: float,
 ) -> tuple[StationEntry, bool] | None:
     norm = normalize_name(place.name)
-    for station in stations:
-        name = station.get("name")
-        if isinstance(name, str) and normalize_name(name) == norm:
+    for station, station_norm in zip(stations, norm_names, strict=True):
+        if station_norm == norm:
             return station, True
 
     # Distance fallback: bind the place to the *nearest* station within

--- a/src/places/osm_client.py
+++ b/src/places/osm_client.py
@@ -32,7 +32,6 @@ import os
 from dataclasses import dataclass
 from typing import Any, NotRequired, TypedDict, cast
 from collections.abc import Iterable, Iterator
-from urllib.parse import urlparse
 
 import requests
 
@@ -116,8 +115,6 @@ DEFAULT_OVERPASS_ENDPOINTS: tuple[str, ...] = (
     "https://overpass-api.de/api/interpreter",
     "https://overpass.kumi.systems/api/interpreter",
 )
-
-_TRUSTED_OVERPASS_HOSTS: frozenset[str] = frozenset(urlparse(url).hostname or "" for url in DEFAULT_OVERPASS_ENDPOINTS)
 
 
 # Vienna bounding box (south, west, north, east). Pulled from the
@@ -252,7 +249,7 @@ def get_overpass_endpoint() -> str:
     if raw in DEFAULT_OVERPASS_ENDPOINTS:
         return raw
     LOGGER.warning(
-        "OVERPASS_URL %s is not on the trusted Overpass host allow-list; falling back to default endpoint",
+        "OVERPASS_URL %s is not on the trusted Overpass endpoint allow-list; falling back to default endpoint",
         sanitize_log_arg(raw),
     )
     return DEFAULT_OVERPASS_ENDPOINTS[0]
@@ -469,7 +466,7 @@ def _normalize_tags(raw: object) -> OSMTags:
 
     Overpass guarantees keys and values are strings, but the JSON
     decoder returns ``object`` so the loop discards any drift defensively
-    (e.g. a ``null`` value smuggled past a Vespian mirror). The result
+    (e.g. a ``null`` value smuggled past a rogue/non-canonical mirror). The result
     is cast to :data:`OSMTags` so downstream call sites benefit from
     strict typing without paying a per-key validation cost; the parser
     contract is that the returned dict is the project's canonical view

--- a/tests/test_first_seen_cleanup.py
+++ b/tests/test_first_seen_cleanup.py
@@ -58,7 +58,7 @@ def test_state_cleanup_keeps_only_current_identities(
     assert set(state_after_first.keys()) == {"guid-a", "guid-b"}
 
     state = build_feed._load_state()
-    build_feed._make_rss([item_b], now, state, deletions={"guid-a"})
+    build_feed._make_rss([item_b], now, state)
     build_feed._save_state(state, deletions={"guid-a"})
 
     state_after_second = build_feed._load_state()

--- a/tests/test_save_state_survivor_first_seen.py
+++ b/tests/test_save_state_survivor_first_seen.py
@@ -150,7 +150,7 @@ def test_end_to_end_survivor_first_seen_is_preserved_on_disk(
 
     state = build_feed._load_state()  # empty on first run
     kept, dropped = build_feed._drop_old_items([expired, ongoing], now, state)
-    build_feed._make_rss(kept, now, state, deletions=dropped)
+    build_feed._make_rss(kept, now, state)
     build_feed._save_state(state, deletions=dropped)
 
     on_disk = json.loads(


### PR DESCRIPTION
Third deep audit — **dead-code / bloat** group. Files disjoint from the other PRs. Behaviour-preserving; each item verified unused.

## Removed / simplified
* `build_feed._make_rss`: drop the vestigial `deletions` param (no-op — deletion happens in `_save_state`) and the unused `identities_in_feed` accumulator; "five"→"four" prefixes comment fixed.
* `feed_types`: delete the unreferenced `VorMessage` / `VorDeparture` TypedDicts.
* `places/osm_client`: remove the unused `_TRUSTED_OVERPASS_HOSTS` frozenset (+ now-unused `urlparse` import); "host"→"endpoint" allow-list wording; "Vespian mirror" → "rogue/non-canonical mirror".
* `places/diagnostics`: drop the redundant `"are blocked"` operand.

## Performance
* `places/merge`: precompute station-name normalisations once in `merge_places` → name-match phase is **O(m+n)** instead of O(m·n) (was re-running `normalize_name`'s NFKD+regex per station per place). `_update_station` never mutates `name`; new stations append their normalized name so later places still dedupe.

## Validation
* ruff clean; mypy --strict adds no new errors. Targeted suites green (osm/diagnostics/places-merge guards, build_feed atom/first-seen/max-items — the 2 atom failures locally are the known PAGES_BASE_URL DNS-sandbox artifact, confirmed identical on baseline; green on CI).

Generated with Claude Code