### PR TITLE
fix(baustellen): leading word-boundary on the U-/S-Bahn ÖPNV tokens (b4)

### DIFF
--- a/src/providers/baustellen.py
+++ b/src/providers/baustellen.py
@@ -75,8 +75,12 @@ _OEPNV_RE: Final = re.compile(
     r"|verkehrsmittel"
     r"|buslinie"
     r"|autobus"
-    r"|u-?bahn"
-    r"|s-?bahn"
+    # Leading \b ONLY: matches "U-Bahn"/"S-Bahn"/"U-Bahnbau"/"U-Bahnstation"
+    # but not the substrings in "Hochschaubahn" ("ubahn") or
+    # "Verkehrsbahnhof" ("sbahn"). A TRAILING \b after "bahn" would wrongly
+    # drop the compound forms (no boundary between "bahn" and "bau") — bug b4.
+    r"|\bu-?bahn"
+    r"|\bs-?bahn"
     r"|öpnv"
     r"|öffentliche[rn]?\s+verkehr"
     r"|\bbus(?:se)?\b"

--- a/tests/test_baustellen_relevance.py
+++ b/tests/test_baustellen_relevance.py
@@ -179,6 +179,11 @@ def test_radius_override_widens_geo_match(
         "Sperre der Buslinie 10A",
         "Linie 46 verkürzt",
         "U6 Teilsperre",
+        # bug b4: the leading-only \b must KEEP the compound U-/S-Bahn forms
+        # (no boundary exists between "bahn" and "bau"/"station").
+        "U-Bahnbau wird gesperrt",
+        "Neubau der U-Bahnstation der U2",
+        "S-Bahn-Stammstrecke betroffen",
     ],
 )
 def test_mentions_oepnv_true(text: str) -> None:
@@ -192,6 +197,10 @@ def test_mentions_oepnv_true(text: str) -> None:
         "Vollsperre der Fahrbahn wegen Rohrlegung",
         "Gehsteigsanierung im Innenhof",
         "Buschenschank am Nussberg",  # 'Busch…' must not trip the \\bbus\\b token
+        # bug b4: the substrings "ubahn" / "sbahn" inside unrelated compounds
+        # must NOT trip the U-/S-Bahn tokens (leading \b on both).
+        "Fahrbahnsanierung bei der Hochschaubahn",
+        "Erneuerung am Verkehrsbahnhof Inzersdorf",
     ],
 )
 def test_mentions_oepnv_false(text: str) -> None:


### PR DESCRIPTION
## b4 — `_OEPNV_RE` `u-?bahn`/`s-?bahn` ohne führendes `\b`

Anders als die Geschwister-Tokens (`\bbus\b`, `\bbim\b`, `\bu[1-6]\b`, `\btram\b`) hatten `u-?bahn`/`s-?bahn` **kein** `\b`. Dadurch matchten die Substrings „ubahn" in **„Hochschaubahn"** und „sbahn" in **„Verkehrsbahnhof"** → eine Nicht-Transit-Baustelle blieb im ÖPNV-Feed.

**Fix:** nur **führendes** `\b` (`\bu-?bahn` / `\bs-?bahn`). Ein **trailing** `\b` nach „bahn" würde die Compound-Formen „U-Bahnbau"/„U-Bahnstation" zerstören (keine Wortgrenze zwischen „bahn" und „bau") — daher bewusst weggelassen.

Empirisch verifiziert: Hochschaubahn/Verkehrsbahnhof → `False`; U-Bahn/U-Bahnbau/U-Bahnstation/S-Bahn-Stammstrecke → `True`.

## Tests / lokal
- `test_mentions_oepnv_true` um die Compound-Formen erweitert (Anti-Regression), `test_mentions_oepnv_false` um die zwei Substring-Fehltreffer.
- **73/73** grün, `ruff`/`mypy` sauber.