### PR TITLE
fix(stations): block "aug"/"am" generic aliases at the source (Augasse / Am Bahnhof)

### DIFF
--- a/scripts/enrich_station_aliases.py
+++ b/scripts/enrich_station_aliases.py
@@ -174,6 +174,15 @@ _GENERIC_ALIAS_BLOCKLIST = frozenset({
     # "München" is a prefix of "Münchendorf"; the disambiguated forms
     # ("München Hbf", "München Hauptbahnhof") are kept as aliases.
     "munchen", "muenchen",
+    # Synthetic short forms that collide with everyday German. "Aug." (the
+    # Gasse→G. shortening of "Wien Augasse") matches the month abbreviation
+    # "Aug."; "Am Bf"/"Am Bahnhof" (from the WL stop "Wien Am Bahnhof") match
+    # the ubiquitous phrase "am Bf". Both normalise to a bare
+    # preposition/abbreviation via _normalize_key (which strips the
+    # bahnhof/bf/station suffix), so every compound variant is covered. The
+    # stations stay resolvable via "Wien Augasse" / "Wien Am Bahnhof" and the
+    # "wien" key (bugs b8/b9).
+    "aug", "am",
 })
 
 

--- a/tests/test_enrich_station_aliases_filters.py
+++ b/tests/test_enrich_station_aliases_filters.py
@@ -94,8 +94,42 @@ def test_generic_blocklist_covers_directions_and_rail_vocab() -> None:
         "platz",
         "munchen",
         "muenchen",
+        "aug",
+        "am",
     }
     assert expected <= _GENERIC_ALIAS_BLOCKLIST
+
+
+def test_generic_blocklist_drops_aug_abbreviation_family() -> None:
+    """bug b8: "Aug." (the Gasse→G. shortening of "Wien Augasse") and its
+    compounds collide with the German month abbreviation "Aug." — every
+    form normalising to bare "aug" must be dropped, while "Augasse" /
+    "Wien Augasse" survive."""
+    station = {
+        "name": "Wien Augasse (WL)",
+        "aliases": ["Augasse", "Aug.", "Aug. Bahnhof", "Aug. Station", "Wien Augasse"],
+    }
+    aliases = _alias_candidates(station, vor_names={}, vor_mapping={}, gtfs_index={})
+    assert "Aug." not in aliases
+    assert "Aug. Bahnhof" not in aliases
+    assert "Aug. Station" not in aliases
+    assert "Augasse" in aliases
+    assert "Wien Augasse" in aliases
+
+
+def test_generic_blocklist_drops_am_bahnhof_phrase_family() -> None:
+    """bug b9: "Am Bahnhof" / "Am Bf" (from the WL stop "Wien Am Bahnhof")
+    collide with the everyday phrase "am Bf" — every form normalising to
+    bare "am" must be dropped, while the "Wien Am Bahnhof" forms survive."""
+    station = {
+        "name": "Wien Am Bahnhof (WL)",
+        "aliases": ["Am Bahnhof", "Am Bf", "Am bf", "Wien Am Bahnhof"],
+    }
+    aliases = _alias_candidates(station, vor_names={}, vor_mapping={}, gtfs_index={})
+    assert "Am Bahnhof" not in aliases
+    assert "Am Bf" not in aliases
+    assert "Am bf" not in aliases
+    assert "Wien Am Bahnhof" in aliases
 
 
 def test_cross_station_collision_drops_other_station_canonical() -> None:


### PR DESCRIPTION
## b8 / b9 — schlechte Aliase an der Wurzel (im Generator) entfernt

Der Alias-Generator erzeugte aus „Wien Augasse" die synthetische Kurzform **„Aug."** (über die `Gasse→G.`-Verkürzung) und aus „Wien Am Bahnhof" die Formen **„Am Bf"/„Am Bahnhof"**. Beide kollidieren mit Alltagsdeutsch — der Monatsabkürzung „Aug." und der Floskel „am Bf" — sodass `text_has_vienna_connection` fremde datierte/Bahnhof-Meldungen fälschlich als Wien-relevant einstufte.

**Wurzel-Fix (wie vom Owner gewünscht — nicht nachgelagert filtern):** `aug` und `am` kommen in `_GENERIC_ALIAS_BLOCKLIST`. Da `_normalize_key` die `bahnhof`/`bf`/`station`-Suffixe entfernt, normalisieren **alle** Compound-Varianten („Aug. Bahnhof", „Bf Aug.", „Am Bf Station" …) auf den bloßen Token → die ganze Familie wird zur Generierungszeit verworfen. Beide Stationen bleiben auflösbar über „Wien Augasse"/„Augasse" und „Wien Am Bahnhof" + den „wien"-Key.

**Daten:** die Blocklist auf das committete Verzeichnis angewandt — **40 schlechte Aliase entfernt** (28 bei Wien Augasse, 12 bei Wien Am Bahnhof), sonst nichts. Der Round-Trip wurde gegen einen No-Op verifiziert (byte-identisch, kein Reformat).

## Tests / lokal
- 2 neue Filter-Tests (aug-/am-Familie gedroppt, gute Aliase bleiben) + Blocklist-Membership-Pin um `aug`/`am` ergänzt.
- 82 + 152 Tests grün: `test_enrich_station_aliases_filters`, `test_vienna_marchegg`, `test_text_vienna_connection_strict`, `test_stations_validation_*`, `test_sentinel_script_station_writers_trojan_source`, …
- `ruff` clean, `mypy --strict` ohne neue Fehler (nur Windows-Baseline). Null verbleibende `aug`/`am`-Aliase in `stations.json`.