### PR TITLE
fix(oebb): rescue rail weather disruptions, keep infra-noun titles, guard bare-Wien phantom

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -195,7 +195,16 @@ _TRANSIT_KEYWORD_RE = re.compile(
     # ``\w{0,4}`` keeps the regex bounded but covers German plural and
     # genitive forms without enumerating every variant.
     r"\b(bauarbeit\w{0,4}|störung\w{0,4}|stoerung\w{0,4}|"
-    r"verspätung\w{0,4}|verspaetung\w{0,4}|sperre\w{0,4}|sperrung\w{0,4}|"
+    r"verspätung\w{0,4}|verspaetung\w{0,4}|"
+    r"zugverspätung\w{0,4}|zugverspaetung\w{0,4}|"
+    # Rail-specific compound closures (Gleissperrung, Streckensperre,
+    # Bahnsperre, …). The plain ``sperrung``/``sperre`` stems below carry
+    # a leading ``\b`` from the group anchor, so without this rail-prefixed
+    # form a weather title like "Hochwasser: Gleissperrung Wien Floridsdorf"
+    # was wrongly dropped (no transit signal recognised). Bounded to the
+    # gleis/strecken/bahn prefixes so a road "Vollsperrung" stays out.
+    r"(?:gleis|strecken|bahn)\w*(?:sperrung|sperre)\w{0,4}|"
+    r"sperre\w{0,4}|sperrung\w{0,4}|"
     r"gesperrt|geschlossen|unterbrochen|eingestellt|"
     r"umleitung\w{0,4}|ersatzverkehr|haltausfall\w{0,4}|zugausfall\w{0,4}|"
     r"streckenunterbrechung\w{0,4}|unterbrechung\w{0,4}|teilausfall\w{0,4}|"
@@ -990,6 +999,39 @@ _TITLE_NOISE_WORDS = frozenset({
     "nahverkehr",
     "nahverkehrszüge",
     "nahverkehrszuege",
+    # Infrastructure-work nouns that frequently TRAIL a single Wien/Pendler
+    # station title ("Wien Meidling Stellwerk", "Wien Praterstern
+    # Umbauarbeiten"). They are common German nouns, never station names, so
+    # the title-residual heuristic must not misread them as an implicit
+    # unknown second endpoint and drop an otherwise-relevant single-station
+    # message (bug b2).
+    "stellwerk",
+    "stellwerke",
+    "sanierung",
+    "sanierungsarbeiten",
+    "umbau",
+    "umbauarbeiten",
+    "ausbau",
+    "ausbauarbeiten",
+    "erneuerung",
+    "erneuerungsarbeiten",
+    "modernisierung",
+    "reparatur",
+    "reparaturarbeiten",
+    "wartung",
+    "wartungsarbeiten",
+    "instandhaltung",
+    "instandhaltungsarbeiten",
+    "ertüchtigung",
+    "ertuechtigung",
+    "brückenarbeiten",
+    "brueckenarbeiten",
+    "gleisarbeiten",
+    "weichenarbeiten",
+    "oberleitungsarbeiten",
+    "vorplatz",
+    "bahnhofsvorplatz",
+    "reisezentrum",
 })
 
 
@@ -1310,6 +1352,13 @@ def _find_stations_in_text(blob: str) -> list[str]:
                 # expansions.
                 token_norm = chunk.casefold().rstrip(".:,;")
                 if token_norm in _GENERIC_STATION_TOKENS:
+                    continue
+                if OEBB_ONLY_VIENNA and token_norm in ("wien", "vienna"):
+                    # The bare area word "Wien"/"Vienna" canonicalises to a
+                    # flagship station ("Wien Hauptbahnhof") — a phantom
+                    # mention. In strict Vienna-only mode that must not seed
+                    # a relevant station from a generic "ab/bis Wien" notice
+                    # (bug b10). Default mode (flag off) is unaffected.
                     continue
                 if len(chunk_alpha) < 3:
                     continue

--- a/tests/test_facility_weather_filter.py
+++ b/tests/test_facility_weather_filter.py
@@ -17,6 +17,38 @@ from __future__ import annotations
 from src.providers.oebb import _is_facility_or_weather_only, _is_relevant
 
 
+class TestRailCompoundWeatherRescue:
+    # bug b3: a weather-prefixed REAL rail disruption (Gleissperrung,
+    # Streckensperre, Bahnsperre, Zugverspätung) carries a rail-specific
+    # transit signal in the title and must be kept; pure weather notices
+    # without such a signal still drop.
+    def test_hochwasser_gleissperrung_kept(self) -> None:
+        assert (
+            _is_relevant(
+                "Hochwasser: Gleissperrung Wien Floridsdorf",
+                "Wegen Hochwasser ist das Gleis in Wien Floridsdorf gesperrt.",
+            )
+            is True
+        )
+
+    def test_sturm_zugverspaetung_kept(self) -> None:
+        assert (
+            _is_relevant(
+                "Sturm: Zugverspätungen Wien Mitte",
+                "Wegen Sturm gibt es Zugverspätungen in Wien Mitte.",
+            )
+            is True
+        )
+
+    def test_pure_weather_still_dropped(self) -> None:
+        assert (
+            _is_facility_or_weather_only(
+                "Sturmwarnung für den Raum Wien", "Heute starker Sturm erwartet."
+            )
+            is True
+        )
+
+
 class TestUserReportedFacilityWeatherDrops:
     def test_aufzug_defekt_wien_hbf_dropped(self) -> None:
         assert _is_relevant("Aufzug defekt: Wien Hauptbahnhof", "x") is False

--- a/tests/test_filter_audit_round4.py
+++ b/tests/test_filter_audit_round4.py
@@ -146,3 +146,21 @@ class TestImplicitRouteToUnknown:
             )
             is True
         )
