### PR TITLE
fix(build_feed): clamp future pubDate in sort key + isolate a failing merge

### DIFF
--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -2821,7 +2821,19 @@ def _drain_completed_futures(
                     provider_name, f"Fetch fehlgeschlagen: {sanitised}"
                 )
             else:
-                merge_result(fetch, result, provider_name)
+                # Isolate a single provider's merge failure: ``merge_result``
+                # (and the report bookkeeping it calls) runs OUTSIDE the
+                # ``future.result()`` try above, so an exception here would
+                # otherwise propagate out of the drain loop and lose every
+                # already-collected item from the other providers.
+                try:
+                    merge_result(fetch, result, provider_name)
+                except Exception as exc:
+                    sanitised = sanitize_log_arg(str(exc))
+                    log.exception("%s merge fehlgeschlagen: %s", name, sanitised)
+                    report.provider_error(
+                        provider_name, f"Merge fehlgeschlagen: {sanitised}"
+                    )
 
 
 def _run_network_fetchers(
@@ -3355,6 +3367,9 @@ def _recency_sort_key(
     first_seen = _parse_first_seen(entry, now_utc) or now_utc
     pub = _parse_datetime(item.get("pubDate"))
     pub_ts = pub.timestamp() if isinstance(pub, datetime) else float("-inf")
+    # Clamp a future pubDate to now: a bogus future publication date must not
+    # rank an item ahead of genuinely-current items in this pubDate tiebreaker.
+    pub_ts = min(pub_ts, now_utc.timestamp())
     guid_val = item.get("guid")
     guid_str = str(guid_val) if guid_val else _identity_for_item(item)
     return (-first_seen.timestamp(), _category_feed_rank(item), -pub_ts, guid_str)

--- a/tests/test_build_feed_sort_merge_robustness.py
+++ b/tests/test_build_feed_sort_merge_robustness.py
@@ -76,7 +76,7 @@ def test_drain_isolates_a_failing_merge(monkeypatch: pytest.MonkeyPatch) -> None
     def fetch() -> list[Any]:
         return []
 
-    fetch.__name__ = "wl_fetch"  # type: ignore[attr-defined]
+    fetch.__name__ = "wl_fetch"
 
     futures = {fut: (fetch, "Wiener Linien", 10)}
     deadlines: dict[Any, float | None] = {fut: None}

--- a/tests/test_build_feed_sort_merge_robustness.py
+++ b/tests/test_build_feed_sort_merge_robustness.py
@@ -1,0 +1,93 @@
+"""Project-wide review follow-ups:
+
+#2 (sort): _recency_sort_key used the raw pubDate timestamp as a tiebreaker,
+   so an item with a bogus FUTURE pubDate ranked ahead of genuinely-current
+   items (within a first_seen + category tie). The pubDate is now clamped to
+   ``now`` for the tiebreaker.
+
+#3 (robustness): in _drain_completed_futures the ``merge_result`` call ran
+   OUTSIDE the ``future.result()`` try, so an exception while merging one
+   provider's result propagated out of the drain loop and lost every
+   already-collected item from the other providers. The merge is now isolated
+   per provider.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from concurrent.futures import Future
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _import_build_feed(monkeypatch: pytest.MonkeyPatch) -> types.ModuleType:
+    module_name = "src.build_feed"
+    root = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(root))
+    monkeypatch.syspath_prepend(str(root / "src"))
+    providers = types.ModuleType("providers")
+    for name in ("wiener_linien", "oebb", "vor"):
+        mod = types.ModuleType(f"providers.{name}")
+        setattr(mod, "fetch_events", lambda: [])
+        monkeypatch.setitem(sys.modules, f"providers.{name}", mod)
+    monkeypatch.setitem(sys.modules, "providers", providers)
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_recency_sort_clamps_future_pubdate(monkeypatch: pytest.MonkeyPatch) -> None:
+    build_feed = _import_build_feed(monkeypatch)
+    now = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+    future = (now + timedelta(days=200)).isoformat()
+    past = (now - timedelta(days=1)).isoformat()
+
+    k_future = build_feed._recency_sort_key({"pubDate": future, "guid": "f"}, {}, now)
+    k_now = build_feed._recency_sort_key({"pubDate": now.isoformat(), "guid": "n"}, {}, now)
+    k_past = build_feed._recency_sort_key({"pubDate": past, "guid": "p"}, {}, now)
+
+    # The future pubDate is clamped to now, so its pubDate tiebreaker (index 2,
+    # ``-pub_ts``) equals the current item's instead of ranking ahead of it.
+    assert k_future[2] == k_now[2]
+    # A genuine past pubDate still sorts AFTER now (a larger ``-pub_ts``).
+    assert k_past[2] > k_now[2]
+
+
+class _FakeReport:
+    def __init__(self) -> None:
+        self.errors: list[tuple[str, str]] = []
+
+    def provider_error(self, name: str, msg: str) -> None:
+        self.errors.append((name, msg))
+
+    def __getattr__(self, _name: str) -> Any:
+        return lambda *a, **k: None
+
+
+def test_drain_isolates_a_failing_merge(monkeypatch: pytest.MonkeyPatch) -> None:
+    build_feed = _import_build_feed(monkeypatch)
+
+    fut: Future[Any] = Future()
+    fut.set_result([{"title": "x"}])
+
+    def fetch() -> list[Any]:
+        return []
+
+    fetch.__name__ = "wl_fetch"  # type: ignore[attr-defined]
+
+    futures = {fut: (fetch, "Wiener Linien", 10)}
+    deadlines: dict[Any, float | None] = {fut: None}
+    pending: set[Any] = {fut}
+    report = _FakeReport()
+
+    def merge_result(_fetch: Any, _result: Any, _name: str) -> None:
+        raise ValueError("boom")
+
+    # Must NOT raise — the merge failure is isolated to the one provider.
+    build_feed._drain_completed_futures(futures, deadlines, pending, report, merge_result)
+
+    assert pending == set()
+    assert any(name == "Wiener Linien" for name, _ in report.errors)


### PR DESCRIPTION
Zwei Funde aus dem projektweiten Review (build_feed.py).

## #2 — Zukunfts-pubDate sortiert vor aktuellen Items
`_recency_sort_key` nutzte den rohen pubDate-Zeitstempel als **dritten Tiebreaker** (nach `first_seen` und Kategorie). Ein Item mit bogus **Zukunfts**-pubDate rangierte damit vor aktuellen Items innerhalb eines Gleichstands. Fix: pubDate für den Tiebreaker auf `now` clampen (`min(pub_ts, now)`). *(Wirkung begrenzt — nur Tiebreaker, nicht der primäre `first_seen`-Sort — aber billig & korrekt.)*

## #3 — Exception in `merge_result` → Item-Verlust
In `_drain_completed_futures` lag der `merge_result`-Aufruf im `else` des `future.result()`-try, also **außerhalb** der Exception-Behandlung. Wirft das Mergen eines Provider-Results (z.B. `_normalize_item_datetimes` an einem malformed Item), propagiert die Exception aus der Drain-Schleife und **alle bereits eingesammelten Items der anderen Provider gehen verloren**. Fix: Merge in eigenen try/except → eine Provider-Merge-Panne wird geloggt + gemeldet, die Schleife läuft weiter.

## Tests / lokal
- Neuer `tests/test_build_feed_sort_merge_robustness.py` (#2: Zukunfts-pubDate-Clamp; #3: fehlschlagender Merge wird isoliert, `pending` leert, andere Items bleiben).
- **23** build_feed-Tests grün, `ruff`/`mypy --strict` sauber, C901 beider Funktionen ≤15 (unverändert).