### PR TITLE
docs(readme): add Health Check workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ### Status Badges
 
 [![Feed Build](https://github.com/Origamihase/wien-oepnv/actions/workflows/build-feed.yml/badge.svg?branch=main)](https://github.com/Origamihase/wien-oepnv/actions/workflows/build-feed.yml)
+[![Health Check](https://github.com/Origamihase/wien-oepnv/actions/workflows/health-check.yml/badge.svg?branch=main)](https://github.com/Origamihase/wien-oepnv/actions/workflows/health-check.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Subscribe to Feed](https://img.shields.io/badge/RSS-Subscribe_to_Feed-orange?style=flat&logo=rss)](https://origamihase.github.io/wien-oepnv/feed.xml)
 [![Website](https://img.shields.io/badge/Website-Wien_ÖPNV-0F1736?style=flat&logo=githubpages&logoColor=white)](https://origamihase.github.io/wien-oepnv/site.html)


### PR DESCRIPTION
## Was

Fügt eine **Status-Badge für den `health-check.yml`-Workflow** in den „Status Badges"-Block der README ein — direkt neben „Feed Build", damit die beiden Pipeline-Status-Badges beieinanderstehen.

```markdown
[![Health Check](`https://github.com/Origamihase/wien-oepnv/actions/workflows/health-check.yml/badge.svg?branch=main)](https://github.com/Origamihase/wien-oepnv/actions/workflows/health-check.yml)`
```

## Warum

Der `health-check.yml`-Watchdog (Live-Canary für WL/ÖBB/Baustellen + Frische von Feed und Stationsverzeichnis) wird damit auf einen Blick sichtbar — grün = alle Quellen erreichbar & Outputs frisch, rot = Handlungsbedarf.

## Hinweise

- Rein additiv (bestehende Badges bleiben unverändert), nur die README betroffen.
- Die Badge zeigt zunächst **„no status" (grau)**, bis der Workflow das erste Mal auf `main` gelaufen ist — per **Actions → Health check → „Run workflow"** sofort befüllbar.
- Format spiegelt exakt die bestehende „Feed Build"-Badge (`?branch=main`).

https://claude.ai/code/session_014E9HSzbN5XUak2Y9ZCcKjF

---
_Generated by [Claude Code](https://claude.ai/code/session_014E9HSzbN5XUak2Y9ZCcKjF)_