### PR TITLE
docs: letzte Doku-Lücken (CHANGELOG-Boilerplate + architecture.md Secret-Scanner-Querverweis)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+Alle nennenswerten Änderungen an diesem Projekt werden in dieser Datei dokumentiert.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Das Format orientiert sich an [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 * **Bugfix: EN-Feed — verstümmelte Masking-Platzhalter beseitigt (2026-06-01)**:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -742,3 +742,17 @@ Die laufende Audit- und Refactoring-Historie liegt in `CHANGELOG.md`
 `docs/archive/audits/` (abgeschlossene Audit-Berichte). Architektur-
 relevante Änderungen sollten zusätzlich diese Karte und gegebenenfalls
 das jeweilige Mermaid-Diagramm aktualisieren.
+
+**Sicherheitsmechanismen** sind bewusst über mehrere Dokumente verteilt –
+diese Karte beschreibt nur die laufzeit-architektonischen Schichten:
+
+* `request_safe`-SSRF-Abwehr (DNS-Rebinding-Schutz, Host-Pinning,
+  privater-Adressraum-Block): § 2 in diesem Dokument.
+* Resilienz-Stack (Circuit-Breaker, Retry, Soft-Fail auf Caches): § 3.
+* Path-Guard (`ALLOWED_ROOTS` auf `docs/`/`data/`/`log/`), atomare
+  Schreiboperationen (`atomic_write`) und der **Secret-Scanner**
+  (`src/utils/secret_scanner.py`, im CI- und pre-commit-Lauf) sind als
+  Entwicklungs-/CI-Werkzeuge in [`development.md`](development.md)
+  dokumentiert.
+* Eine konsolidierte Gesamtübersicht steht in [`AGENTS.md`](../AGENTS.md);
+  die Meldewege für Schwachstellen in [`SECURITY.md`](../SECURITY.md).


### PR DESCRIPTION
Nachzug zum Doku-Audit (#1746): schließt die zwei letzten Lücken, die ein deterministischer Englisch-Sweep über **alle** `.md`-Dateien (rekursiv) noch aufdeckte.

- **CHANGELOG.md**: die englische Keep-a-Changelog-Kopfzeile eingedeutscht („Alle nennenswerten Änderungen … / Das Format orientiert sich an …").
- **docs/architecture.md (§8 Querverweise)**: expliziter Verweis auf die über mehrere Dokumente verteilten Sicherheitsmechanismen — insbesondere den **Secret-Scanner**, der zuvor in der Architektur-Karte gar nicht erwähnt war (er ist als CI-/Dev-Werkzeug in `development.md` dokumentiert; die Karte verlinkt nun korrekt dorthin).

Sweep-Ergebnis: Alle handgepflegten `.md`-Docs (README, `docs/**`, AGENTS, CONTRIBUTING, SECURITY, CHANGELOG) sind damit durchgehend deutsch. Ausgenommen bleiben die **eingefrorenen** historischen Audits unter `docs/archive/audits/` und ein bewusst belassenes englisches Docstring-Zitat im CHANGELOG.

Nur Dokumentation.