### PR TITLE
test: isolate Stammstrecke episode-start ledger writes in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -261,6 +261,37 @@ def isolate_stats_writes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Ite
     yield
 
 
+@pytest.fixture(autouse=True)
+def isolate_episode_starts_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[None]:
+    """Redirect the Stammstrecke episode-start ledger to a per-test tmp file.
+
+    ``src.feed.stammstrecke`` persists the first-observed episode start to
+    ``cache/stammstrecke/episode_starts.json`` under the repo root
+    (:data:`~src.feed.stammstrecke.EPISODE_STARTS_PATH`). That file is
+    intentionally committed and refreshed by the Stammstrecke workflow, so a
+    stray test write is easy to wave through in review as "the cache updated".
+    Any test that drives the compute path without passing an explicit
+    ``episode_starts_path`` falls back to ``EPISODE_STARTS_PATH`` and mutates
+    the tracked seed, dirtying the working tree and risking an accidental
+    commit of synthetic test rows.
+
+    The canonical statemachine tests already inject a tmp path; integration
+    tests that exercise the ledger only as a side effect do not — so isolate
+    it globally, mirroring :func:`isolate_stats_writes`. The override is
+    monkeypatched on the module attribute, which the producer reads at call
+    time (``episode_starts_path or EPISODE_STARTS_PATH``), so an explicit
+    keyword still wins for tests that target their own path.
+    """
+    from src.feed import stammstrecke
+
+    monkeypatch.setattr(
+        stammstrecke, "EPISODE_STARTS_PATH", tmp_path / "episode_starts.json"
+    )
+    yield
+
+
 # ---------------------------------------------------------------------------
 # CircuitBreaker test-isolation fixture
 #


### PR DESCRIPTION
## What

Adds an autouse pytest fixture (`isolate_episode_starts_writes`) in `tests/conftest.py` that redirects the Stammstrecke episode-start ledger to a per-test `tmp_path`, so the test suite can no longer mutate the committed `cache/stammstrecke/episode_starts.json`.

## Why

The episode-start ledger persists to `EPISODE_STARTS_PATH` (`src/feed/stammstrecke.py:135`), a file that is intentionally committed and refreshed by the Stammstrecke workflow. Integration tests that drive the compute path without injecting an explicit `episode_starts_path` fall back to that real file via `episode_starts_path or EPISODE_STARTS_PATH` (`stammstrecke.py:474`) and write into it. A local `pytest` run therefore dirties the working tree — and because the file legitimately changes via the workflow, a stray test diff is easy to wave through in review, risking an accidental commit of synthetic test rows.

`conftest.py` already isolates `REQUEST_COUNT_FILE` (`reset_vor_request_count`) and `DEFAULT_STATS_DIR` (`isolate_stats_writes`), but `EPISODE_STARTS_PATH` had no such guard. The canonical `test_stammstrecke_statemachine.py` tests already inject a tmp path; the leak comes from integration-level tests that touch the ledger only as a side effect.

## How

One autouse fixture mirroring `isolate_stats_writes`. The producer reads the module global at call time, so monkeypatching `stammstrecke.EPISODE_STARTS_PATH` is picked up by the fallback, while an explicit `episode_starts_path` keyword still wins for tests that target their own path. `EPISODE_STARTS_PATH` has a single consumer and no test assertions, so the global patch is safe.

## Verification

- The subset of integration tests that previously dirtied `cache/stammstrecke/episode_starts.json` now leaves the working tree clean (215 passed).
- Full suite: **8889 passed, 2 skipped** (pre-existing `jsonschema` skips), working tree **clean** afterward — confirms no regression and no remaining pollution.
- `ruff check` clean.

## Scope note

This is the one substantive item from the audit follow-up. The other candidate (Dependabot `pip` coverage) turned out to be **already present** in `.github/dependabot.yml`, so no change was needed there.

https://claude.ai/code/session_01Kv2C2iXyqmkem8pyKghLZc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kv2C2iXyqmkem8pyKghLZc)_