### PR TITLE
fix(stammstrecke): treat empty rtDate/rtDepDate as "no explicit date"

### DIFF
--- a/scripts/update_stammstrecke_status.py
+++ b/scripts/update_stammstrecke_status.py
@@ -1205,7 +1205,12 @@ def _leg_departure_delay_minutes(leg: Mapping[str, Any]) -> float | None:
     # heuristic below is only applied when it did NOT — otherwise the
     # explicit date is authoritative and a same-day early departure is a
     # legitimate small-magnitude negative delay we must record verbatim.
-    rt_date_explicit = origin.get("rtDate") or origin.get("rtDepDate")
+    # ``or None`` collapses an EMPTY-string rtDate/rtDepDate to ``None``:
+    # ``"" or "" == ""`` is falsy but not ``None``, which would make the
+    # ``rt_date_explicit is None`` heuristic gate below evaluate False and
+    # wrongly skip the midnight-rollover correction (a 23:55 leg with
+    # rtTime "00:05" then yields a bogus ≈ −23h50m delay).
+    rt_date_explicit = origin.get("rtDate") or origin.get("rtDepDate") or None
     rt_date = rt_date_explicit or sched_date
     actual = _parse_vao_dt(rt_date, rt_time)
     if actual is None:

--- a/tests/scripts/test_update_stammstrecke_status.py
+++ b/tests/scripts/test_update_stammstrecke_status.py
@@ -418,6 +418,27 @@ def test_leg_departure_delay_handles_early_across_midnight_rollover() -> None:
     assert script._leg_departure_delay_minutes(leg) == -11.0
 
 
+def test_leg_departure_delay_applies_midnight_heuristic_with_empty_rtdepdate() -> None:
+    """bug: an EMPTY-string ``rtDepDate`` ('') is falsy but not ``None``, so
+    without the ``or None`` normalisation the ``rt_date_explicit is None`` gate
+    skipped the midnight-rollover heuristic — a 23:55 leg departing 00:05 then
+    yielded a bogus ≈ −23h50m delay instead of the true ~10 min.
+    """
+
+    leg = {
+        "type": "JNY",
+        "name": "S 1",
+        "category": "S",
+        "Origin": {
+            "date": "2026-05-09",
+            "time": "23:55:00",
+            "rtTime": "00:05:00",  # 10 min late, lands on the next day.
+            "rtDepDate": "",  # empty string → must count as "no explicit date".
+        },
+    }
+    assert script._leg_departure_delay_minutes(leg) == 10.0
+
+
 def test_leg_departure_delay_skips_unparseable_schedule() -> None:
     """When the scheduled timestamp is malformed we cannot compute a
     delta — return ``None`` rather than risk a misleading 0.


### PR DESCRIPTION
## Fund #4 (projektweiter Review) — Stammstrecke-Verspätung um Mitternacht falsch

`_leg_departure_delay_minutes` (scripts/update_stammstrecke_status.py) bestimmt mit `origin.get("rtDate") or origin.get("rtDepDate")`, ob VAO ein explizites Echtzeit-Datum lieferte. Sind **beide leere Strings** `""`, ist das Ergebnis `""` — falsy, aber **nicht** `None` → der Gate `if rt_date_explicit is None` ist False → die **Mitternachts-Heuristik wird übersprungen**. Ein 23:55-Leg mit rtTime „00:05" fällt dann auf das Plan-Datum zurück und liefert ≈ **−23h50m** statt der echten **~10 Min** — was in den Richtungs-Mittelwert der Stammstrecke einfließt.

**Fix:** `… or None` anhängen → leerer String kollabiert zu `None`, die Heuristik greift. Ein echtes (nicht-leeres) `rtDepDate` bleibt unverändert maßgeblich.

*(Hinweis: der ursprüngliche Review-Fund hatte das Beispiel falsch — mit gültigem `rtDepDate='2026-05-10'` ist das Ergebnis korrekt; der echte Trigger ist der **leere String**.)*

## Tests / lokal
- Test in `test_update_stammstrecke_status.py` (leeres `rtDepDate` → Heuristik greift → 10.0 min). **7** leg-departure-Tests grün, `ruff`/`mypy` ohne neue Fehler.