### PR TITLE
fix(merge): block platform/track-number merges without re-breaking date variants

### DIFF
--- a/src/feed/merge.py
+++ b/src/feed/merge.py
@@ -229,6 +229,26 @@ def _get_tokens(name: str) -> set[str]:
     return set(x for x in re.split(r"\W+", _normalize_name(name)) if x)
 
 
+# Numbers that pin a title to a specific platform / track. ONLY digits
+# directly after a platform/track keyword are captured — a date ("ab 03.
+# November") or line number is deliberately NOT, so a same-event pair on
+# different dates still merges (bug b7). Linear; the keyword alternation is
+# plain literals and the capture is a bounded ``\d+``.
+_PLATFORM_NUMBER_RE = re.compile(
+    r"\b(?:bahnsteigkante|bahnsteige|bahnsteig|gleise|gleis|steig|sektor|bstg)"
+    r"\s*\.?\s*(\d+)",
+    re.IGNORECASE,
+)
+
+
+def _platform_numbers(name: str) -> frozenset[str]:
+    """Return the platform/track numbers a title pins to, e.g.
+    ``frozenset({"1"})`` for "Bahnsteig 1 Wien Mitte". Two otherwise-
+    overlapping titles that name DIFFERENT, non-overlapping platforms
+    describe distinct incidents and must not be merged (bug b7)."""
+    return frozenset(_PLATFORM_NUMBER_RE.findall(name))
+
+
 def _has_significant_overlap(name1: str, name2: str) -> bool:
     """
     Checks if names share significant words or a long common substring.
@@ -238,11 +258,18 @@ def _has_significant_overlap(name1: str, name2: str) -> bool:
         _normalize_name(name2),
         _get_tokens(name1),
         _get_tokens(name2),
+        _platform_numbers(name1),
+        _platform_numbers(name2),
     )
 
 
 def _has_significant_overlap_cached(
-    n1: str, n2: str, t1: set[str], t2: set[str]
+    n1: str,
+    n2: str,
+    t1: set[str],
+    t2: set[str],
+    p1: frozenset[str] = frozenset(),
+    p2: frozenset[str] = frozenset(),
 ) -> bool:
     """Variant of ``_has_significant_overlap`` that consumes pre-computed
     normalized names and token sets.
