### PR TITLE
fix(stations): drop opaque 3-char bst-code aliases from the Vienna regex (b11)

### DIFF
--- a/src/utils/stations.py
+++ b/src/utils/stations.py
@@ -1019,8 +1019,13 @@ def _vienna_stations_regex() -> re.Pattern[str]:
                 if alias:
                     vienna.add(str(alias).strip().lower())
 
-    # Filtere ungenaue Alias-Namen und reine Zahlen (z.B. IDs) heraus
-    vienna = {n for n in vienna if len(n) >= 3 and not n.isdigit()}
+    # Filtere ungenaue Alias-Namen und reine Zahlen (z.B. IDs) heraus. Die
+    # Mindestlänge 4 (wie in :func:`_non_vienna_stations_regex`) entfernt die
+    # opaken 3-Zeichen ÖBB-Betriebsstellencodes (HAK/STK/REN/HET/SUE/…), die
+    # sonst als ganzes Wort auf Alltagstoken wie die Handelsakademie-Abkürzung
+    # "HAK" matchen und ein falsches Wien-Signal liefern — echte Meldungen
+    # referenzieren diese Stationen über den Vollnamen (Bug b11).
+    vienna = {n for n in vienna if len(n) >= 4 and not n.isdigit()}
     vienna -= {"hbf", "bf", "bahnhof", "hauptbahnhof", "station"}
 
     if not vienna:

--- a/tests/test_vienna_opaque_code_aliases.py
+++ b/tests/test_vienna_opaque_code_aliases.py
@@ -1,0 +1,36 @@
+"""bug b11: opaque 3-char ÖBB Betriebsstellen-codes (HAK/STK/REN/HET/SUE/…)
+were admitted into the Vienna-detection regex as whole-word alternatives and
+matched everyday tokens — most notably the Handelsakademie abbreviation
+"HAK" — as a false Vienna signal. Raising the minimum alias length to 4
+(mirroring _non_vienna_stations_regex) drops these opaque codes while keeping
+every real station reference, which always uses the full name.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.utils.stations import text_has_vienna_connection
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Die HAK feiert ein Fest.",  # Handelsakademie abbreviation, not a station
+        "Abschnitt Stk wird saniert.",
+        "Der Zug nach Ren ist verspätet.",
+    ],
+)
+def test_opaque_three_char_codes_no_longer_match(text: str) -> None:
+    assert text_has_vienna_connection(text) is False
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Sperre bei Wien Mitte.",
+        "Störung Wien Hauptbahnhof.",
+        "Umbau bei Karlsplatz.",
+    ],
+)
+def test_real_vienna_references_still_match(text: str) -> None:
+    assert text_has_vienna_connection(text) is True


### PR DESCRIPTION
## b11 — opake 3-Zeichen-Betriebsstellencodes erzeugten falsche Wien-Treffer

`_vienna_stations_regex` ließ Aliase ab Länge **≥3** zu → die opaken 3-Zeichen ÖBB-Betriebsstellencodes (HAK/STK/REN/HET/SUE/…) landeten als Ganzwort-Alternativen im Vienna-Erkennungs-Regex und matchten Alltagstoken — allen voran die **Handelsakademie-Abkürzung „HAK"** — als falsches Wien-Signal.

**Fix:** Mindestlänge **≥4** (wie im Geschwister `_non_vienna_stations_regex`). Eine Enumeration bestätigte: die **12 entfernten Terme sind ausnahmslos opake Codes** (bse, hak, het, hns, lga, ren, sdf, stc, stk, sty, sue, wwb) — **kein** legitimer Stationsbezug. Echte Wien-Stationen (Vollname) matchen weiter → **kein Overblocking**.

Empirisch: „Die HAK feiert" / „Abschnitt Stk" / „nach Ren" → `False`; „Wien Mitte" / „Wien Hauptbahnhof" / „Karlsplatz" → `True`.

## Tests / lokal
- Neuer `tests/test_vienna_opaque_code_aliases.py` (opake Codes → False; echte Referenzen → True).
- **121/121** grün (vienna-marchegg, text-vienna-strict, vienna-regex-numeric, enrich-aliases, stations-metadata, utils-stats). `ruff`/`mypy` sauber.