### PR TITLE
fix(wl): fall back to a label when a punctuation-only title tidies to empty

### DIFF
--- a/src/providers/wl_fetch.py
+++ b/src/providers/wl_fetch.py
@@ -638,7 +638,12 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
                 continue
 
             title_raw = str(ti.get("title") or ti.get("name") or "Meldung").strip()
-            title = _tidy_title_wl(title_raw)
+            # ``_tidy_title_wl`` strips leading/trailing dashes/colons, so a
+            # source title of only punctuation ("---") tidies to "" — then
+            # ``_ensure_line_prefix`` would render just the line codes
+            # ("U1/U2") with no description. Fall back to a generic label so
+            # the title stays informative (mirrors the line-640 fallback).
+            title = _tidy_title_wl(title_raw) or "Meldung"
             desc_raw = str(ti.get("description") or "").strip()
             # Do NOT strip HTML here, we need to preserve links (Task 3)
             desc = desc_raw
@@ -733,7 +738,12 @@ def fetch_events(timeout: int = 20) -> list[dict[str, Any]]:
             title_raw = str(
                 poi.get("title") or poi.get("name") or "Hinweis"
             ).strip()
-            title = _tidy_title_wl(title_raw)
+            # ``_tidy_title_wl`` strips leading/trailing dashes/colons, so a
+            # source title of only punctuation ("---") tidies to "" — then
+            # ``_ensure_line_prefix`` would render just the line codes
+            # ("U1/U2") with no description. Fall back to a generic label so
+            # the title stays informative (mirrors the line-640 fallback).
+            title = _tidy_title_wl(title_raw) or "Meldung"
             desc_raw = str(poi.get("description") or "").strip()
             # Do NOT strip HTML here, we need to preserve links (Task 3)
             desc = desc_raw

--- a/tests/test_wl_title.py
+++ b/tests/test_wl_title.py
@@ -11,6 +11,19 @@ from src.providers.wl_lines import (
 from src.providers.wl_text import _tidy_title_wl
 
 
+def test_punctuation_only_title_falls_back_to_label() -> None:
+    # bug: a WL source title of only punctuation ("---") tidies to "" because
+    # _tidy_title_wl strips leading/trailing dashes/colons; _ensure_line_prefix
+    # then renders just the line codes ("U1/U2") with no description. The
+    # ``or "Meldung"`` fallback at the call site keeps the title informative.
+    assert _tidy_title_wl("---") == ""
+    assert _ensure_line_prefix("", ["U1", "U2"]) == "U1/U2"  # the malformed case
+    assert (
+        _ensure_line_prefix(_tidy_title_wl("---") or "Meldung", ["U1", "U2"])
+        == "U1/U2: Meldung"
+    )
+
+
 def test_bucket_merge_prefers_informative_title_and_description(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Fund #1 (projektweiter Review) — WL-Titel werden leer/verstümmelt

Ein WL-Quelltitel nur aus Bindestrichen/Doppelpunkten (z.B. „---") wird von `_tidy_title_wl` zu `""` reduziert (es strippt führendes/abschließendes `" -–—:/\t"`). Der leere Titel fließt in `_ensure_line_prefix`, das dann **nur die Linien-Codes** rendert — „**U1/U2**" ohne Beschreibung (uninformatives Feed-Item).

**Fix:** Fallback auf das generische Label „Meldung" an beiden `_tidy_title_wl`-Call-Sites (wie der bestehende `title_raw`-Fallback in Zeile 640) → gerenderter Titel bleibt „U1/U2: Meldung".

Verifiziert: `_tidy_title_wl("---") == ""`; `_ensure_line_prefix("", ["U1","U2"]) == "U1/U2"` (Bug); `_ensure_line_prefix("Meldung", ["U1","U2"]) == "U1/U2: Meldung"` (Fix).

## Tests / lokal
- Test in `test_wl_title.py` (Mechanismus). **22/22** grün, `ruff`/`mypy` sauber.