+
+    def test_wien_single_station_with_infrastructure_noun_kept(self) -> None:
+        # bug b2: a trailing infrastructure-work noun (Stellwerk,
+        # Umbauarbeiten, …) is a description, not an implicit unknown second
+        # endpoint — the single-station Wien message must keep.
+        assert (
+            _is_relevant(
+                "Bauarbeiten Wien Meidling Stellwerk",
+                "Wegen Bauarbeiten gesperrt.",
+            )
+            is True
+        )
+        assert (
+            _is_relevant(
+                "Wien Praterstern Umbauarbeiten", "Bauarbeiten am Bahnsteig."
+            )
+            is True
+        )

--- a/tests/test_oebb_whitelist.py
+++ b/tests/test_oebb_whitelist.py
@@ -30,6 +30,19 @@ def station_entries() -> Any:  # JSON-derived list of dicts; full typing require
     return entries
 
 
+def test_bare_wien_phantom_suppressed_under_only_vienna(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # bug b10: bare "Wien" canonicalises to the flagship "Wien Hauptbahnhof"
+    # (a phantom station). Under OEBB_ONLY_VIENNA that must NOT seed a
+    # relevant station from a generic "ab/bis Wien" notice. Default mode
+    # (flag off) keeps the existing behaviour.
+    monkeypatch.setattr(oebb, "OEBB_ONLY_VIENNA", True)
+    assert oebb._is_relevant("Bauarbeiten ab Wien", "Hinweise zu Reisen ab Wien.") is False
+    monkeypatch.setattr(oebb, "OEBB_ONLY_VIENNA", False)
+    assert oebb._is_relevant("Bauarbeiten ab Wien", "Hinweise zu Reisen ab Wien.") is True
+
+
 @pytest.fixture(scope="module")
 def pendler_station(station_entries: Any) -> Any:  # entry["name"] narrowing to str needs cast
     for entry in station_entries:


### PR DESCRIPTION
Drei unabhängige Korrekturen an der ÖBB-Relevanz (`src/providers/oebb.py`), je mit Test.

## b3 — wetterbedingte Bahn-Störungen wurden verworfen
`_TRANSIT_KEYWORD_RE` erkennt jetzt rail-spezifische Compound-Sperrungen (`Gleissperrung`/`Streckensperre`/`Bahnsperre`, via `(?:gleis|strecken|bahn)\w*(?:sperrung|sperre)`) und `Zugverspätung`. Ein wetter-präfigierter echter Bahn-Vorfall („Hochwasser: Gleissperrung Wien Floridsdorf") wird nicht mehr als reine Wettermeldung gedroppt. **Bewusst NICHT** ergänzt: blanke Verben (`ausgefallen`/`blockiert`/`verspätet`) — die würden Nicht-Transit-Wetter/Event-Meldungen fälschlich retten. Straßen-`Vollsperrung` bleibt außen vor.

## b2 — Einzelstationsmeldungen mit Schluss-Substantiv wurden gedroppt
Infrastruktur-Nomen (`Stellwerk`, `Sanierung`, `Umbau`, `Umbauarbeiten`, `Erneuerung`, …) sind jetzt in `_TITLE_NOISE_WORDS`. Ein Titel wie „Wien Meidling Stellwerk" wird nicht mehr als impliziter unbekannter zweiter Endpunkt fehlgedeutet. `_TITLE_NOISE_WORDS` wird ausschließlich von `_title_has_unknown_endpoint` genutzt → Routen-Extraktion unberührt. Keiner der Begriffe ist ein Stationsname; der intendierte Drop („… Hauptbahnhof Brixlegg/Semmering") bleibt erhalten.

## b10 — Phantom-Station aus bloßem „Wien"
In `_find_stations_in_text` kanonisiert das bloße Flächenwort „Wien"/„Vienna" unter `OEBB_ONLY_VIENNA` nicht mehr zu „Wien Hauptbahnhof". Latent (Flag default aus) → Default-Verhalten unverändert.

## Tests / lokal
170/170 grün in den betroffenen oebb-Testdateien (inkl. 3 neue). `ruff` clean, `mypy --strict` ohne neue Fehler (nur die bekannte Windows-`fcntl`/`fchmod`-Baseline). C901: nur die zwei bereits baselineten Funktionen (`_clean_title_keep_places`=26, `_title_has_unknown_endpoint`=27) — beide unverändert; `_find_stations_in_text` bleibt mit +1 Branch bei 13 (≤15).