### PR TITLE
fix(build_feed): EN-Feed — verstümmelte Masking-Platzhalter beseitigen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+* **Bugfix: EN-Feed — verstümmelte Masking-Platzhalter beseitigt (2026-06-01)**:
+  Im englischen Feed (`docs/feed.en.xml`) erschienen in manchen Item-Titeln rohe
+  Masking-Sentinels (z. B. `XENT…X1X/XENT…X2X: XENT…X0X`) statt der übersetzten
+  Linien/Stationen, während die Description desselben Items korrekt war. Ursache:
+  Das NMT-Modell (Helsinki `opus-mt-de-en`, SentencePiece) **verstümmelt** die
+  opaken Platzhalter — beobachtet wurden ein gedropptes Hex-Zeichen im
+  Per-Prozess-Nonce, ein kleingeschriebenes Präfix (`XGLO` → `XGLo`), ins
+  Englische „übersetzte" Nonce-Fragmente (`…de…` → `…en…`, ein verirrtes `from`)
+  und ein abgeschnittener Index. Jede dieser Verstümmelungen lässt das
+  **exakt-Nonce**-Unmasking scheitern, sodass der Sentinel verbatim durchrutscht,
+  als „Übersetzung" gecacht (`data/first_seen.json`) und auf Cache-Hits ungeprüft
+  ausgeliefert wird. Titel sind anfälliger als Summaries, weil sie fast nur dicht
+  gepackte Platzhalter (`Linie/Linie: Station`) ohne übersetzbaren Text enthalten.
+  Vier Verteidigungslinien in `src/build_feed.py`:
+  * **Safety-Net**: Ein Rest-Platzhalter nach dem Unmask (nonce-agnostischer
+    Detektor `_RESIDUAL_PLACEHOLDER_RE`) wertet die Übersetzung als
+    fehlgeschlagen → sie wird **nicht** gecacht und das Item fällt verbatim auf
+    den deutschen Quelltext zurück (DE↔EN-Inhalts-Parität bleibt gewahrt).
+  * **Cache-Self-Heal**: Ein bereits vergifteter Cache-Hit wird als Miss
+    behandelt und neu übersetzt, sodass Alt-Poison nie mehr ausgeliefert wird.
+  * **Qualitäts-Bypass**: Rein-Entity-Titel (`86A/87A: Wiedgasse` — nur
+    Platzhalter + Satzzeichen, kein `XGLO`) überspringen das Modell ganz und
+    werden direkt entmaskiert — korrektes Englisch ohne Modell-Risiko, ohne
+    DE-Fallback.
+  * **Daten-Bereinigung**: Die 13 bereits vergifteten Cache-Werte in
+    `data/first_seen.json` zurückgesetzt; der nächste Build berechnet sie über
+    die gehärtete Pipeline neu.
 * **Feed-Filter & Dedup: Korrektheits-Welle (Bugs b1–b14, 2026-06-01)**:
   Eine Reihe verifizierter Filter-Fehler behoben, die echte Wien-Meldungen
   fälschlich verwarfen oder irrelevante Meldungen aufnahmen. Jeder Fix ist

--- a/data/first_seen.json
+++ b/data/first_seen.json
@@ -473,7 +473,7 @@
     "translations": {
       "en": {
         "summary": "Stop change of lines 52 towards Baumgarten and 60 towards Rodaun stop: Rustengasse From: Mariahilfer street 186-188 To: Mariahilfer street 180-182 \u2026",
-        "title": "XENT7473from307en9ecebX1X/XENT7473from307en9ecebX2X: XENT7473from307en9ecebX0X"
+        "title": ""
       },
       "epoch": 3
     }
@@ -1153,7 +1153,7 @@
     "first_seen": "2026-05-31T06:01:04.401598+00:00",
     "translations": {
       "en": {
-        "title": "1: XGLoe80319d6d7b56baeX0X Women's run"
+        "title": ""
       },
       "epoch": 3
     }
