### PR TITLE
fix(oebb): route-regex boundary tokens (b1) + strict-mode lone-Pendler gate (b12)

### DIFF
--- a/src/providers/oebb.py
+++ b/src/providers/oebb.py
@@ -486,8 +486,9 @@ _ZWISCHEN_PLAIN_RE = re.compile(
     # train clause and produced frankenstring endpoints.
     r"einige|keine|kein|alle|mehrere|wenige|s[äa]mtliche|"
     # Intermediate-via marker — ends the captured endpoint at the via stop
-    # so "Mödling über Wiener Neudorf" yields b="Mödling".
-    r"[üu]ber|via"
+    # so "Mödling über Wiener Neudorf" yields b="Mödling". ``zu|zur`` ends it
+    # at the dominant ÖBB closer "kommt es zwischen X und Y zu <…>" (bug b1).
+    r"zu|zur|[üu]ber|via"
     r")\b"
     r"|[,;!?]"  # Plain sentence punctuation (period excluded — see above)
     r"|[—–]"  # German em-/en-dash often introduces a side remark
@@ -519,7 +520,7 @@ _VON_NACH_PLAIN_RE = re.compile(
     r"auf|au[ßs]er\s+betrieb|nicht|kein|von|bis|am|im|in\s+der|"
     r"f[üu]r|wegen|aufgrund|durch|infolge|"
     r"ist|sind|war|waren|wird|werden|kann|k[öo]nnen|"
-    r"f[äa]hrt|fahren|kommt|fallen|halten|halten\s+nicht)\b"
+    r"f[äa]hrt|fahren|kommt|fallen|halten|halten\s+nicht|[üu]ber|via)\b"
     r"|[,;!?]"
     r"|[—–]"
     r"|<"
@@ -544,7 +545,7 @@ _STRECKE_PLAIN_RE = re.compile(
     r"betroffen|beeintr[äa]chtigt|gest[öo]rt|eingeschr[äa]nkt|"
     r"auf|au[ßs]er\s+betrieb|nicht|kein|von|bis|am|im|in\s+der|"
     r"f[üu]r|wegen|aufgrund|durch|infolge|"
-    r"ist|sind|war|waren|wird|werden|kann|k[öo]nnen)\b"
+    r"ist|sind|war|waren|wird|werden|kann|k[öo]nnen|kommt|fahren|fallen|halten|[üu]ber|via)\b"
     r"|[,;!?]"
     r"|[—–]"
     r"|<"
@@ -1193,7 +1194,7 @@ def _is_relevant(title: str, description: str) -> bool:
         info = station_info(s)
         if not info:
             continue
-        if info.in_vienna or info.pendler:
+        if info.in_vienna or (info.pendler and not OEBB_ONLY_VIENNA):
             has_relevant = True
         else:
             has_distant = True

--- a/tests/test_oebb_route_boundaries_strict.py
+++ b/tests/test_oebb_route_boundaries_strict.py
@@ -1,0 +1,59 @@
+"""bug b1: the route regexes (_ZWISCHEN_/_VON_NACH_/_STRECKE_PLAIN_RE)
+over-extended the second endpoint into the predicate because their boundary
+alternation lacked ``zu``/``zur`` (zwischen), ``über``/``via`` (von-nach +
+strecke) and the predicate verbs (strecke). The standard ÖBB phrasing
+"kommt es zwischen X und Y zu …" then produced a frankenstring endpoint, the
+real Wien route was mis-classified as "unknown" and the message dropped.
+
+bug b12: in the single-station path a Pendler-only mention was counted as
+relevant even under OEBB_ONLY_VIENNA, where the route rule requires BOTH
+endpoints inside Vienna — so a lone Pendler message leaked in strict mode.
+"""
+from __future__ import annotations
+
+import pytest
+
+import src.providers.oebb as oebb
+from src.providers.oebb import _is_relevant
+
+
+class TestRouteBoundaryTokens:
+    def test_zwischen_zu_keeps_wien_route(self) -> None:
+        assert (
+            _is_relevant(
+                "Bauarbeiten",
+                "Aufgrund von Bauarbeiten kommt es zwischen Wien Mitte und "
+                "Flughafen Wien zu Einschränkungen.",
+            )
+            is True
+        )
+
+    def test_von_nach_ueber_keeps_wien_route(self) -> None:
+        assert (
+            _is_relevant(
+                "Bauarbeiten",
+                "Von Wien Meidling nach Mödling über Wiener Neudorf ist die "
+                "Strecke gesperrt.",
+            )
+            is True
+        )
+
+    def test_strecke_kommt_keeps_wien_route(self) -> None:
+        assert (
+            _is_relevant(
+                "Verspätungen",
+                "Auf der Strecke Wien Meidling - Wien Hauptbahnhof kommt es "
+                "zu Verspätungen.",
+            )
+            is True
+        )
+
+
+def test_lone_pendler_dropped_only_under_strict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    msg = ("Störung Mödling", "Wegen einer Störung kommt es zu Verspätungen.")
+    monkeypatch.setattr(oebb, "OEBB_ONLY_VIENNA", True)
+    assert oebb._is_relevant(*msg) is False
+    monkeypatch.setattr(oebb, "OEBB_ONLY_VIENNA", False)
+    assert oebb._is_relevant(*msg) is True


### PR DESCRIPTION
Zwei vom Fix-Design-Workflow freigegebene, bisher nicht geshippte Fixes (oebb.py).

## b1 — Routen-Regexe verschluckten den zweiten Endpunkt (HÖCHSTER Wert)
`_ZWISCHEN_/_VON_NACH_/_STRECKE_PLAIN_RE`: der non-greedy `(?P<b>.+?)` überdehnte, weil der Grenzwort-Alternation Tokens fehlten. Die **Standard-ÖBB-Formulierung** „kommt es zwischen X und Y **zu** <Einschränkungen>" machte Endpunkt B zum Frankenstring → Route als „unknown" → echte Wien-Route **gedroppt**.
Fix = `zu|zur` (zwischen), `über|via` (von-nach + strecke), Prädikatsverben `kommt|fahren|fallen|halten` (strecke) in die bestehenden `\s+(?:…)\b`-Alternationen. stations.json-Ganzwort-Scan: **0** Stationsnamen matchen die neuen Tokens → kein echter Endpunkt wird abgeschnitten. Empirisch: „… zwischen Wien Mitte und Flughafen Wien zu …" → Route `(Wien Mitte, Flughafen Wien)`, `_is_relevant=True` (vorher dropped).

## b12 — `OEBB_ONLY_VIENNA`: Pendler leckte im Strict-Mode
Im Einzelstation-Pfad zählte eine reine Pendler-Erwähnung als relevant, obwohl die Routenregel im Strict-Mode **beide** Endpunkte in Wien verlangt. Fix = `info.in_vienna or (info.pendler and not OEBB_ONLY_VIENNA)`. Lone-Pendler droppt jetzt im Strict-Mode; Default (Flag aus) unverändert.

## Tests / lokal
- Neuer `tests/test_oebb_route_boundaries_strict.py` (b1: zu/über/strecke-kommt behalten Wien-Route; b12: lone-Pendler droppt nur unter strict).
- **240/240** grün in der oebb-Testsuite. `ruff` clean, `mypy --strict` ohne neue Fehler, C901: `_is_relevant` bleibt ≤15, nur die zwei baseline-Funktionen unverändert.