### PR TITLE
ci(claude-review): beratenden Review-Schritt ausfallsicher machen (kein rotes X mehr bei Aussetzern)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,13 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        # Das Review ist beratend (postet Kommentare) und niemals ein
+        # Qualitäts-Gate — ein Fehlschlag heißt nie „Code schlecht", sondern
+        # immer Infra/Token/Transient (fehlendes Secret auf Fork-PRs, ein
+        # transienter API-Aussetzer o. Ä.). Damit solche Aussetzer keinen
+        # roten Check erzeugen, läuft der Schritt mit continue-on-error; auf
+        # regulären PRs läuft das Review unverändert und postet Kommentare.
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Kontext

Folge-PR zu #1759 (Dependabot-Guard). Beobachtung dort: `claude-review` schlug auch auf einem **regulären** PR (#1759) rot fehl — aber nur einmalig (~30 Sek), während die nächste gleichartige PR #1760 ein volles ~3,5-Min-Review **erfolgreich** durchlief. Es gibt also **kein** systematisches Problem mit Automations-/Claude-PRs (das Secret ist dort verfügbar) — #1759 war ein **transienter** Aussetzer.

## Warum dieser Fix

Der `claude-review`-Job ist **beratend**: Er postet Review-Kommentare und ist **niemals ein Qualitäts-Gate**. Ein Non-Zero-Exit bedeutet daher immer ein Infra-/Token-/Transient-Problem (fehlendes Secret auf Fork-PRs, transienter API-Aussetzer), **nie** „Code schlecht". Trotzdem erzeugte bisher jeder solche Aussetzer ein **rotes X**.

## Änderung

```yaml
- name: Run Claude Code Review
  id: claude-review
  continue-on-error: true   # ← neu
  uses: anthropics/claude-code-action@v1
```

- Auf regulären PRs läuft das Review **unverändert** und postet Kommentare.
- Ein Fehlschlag (Fork ohne Secret, transienter Fehler) färbt den Check **nicht mehr rot**.
- Der **Dependabot-Guard** aus #1759 bleibt (sauberes Skip statt Runner-Verschwendung für token-lose Bot-PRs).
- `continue-on-error` sitzt **nur** am Review-Schritt — ein echter Checkout-Fehler bleibt sichtbar.

## Bewusst *nicht* gemacht

Den Guard pauschal auf „alle Bots/Automation überspringen" auszuweiten — das hätte **funktionierende** Reviews abgeschaltet (z. B. auf #1760).

## Hinweis

Behebt das *rote X* dauerhaft. Sollte das Review auf regulären PRs einmal **dauerhaft** ausfallen (statt transient), wäre das nun ein grüner Check ohne Kommentare — sichtbar daran, dass keine Review-Kommentare mehr erscheinen; dann wäre die Ursache (z. B. ein abgelaufenes `CLAUDE_CODE_OAUTH_TOKEN`) separat zu prüfen.

https://claude.ai/code/session_01CyQQBn4FESowSbfJA6DwX8

---
_Generated by [Claude Code](https://claude.ai/code/session_01CyQQBn4FESowSbfJA6DwX8)_