### PR TITLE
fix(env): return content (not the stray opening quote) for an unclosed quote

### DIFF
--- a/src/utils/env.py
+++ b/src/utils/env.py
@@ -259,8 +259,12 @@ def _parse_value(value: str) -> str:
         parts.append(char)
         idx += 1
 
-    # If no closing quote found, return as is (consistent with flexible parsing)
-    return value
+    # No closing quote: the operator opened a quote and forgot to close it.
+    # Return the decoded CONTENT after the opening quote (consistent with the
+    # closed-quote path above) instead of ``value`` itself — keeping the stray
+    # opening quote yielded values like ``"abc`` that silently corrupt a
+    # token/credential at the use site.
+    return "".join(parts)
 
 
 def _decode_escape(quote_char: str, next_char: str) -> str | None:

--- a/tests/test_env_unclosed_quote.py
+++ b/tests/test_env_unclosed_quote.py
@@ -1,0 +1,28 @@
+"""bug: env._parse_value returned the raw value INCLUDING the unclosed opening
+quote for a value like ``"abc`` (operator opened a quote and forgot to close
+it), so the stray quote silently corrupted the token/credential at the use
+site. It now returns the decoded content after the opening quote, consistent
+with the closed-quote path — closed, unquoted and commented values are
+unchanged.
+"""
+from src.utils.env import _parse_value
+
+
+def test_unclosed_double_quote_returns_content_without_quote() -> None:
+    assert _parse_value('"abc') == "abc"
+    # escapes are decoded just like a closed double-quoted value
+    assert _parse_value('"a\\tb') == "a\tb"
+    # a lone opening quote yields the empty content
+    assert _parse_value('"') == ""
+
+
+def test_unclosed_single_quote_returns_content_without_quote() -> None:
+    assert _parse_value("'xyz") == "xyz"
+
+
+def test_closed_and_unquoted_values_unchanged() -> None:
+    assert _parse_value('"abc"') == "abc"
+    assert _parse_value("'xyz'") == "xyz"
+    assert _parse_value("abc") == "abc"
+    assert _parse_value("value # comment") == "value"
+    assert _parse_value('"a\\tb"') == "a\tb"


### PR DESCRIPTION
## Fund #5 (projektweiter Review) — `.env` mit ungeschlossenem Quote

`_parse_value` gab bei einem Wert wie `KEY="abc` (öffnendes Quote, kein schließendes) den **rohen Wert inklusive des öffnenden Quotes** zurück (`'"abc'`). Das streunende Quote korrumpiert still ein Token/Credential an der Verwendungsstelle (z.B. Auth bricht).

**Fix:** `return "".join(parts)` — der bereits geparste/dekodierte Inhalt **nach** dem öffnenden Quote, konsistent mit dem Pfad für geschlossene Quotes. Geschlossene, unquoted und kommentierte Werte bleiben **unverändert** (Fall-für-Fall verifiziert): `"abc"`→`abc`, `abc`→`abc`, `value # comment`→`value`, `"a\tb"`→`a⇥b`; nur `"abc`→`abc` (statt `'"abc'`).

## Tests / lokal
- Neuer `tests/test_env_unclosed_quote.py`. Volle env-Suite grün, `ruff`/`mypy` sauber.