### PR TITLE
fix(merge): stop-word "Wien" + Bahnhof-abbreviation normalisation so distinct routes stop over-merging

### DIFF
--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -166,6 +166,14 @@ _STOP_WORDS = {
     "hbf",
     "bf",
     "bhf",
+    # The ubiquitous city qualifier — nearly every Vienna station name
+    # carries it, so without this two DIFFERENT Vienna routes that merely
+    # share "Wien" reach the overlap threshold and wrongly merge (bug b6).
+    # Safe to drop only because _normalize_name first folds Hbf/Bf into
+    # their spelled-out forms, so cross-provider Hbf/Hauptbahnhof pairs
+    # still share the distinctive station token.
+    "wien",
+    "vienna",
 }
 
 
@@ -200,8 +208,20 @@ def _parse_title(title: str) -> tuple[set[str], str]:
 
 
 def _normalize_name(name: str) -> str:
-    """Removes digits and lowercases the name for comparison."""
-    return re.sub(r"\d+", "", name).lower().strip()
+    """Lowercase, expand the Bahnhof-family abbreviations (Hbf/Bhf/Bf →
+    …bahnhof) so an abbreviated station name and its spelled-out form
+    tokenise identically, then drop digits for comparison.
+
+    The abbreviation expansion is what lets ``wien`` safely join the stop
+    words (bug b6): "Wien Hbf" and "Wien Hauptbahnhof" reduce to the same
+    meaningful token ``hauptbahnhof`` and still dedup across providers,
+    while two different routes that merely share "Wien" no longer do.
+    """
+    lowered = re.sub(r"\d+", "", name).lower()
+    lowered = re.sub(r"\bhbf\b", "hauptbahnhof", lowered)
+    lowered = re.sub(r"\bbhf\b", "bahnhof", lowered)
+    lowered = re.sub(r"\bbf\b", "bahnhof", lowered)
+    return lowered.strip()
 
 
 def _get_tokens(name: str) -> set[str]:

--- a/tests/test_merge_wien_normalization.py
+++ b/tests/test_merge_wien_normalization.py
@@ -1,0 +1,52 @@
+"""Bug b6: the city qualifier "Wien" must not bridge two different routes
+into one merged feed item, while the same incident reported with an
+abbreviated vs. spelled-out Bahnhof name must still dedup across providers.
+
+The fix pairs two changes in :mod:`src.feed.merge`: ``_normalize_name`` now
+folds the Bahnhof-family abbreviations (Hbf/Bhf/Bf → …bahnhof) before
+tokenising, and ``wien``/``vienna`` join ``_STOP_WORDS``. Together they keep
+the distinctive station token shared across "Hbf"/"Hauptbahnhof" reports
+while stripping the ubiquitous "Wien" that otherwise inflates the overlap of
+two distinct routes.
+"""
+
+from typing import Any
+
+from src.feed.merge import deduplicate_fuzzy
+
+
+def test_bahnhof_abbreviation_merges_cross_provider() -> None:
+    # The SAME incident reported as "Wien Hbf" (ÖBB) and "Wien
+    # Hauptbahnhof" (WL) must still dedup once "wien" is a stop word — the
+    # Hbf→Hauptbahnhof normalisation keeps the station token shared (without
+    # it, the only meaningful tokens would be {hbf}→∅ vs {hauptbahnhof}).
+    items: list[dict[str, Any]] = [
+        {"guid": "a", "_identity": "oebb|a", "source": "ÖBB", "title": "S1: Wien Hbf"},
+        {
+            "guid": "b",
+            "_identity": "wl|b",
+            "source": "Wiener Linien",
+            "title": "S1: Wien Hauptbahnhof",
+        },
+    ]
+    assert len(deduplicate_fuzzy(items)) == 1
+
+
+def test_wien_qualifier_does_not_bridge_distinct_routes() -> None:
+    # Two DIFFERENT routes on the same line that share only the city
+    # qualifier "Wien" must stay separate now that "wien" is a stop word.
+    items: list[dict[str, Any]] = [
+        {
+            "guid": "a",
+            "_identity": "x|a",
+            "source": "ÖBB",
+            "title": "S1: Wien Meidling ↔ Wien Liesing",
+        },
+        {
+            "guid": "b",
+            "_identity": "x|b",
+            "source": "ÖBB",
+            "title": "S1: Wien Meidling ↔ Wien Floridsdorf",
+        },
+    ]
+    assert len(deduplicate_fuzzy(items)) == 2


### PR DESCRIPTION
## b6 — Fuzzy-Dedup verschmolz verschiedene Routen über das Wort „Wien"

Zwei **unterschiedliche** Wiener Routen auf derselben Linie, die nur den allgegenwärtigen Stadtqualifier „Wien" teilen, erreichten die 0.4-Token-Overlap-Schwelle und wurden zu einem Feed-Item verschmolzen:
`S1: Wien Meidling ↔ Wien Liesing` + `S1: Wien Meidling ↔ Wien Floridsdorf` → 1 Item (Bug).

**Fix (zwei zusammengehörige Änderungen in `src/feed/merge.py`):**
1. `wien`/`vienna` kommen in `_STOP_WORDS` — der Qualifier treibt keine Merges mehr.
2. `_normalize_name` faltet die Bahnhof-Abkürzungen (`Hbf`/`Bhf`/`Bf` → `…bahnhof`) **vor** der Tokenisierung. Das ist nötig, damit dieselbe Meldung als `Wien Hbf` (ÖBB) und `Wien Hauptbahnhof` (WL) weiterhin über den distinktiven Stationstoken dedupliziert — sonst wäre der einzige bedeutsame Token `{hbf}`→∅ vs `{hauptbahnhof}` und die Cross-Provider-Dedup würde brechen (genau die Regression, die den naiven „nur wien-Stopword"-Fix gekillt hat).

## Tests / lokal
- Neuer `tests/test_merge_wien_normalization.py`: Cross-Provider-Hbf-Merge bleibt (len 1); zwei Wien-Routen mergen nicht mehr (len 2).
- **132/132** grün in der gesamten Dedup-/Merge-Suite (test_feed_merge, test_dedupe_items, test_deduplication_quality, test_fuzzy_merge_stopwords, …).
- `ruff` clean, `mypy --strict` ohne neue Fehler (nur Windows-`fcntl`/`fchmod`-Baseline), `deduplicate_fuzzy`-Komplexität unverändert (21, baselined).