@@ -1377,7 +1377,7 @@
     "translations": {
       "en": {
         "summary": "Stop change of lines 86A towards Breitenlee, Arnikaweg and 87A towards Hermann-Gebauer-Stra\u00dfe stop: Wiedgasse From: Wiedgasse before Konstanziagasse \u2026",
-        "title": "XENT440c384b5ae3ae8X1X/XENT440c384b5ae3ae8X2X: XENT440c384b5ae3ae8X0X"
+        "title": ""
       },
       "epoch": 3
     }
@@ -1696,8 +1696,8 @@
     "first_seen": "2026-05-31T01:30:46.125180+00:00",
     "translations": {
       "en": {
-        "summary": "XGLof79227f1a283e8dbX0X in both directions. XGLof79227f1a283e8dbX1X: Not foreseeable.",
-        "title": "N29: XGLof79227f1a283e8dbX0X because of XGLof79227f1a283e8dbX1X"
+        "summary": "",
+        "title": ""
       },
       "epoch": 3
     }
@@ -2265,7 +2265,7 @@
     "first_seen": "2026-05-31T19:00:50.312434+00:00",
     "translations": {
       "en": {
-        "title": "XENTe736dbb52a8f8cfX0X: XGLoe736dbb52a8f8cfX0X Foreigner XGLoe736dbb52a8f8cfX1X"
+        "title": ""
       },
       "epoch": 3
     }
@@ -2295,7 +2295,7 @@
     "translations": {
       "en": {
         "summary": "Stop change of lines 62 and 16A towards Oper, Karlsplatz U or Alaudagasse U stop: Schloss Hetzendorf From: Hetzendorfer Stra\u00dfe 79 To: Hetzendorfer \u2026",
-        "title": "XENT440c384b5ae3ae8X1X/XENT440c384b5ae3ae8X2X: XENT440c384b5ae3ae8X0X"
+        "title": ""
       },
       "epoch": 3
     }
