### PR TITLE
fix(feed): keep long-range end dates and de-dup U-Bahn line title prefix

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -331,14 +331,20 @@ def read_cache_oebb() -> list[Any]:
 
 def _baustellen_title_names_station(title: str, label: str) -> bool:
     """Return ``True`` if ``title`` already mentions a distinctive token of
-    the station ``label``, so the prefix isn't doubled up (e.g. avoid
-    ``Wien Floridsdorf: Umbau Bahnhofsvorplatz Floridsdorf``). The generic
-    ``Wien`` token (and other ≤4-char tokens) is ignored on purpose."""
+    the station/line ``label``, so the prefix isn't doubled up (e.g. avoid
+    ``Wien Floridsdorf: Umbau Bahnhofsvorplatz Floridsdorf`` or
+    ``U2: … U2 …``). The generic ``Wien`` token (and other ≤4-char tokens)
+    is ignored on purpose — except the short U-Bahn line labels ``U1``–``U6``,
+    which are distinctive and matched as a whole word."""
     lowered = title.lower()
-    return any(
-        len(token) > 4 and token in lowered
-        for token in re.split(r"\W+", label.lower())
-    )
+    for token in re.split(r"\W+", label.lower()):
+        if not token:
+            continue
+        if len(token) > 4 and token in lowered:
+            return True
+        if re.fullmatch(r"u[1-6]", token) and re.search(rf"\b{token}\b", lowered):
+            return True
+    return False
 
 
 def _post_filter_baustellen(items: list[Any]) -> list[Any]:
@@ -758,8 +764,17 @@ def format_local_times(
     if isinstance(end, datetime):
         end_local = _to_utc(end).astimezone(_VIENNA_TZ)
 
-    if start_local and end_local and (end_local - start_local).days > 180:
-        log.warning("Enddatum liegt mehr als 180 Tage nach Startdatum. Setze Enddatum auf None.")
+    # Guard against absurd end dates, but keep legitimate multi-month
+    # disruptions: cap the start→end span at the configured absolute item
+    # horizon (ABSOLUTE_MAX_AGE_DAYS, default 540) instead of a hard-coded
+    # 180 days, so a real long-running range still renders as a range
+    # instead of collapsing to "Seit …".
+    max_span_days = feed_config.ABSOLUTE_MAX_AGE_DAYS
+    if start_local and end_local and (end_local - start_local).days > max_span_days:
+        log.warning(
+            "Enddatum liegt mehr als %s Tage nach Startdatum. Setze Enddatum auf None.",
+            max_span_days,
+        )
         end_local = None
 
     today = datetime.now(_VIENNA_TZ)

--- a/tests/test_baustellen_relevance.py
+++ b/tests/test_baustellen_relevance.py
@@ -270,6 +270,17 @@ def test_post_filter_prefixes_u_bahn_line_when_not_geo() -> None:
     assert out["title"] == "U2/U5: Neubaugasse"
 
 
+def test_post_filter_does_not_double_name_u_bahn_line() -> None:
+    # Title already names the U-Bahn line → no redundant "U2:" prefix.
+    item = {
+        "title": "U2 Rathaus gesperrt",
+        "description": "Für den U-Bahnbau der U2 wird gesperrt.",
+        "location": _loc(*FAR_AWAY),
+    }
+    [out] = _post_filter_baustellen([item])
+    assert out["title"] == "U2 Rathaus gesperrt"
+
+
 def test_post_filter_does_not_guess_a_bus_tram_line() -> None:
     # Bus/tram impact → kept, but NO guessed line prefix (only U-Bahn/Bahnhof).
     item = {

--- a/tests/test_build_feed_date_logic.py
+++ b/tests/test_build_feed_date_logic.py
@@ -84,3 +84,36 @@ def test_format_local_times_end_before_start_past(
     # Verify the warning was logged
     warnings = [record.getMessage() for record in caplog.records if record.levelname == "WARNING"]
     assert "Enddatum liegt vor Startdatum" in warnings
+
+
+def test_format_local_times_long_range_keeps_end(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    build_feed = _import_build_feed(monkeypatch)
+
+    class MockDatetime(dt_module.datetime):
+        @classmethod
+        def now(cls, tz: Any = None) -> datetime:  # type: ignore[override]
+            return cls(2026, 6, 1, 12, 0, tzinfo=tz)
+
+    monkeypatch.setattr(build_feed, "datetime", MockDatetime)
+
+    # ~274-day span: longer than the old hard-coded 180-day cap but well
+    # within ABSOLUTE_MAX_AGE_DAYS (540), so the explicit end date must
+    # survive and render as a range instead of collapsing to "Seit …".
+    start = MockDatetime(2026, 1, 1, 12, 0, tzinfo=dt_module.UTC)
+    end = MockDatetime(2026, 10, 2, 12, 0, tzinfo=dt_module.UTC)
+
+    with caplog.at_level(logging.WARNING):
+        result = build_feed.format_local_times(start, end)
+
+    # Renders as a range (start … end), not the single-date "Seit …" form,
+    # so the explicit end date is preserved. (The separator between the
+    # dates uses narrow no-break spaces around an en-dash, so assert on the
+    # two date boundaries rather than the exact glyphs.)
+    assert result.startswith("01.01.2026")
+    assert result.endswith("02.10.2026")
+    assert not result.startswith("Seit")
+    warnings = [record.getMessage() for record in caplog.records if record.levelname == "WARNING"]
+    assert not any("Setze Enddatum auf None" in message for message in warnings)

--- a/tests/test_sentinel_allow_nan_writer_audit_walker.py
+++ b/tests/test_sentinel_allow_nan_writer_audit_walker.py
@@ -93,7 +93,7 @@ Three documented sites live here today:
   motivates the non-finite-literal axis (committed-to-main artefact
   that strict parsers must handle) does not apply.
 
-* ``src/build_feed.py:_identity_for_item`` (lines 2481 and 2490) —
+* ``src/build_feed.py:_identity_for_item`` (lines 2496 and 2505) —
   two ``json.dumps(item, sort_keys=True, default=str)`` calls compute
   the SHA-256 input for the feed-item identity hash. The serialised
   bytes flow into ``hashlib.sha256(raw.encode("utf-8", "surrogatepass")).hexdigest()``
@@ -142,8 +142,8 @@ ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
         # into ``hashlib.sha256(...).hexdigest()`` on the very next
         # line and are not retained anywhere else. No parser-consumed
         # artefact, so the threat model does not apply.
-        ("src/build_feed.py", 2481),
-        ("src/build_feed.py", 2490),
+        ("src/build_feed.py", 2496),
+        ("src/build_feed.py", 2505),
     }
 )
 
@@ -536,7 +536,7 @@ def test_allowlist_is_minimal_and_documented() -> None:
     assert ALLOWLIST == frozenset(
         {
             ("src/places/hafas_client.py", 289),
-            ("src/build_feed.py", 2481),
-            ("src/build_feed.py", 2490),
+            ("src/build_feed.py", 2496),
+            ("src/build_feed.py", 2505),
         }
     )


### PR DESCRIPTION
## Was

Zwei kleine, unabhängige Korrekturen am Feed-Filter (`src/build_feed.py`).

### b13 — `format_local_times`: 180-Tage-Fenster löschte echte Enddaten
Bei einer Spanne `> 180` Tage wurde das Enddatum bedingungslos auf `None` gesetzt → eine legitime mehrmonatige Störung wurde als offen-endend `„Seit DD.MM.YYYY"` gerendert statt als Zeitraum. Jetzt wird die Spanne an `feed_config.ABSOLUTE_MAX_AGE_DAYS` (Default **540**) gekappt statt an der willkürlichen 180-Tage-Konstante. Absurd weit in der Zukunft liegende Enddaten bleiben weiterhin abgefangen.

### b14 — `_baustellen_title_names_station`: U-Bahn-Linienpräfix verdoppelt
Der `len(token) > 4`-Guard (eingeführt, um das generische „Wien" zu ignorieren) übersprang auch alle U1–U6-Tokens, sodass der Präfix selbst dann angehängt wurde, wenn der Titel die Linie schon nennt → `„U2: U2 Rathaus gesperrt"`. U1–U6 werden jetzt als Ganzwort-Treffer erkannt; der bestehende >4-Zeichen-Stationspfad bleibt unverändert.

## Tests
- `tests/test_build_feed_date_logic.py::test_format_local_times_long_range_keeps_end` — 274-Tage-Spanne behält Enddatum (Zeitraum statt „Seit …"), keine Warnung.
- `tests/test_baustellen_relevance.py::test_post_filter_does_not_double_name_u_bahn_line` — Titel nennt U2 bereits → kein Präfix.

Lokal: 68/68 grün in den betroffenen Testdateien, `ruff` clean, `mypy --strict` ohne neue Fehler (nur die bekannten Windows-only `fcntl`/`os.fchmod`-Baseline-Einträge), Komplexität unverändert.