### PR TITLE
fix(stations-validation): accept int bst_code/vor_id in the required-alias check

### DIFF
--- a/src/utils/stations_validation.py
+++ b/src/utils/stations_validation.py
@@ -673,12 +673,17 @@ def _find_alias_issues(
         required: list[str] = []
         if name:
             required.append(name)
+        # Accept ``str | int`` for the identity fields (bst_code / vor_id),
+        # matching the sibling validators _find_cross_station_id_conflicts and
+        # _find_identity_field_conflicts. A directory entry whose bst_code is a
+        # JSON integer would otherwise be silently skipped here, so a genuinely
+        # missing required alias for that station went unreported (bug #8).
         bst_code = entry.get("bst_code")
-        if isinstance(bst_code, str) and bst_code.strip():
-            required.append(bst_code.strip())
+        if isinstance(bst_code, str | int) and str(bst_code).strip():
+            required.append(str(bst_code).strip())
         vor_id = entry.get("vor_id")
-        if isinstance(vor_id, str) and vor_id.strip():
-            required.append(vor_id.strip())
+        if isinstance(vor_id, str | int) and str(vor_id).strip():
+            required.append(str(vor_id).strip())
 
         alias_set = {alias.lower() for alias in aliases}
         missing_required = [value for value in required if value.lower() not in alias_set]

--- a/tests/test_stations_validation_int_id.py
+++ b/tests/test_stations_validation_int_id.py
@@ -1,0 +1,42 @@
+"""bug #8: _find_alias_issues guarded the identity fields with
+``isinstance(bst_code, str)`` only, while the sibling validators
+(_find_cross_station_id_conflicts, _find_identity_field_conflicts) accept
+``str | int``. A directory entry whose bst_code is a JSON integer was
+therefore silently skipped, so a genuinely missing required alias for that
+station went unreported.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from src.utils.stations_validation import _find_alias_issues
+
+
+def _station(**over: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "name": "Teststation",
+        "aliases": ["Teststation"],
+        "source": "oebb",
+    }
+    base.update(over)
+    return base
+
+
+def test_integer_bst_code_missing_alias_is_reported() -> None:
+    issues = list(_find_alias_issues([_station(bst_code=12345)]))
+    assert len(issues) == 1
+    assert "12345" in issues[0].reason
+
+
+def test_integer_bst_code_present_as_alias_is_ok() -> None:
+    issues = list(
+        _find_alias_issues([_station(bst_code=12345, aliases=["Teststation", "12345"])])
+    )
+    assert issues == []
+
+
+def test_string_bst_code_path_unchanged() -> None:
+    # The original str path must keep reporting a missing required alias.
+    issues = list(_find_alias_issues([_station(bst_code="ABC")]))
+    assert len(issues) == 1
+    assert "ABC" in issues[0].reason


### PR DESCRIPTION
## Fund #8 (projektweiter Review) — Validierung überspringt int-`bst_code`

`_find_alias_issues` prüfte die Identitätsfelder nur mit `isinstance(bst_code, str)`, während die **Geschwister-Validatoren** `_find_cross_station_id_conflicts` (Zeile 876) und `_find_identity_field_conflicts` (Zeile 959) `str | int` akzeptieren. Ein Verzeichnis-Eintrag mit einem **JSON-Integer**-`bst_code` wurde hier still übersprungen → ein tatsächlich fehlender Pflicht-Alias für diese Station blieb **unentdeckt**.

**Fix:** Guard an die Geschwister angleichen — `isinstance(..., str | int)` + `str(...)`. Geringe Wirkung auf den Feed (reine Validierungs-Vollständigkeit), niedriges Risiko.

## Tests / lokal
- Neuer `tests/test_stations_validation_int_id.py` (int-`bst_code` ohne Alias → gemeldet; mit Alias → ok; str-Pfad unverändert).
- **15** Tests grün (inkl. cross-name, self-collision, metadata). `ruff`/`mypy` sauber, C901 ≤15.