@@ -3314,7 +3314,7 @@
     "first_seen": "2026-05-31T06:01:04.401598+00:00",
     "translations": {
       "en": {
-        "summary": "Operation only between Heiligenstadt S U and Sturgasse. XGLoe80319d6d7b56baeX0X: 13:00 o'clock. Reason: running event in the Hauptallee.",
+        "summary": "",
         "title": "11A: running event"
       },
       "epoch": 3
@@ -3324,8 +3324,8 @@
     "first_seen": "2026-05-29T13:05:03.044310+00:00",
     "translations": {
       "en": {
-        "summary": "Stop change of lines 10A and 39A towards Heiligenstadt S U Stop: Barawitzkagasse From: Barawitzkagasse 4-6 To: Barawitzkagasse XENT451aac69e31fe947X",
-        "title": "XENT440c384b5ae3ae8X1X/XENT440c384b5ae3ae8X2X: XENT440c384b5ae3ae8X0X"
+        "summary": "",
+        "title": ""
       },
       "epoch": 3
     }
@@ -3365,7 +3365,7 @@
     "translations": {
       "en": {
         "summary": "After an service obstruction there are different intervals.",
-        "title": "25: XGLO440c384b5ae3ae8X0X because of XGLO440c384b5ae3ae8X1X"
+        "title": ""
       },
       "epoch": 3
     }
@@ -3395,7 +3395,7 @@
     "translations": {
       "en": {
         "summary": "Stop change of line 7A towards Reumannplatz U Stop: Antonsplatz From: Antonsplatz 13 before Rechberggasse To: Antonsplatz 16 Duration: 22. April 2026, approximately \u2026",
-        "title": "XENT7473from307de9ecebX1X: XENT7473from307de9ecebX0X"
+        "title": ""
       },
       "epoch": 3
     }
@@ -3817,7 +3817,7 @@
     "first_seen": "2026-05-31T06:30:44.019648+00:00",
     "translations": {
       "en": {
-        "title": "XENTf39f8888bebba0c0fX0X: Women's run trains stop at line O"
+        "title": ""
       },
       "epoch": 3
     }

--- a/src/build_feed.py
+++ b/src/build_feed.py
@@ -1655,6 +1655,27 @@ _UNMASK_PLACEHOLDER_RE: re.Pattern[str] = re.compile(
     _ENTITY_PLACEHOLDER_RE.pattern + "|XGLO" + _PLACEHOLDER_NONCE + r"X\d+X"
 )
 
+# Nonce-AGNOSTIC detector for placeholders that survived the unmask step
+# because the NMT model MANGLED them. Observed corruptions in cached EN output
+# (``data/first_seen.json``): a dropped hex char in the nonce, the prefix
+# lower-cased (``XGLO`` → ``XGLo``), German-looking nonce fragments translated
+# to English (a stray ``from`` / ``…de…`` → ``…en…``) and a truncated index.
+# Each of these defeats the EXACT-nonce :data:`_UNMASK_PLACEHOLDER_RE`, so the
+# token leaks into the feed verbatim. Unlike that sweep, this pattern does NOT
+# pin the per-process nonce: it matches the ``XENT``/``XGLO`` prefix
+# (case-insensitively, to catch the lower-cased form) followed by an arbitrary
+# alphanumeric nonce body — ``[A-Za-z0-9]`` rather than hex so a *translated*
+# nonce fragment still matches — and the literal ``X`` index separator. That
+# trailing ``X`` is what separates a leaked sentinel from a real German word
+# beginning with the same letters (e.g. ``Xentenplatz`` has no such ``X``),
+# keeping the false-positive rate effectively zero on ÖPNV text (every station,
+# line and operator is masked before translation). Used as a post-unmask
+# safety net and a cache-hit self-heal trigger.
+_RESIDUAL_PLACEHOLDER_RE: re.Pattern[str] = re.compile(
+    r"(?:XENT|XGLO)[A-Za-z0-9]*X",
+    re.IGNORECASE,
+)
+
 
 def _apply_domain_glossary(
     text: str,
@@ -1809,6 +1830,32 @@ def _get_translation_pipeline() -> Any:
     return _TRANSLATION_STATE["pipeline"]
 
 
+def _is_non_translatable_content(masked_text: str) -> bool:
+    """True when ``masked_text`` holds nothing the ML model needs to translate.
+
+    After :func:`_mask_entities`, an all-entity title such as
+    ``86A/87A: Wiedgasse`` becomes a run of verbatim entity placeholders joined
+    by punctuation (``XENT…X1X/XENT…X2X: XENT…X0X``) — there is no German prose
+    left to render. Feeding that to the NMT model is pure downside: the
+    SentencePiece tokenizer can mangle the densely-packed placeholders (the
+    EN-feed sentinel-leak bug) for zero translation benefit. When this returns
+    ``True`` the caller skips the model and unmasks the masked text directly,
+    reproducing the correct, language-neutral surface forms.
+
+    Returns ``True`` only when — after removing every entity placeholder — the
+    remainder carries no alphabetic character, AND no glossary (``XGLO``)
+    placeholder is present. ``XGLO`` placeholders stand in for German jargon the
+    model still has to translate into English, so their presence forces the full
+    pipeline.
+    """
+    if not masked_text.strip():
+        return False
+    if "XGLO" in masked_text:
+        return False
+    remaining = _ENTITY_PLACEHOLDER_RE.sub("", masked_text)
+    return not any(ch.isalpha() for ch in remaining)
+
+
 def _translate_text_attempt(
     text: str,
     ident: str = "",
@@ -1867,6 +1914,14 @@ def _translate_text_attempt(
     )
     masked_text, entity_mapping = _mask_entities(glossary_processed)
     combined_mapping = {**glossary_mapping, **entity_mapping}
+    # Entity-only fast path: when masking leaves nothing translatable (a title
+    # that is just line/station placeholders + punctuation), skip the NMT model
+    # entirely. Round-tripping such a string through Marian risks mangling the
+    # densely-packed placeholders (EN-feed sentinel leak) for no translation
+    # gain — unmasking the masked text reproduces the correct, language-neutral
+    # surface forms directly.
+    if _is_non_translatable_content(masked_text):
+        return _unmask_entities(masked_text, combined_mapping)
     try:
         # ``truncation=True`` enforces the model's input cap (512 tokens
         # for opus-mt-de-en) BEFORE Marian asserts and crashes the
@@ -1901,7 +1956,20 @@ def _translate_text_attempt(
             sanitize_log_arg(ident or "<unknown>"),
         )
         return None
-    return _unmask_entities(translated, combined_mapping)
+    unmasked = _unmask_entities(translated, combined_mapping)
+    if _RESIDUAL_PLACEHOLDER_RE.search(unmasked):
+        # The model mangled a placeholder so badly the exact-nonce unmask could
+        # not restore it (dropped/translated nonce chars, lower-cased prefix,
+        # truncated index). Treat the whole translation as FAILED so the caller
+        # does not cache it and falls back to the German source — a raw sentinel
+        # must never reach subscribers.
+        log.warning(
+            "Translation for identity %s left a residual placeholder; "
+            "discarding and falling back to source.",
+            sanitize_log_arg(ident or "<unknown>"),
+        )
+        return None
+    return unmasked
 
 
 def _translate_text(
@@ -2009,7 +2077,17 @@ def _cached_translation(
         translations_raw["en"] = en_raw
     cached = en_raw.get(field)
     if isinstance(cached, str) and cached and cached != text:
-        return cached, True
+        if not _RESIDUAL_PLACEHOLDER_RE.search(cached):
+            return cached, True
+        # Self-heal: a value persisted by an earlier build carries a residual
+        # placeholder (the NMT model mangled it, defeating the exact-nonce
+        # unmask). Treat the hit as a MISS and re-translate below so a raw
+        # sentinel is never served from cache to subscribers.
+        log.info(
+            "Cache self-heal: residual placeholder in EN %s for %s; retrying.",
+            sanitize_log_arg(field),
+            sanitize_log_arg(ident),
+        )
     if isinstance(cached, str) and cached == text:
         # Stale-fallback heuristic: a prior run cached the German
         # source as the "translation" — re-attempt now that the

--- a/tests/test_en_feed_placeholder_leak.py
+++ b/tests/test_en_feed_placeholder_leak.py
@@ -1,0 +1,197 @@
+"""Regression guards for the EN-feed entity-placeholder leak.
+
+The Helsinki opus-mt-de-en (Marian/SentencePiece) translation model can MANGLE
+the opaque masking placeholders it is handed — observed in cached output:
+dropping a hex char from the per-process nonce, lower-casing the ``XGLO``
+prefix to ``XGLo``, translating German-looking nonce fragments to English
+(``…de…`` -> ``…en…``, a stray ``from``), and truncating the trailing index.
+Any of these defeats the EXACT-nonce unmask sweep, so the raw sentinel leaked
+into ``docs/feed.en.xml`` titles and was then cached and served indefinitely.
+
+These tests pin the three defences:
+  * the nonce-agnostic residual detector ``_RESIDUAL_PLACEHOLDER_RE``,
+  * the entity-only model bypass (``_is_non_translatable_content``) that keeps
+    all-entity titles out of the model entirely,
+  * the post-unmask safety net (translation -> ``None`` -> German fallback),
+  * the cache self-heal that re-translates a poisoned cache hit.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from src import build_feed as bf
+
+
+# --------------------------------------------------------------------------- #
+# Residual-placeholder detector                                               #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "leaked",
+    [
+        # dropped hex char in the nonce (15 instead of 16)
+        "XENT440c384b5ae3ae8X1X/XENT440c384b5ae3ae8X2X: XENT440c384b5ae3ae8X0X",
+        # prefix lower-cased by the model
+        "stop XGLoe736dbb52a8f8cfX0X here",
+        # German-looking nonce fragments translated to English (non-hex letters)
+        "ab XENT7473from307en9ecebX1X cd",
+        # trailing index truncated
+        "Barawitzkagasse XENT451aac69e31fe947X",
+    ],
+)
+def test_residual_detector_catches_every_mangled_form(leaked: str) -> None:
+    assert bf._RESIDUAL_PLACEHOLDER_RE.search(leaked) is not None
+
+
+@pytest.mark.parametrize(
+    "clean",
+    [
+        "86A/87A: Wiedgasse",
+        "U6: Karlsplatz",
+        # real-ish German words that merely START like the prefixes but lack the
+        # disambiguating trailing ``X`` — must NOT trip the detector
+        "Xentenplatz und Xentgasse",
+        "Stop change of lines 10A and 39A towards Heiligenstadt",
+        "ÖBB Wiener Linien VOR Praterstern",
+    ],
+)
+def test_residual_detector_no_false_positive(clean: str) -> None:
+    assert bf._RESIDUAL_PLACEHOLDER_RE.search(clean) is None
+
+
+# --------------------------------------------------------------------------- #
+# Entity-only bypass predicate                                                #
+# --------------------------------------------------------------------------- #
+def _ent(index: int) -> str:
+    return bf._ENTITY_PLACEHOLDER_FORMAT.format(index=index)
+
+
+def _glo(index: int) -> str:
+    return bf._GLOSSARY_PLACEHOLDER_FORMAT.format(index=index)
+
+
+def test_non_translatable_entity_only_title() -> None:
+    masked = f"{_ent(1)}/{_ent(2)}: {_ent(0)}"
+    assert bf._is_non_translatable_content(masked) is True
+
+
+def test_non_translatable_false_when_prose_present() -> None:
+    masked = f"{_ent(0)}: Aufzug außer Betrieb"
+    assert bf._is_non_translatable_content(masked) is False
+
+
+def test_non_translatable_false_when_glossary_present() -> None:
+    # XGLO placeholders stand in for German jargon that STILL needs the model.
+    masked = f"{_ent(0)}: {_glo(0)}"
+    assert bf._is_non_translatable_content(masked) is False
+
+
+def test_non_translatable_false_for_blank() -> None:
+    assert bf._is_non_translatable_content("   ") is False
+
+
+# --------------------------------------------------------------------------- #
+# _translate_text_attempt: bypass + safety net                                #
+# --------------------------------------------------------------------------- #
+def test_entity_only_title_bypasses_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    nonce = bf._PLACEHOLDER_NONCE
+    masked = f"XENT{nonce}X1X/XENT{nonce}X2X: XENT{nonce}X0X"
+    mapping = {
+        f"XENT{nonce}X0X": "Wiedgasse",
+        f"XENT{nonce}X1X": "86A",
+        f"XENT{nonce}X2X": "87A",
+    }
+    monkeypatch.setattr(bf, "_apply_domain_glossary", lambda t, **k: (t, {}))
+    monkeypatch.setattr(bf, "_mask_entities", lambda t: (masked, mapping))
+    pipe = MagicMock()
+    monkeypatch.setattr(bf, "_get_translation_pipeline", lambda: pipe)
+
+    result = bf._translate_text_attempt("86A/87A: Wiedgasse", ident="bypass-1")
+
+    assert result == "86A/87A: Wiedgasse"
+    pipe.assert_not_called()  # model never invoked for an all-entity title
+
+
+def test_residual_after_unmask_discards_translation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nonce = bf._PLACEHOLDER_NONCE
+    masked = f"XENT{nonce}X0X Stoerung"
+    mapping = {f"XENT{nonce}X0X": "Praterstern"}
+    monkeypatch.setattr(bf, "_apply_domain_glossary", lambda t, **k: (t, {}))
+    monkeypatch.setattr(bf, "_mask_entities", lambda t: (masked, mapping))
+    # The model mangles the placeholder (drops the last nonce char) so the
+    # exact-nonce unmask cannot restore it.
+    mangled = f"XENT{nonce[:-1]}X0X disruption"
+    monkeypatch.setattr(
+        bf, "_get_translation_pipeline",
+        lambda: (lambda *a, **k: [{"translation_text": mangled}]),
+    )
+
+    result = bf._translate_text_attempt("Praterstern Stoerung", ident="resid-1")
+
+    assert result is None  # signalled as failed -> caller falls back to German
+
+
+def test_clean_translation_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    nonce = bf._PLACEHOLDER_NONCE
+    masked = f"XENT{nonce}X0X Stoerung"
+    mapping = {f"XENT{nonce}X0X": "Praterstern"}
+    monkeypatch.setattr(bf, "_apply_domain_glossary", lambda t, **k: (t, {}))
+    monkeypatch.setattr(bf, "_mask_entities", lambda t: (masked, mapping))
+    # Model echoes the placeholder intact -> unmask restores it cleanly.
+    good = f"XENT{nonce}X0X disruption"
+    monkeypatch.setattr(
+        bf, "_get_translation_pipeline",
+        lambda: (lambda *a, **k: [{"translation_text": good}]),
+    )
+
+    result = bf._translate_text_attempt("Praterstern Stoerung", ident="ok-1")
+
+    assert result == "Praterstern disruption"
+
+
+# --------------------------------------------------------------------------- #
+# _cached_translation: self-heal vs. clean hit                                #
+# --------------------------------------------------------------------------- #
+def test_cache_self_heals_poisoned_hit(monkeypatch: pytest.MonkeyPatch) -> None:
+    poisoned = "XENT440c384b5ae3ae8X1X: XENT440c384b5ae3ae8X0X"
+    state: dict[str, dict[str, Any]] = {
+        "poison-id": {"translations": {"en": {"title": poisoned}}}
+    }
+    calls: list[str] = []
+
+    def fake_attempt(text: str, ident: str = "", **_: Any) -> str:
+        calls.append(text)
+        return "U1: Stephansplatz"
+
+    monkeypatch.setattr(bf, "_translate_text_attempt", fake_attempt)
+
+    out, ok = bf._cached_translation("U1: Stephansplatz", "title", "poison-id", state)
+
+    assert ok is True
+    assert out == "U1: Stephansplatz"
+    assert calls == ["U1: Stephansplatz"]  # re-translated, not served from cache
+    # poisoned value overwritten with the clean re-translation
+    assert state["poison-id"]["translations"]["en"]["title"] == "U1: Stephansplatz"
+
+
+def test_clean_cache_hit_served_without_retranslation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The cached EN must DIFFER from the DE source, otherwise the pre-existing
+    # "Sticky-German" guard (cached == source -> stale -> retry) fires first.
+    state: dict[str, dict[str, Any]] = {
+        "clean-id": {"translations": {"en": {"title": "U6: Elevator out of order"}}}
+    }
+
+    def boom(*_a: Any, **_k: Any) -> str:
+        raise AssertionError("a clean cache hit must not be re-translated")
+
+    monkeypatch.setattr(bf, "_translate_text_attempt", boom)
+
+    out, ok = bf._cached_translation("U6: Aufzug außer Betrieb", "title", "clean-id", state)
+
+    assert (out, ok) == ("U6: Elevator out of order", True)

--- a/tests/test_sentinel_allow_nan_writer_audit_walker.py
+++ b/tests/test_sentinel_allow_nan_writer_audit_walker.py
@@ -93,7 +93,7 @@ Three documented sites live here today:
   motivates the non-finite-literal axis (committed-to-main artefact
   that strict parsers must handle) does not apply.
 
-* ``src/build_feed.py:_identity_for_item`` (lines 2496 and 2505) —
+* ``src/build_feed.py:_identity_for_item`` (lines 2574 and 2583) —
   two ``json.dumps(item, sort_keys=True, default=str)`` calls compute
   the SHA-256 input for the feed-item identity hash. The serialised
   bytes flow into ``hashlib.sha256(raw.encode("utf-8", "surrogatepass")).hexdigest()``
@@ -142,8 +142,8 @@ ALLOWLIST: frozenset[tuple[str, int]] = frozenset(
         # into ``hashlib.sha256(...).hexdigest()`` on the very next
         # line and are not retained anywhere else. No parser-consumed
         # artefact, so the threat model does not apply.
-        ("src/build_feed.py", 2496),
-        ("src/build_feed.py", 2505),
+        ("src/build_feed.py", 2574),
+        ("src/build_feed.py", 2583),
     }
 )
 
@@ -536,7 +536,7 @@ def test_allowlist_is_minimal_and_documented() -> None:
     assert ALLOWLIST == frozenset(
         {
             ("src/places/hafas_client.py", 289),
-            ("src/build_feed.py", 2496),
-            ("src/build_feed.py", 2505),
+            ("src/build_feed.py", 2574),
+            ("src/build_feed.py", 2583),
         }
     )


### PR DESCRIPTION
## Problem
Der **englische** Feed (`docs/feed.en.xml`) zeigte in manchen Item-Titeln rohe Masking-Sentinels statt der übersetzten Linien/Stationen, während die **Description desselben Items korrekt** war:

```
<title>XENT440c384b5ae3ae8X1X/XENT440c384b5ae3ae8X2X: XENT440c384b5ae3ae8X0X</title>
```

## Root Cause
Das NMT-Modell (`opus-mt-de-en`, Marian/SentencePiece) **verstümmelt** die opaken Platzhalter `XENT<nonce>X<i>X` / `XGLO…`. Beweise aus `data/first_seen.json`:
- `440c384b5ae3ae8` = **15** Hex-Zeichen statt 16 → gedropptes Zeichen.
- `XGLoe736dbb52a8f8cf` → Präfix `XGLO` **kleingeschrieben** zu `XGLo`.
- `XENT7473from307en9eceb` → deutsche Nonce-Fragmente **ins Englische übersetzt** (`de`→`en`, ein `from`).
- `XENT451aac69e31fe947X` → **Index abgeschnitten**.

Das verstümmelte Token matcht den **exakt-Nonce**-Unmask nicht mehr → überlebt verbatim → wird als „Übersetzung" gecacht → auf Cache-Hits **ungeprüft** ausgeliefert. Titel sind anfälliger als Summaries: ein Rein-Entity-Titel (`Linie/Linie: Station`) maskiert zu dicht gepackten Platzhaltern, die der Tokenizer verschmilzt.

## Fix — vier Verteidigungslinien (`src/build_feed.py`)
1. **`_RESIDUAL_PLACEHOLDER_RE`** — nonce-agnostischer Detektor (`(?:XENT|XGLO)[A-Za-z0-9]*X`, case-insensitiv). Das zwingende Schluss-`X` schließt echte Wörter wie „Xentenplatz" aus; `[A-Za-z0-9]` (statt Hex) fängt auch die ins-Englische-übersetzten Nonce-Fragmente.
2. **Safety-Net** — Rest-Platzhalter nach dem Unmask ⇒ `_translate_text_attempt` liefert `None` ⇒ nicht gecacht, DE-Fallback (Inhalts-Parität gewahrt).
3. **Cache-Self-Heal** — vergifteter Cache-Hit wird als Miss behandelt & neu übersetzt; Alt-Poison wird nie mehr ausgeliefert.
4. **Qualitäts-Bypass** (`_is_non_translatable_content`) — Rein-Entity-Titel (nur Platzhalter + Satzzeichen, kein `XGLO`) überspringen das Modell und werden direkt entmaskiert: korrektes EN ohne Modellrisiko, **ohne** DE-Fallback.

Zusätzlich: die **13 bereits vergifteten** Cache-Werte in `data/first_seen.json` zurückgesetzt (Neuberechnung beim nächsten Build), und der `allow_nan`-Writer-Walker auf die verschobenen `json.dumps`-Zeilen (2574/2583) nachgezogen.

## Tests
`tests/test_en_feed_placeholder_leak.py` (18 Fälle): Detektor matcht alle verstümmelten Formen / keine False-Positives; Bypass überspringt das Modell; Safety-Net verwirft Rest-Platzhalter; Self-Heal vs. sauberer Cache-Hit.

Lokal verifiziert: ruff ✓, C901-Gate ✓ (≤15), mypy (nur bekannte Windows-`fcntl`/`fchmod`-Artefakte, 0 im Fix-Code), neue + bestehende Translation/Masking-Tests ✓.