### PR TITLE
fix(baustellen): abbreviation-aware sentence split in oepnv_lead

### DIFF
--- a/src/providers/baustellen.py
+++ b/src/providers/baustellen.py
@@ -44,6 +44,23 @@ _UBAHN_RE: Final = re.compile(r"\bu([1-6])\b", re.IGNORECASE)
 # ., ! or ? followed by whitespace — linear, no backtracking.
 _SENTENCE_SPLIT_RE: Final = re.compile(r"(?<=[.!?])\s+")
 
+# Abbreviations / ordinals whose trailing period is NOT a sentence end.
+# :func:`_split_into_sentences` re-merges any fragment that ``_SENTENCE_SPLIT_RE``
+# cut right after one of these — "Die Haltestelle Nr. 4351 …" and "ab 3. März
+# …" must stay intact (bug b5). Unlike an uppercase-follower gate this leaves a
+# genuine boundary before a lowercase- or number-initial next sentence
+# splittable, so the ÖPNV sentence can still be reordered to the front.
+# Anchored at end-of-fragment; the alternation is plain literals — linear.
+_NO_SENTENCE_BREAK_RE: Final = re.compile(
+    r"(?:"
+    r"\b(?:nr|bzw|ca|usw|etc|inkl|exkl|ggf|evtl|max|min|vgl|str|pl|dr|"
+    r"hausnr|mio|mrd|tel|geb|lt|bspw|abs|kfz)"
+    r"|\bz\.\s?b|\bu\.\s?a|\bd\.\s?h"  # z.B. / u.a. / d.h.
+    r"|\b\d{1,2}"  # day/month ordinal ("3." in "3. März")
+    r")\.\s*$",
+    re.IGNORECASE,
+)
+
 # Public-transport vocabulary for the text signal. A construction site whose
 # title/description mentions any of these affects ÖPNV even when it is not
 # right next to a rail Bahnhof (e.g. a bus/tram stop being relocated). The
@@ -136,6 +153,21 @@ def u_bahn_lines(text: str) -> list[str]:
     return sorted({f"U{digit}" for digit in _UBAHN_RE.findall(text or "")})
 
 
+def _split_into_sentences(text: str) -> list[str]:
+    """Split ``text`` into sentences, re-merging fragments that the linear
+    splitter cut at a German abbreviation or a day/month ordinal so they
+    stay intact (bug b5). No uppercase-follower gate, so a genuine boundary
+    before a lowercase- or number-initial next sentence is still split."""
+    fragments = _SENTENCE_SPLIT_RE.split(text)
+    merged: list[str] = []
+    for fragment in fragments:
+        if merged and _NO_SENTENCE_BREAK_RE.search(merged[-1]):
+            merged[-1] = f"{merged[-1]} {fragment}"
+        else:
+            merged.append(fragment)
+    return merged
+
+
 def oepnv_lead(text: str) -> str:
     """Reorder ``text`` so the first sentence that mentions public transport
     comes first (remaining sentences keep their order).
@@ -148,7 +180,7 @@ def oepnv_lead(text: str) -> str:
 
     if not text:
         return text
-    sentences = _SENTENCE_SPLIT_RE.split(text.strip())
+    sentences = _split_into_sentences(text.strip())
     for index, sentence in enumerate(sentences):
         if _OEPNV_RE.search(sentence):
             if index == 0:

--- a/tests/test_baustellen_relevance.py
+++ b/tests/test_baustellen_relevance.py
@@ -323,6 +323,28 @@ def test_oepnv_lead_noop_when_already_leading_or_no_match() -> None:
     assert oepnv_lead("") == ""
 
 
+def test_oepnv_lead_keeps_abbreviation_period_intact() -> None:
+    # bug b5: "Nr." is an abbreviation, not a sentence end — the stop number
+    # stays attached when the ÖPNV sentence is surfaced (was mangled to
+    # "Die Haltestelle Nr. <other sentence> 4351 …").
+    out = oepnv_lead("Fahrbahnerneuerung. Die Haltestelle Nr. 4351 wird verlegt.")
+    assert out.startswith("Die Haltestelle Nr. 4351 wird verlegt.")
+
+
+def test_oepnv_lead_keeps_date_ordinal_intact() -> None:
+    # bug b5: the day ordinal "3." must not split "3. März".
+    out = oepnv_lead("Ab 3. März gilt eine Umleitung. Die Buslinie wird verlegt.")
+    assert out.startswith("Die Buslinie wird verlegt.")
+    assert "3. März" in out
+
+
+def test_oepnv_lead_still_splits_lowercase_next_sentence() -> None:
+    # No uppercase-follower gate: a real boundary before a lowercase-initial
+    # next sentence is still split, so the ÖPNV sentence is surfaced.
+    out = oepnv_lead("Fahrbahn wird saniert. die Haltestelle wird verlegt.")
+    assert out.startswith("die Haltestelle wird verlegt.")
+
+
 def test_sample_linestring_description_leads_with_oepnv() -> None:
     payload = json.loads(SAMPLE_PATH.read_text(encoding="utf-8"))
     events = update_baustellen_cache._collect_events(payload)


### PR DESCRIPTION
## b5 — `oepnv_lead` zerschnitt Sätze an deutschen Abkürzungen

`_SENTENCE_SPLIT_RE` splittete an **jedem** „." + Whitespace. Bei „Die Haltestelle Nr. 4351 wird verlegt." wurde an „Nr." getrennt, und das Vorziehen des ÖPNV-Satzes spleißte einen fremden Satz zwischen „Nr." und „4351" → verstümmelte Feed-Beschreibung.

**Fix:** `_split_into_sentences` ersetzt den naiven Split. Es remerged jedes Fragment, das hinter einer deutschen **Abkürzung** (`Nr.`/`bzw.`/`ca.`/`z.B.`/`u.a.`/`inkl.`/…) oder einer **Tag-/Monats-Ordinalzahl** („3. März") geschnitten wurde. Anders als ein Großbuchstaben-Gate (das der build_feed-Summary-Pfad nutzt) splittet es eine echte Grenze vor einem **klein- oder zahl-initialen** Folgesatz weiterhin — genau die Regression, die den ersten Entwurf killte, ist damit vermieden.

## Tests / lokal
- 3 neue Tests: „Nr."-Abkürzung bleibt intakt, „3. März"-Ordinalzahl bleibt intakt, klein-initialer Folgesatz wird weiter gesplittet.
- **68/68** grün in `test_baustellen_relevance.py` (inkl. bestehende `oepnv_lead`-Tests + Sample-Pipeline). `ruff`/C901 clean, `mypy --strict` ohne neue Fehler.