### PR TITLE
ci(claude-review): Job auf Dependabot-PRs überspringen

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,12 @@ on:
 
 jobs:
   claude-review:
+    # Dependabot-PRs erhalten aus Sicherheitsgründen keinen Zugriff auf
+    # Repository-Secrets — CLAUDE_CODE_OAUTH_TOKEN ist dort leer, wodurch die
+    # Action ohne gültiges Token sofort fehlschlägt (rotes X trotz grüner
+    # Pflicht-Checks). Solche PRs daher überspringen.
+    if: github.actor != 'dependabot[bot]'
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## Problem

Alle aktuell offenen Dependabot-PRs (#1750–#1757) zeigen ein rotes `claude-review`-X — **obwohl alle Pflicht-Checks grün sind** (`Run test suite`, `mypy --strict`, `Bandit`, `CodeQL`/`Analyze`, `C901 complexity gate`, `build`). Die Updates selbst sind also einwandfrei.

## Root Cause

Der Job in `claude-code-review.yml` startet `anthropics/claude-code-action@v1` mit `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`. **GitHub gibt Dependabot-getriggerten Workflow-Runs aus Sicherheitsgründen keinen Zugriff auf Repository-Secrets** — das Token ist dort leer, und die Action bricht mangels gültigem Token nach wenigen Sekunden ab.

**Beweis:** Auf dem Menschen-PR #1748 lief derselbe Job erfolgreich ~3 Min durch (Token vorhanden); auf den Dependabot-PRs stirbt er in ~10 Sek.

## Fix

Ein job-level Guard überspringt den Review auf Dependabot-PRs (er könnte ohne Token ohnehin nichts tun):

```yaml
jobs:
  claude-review:
    if: github.actor != 'dependabot[bot]'
```

Auf regulären PRs läuft der Job unverändert weiter. Übersprungene Jobs melden `skipped` (kein `failure`), das rote X verschwindet also.

## Hinweise

- **Damit die 8 bereits offenen Dependabot-PRs grün werden, muss dieser Fix erst nach `main` gemergt und die PRs danach rebased werden** (`@dependabot rebase` bzw. nächster Push auf main) — `pull_request`-Runs nutzen die Workflow-Datei vom PR-Head-Branch. Gerne stoße ich die Rebases nach dem Merge an.
- Bewusst **nur** auf Dependabot beschränkt; Fork-/Externe-PRs (die ebenfalls keine Secrets sehen) bleiben unangetastet, da die auskommentierten Hinweise im Workflow auf gewollte Reviews externer Beiträge hindeuten.

https://claude.ai/code/session_01CyQQBn4FESowSbfJA6DwX8

---
_Generated by [Claude Code](https://claude.ai/code/session_01CyQQBn4FESowSbfJA6DwX8)_