@@ -256,6 +283,13 @@ def _has_significant_overlap_cached(
     reusing them on every comparison drops the parse work from O(n²) to
     O(n) without changing the comparison semantics.
     """
+    # Distinct, non-overlapping platform/track numbers ("Bahnsteig 1" vs
+    # "Bahnsteig 5") mark different incidents at the same station — never
+    # merge them even when the rest of the title matches (bug b7). Only
+    # fires when BOTH titles pin a platform, so a platform-specific item
+    # still merges into a general one.
+    if p1 and p2 and p1.isdisjoint(p2):
+        return False
     if not n1 or not n2:
         return False
 
@@ -551,6 +585,7 @@ def deduplicate_fuzzy(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
         # inner loop — reused on every existing-item comparison.
         norm_name = _normalize_name(name)
         tokens = _get_tokens(name)
+        plat = _platform_numbers(name)
 
         for idx, existing in enumerate(merged_items):
             ex_lines, ex_name, ex_norm_name, ex_tokens = merged_cache[idx]
@@ -564,7 +599,8 @@ def deduplicate_fuzzy(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
             # Optimization: Check lines first (cheaper)
             if line_overlap > 0.3:
                 if _has_significant_overlap_cached(
-                    norm_name, ex_norm_name, tokens, ex_tokens
+                    norm_name, ex_norm_name, tokens, ex_tokens,
+                    plat, _platform_numbers(ex_name),
                 ):
                     # Provider priority logic — legacy VOR disruption provider only.
                     # The standalone VOR disruption provider (source == "vor") was

--- a/tests/test_merge_platform_numbers.py
+++ b/tests/test_merge_platform_numbers.py
@@ -1,0 +1,65 @@
+"""Bug b7: ``_normalize_name`` strips all digits before tokenising, so two
+titles that differ ONLY by a platform/track number ("Bahnsteig 1" vs
+"Bahnsteig 5") collapse to identical tokens and wrongly merge into one feed
+item. ``_platform_numbers`` captures the platform-pinned digits so a merge is
+blocked when both titles name different, non-overlapping platforms — while a
+same-event pair that merely carries different DATE numbers ("ab 03./10.
+November") still merges, because dates are not captured.
+"""
+
+from typing import Any
+
+from src.feed.merge import _platform_numbers, deduplicate_fuzzy
+
+
+def test_platform_numbers_extracts_only_platform_digits() -> None:
+    assert _platform_numbers("Bahnsteig 1 Wien Mitte") == frozenset({"1"})
+    assert _platform_numbers("Gleis 3 und Gleis 7") == frozenset({"3", "7"})
+    # Dates and line numbers are NOT platform numbers.
+    assert _platform_numbers("Umleitung ab 03. November") == frozenset()
+    assert _platform_numbers("Linie 60A Sperre") == frozenset()
+
+
+def test_distinct_platform_numbers_block_merge() -> None:
+    # Same line + station, different platforms → distinct incidents.
+    items: list[dict[str, Any]] = [
+        {"guid": "a", "_identity": "x|a", "title": "S1: Bahnsteig 1 Wien Mitte"},
+        {"guid": "b", "_identity": "x|b", "title": "S1: Bahnsteig 5 Wien Mitte"},
+    ]
+    assert len(deduplicate_fuzzy(items)) == 2
+
+
+def test_same_platform_still_merges() -> None:
+    items: list[dict[str, Any]] = [
+        {
+            "guid": "a",
+            "_identity": "x|a",
+            "title": "S1: Bahnsteig 1 Wien Mitte",
+            "description": "Erste Meldung.",
+        },
+        {
+            "guid": "b",
+            "_identity": "x|b",
+            "title": "S1: Bahnsteig 1 Wien Mitte",
+            "description": "Zweite Meldung.",
+        },
+    ]
+    assert len(deduplicate_fuzzy(items)) == 1
+
+
+def test_date_variant_in_title_still_merges() -> None:
+    # Regression guard: differing DATE numbers in the title (not platforms)
+    # must NOT block the merge of the same incident reported twice.
+    items: list[dict[str, Any]] = [
+        {
+            "guid": "a",
+            "_identity": "x|a",
+            "title": "S80: Umleitung ab 03. November Wien Praterstern",
+        },
+        {
+            "guid": "b",
+            "_identity": "x|b",
+            "title": "S80: Umleitung ab 10. November Wien Praterstern",
+        },
+    ]
+    assert len(deduplicate_fuzzy(items)) == 1


### PR DESCRIPTION
## b7 — Bahnsteig/Gleis-Nummern unterscheiden, ohne Datums-Merges zu brechen

`_normalize_name` entfernt **alle** Ziffern vor der Tokenisierung — „Bahnsteig 1" und „Bahnsteig 5" kollabieren zu identischen Tokens und werden fälschlich zu einem Feed-Item verschmolzen.

**Fix:** `_platform_numbers` erfasst **nur** Ziffern direkt nach einem Bahnsteig-/Gleis-Schlüsselwort (`Bahnsteig`/`Gleis`/`Steig`/`Sektor`/…). In `_has_significant_overlap_cached` wird ein Merge blockiert, wenn **beide** Titel **unterschiedliche, disjunkte** Plattformen nennen. Ein gleicher Vorfall mit nur abweichender **Datums**-Zahl („Umleitung ab 03./10. November") mergt weiterhin, weil Datumszahlen nicht erfasst werden — genau die Regression, die den ersten Entwurf killte.

**Komplexität:** Die Entscheidung liegt in `_has_significant_overlap_cached` (6→9, ≤15); `deduplicate_fuzzy` bekommt **keinen** neuen Branch und bleibt auf seiner C901-Baseline (**21**).

## Tests / lokal
- Neuer `tests/test_merge_platform_numbers.py`: `_platform_numbers` erfasst nur Plattform-Ziffern (nicht Datum/Linie); disjunkte Bahnsteige blocken (len 2); gleicher Bahnsteig mergt (len 1); Datums-Variante mergt (len 1).
- **124/124** grün in der gesamten Merge-Suite. `ruff` clean, `mypy --strict` ohne neue Fehler, `deduplicate_fuzzy` unverändert bei 21.